### PR TITLE
feat(il): add Parser (subset) and Verifier; round-trip + verify tests for two example IL programs

### DIFF
--- a/docs/examples/il/hello_cond.il
+++ b/docs/examples/il/hello_cond.il
@@ -1,0 +1,44 @@
+il 0.1
+extern @rt_print_str(str) -> void
+extern @rt_print_i64(i64) -> void
+
+global const str @.L0 = "HELLO"
+global const str @.L1 = "READY"
+
+func @main() -> i32 {
+entry:
+  %x_slot = alloca 8
+  %y_slot = alloca 8
+
+  %t0 = add 2, 3
+  store i64, %x_slot, %t0
+
+  %xv = load i64, %x_slot
+  %t1 = mul %xv, 2
+  store i64, %y_slot, %t1
+
+  %s0 = const_str @.L0
+  call @rt_print_str(%s0)
+
+  %s1 = const_str @.L1
+  call @rt_print_str(%s1)
+
+  %yv0 = load i64, %y_slot
+  call @rt_print_i64(%yv0)
+
+  %yv1 = load i64, %y_slot
+  %cond = scmp_gt %yv1, 8
+  cbr %cond, label then80, label else60
+
+else60:
+  call @rt_print_i64(4)
+  br label after
+
+then80:
+  %yv2 = load i64, %y_slot
+  call @rt_print_i64(%yv2)
+  br label after
+
+after:
+  ret 0
+}

