### PR TITLE
feat(support): add symbols, interner, diagnostics, arena, options + unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Build
         run: cmake --build build --config Debug
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build -C Debug --output-on-failure

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,4 @@
-add_library(support STATIC support/placeholder.cpp)
-set_target_properties(support PROPERTIES LINKER_LANGUAGE CXX)
+add_subdirectory(support)
 
 add_library(il_core STATIC il/core/placeholder.cpp)
 set_target_properties(il_core PROPERTIES LINKER_LANGUAGE CXX)

--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(support STATIC
+  string_interner.cpp
+  source_manager.cpp
+  diagnostics.cpp
+  arena.cpp
+)
+
+target_include_directories(support PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/src/support/arena.cpp
+++ b/src/support/arena.cpp
@@ -1,0 +1,13 @@
+#include "arena.h"
+namespace il::support {
+Arena::Arena(size_t size) : buffer_(size) {}
+void *Arena::allocate(size_t size, size_t align) {
+  size_t current = offset_;
+  size_t aligned = (current + align - 1) & ~(align - 1);
+  if (aligned + size > buffer_.size())
+    return nullptr;
+  offset_ = aligned + size;
+  return buffer_.data() + aligned;
+}
+void Arena::reset() { offset_ = 0; }
+} // namespace il::support

--- a/src/support/arena.h
+++ b/src/support/arena.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <cstddef>
+#include <vector>
+/// @brief Simple bump allocator for fast allocations.
+/// @invariant Allocations are not individually freed; use reset() to reuse.
+/// @ownership Owns its internal buffer.
+namespace il::support {
+class Arena {
+public:
+  explicit Arena(size_t size);
+  void *allocate(size_t size, size_t align);
+  void reset();
+
+private:
+  std::vector<std::byte> buffer_;
+  size_t offset_ = 0;
+};
+} // namespace il::support

--- a/src/support/diagnostics.cpp
+++ b/src/support/diagnostics.cpp
@@ -1,0 +1,30 @@
+#include "diagnostics.h"
+namespace il::support {
+void DiagnosticEngine::report(Diagnostic d) {
+  if (d.severity == Severity::Error)
+    ++errors_;
+  else if (d.severity == Severity::Warning)
+    ++warnings_;
+  diags_.push_back(std::move(d));
+}
+static const char *toString(Severity s) {
+  switch (s) {
+  case Severity::Note:
+    return "note";
+  case Severity::Warning:
+    return "warning";
+  case Severity::Error:
+    return "error";
+  }
+  return "";
+}
+void DiagnosticEngine::printAll(std::ostream &os, const SourceManager *sm) const {
+  for (const auto &d : diags_) {
+    if (d.loc.isValid() && sm) {
+      auto path = sm->getPath(d.loc.file_id);
+      os << path << ":" << d.loc.line << ":" << d.loc.column << ": ";
+    }
+    os << toString(d.severity) << ": " << d.message << '\n';
+  }
+}
+} // namespace il::support

--- a/src/support/diagnostics.h
+++ b/src/support/diagnostics.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "source_manager.h"
+#include <ostream>
+#include <string>
+#include <vector>
+/// @brief Records diagnostics and prints them later.
+/// @invariant Counts reflect reported diagnostics.
+/// @ownership Owns stored diagnostic messages.
+namespace il::support {
+enum class Severity { Note, Warning, Error };
+struct Diagnostic {
+  Severity severity;
+  std::string message;
+  SourceLoc loc;
+};
+class DiagnosticEngine {
+public:
+  void report(Diagnostic d);
+  void printAll(std::ostream &os, const SourceManager *sm = nullptr) const;
+  size_t errorCount() const { return errors_; }
+  size_t warningCount() const { return warnings_; }
+
+private:
+  std::vector<Diagnostic> diags_;
+  size_t errors_ = 0;
+  size_t warnings_ = 0;
+};
+} // namespace il::support

--- a/src/support/options.h
+++ b/src/support/options.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <string>
+/// @brief Global options controlling compiler behavior.
+/// @invariant Flags are independent booleans.
+/// @ownership Value type.
+namespace il::support {
+struct Options {
+  bool trace = false;
+  bool verify = true;
+  std::string target = "x86_64";
+};
+} // namespace il::support

--- a/src/support/placeholder.cpp
+++ b/src/support/placeholder.cpp
@@ -1,4 +1,0 @@
-// TODO: implement support library
-namespace support {
-int placeholder() { return 0; }
-} // namespace support

--- a/src/support/result.h
+++ b/src/support/result.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <string>
+#include <utility>
+/// @brief Minimal expected-like container.
+/// @invariant Either holds a value or an error string.
+/// @ownership Owns stored value/error.
+namespace il::support {
+template <typename T> class Result {
+public:
+  Result(T value) : has_value_(true), value_(std::move(value)) {}
+  Result(std::string error) : has_value_(false), error_(std::move(error)) {}
+  bool isOk() const { return has_value_; }
+  T &value() { return value_; }
+  const T &value() const { return value_; }
+  const std::string &error() const { return error_; }
+
+private:
+  bool has_value_;
+  T value_{};
+  std::string error_;
+};
+} // namespace il::support

--- a/src/support/source_manager.cpp
+++ b/src/support/source_manager.cpp
@@ -1,0 +1,12 @@
+#include "source_manager.h"
+namespace il::support {
+uint32_t SourceManager::addFile(std::string path) {
+  files_.push_back(std::move(path));
+  return static_cast<uint32_t>(files_.size());
+}
+std::string_view SourceManager::getPath(uint32_t file_id) const {
+  if (file_id == 0 || file_id > files_.size())
+    return {};
+  return files_[file_id - 1];
+}
+} // namespace il::support

--- a/src/support/source_manager.h
+++ b/src/support/source_manager.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+/// @brief Tracks mapping from file ids to paths and source locations.
+/// @invariant File id 0 is invalid.
+/// @ownership Owns stored file path strings.
+namespace il::support {
+struct SourceLoc {
+  uint32_t file_id = 0;
+  uint32_t line = 0;
+  uint32_t column = 0;
+  bool isValid() const { return file_id != 0; }
+};
+class SourceManager {
+public:
+  uint32_t addFile(std::string path);
+  std::string_view getPath(uint32_t file_id) const;
+
+private:
+  std::vector<std::string> files_;
+};
+} // namespace il::support

--- a/src/support/string_interner.cpp
+++ b/src/support/string_interner.cpp
@@ -1,0 +1,17 @@
+#include "string_interner.h"
+namespace il::support {
+Symbol StringInterner::intern(std::string_view str) {
+  auto it = map_.find(std::string(str));
+  if (it != map_.end())
+    return it->second;
+  storage_.emplace_back(str);
+  Symbol sym{static_cast<uint32_t>(storage_.size())};
+  map_.emplace(storage_.back(), sym);
+  return sym;
+}
+std::string_view StringInterner::lookup(Symbol sym) const {
+  if (sym.id == 0 || sym.id > storage_.size())
+    return {};
+  return storage_[sym.id - 1];
+}
+} // namespace il::support

--- a/src/support/string_interner.h
+++ b/src/support/string_interner.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "symbol.h"
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+/// @brief Interns strings to provide stable Symbol identifiers.
+/// @invariant Symbol 0 is reserved for invalid.
+/// @ownership Stores copies of strings internally.
+namespace il::support {
+class StringInterner {
+public:
+  Symbol intern(std::string_view str);
+  std::string_view lookup(Symbol sym) const;
+
+private:
+  std::unordered_map<std::string, Symbol> map_;
+  std::vector<std::string> storage_;
+};
+} // namespace il::support

--- a/src/support/symbol.h
+++ b/src/support/symbol.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <cstdint>
+#include <functional>
+/// @brief Opaque identifier for interned strings.
+/// @invariant 0 denotes an invalid symbol.
+/// @ownership Value type, no ownership semantics.
+namespace il::support {
+struct Symbol {
+  uint32_t id = 0;
+  friend bool operator==(Symbol a, Symbol b) noexcept { return a.id == b.id; }
+  friend bool operator!=(Symbol a, Symbol b) noexcept { return a.id != b.id; }
+  explicit operator bool() const noexcept { return id != 0; }
+};
+} // namespace il::support
+namespace std {
+template <> struct hash<il::support::Symbol> {
+  size_t operator()(il::support::Symbol s) const noexcept { return s.id; }
+};
+} // namespace std

--- a/src/tools/ilc/ilc.cpp
+++ b/src/tools/ilc/ilc.cpp
@@ -1,9 +1,12 @@
+#include "support/diagnostics.h"
 #include <iostream>
-
 int main(int argc, char **argv) {
   (void)argc;
   (void)argv;
+  il::support::DiagnosticEngine engine;
+  engine.report({il::support::Severity::Error, "demo diagnostic", {}});
+  engine.printAll(std::cerr);
   std::cout << "ilc v0.1.0\n";
   std::cout << "Usage: ilc [--help]\n";
-  return 0;
+  return engine.errorCount() ? 1 : 0;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,3 @@
-# Tests will be added here in the future
+add_executable(test_support unit/test_support.cpp)
+target_link_libraries(test_support PRIVATE support)
+add_test(NAME test_support COMMAND test_support)

--- a/tests/unit/test_support.cpp
+++ b/tests/unit/test_support.cpp
@@ -1,0 +1,31 @@
+#include "support/arena.h"
+#include "support/diagnostics.h"
+#include "support/string_interner.h"
+#include <cassert>
+#include <sstream>
+int main() {
+  // String interner uniqueness and lookup
+  il::support::StringInterner interner;
+  auto a = interner.intern("hello");
+  auto b = interner.intern("hello");
+  assert(a == b);
+  assert(interner.lookup(a) == "hello");
+
+  // Diagnostic formatting
+  il::support::SourceManager sm;
+  il::support::SourceLoc loc{sm.addFile("test"), 1, 1};
+  il::support::DiagnosticEngine de;
+  de.report({il::support::Severity::Error, "oops", loc});
+  std::ostringstream oss;
+  de.printAll(oss, &sm);
+  assert(oss.str().find("error: oops") != std::string::npos);
+  assert(oss.str().find("test:1:1") != std::string::npos);
+
+  // Arena alignment
+  il::support::Arena arena(64);
+  void *p1 = arena.allocate(1, 1);
+  (void)p1;
+  void *p2 = arena.allocate(sizeof(double), alignof(double));
+  assert(reinterpret_cast<uintptr_t>(p2) % alignof(double) == 0);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- implement support library with symbol interning, source locations, diagnostics, bump arena, tiny result and options
- add unit tests for interner, diagnostics and arena
- demo diagnostic emission in `ilc`

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --config Debug`
- `ctest --test-dir build -C Debug --output-on-failure`
- `./build/src/tools/ilc/ilc >/tmp/ilc.out 2>&1 || true && cat /tmp/ilc.out`


------
https://chatgpt.com/codex/tasks/task_e_68b1236fe5148324ba3dad7ef977bb6e