--- a/docs/examples/il/sum_1_to_10.il
+++ b/docs/examples/il/sum_1_to_10.il
@@ -1,0 +1,43 @@
+il 0.1
+extern @rt_print_str(str) -> void
+extern @rt_print_i64(i64) -> void
+
+global const str @.L0 = "SUM 1..10"
+global const str @.L1 = "DONE"
+
+func @main() -> i32 {
+entry:
+  %i_slot = alloca 8
+  %s_slot = alloca 8
+
+  %h = const_str @.L0
+  call @rt_print_str(%h)
+
+  store i64, %i_slot, 1
+  store i64, %s_slot, 0
+  br label loop_head
+
+loop_head:
+  %i0 = load i64, %i_slot
+  %c = scmp_le %i0, 10
+  cbr %c, label loop_body, label done
+
+loop_body:
+  %s0 = load i64, %s_slot
+  %s1 = add %s0, %i0
+  store i64, %s_slot, %s1
+
+  %i1 = add %i0, 1
+  store i64, %i_slot, %i1
+
+  br label loop_head
+
+done:
+  %s2 = load i64, %s_slot
+  call @rt_print_i64(%s2)
+
+  %d = const_str @.L1
+  call @rt_print_str(%d)
+
+  ret 0
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,9 +16,13 @@ add_library(il_build STATIC il/build/IRBuilder.cc)
 target_link_libraries(il_build PUBLIC il_core support)
 target_include_directories(il_build PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_library(il_io STATIC il/io/Serializer.cc)
+add_library(il_io STATIC il/io/Serializer.cc il/io/Parser.cc)
 target_link_libraries(il_io PUBLIC il_core)
 target_include_directories(il_io PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(il_verify STATIC il/verify/Verifier.cc)
+target_link_libraries(il_verify PUBLIC il_core)
+target_include_directories(il_verify PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(il_vm STATIC vm/placeholder.cpp)
 set_target_properties(il_vm PROPERTIES LINKER_LANGUAGE CXX)
@@ -32,7 +36,7 @@ target_link_libraries(ilc PRIVATE support il_core il_build il_io il_vm il_codege
 
 add_executable(il-verify tools/il-verify/il-verify.cpp)
 set_target_properties(il-verify PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/il-verify)
-target_link_libraries(il-verify PRIVATE support il_core il_build il_io il_vm)
+target_link_libraries(il-verify PRIVATE support il_core il_build il_io il_vm il_verify)
 
 add_executable(il-dis tools/il-dis/main.cpp)
 set_target_properties(il-dis PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/il-dis)

--- a/src/il/io/Parser.cc
+++ b/src/il/io/Parser.cc
@@ -1,0 +1,256 @@
+#include "il/io/Parser.h"
+#include "il/core/Opcode.h"
+#include "il/core/Value.h"
+#include <cctype>
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
+
+using namespace il::core;
+
+namespace il::io {
+
+namespace {
+std::string trim(const std::string &s) {
+  size_t b = 0;
+  while (b < s.size() && std::isspace(static_cast<unsigned char>(s[b])))
+    ++b;
+  size_t e = s.size();
+  while (e > b && std::isspace(static_cast<unsigned char>(s[e - 1])))
+    --e;
+  return s.substr(b, e - b);
+}
+
+Type parseType(const std::string &t) {
+  if (t == "i64" || t == "i32")
+    return Type(Type::Kind::I64);
+  if (t == "i1")
+    return Type(Type::Kind::I1);
+  if (t == "f64")
+    return Type(Type::Kind::F64);
+  if (t == "ptr")
+    return Type(Type::Kind::Ptr);
+  if (t == "str")
+    return Type(Type::Kind::Str);
+  return Type(Type::Kind::Void);
+}
+
+Value parseValue(const std::string &tok, const std::unordered_map<std::string, unsigned> &temps) {
+  if (tok.empty())
+    return Value::constInt(0);
+  if (tok[0] == '%') {
+    auto it = temps.find(tok.substr(1));
+    if (it != temps.end())
+      return Value::temp(it->second);
+    return Value::temp(0); // undefined temp will be diagnosed later
+  }
+  if (tok[0] == '@')
+    return Value::global(tok.substr(1));
+  if (tok == "null")
+    return Value::null();
+  if (tok.size() >= 2 && tok.front() == '"' && tok.back() == '"')
+    return Value::constStr(tok.substr(1, tok.size() - 2));
+  return Value::constInt(std::stoll(tok));
+}
+
+std::string readToken(std::istringstream &ss) {
+  std::string t;
+  ss >> t;
+  if (!t.empty() && t.back() == ',')
+    t.pop_back();
+  return t;
+}
+
+} // namespace
+
+bool Parser::parse(std::istream &is, Module &m, std::ostream &err) {
+  std::string line;
+  Function *curFn = nullptr;
+  BasicBlock *curBB = nullptr;
+  std::unordered_map<std::string, unsigned> tempIds;
+  unsigned nextTemp = 0;
+  while (std::getline(is, line)) {
+    line = trim(line);
+    if (line.empty())
+      continue;
+    if (!curFn) {
+      if (line.rfind("il ", 0) == 0)
+        continue;
+      if (line.rfind("extern", 0) == 0) {
+        size_t at = line.find('@');
+        size_t lp = line.find('(', at);
+        size_t rp = line.find(')', lp);
+        size_t arr = line.find("->", rp);
+        std::string name = line.substr(at + 1, lp - at - 1);
+        std::string paramsStr = line.substr(lp + 1, rp - lp - 1);
+        std::vector<Type> params;
+        std::stringstream pss(paramsStr);
+        std::string p;
+        while (std::getline(pss, p, ',')) {
+          p = trim(p);
+          if (!p.empty())
+            params.push_back(parseType(p));
+        }
+        std::string retStr = trim(line.substr(arr + 2));
+        m.externs.push_back({name, parseType(retStr), params});
+        continue;
+      }
+      if (line.rfind("global", 0) == 0) {
+        size_t at = line.find('@');
+        size_t eq = line.find('=', at);
+        size_t q1 = line.find('"', eq);
+        size_t q2 = line.rfind('"');
+        std::string name = trim(line.substr(at + 1, eq - at - 1));
+        std::string init = line.substr(q1 + 1, q2 - q1 - 1);
+        m.globals.push_back({name, Type(Type::Kind::Str), init});
+        continue;
+      }
+      if (line.rfind("func", 0) == 0) {
+        size_t at = line.find('@');
+        size_t lp = line.find('(', at);
+        size_t rp = line.find(')', lp);
+        size_t arr = line.find("->", rp);
+        size_t lb = line.find('{', arr);
+        std::string name = line.substr(at + 1, lp - at - 1);
+        std::string paramsStr = line.substr(lp + 1, rp - lp - 1);
+        std::vector<Param> params;
+        std::stringstream pss(paramsStr);
+        std::string p;
+        while (std::getline(pss, p, ',')) {
+          p = trim(p);
+          if (p.empty())
+            continue;
+          std::stringstream ps(p);
+          std::string ty, nm;
+          ps >> ty >> nm;
+          if (!ty.empty() && !nm.empty() && nm[0] == '%')
+            params.push_back({nm.substr(1), parseType(ty)});
+        }
+        std::string retStr = trim(line.substr(arr + 2, lb - arr - 2));
+        m.functions.push_back({name, parseType(retStr), params, {}});
+        curFn = &m.functions.back();
+        curBB = nullptr;
+        tempIds.clear();
+        nextTemp = 0;
+        continue;
+      }
+      err << "Unexpected line: " << line << "\n";
+      return false;
+    } else {
+      if (line[0] == '}') {
+        curFn = nullptr;
+        curBB = nullptr;
+        continue;
+      }
+      if (line.back() == ':' && line.find(' ') == std::string::npos) {
+        std::string label = line.substr(0, line.size() - 1);
+        curFn->blocks.push_back({label, {}, false});
+        curBB = &curFn->blocks.back();
+        continue;
+      }
+      if (!curBB) {
+        err << "Instruction outside block\n";
+        return false;
+      }
+      Instr in;
+      if (line[0] == '%') {
+        size_t eq = line.find('=');
+        std::string res = trim(line.substr(1, eq - 1));
+        auto [it, inserted] = tempIds.emplace(res, nextTemp);
+        if (inserted)
+          nextTemp++;
+        in.result = it->second;
+        line = trim(line.substr(eq + 1));
+      }
+      std::string op;
+      std::istringstream ss(line);
+      ss >> op;
+      if (op == "add" || op == "mul" || op == "scmp_gt" || op == "scmp_le") {
+        std::string a = readToken(ss);
+        std::string b = readToken(ss);
+        in.operands.push_back(parseValue(a, tempIds));
+        in.operands.push_back(parseValue(b, tempIds));
+        if (op == "add")
+          in.op = Opcode::Add;
+        else if (op == "mul")
+          in.op = Opcode::Mul;
+        else if (op == "scmp_gt")
+          in.op = Opcode::SCmpGT;
+        else
+          in.op = Opcode::SCmpLE;
+        in.type =
+            (op == "scmp_gt" || op == "scmp_le") ? Type(Type::Kind::I1) : Type(Type::Kind::I64);
+      } else if (op == "alloca") {
+        std::string sz = readToken(ss);
+        in.op = Opcode::Alloca;
+        in.operands.push_back(parseValue(sz, tempIds));
+        in.type = Type(Type::Kind::Ptr);
+      } else if (op == "load") {
+        std::string ty = readToken(ss);
+        std::string ptr = readToken(ss);
+        in.op = Opcode::Load;
+        in.type = parseType(ty);
+        in.operands.push_back(parseValue(ptr, tempIds));
+      } else if (op == "store") {
+        std::string ty = readToken(ss);
+        std::string ptr = readToken(ss);
+        std::string val = readToken(ss);
+        in.op = Opcode::Store;
+        in.type = parseType(ty);
+        in.operands.push_back(parseValue(ptr, tempIds));
+        in.operands.push_back(parseValue(val, tempIds));
+      } else if (op == "const_str") {
+        std::string g = readToken(ss);
+        in.op = Opcode::ConstStr;
+        if (!g.empty() && g[0] == '@')
+          in.operands.push_back(Value::global(g.substr(1)));
+        in.type = Type(Type::Kind::Str);
+      } else if (op == "call") {
+        size_t at = line.find('@');
+        size_t lp = line.find('(', at);
+        size_t rp = line.find(')', lp);
+        in.op = Opcode::Call;
+        in.callee = line.substr(at + 1, lp - at - 1);
+        std::string args = line.substr(lp + 1, rp - lp - 1);
+        std::stringstream as(args);
+        std::string a;
+        while (std::getline(as, a, ',')) {
+          a = trim(a);
+          if (!a.empty())
+            in.operands.push_back(parseValue(a, tempIds));
+        }
+        in.type = Type(Type::Kind::Void);
+      } else if (op == "br") {
+        std::string w = readToken(ss);
+        std::string l = readToken(ss);
+        in.op = Opcode::Br;
+        in.labels.push_back(l);
+        in.type = Type(Type::Kind::Void);
+      } else if (op == "cbr") {
+        std::string c = readToken(ss);
+        std::string word = readToken(ss);
+        std::string l1 = readToken(ss);
+        word = readToken(ss);
+        std::string l2 = readToken(ss);
+        in.op = Opcode::CBr;
+        in.operands.push_back(parseValue(c, tempIds));
+        in.labels.push_back(l1);
+        in.labels.push_back(l2);
+        in.type = Type(Type::Kind::Void);
+      } else if (op == "ret") {
+        std::string v;
+        if (ss >> v)
+          in.operands.push_back(parseValue(v, tempIds));
+        in.op = Opcode::Ret;
+        in.type = Type(Type::Kind::Void);
+      } else {
+        err << "Unknown opcode: " << op << "\n";
+        return false;
+      }
+      curBB->instructions.push_back(std::move(in));
+    }
+  }
+  return true;
+}
+
+} // namespace il::io

--- a/src/il/io/Parser.h
+++ b/src/il/io/Parser.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "il/core/Module.h"
+#include <istream>
+#include <ostream>
+
+namespace il::io {
+
+/// @brief Hand-rolled parser for textual IL subset.
+class Parser {
+public:
+  /// Parse IL from stream into module. Returns true on success.
+  static bool parse(std::istream &is, il::core::Module &m, std::ostream &err);
+};
+
+} // namespace il::io

--- a/src/il/io/Serializer.cc
+++ b/src/il/io/Serializer.cc
@@ -53,6 +53,11 @@ void Serializer::write(const Module &m, std::ostream &os) {
         } else if (in.op == Opcode::CBr) {
           os << " " << il::core::toString(in.operands[0]) << ", label " << in.labels[0]
              << ", label " << in.labels[1];
+        } else if (in.op == Opcode::Load) {
+          os << " " << in.type.toString() << ", " << il::core::toString(in.operands[0]);
+        } else if (in.op == Opcode::Store) {
+          os << " " << in.type.toString() << ", " << il::core::toString(in.operands[0]) << ", "
+             << il::core::toString(in.operands[1]);
         } else {
           if (!in.operands.empty())
             os << " ";

--- a/src/il/verify/Verifier.cc
+++ b/src/il/verify/Verifier.cc
@@ -1,0 +1,244 @@
+#include "il/verify/Verifier.h"
+#include "il/core/Opcode.h"
+#include <unordered_map>
+#include <unordered_set>
+
+using namespace il::core;
+
+namespace il::verify {
+
+namespace {
+bool isTerminator(Opcode op) { return op == Opcode::Br || op == Opcode::CBr || op == Opcode::Ret; }
+
+Type valueType(const Value &v, const std::unordered_map<unsigned, Type> &temps) {
+  switch (v.kind) {
+  case Value::Kind::Temp: {
+    auto it = temps.find(v.id);
+    if (it != temps.end())
+      return it->second;
+    return Type(Type::Kind::Void);
+  }
+  case Value::Kind::ConstInt:
+    return Type(Type::Kind::I64);
+  case Value::Kind::ConstFloat:
+    return Type(Type::Kind::F64);
+  case Value::Kind::ConstStr:
+    return Type(Type::Kind::Str);
+  case Value::Kind::GlobalAddr:
+  case Value::Kind::NullPtr:
+    return Type(Type::Kind::Ptr);
+  }
+  return Type(Type::Kind::Void);
+}
+
+} // namespace
+
+bool Verifier::verify(const Module &m, std::ostream &err) {
+  std::unordered_map<std::string, const Extern *> externs;
+  for (const auto &e : m.externs)
+    externs[e.name] = &e;
+  std::unordered_map<std::string, const Function *> funcs;
+  for (const auto &f : m.functions)
+    funcs[f.name] = &f;
+
+  bool ok = true;
+  for (const auto &fn : m.functions) {
+    std::unordered_set<std::string> labels;
+    std::unordered_map<unsigned, Type> temps;
+    for (const auto &bb : fn.blocks) {
+      if (!labels.insert(bb.label).second) {
+        err << "Duplicate label " << bb.label << " in function " << fn.name << "\n";
+        ok = false;
+      }
+    }
+    for (const auto &bb : fn.blocks) {
+      if (bb.instructions.empty()) {
+        err << "Empty block " << bb.label << " in function " << fn.name << "\n";
+        ok = false;
+        continue;
+      }
+      if (!isTerminator(bb.instructions.back().op)) {
+        err << "Block " << bb.label << " missing terminator in function " << fn.name << "\n";
+        ok = false;
+      }
+      bool seenTerm = false;
+      for (const auto &in : bb.instructions) {
+        if (seenTerm) {
+          err << "Instruction after terminator in block " << bb.label << "\n";
+          ok = false;
+          break;
+        }
+        if (isTerminator(in.op))
+          seenTerm = true;
+        switch (in.op) {
+        case Opcode::Alloca:
+          if (in.operands.size() != 1) {
+            err << "alloca operand count\n";
+            ok = false;
+          }
+          if (in.result)
+            temps[*in.result] = Type(Type::Kind::Ptr);
+          break;
+        case Opcode::Add:
+        case Opcode::Mul: {
+          if (in.operands.size() != 2) {
+            err << "binary op operand count\n";
+            ok = false;
+          }
+          for (const auto &v : in.operands) {
+            if (valueType(v, temps).kind != Type::Kind::I64) {
+              err << "binary op type mismatch\n";
+              ok = false;
+            }
+          }
+          if (in.result)
+            temps[*in.result] = Type(Type::Kind::I64);
+          break;
+        }
+        case Opcode::SCmpGT:
+        case Opcode::SCmpLE: {
+          if (in.operands.size() != 2) {
+            err << "cmp operand count\n";
+            ok = false;
+          }
+          for (const auto &v : in.operands) {
+            if (valueType(v, temps).kind != Type::Kind::I64) {
+              err << "cmp type mismatch\n";
+              ok = false;
+            }
+          }
+          if (in.result)
+            temps[*in.result] = Type(Type::Kind::I1);
+          break;
+        }
+        case Opcode::Load: {
+          if (in.operands.size() != 1) {
+            err << "load operand count\n";
+            ok = false;
+          }
+          if (valueType(in.operands[0], temps).kind != Type::Kind::Ptr) {
+            err << "load pointer type mismatch\n";
+            ok = false;
+          }
+          if (in.result)
+            temps[*in.result] = in.type;
+          break;
+        }
+        case Opcode::Store: {
+          if (in.operands.size() != 2) {
+            err << "store operand count\n";
+            ok = false;
+          }
+          if (valueType(in.operands[0], temps).kind != Type::Kind::Ptr) {
+            err << "store pointer type mismatch\n";
+            ok = false;
+          }
+          if (valueType(in.operands[1], temps).kind != in.type.kind) {
+            err << "store value type mismatch\n";
+            ok = false;
+          }
+          break;
+        }
+        case Opcode::ConstStr: {
+          if (in.operands.size() != 1 || in.operands[0].kind != Value::Kind::GlobalAddr) {
+            err << "const_str operand\n";
+            ok = false;
+          } else {
+            bool found = false;
+            for (const auto &g : m.globals)
+              if (g.name == in.operands[0].str)
+                found = true;
+            if (!found) {
+              err << "unknown global @" << in.operands[0].str << "\n";
+              ok = false;
+            }
+          }
+          if (in.result)
+            temps[*in.result] = Type(Type::Kind::Str);
+          break;
+        }
+        case Opcode::Call: {
+          const Extern *sig = nullptr;
+          auto itExt = externs.find(in.callee);
+          if (itExt != externs.end())
+            sig = itExt->second;
+          else {
+            auto itFn = funcs.find(in.callee);
+            if (itFn != funcs.end()) {
+              sig = reinterpret_cast<const Extern *>(itFn->second);
+            }
+          }
+          if (!sig) {
+            err << "unknown callee @" << in.callee << "\n";
+            ok = false;
+            break;
+          }
+          if (in.operands.size() != sig->params.size()) {
+            err << "call arg count\n";
+            ok = false;
+          }
+          for (size_t i = 0; i < in.operands.size() && i < sig->params.size(); ++i) {
+            if (valueType(in.operands[i], temps).kind != sig->params[i].kind) {
+              err << "call arg type mismatch\n";
+              ok = false;
+            }
+          }
+          if (in.result)
+            temps[*in.result] = sig->retType;
+          break;
+        }
+        case Opcode::Br: {
+          if (in.labels.size() != 1) {
+            err << "br label count\n";
+            ok = false;
+          }
+          break;
+        }
+        case Opcode::CBr: {
+          if (in.operands.size() != 1 || in.labels.size() != 2) {
+            err << "cbr operand/label count\n";
+            ok = false;
+          }
+          if (valueType(in.operands[0], temps).kind != Type::Kind::I1) {
+            err << "cbr condition type\n";
+            ok = false;
+          }
+          break;
+        }
+        case Opcode::Ret: {
+          if (fn.retType.kind == Type::Kind::Void) {
+            if (!in.operands.empty()) {
+              err << "ret void with value\n";
+              ok = false;
+            }
+          } else {
+            if (in.operands.size() != 1) {
+              err << "ret missing value\n";
+              ok = false;
+            } else if (valueType(in.operands[0], temps).kind != fn.retType.kind) {
+              err << "ret value type mismatch\n";
+              ok = false;
+            }
+          }
+          break;
+        }
+        default:
+          break;
+        }
+      }
+    }
+    for (const auto &bb : fn.blocks) {
+      for (const auto &in : bb.instructions) {
+        for (const auto &lbl : in.labels) {
+          if (!labels.count(lbl)) {
+            err << "unknown label " << lbl << " in function " << fn.name << "\n";
+            ok = false;
+          }
+        }
+      }
+    }
+  }
+  return ok;
+}
+
+} // namespace il::verify

--- a/src/il/verify/Verifier.h
+++ b/src/il/verify/Verifier.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "il/core/Module.h"
+#include <ostream>
+
+namespace il::verify {
+
+/// @brief Verifies structural and type rules for a module.
+class Verifier {
+public:
+  /// Verify module. Returns true on success, false and emits diagnostics on err.
+  static bool verify(const il::core::Module &m, std::ostream &err);
+};
+
+} // namespace il::verify

--- a/src/tools/il-verify/il-verify.cpp
+++ b/src/tools/il-verify/il-verify.cpp
@@ -1,9 +1,27 @@
+#include "il/io/Parser.h"
+#include "il/verify/Verifier.h"
+#include <fstream>
 #include <iostream>
+#include <sstream>
 
 int main(int argc, char **argv) {
-  (void)argc;
-  (void)argv;
-  std::cout << "il-verify v0.1.0\n";
-  std::cout << "Usage: il-verify [--help]\n";
+  if (argc != 2) {
+    std::cerr << "Usage: il-verify <file.il>\n";
+    return 1;
+  }
+  std::ifstream in(argv[1]);
+  if (!in) {
+    std::cerr << "cannot open " << argv[1] << "\n";
+    return 1;
+  }
+  il::core::Module m;
+  if (!il::io::Parser::parse(in, m, std::cerr))
+    return 1;
+  std::ostringstream diag;
+  if (!il::verify::Verifier::verify(m, diag)) {
+    std::cerr << diag.str();
+    return 1;
+  }
+  std::cout << "OK\n";
   return 0;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,3 +6,11 @@ add_executable(test_il_serialize unit/test_il_serialize.cpp)
 target_link_libraries(test_il_serialize PRIVATE il_core il_build il_io support)
 target_compile_definitions(test_il_serialize PRIVATE TESTS_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 add_test(NAME test_il_serialize COMMAND test_il_serialize)
+
+add_executable(test_il_roundtrip golden/test_il_roundtrip.cpp)
+target_link_libraries(test_il_roundtrip PRIVATE il_core il_io il_verify support)
+target_compile_definitions(test_il_roundtrip PRIVATE EXAMPLES_DIR="${CMAKE_SOURCE_DIR}/docs/examples")
+add_test(NAME test_il_roundtrip COMMAND test_il_roundtrip)
+
+add_test(NAME il_verify_hello_cond COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/hello_cond.il)
+add_test(NAME il_verify_sum_1_to_10 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/sum_1_to_10.il)

--- a/tests/golden/test_il_roundtrip.cpp
+++ b/tests/golden/test_il_roundtrip.cpp
@@ -1,0 +1,35 @@
+#include "il/io/Parser.h"
+#include "il/io/Serializer.h"
+#include "il/verify/Verifier.h"
+#include <cassert>
+#include <fstream>
+#include <sstream>
+
+int main() {
+  const char *files[] = {EXAMPLES_DIR "/il/hello_cond.il", EXAMPLES_DIR "/il/sum_1_to_10.il"};
+  for (const char *path : files) {
+    std::ifstream in(path);
+    std::stringstream buf;
+    buf << in.rdbuf();
+    buf.seekg(0);
+    il::core::Module m1;
+    std::ostringstream err1;
+    bool ok = il::io::Parser::parse(buf, m1, err1);
+    assert(ok && err1.str().empty());
+    std::string s1 = il::io::Serializer::toString(m1);
+    std::istringstream in2(s1);
+    il::core::Module m2;
+    std::ostringstream err2;
+    ok = il::io::Parser::parse(in2, m2, err2);
+    assert(ok && err2.str().empty());
+    std::string s2 = il::io::Serializer::toString(m2);
+    if (!s1.empty() && s1.back() == '\n')
+      s1.pop_back();
+    if (!s2.empty() && s2.back() == '\n')
+      s2.pop_back();
+    assert(s1 == s2);
+    std::ostringstream diag;
+    assert(il::verify::Verifier::verify(m1, diag) && diag.str().empty());
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary
- implement hand-rolled Parser for subset of IL and structural/type Verifier
- extend il-verify tool to parse and check modules
- add example IL programs and round-trip verification tests

## Testing
- `cmake -S . -B build && cmake --build build -j`
- `cd build && ctest --output-on-failure`
- `build/src/tools/il-verify/il-verify docs/examples/il/hello_cond.il`
- `build/src/tools/il-verify/il-verify docs/examples/il/sum_1_to_10.il`


------
https://chatgpt.com/codex/tasks/task_e_68b1278369b08324912db10292da8a69