### PR TITLE
feat(frontend/basic): lexer+parser+AST with stable dump; add AST goldens for two BASIC examples

### DIFF
--- a/docs/examples/basic/ex1_hello_cond.bas
+++ b/docs/examples/basic/ex1_hello_cond.bas
@@ -1,0 +1,3 @@
+10 LET X = 5
+20 IF X = 5 THEN PRINT "Hello" ELSE PRINT "Bye"
+30 END

--- a/docs/examples/basic/ex2_sum_1_to_10.bas
+++ b/docs/examples/basic/ex2_sum_1_to_10.bas
@@ -1,0 +1,8 @@
+10 LET S = 0
+20 LET I = 1
+30 WHILE I <= 10
+40 LET S = S + I
+50 LET I = I + 1
+60 WEND
+70 PRINT S
+80 END

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,8 @@ target_link_libraries(il_vm PUBLIC il_core rt)
 add_library(il_codegen_x86_64 STATIC codegen/x86_64/placeholder.cpp)
 set_target_properties(il_codegen_x86_64 PROPERTIES LINKER_LANGUAGE CXX)
 
+add_subdirectory(frontends/basic)
+
 add_executable(ilc tools/ilc/ilc.cpp)
 set_target_properties(ilc PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/ilc)
 target_link_libraries(ilc PRIVATE il_core il_io il_vm il_verify)
@@ -42,3 +44,7 @@ target_link_libraries(il-verify PRIVATE support il_core il_build il_io il_vm il_
 add_executable(il-dis tools/il-dis/main.cpp)
 set_target_properties(il-dis PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/il-dis)
 target_link_libraries(il-dis PRIVATE support il_core il_build il_io)
+
+add_executable(basic-ast tools/basic-ast/main.cpp)
+set_target_properties(basic-ast PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/basic-ast)
+target_link_libraries(basic-ast PRIVATE basic_frontend support)

--- a/src/frontends/basic/AST.cpp
+++ b/src/frontends/basic/AST.cpp
@@ -1,0 +1,62 @@
+#include "frontends/basic/AST.h"
+
+namespace il::basic {
+
+BinaryExpr::BinaryExpr(std::string o, std::unique_ptr<Expr> l,
+                       std::unique_ptr<Expr> r, support::SourceLoc loc)
+    : op(std::move(o)), lhs(std::move(l)), rhs(std::move(r)) {
+  kind = Kind::Binary;
+  this->loc = loc;
+}
+
+CallExpr::CallExpr(std::string n, std::vector<std::unique_ptr<Expr>> a,
+                   support::SourceLoc l)
+    : name(std::move(n)), args(std::move(a)) {
+  kind = Kind::Call;
+  loc = l;
+}
+
+PrintStmt::PrintStmt(std::unique_ptr<Expr> e, int ln, support::SourceLoc l)
+    : expr(std::move(e)) {
+  kind = Kind::Print;
+  line = ln;
+  loc = l;
+}
+
+LetStmt::LetStmt(std::string n, std::unique_ptr<Expr> e, int ln,
+                 support::SourceLoc l)
+    : name(std::move(n)), expr(std::move(e)) {
+  kind = Kind::Let;
+  line = ln;
+  loc = l;
+}
+
+IfStmt::IfStmt(std::unique_ptr<Expr> c, std::unique_ptr<Stmt> t,
+               std::unique_ptr<Stmt> e, int ln, support::SourceLoc l)
+    : cond(std::move(c)), then_branch(std::move(t)), else_branch(std::move(e)) {
+  kind = Kind::If;
+  line = ln;
+  loc = l;
+}
+
+WhileStmt::WhileStmt(std::unique_ptr<Expr> c, std::vector<std::unique_ptr<Stmt>> b,
+                     int ln, support::SourceLoc l)
+    : cond(std::move(c)), body(std::move(b)) {
+  kind = Kind::While;
+  line = ln;
+  loc = l;
+}
+
+GotoStmt::GotoStmt(int tgt, int ln, support::SourceLoc l) : target(tgt) {
+  kind = Kind::Goto;
+  line = ln;
+  loc = l;
+}
+
+EndStmt::EndStmt(int ln, support::SourceLoc l) {
+  kind = Kind::End;
+  line = ln;
+  loc = l;
+}
+
+} // namespace il::basic

--- a/src/frontends/basic/AST.h
+++ b/src/frontends/basic/AST.h
@@ -1,0 +1,89 @@
+#pragma once
+#include <memory>
+#include <string>
+#include <vector>
+#include "support/source_manager.h"
+
+namespace il::basic {
+
+struct Expr {
+  enum class Kind { Int, String, Var, Binary, Call };
+  Kind kind;
+  support::SourceLoc loc;
+  virtual ~Expr() = default;
+};
+
+struct IntExpr : Expr {
+  int value;
+  explicit IntExpr(int v, support::SourceLoc l) : value(v) { kind = Kind::Int; loc = l; }
+};
+
+struct StringExpr : Expr {
+  std::string value;
+  StringExpr(std::string v, support::SourceLoc l) : value(std::move(v)) { kind = Kind::String; loc = l; }
+};
+
+struct VarExpr : Expr {
+  std::string name;
+  VarExpr(std::string n, support::SourceLoc l) : name(std::move(n)) { kind = Kind::Var; loc = l; }
+};
+
+struct BinaryExpr : Expr {
+  std::string op;
+  std::unique_ptr<Expr> lhs;
+  std::unique_ptr<Expr> rhs;
+  BinaryExpr(std::string o, std::unique_ptr<Expr> l, std::unique_ptr<Expr> r, support::SourceLoc loc);
+};
+
+struct CallExpr : Expr {
+  std::string name;
+  std::vector<std::unique_ptr<Expr>> args;
+  CallExpr(std::string n, std::vector<std::unique_ptr<Expr>> a, support::SourceLoc l);
+};
+
+struct Stmt {
+  enum class Kind { Print, Let, If, While, Goto, End };
+  Kind kind;
+  int line = 0;
+  support::SourceLoc loc;
+  virtual ~Stmt() = default;
+};
+
+struct PrintStmt : Stmt {
+  std::unique_ptr<Expr> expr;
+  PrintStmt(std::unique_ptr<Expr> e, int ln, support::SourceLoc l);
+};
+
+struct LetStmt : Stmt {
+  std::string name;
+  std::unique_ptr<Expr> expr;
+  LetStmt(std::string n, std::unique_ptr<Expr> e, int ln, support::SourceLoc l);
+};
+
+struct IfStmt : Stmt {
+  std::unique_ptr<Expr> cond;
+  std::unique_ptr<Stmt> then_branch;
+  std::unique_ptr<Stmt> else_branch;
+  IfStmt(std::unique_ptr<Expr> c, std::unique_ptr<Stmt> t, std::unique_ptr<Stmt> e, int ln, support::SourceLoc l);
+};
+
+struct WhileStmt : Stmt {
+  std::unique_ptr<Expr> cond;
+  std::vector<std::unique_ptr<Stmt>> body;
+  WhileStmt(std::unique_ptr<Expr> c, std::vector<std::unique_ptr<Stmt>> b, int ln, support::SourceLoc l);
+};
+
+struct GotoStmt : Stmt {
+  int target;
+  GotoStmt(int tgt, int ln, support::SourceLoc l);
+};
+
+struct EndStmt : Stmt {
+  EndStmt(int ln, support::SourceLoc l);
+};
+
+struct Program {
+  std::vector<std::unique_ptr<Stmt>> statements;
+};
+
+} // namespace il::basic

--- a/src/frontends/basic/AstPrinter.cpp
+++ b/src/frontends/basic/AstPrinter.cpp
@@ -1,0 +1,111 @@
+#include "frontends/basic/AstPrinter.h"
+#include <iomanip>
+#include <sstream>
+
+namespace il::basic {
+
+static void printStmtNoLine(const Stmt *s, std::ostream &os) {
+  AstPrinter::printStmt(s, os, false);
+}
+
+static void printExprWrap(const Expr *e, std::ostream &os) {
+  AstPrinter::printExpr(e, os);
+}
+
+void AstPrinter::printExpr(const Expr *e, std::ostream &os) {
+  switch (e->kind) {
+  case Expr::Kind::Int:
+    os << "Int(" << static_cast<const IntExpr*>(e)->value << ")";
+    break;
+  case Expr::Kind::String:
+    os << "Str(" << std::quoted(static_cast<const StringExpr*>(e)->value) << ")";
+    break;
+  case Expr::Kind::Var:
+    os << "Var(" << static_cast<const VarExpr*>(e)->name << ")";
+    break;
+  case Expr::Kind::Binary: {
+    auto *b = static_cast<const BinaryExpr*>(e);
+    os << "Bin(" << b->op << ", ";
+    printExprWrap(b->lhs.get(), os);
+    os << ", ";
+    printExprWrap(b->rhs.get(), os);
+    os << ")";
+    break;
+  }
+  case Expr::Kind::Call: {
+    auto *c = static_cast<const CallExpr*>(e);
+    os << "Call(" << c->name;
+    for (size_t i = 0; i < c->args.size(); ++i) {
+      os << (i == 0 ? ", " : ", ");
+      printExprWrap(c->args[i].get(), os);
+    }
+    os << ")";
+    break;
+  }
+  }
+}
+
+void AstPrinter::printStmt(const Stmt *s, std::ostream &os, bool include_line) {
+  if (include_line) {
+    os << s->line << ':';
+  }
+  switch (s->kind) {
+  case Stmt::Kind::Print:
+    os << "PRINT(";
+    printExprWrap(static_cast<const PrintStmt*>(s)->expr.get(), os);
+    os << ')';
+    break;
+  case Stmt::Kind::Let: {
+    auto *l = static_cast<const LetStmt*>(s);
+    os << "LET(" << l->name << ", ";
+    printExprWrap(l->expr.get(), os);
+    os << ')';
+    break;
+  }
+  case Stmt::Kind::If: {
+    auto *i = static_cast<const IfStmt*>(s);
+    os << "IF(";
+    printExprWrap(i->cond.get(), os);
+    os << ", ";
+    printStmtNoLine(i->then_branch.get(), os);
+    if (i->else_branch) {
+      os << ", ";
+      printStmtNoLine(i->else_branch.get(), os);
+    }
+    os << ')';
+    break;
+  }
+  case Stmt::Kind::While: {
+    auto *w = static_cast<const WhileStmt*>(s);
+    os << "WHILE(";
+    printExprWrap(w->cond.get(), os);
+    os << ")[";
+    for (size_t idx = 0; idx < w->body.size(); ++idx) {
+      if (idx) os << ' ';
+      printStmt(w->body[idx].get(), os, true);
+      if (idx + 1 < w->body.size()) os << ';';
+    }
+    os << ']';
+    break;
+  }
+  case Stmt::Kind::Goto: {
+    auto *g = static_cast<const GotoStmt*>(s);
+    os << "GOTO(" << g->target << ')';
+    break;
+  }
+  case Stmt::Kind::End:
+    os << "END";
+    break;
+  }
+}
+
+std::string AstPrinter::print(const Program &prog) {
+  std::ostringstream oss;
+  for (size_t i = 0; i < prog.statements.size(); ++i) {
+    printStmt(prog.statements[i].get(), oss, true);
+    if (i + 1 < prog.statements.size()) oss << '\n';
+  }
+  return oss.str();
+}
+
+} // namespace il::basic

--- a/src/frontends/basic/AstPrinter.h
+++ b/src/frontends/basic/AstPrinter.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <ostream>
+#include <string>
+#include "frontends/basic/AST.h"
+
+namespace il::basic {
+
+class AstPrinter {
+public:
+  static std::string print(const Program &prog);
+  static void printStmt(const Stmt *s, std::ostream &os, bool include_line = true);
+  static void printExpr(const Expr *e, std::ostream &os);
+};
+
+} // namespace il::basic

--- a/src/frontends/basic/CMakeLists.txt
+++ b/src/frontends/basic/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(basic_frontend STATIC
+  Token.cpp
+  Lexer.cpp
+  AST.cpp
+  AstPrinter.cpp
+  Parser.cpp
+)
+
+target_link_libraries(basic_frontend PUBLIC support)
+
+target_include_directories(basic_frontend PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../..)

--- a/src/frontends/basic/Lexer.cpp
+++ b/src/frontends/basic/Lexer.cpp
@@ -1,0 +1,159 @@
+#include "frontends/basic/Lexer.h"
+#include <cctype>
+#include <cassert>
+#include <string>
+
+namespace il::basic {
+
+Lexer::Lexer(std::string source, uint32_t file_id)
+    : source_(std::move(source)), file_id_(file_id) {}
+
+char Lexer::peek() const {
+  if (pos_ >= source_.size()) return '\0';
+  return source_[pos_];
+}
+
+char Lexer::peekNext() const {
+  if (pos_ + 1 >= source_.size()) return '\0';
+  return source_[pos_ + 1];
+}
+
+char Lexer::advance() {
+  char c = peek();
+  if (c == '\n') {
+    line_++;
+    column_ = 1;
+  } else {
+    column_++;
+  }
+  pos_++;
+  return c;
+}
+
+bool Lexer::match(char c) {
+  if (peek() != c) return false;
+  advance();
+  return true;
+}
+
+Token Lexer::makeToken(TokenKind kind, std::string text, int int_value) {
+  Token t;
+  t.kind = kind;
+  t.text = std::move(text);
+  t.int_value = int_value;
+  t.loc = {file_id_, line_, column_};
+  return t;
+}
+
+void Lexer::skipWhitespace() {
+  while (true) {
+    char c = peek();
+    if (c == ' ' || c == '\t' || c == '\r') {
+      advance();
+    } else {
+      break;
+    }
+  }
+}
+
+Token Lexer::lexNumber() {
+  uint32_t start_col = column_;
+  int value = 0;
+  while (std::isdigit(peek())) {
+    value = value * 10 + (advance() - '0');
+  }
+  Token t;
+  t.kind = TokenKind::Integer;
+  t.int_value = value;
+  t.loc = {file_id_, line_, start_col};
+  return t;
+}
+
+Token Lexer::lexString() {
+  uint32_t start_col = column_;
+  advance(); // consume opening quote
+  std::string s;
+  while (peek() && peek() != '"') {
+    s.push_back(advance());
+  }
+  if (peek() == '"') advance();
+  Token t;
+  t.kind = TokenKind::String;
+  t.text = s;
+  t.loc = {file_id_, line_, start_col};
+  return t;
+}
+
+static bool isIdentStart(char c) { return std::isalpha(c) || c == '_'; }
+static bool isIdentChar(char c) {
+  return std::isalnum(c) || c == '_' || c == '$';
+}
+
+Token Lexer::lexIdentifier() {
+  uint32_t start_col = column_;
+  std::string s;
+  while (isIdentChar(peek())) {
+    s.push_back(std::toupper(advance()));
+  }
+  Token t;
+  t.loc = {file_id_, line_, start_col};
+  t.text = s;
+  if (s == "PRINT") t.kind = TokenKind::KeywordPrint;
+  else if (s == "LET") t.kind = TokenKind::KeywordLet;
+  else if (s == "IF") t.kind = TokenKind::KeywordIf;
+  else if (s == "THEN") t.kind = TokenKind::KeywordThen;
+  else if (s == "ELSE") t.kind = TokenKind::KeywordElse;
+  else if (s == "WHILE") t.kind = TokenKind::KeywordWhile;
+  else if (s == "WEND") t.kind = TokenKind::KeywordWend;
+  else if (s == "GOTO") t.kind = TokenKind::KeywordGoto;
+  else if (s == "END") t.kind = TokenKind::KeywordEnd;
+  else t.kind = TokenKind::Identifier;
+  return t;
+}
+
+std::vector<Token> Lexer::lex() {
+  std::vector<Token> toks;
+  while (true) {
+    skipWhitespace();
+    uint32_t start_col = column_;
+    char c = peek();
+    if (c == '\0') {
+      Token t; t.kind = TokenKind::Eof; t.loc = {file_id_, line_, column_};
+      toks.push_back(t); break;
+    }
+    if (c == '\n') {
+      advance();
+      Token t; t.kind = TokenKind::Newline; t.loc = {file_id_, line_-1, start_col};
+      toks.push_back(t); continue;
+    }
+    if (std::isdigit(c)) { toks.push_back(lexNumber()); continue; }
+    if (c == '"') { toks.push_back(lexString()); continue; }
+    if (isIdentStart(c)) { toks.push_back(lexIdentifier()); continue; }
+    advance();
+    Token t; t.loc = {file_id_, line_, start_col};
+    switch (c) {
+    case '+': t.kind = TokenKind::Plus; break;
+    case '-': t.kind = TokenKind::Minus; break;
+    case '*': t.kind = TokenKind::Star; break;
+    case '/': t.kind = TokenKind::Slash; break;
+    case '(': t.kind = TokenKind::LParen; break;
+    case ')': t.kind = TokenKind::RParen; break;
+    case ',': t.kind = TokenKind::Comma; break;
+    case '=': t.kind = TokenKind::Equals; break;
+    case '<':
+      if (match('>')) { t.kind = TokenKind::NotEqual; t.loc.column = start_col; }
+      else if (match('=')) { t.kind = TokenKind::LessEqual; t.loc.column = start_col; }
+      else { t.kind = TokenKind::Less; }
+      break;
+    case '>':
+      if (match('=')) { t.kind = TokenKind::GreaterEqual; t.loc.column = start_col; }
+      else { t.kind = TokenKind::Greater; }
+      break;
+    default: t.kind = TokenKind::Eof; break; // unknown char -> eof to terminate
+    }
+    toks.push_back(t);
+  }
+  return toks;
+}
+
+} // namespace il::basic

--- a/src/frontends/basic/Lexer.h
+++ b/src/frontends/basic/Lexer.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "frontends/basic/Token.h"
+
+namespace il::basic {
+
+class Lexer {
+public:
+  Lexer(std::string source, uint32_t file_id);
+  std::vector<Token> lex();
+
+private:
+  char peek() const;
+  char peekNext() const;
+  char advance();
+  bool match(char c);
+  void skipWhitespace();
+  Token makeToken(TokenKind kind, std::string text = "", int int_value = 0);
+  Token lexNumber();
+  Token lexString();
+  Token lexIdentifier();
+
+  std::string source_;
+  size_t pos_ = 0;
+  uint32_t line_ = 1;
+  uint32_t column_ = 1;
+  uint32_t file_id_;
+};
+
+} // namespace il::basic

--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -1,0 +1,197 @@
+#include "frontends/basic/Parser.h"
+#include <stdexcept>
+
+namespace il::basic {
+
+Parser::Parser(std::vector<Token> tokens) : tokens_(std::move(tokens)) {}
+
+const Token &Parser::peek() const { return tokens_[pos_]; }
+
+bool Parser::match(TokenKind kind) {
+  if (peek().kind != kind) return false;
+  ++pos_;
+  return true;
+}
+
+const Token &Parser::consume(TokenKind kind) {
+  if (peek().kind != kind) throw std::runtime_error("unexpected token");
+  return tokens_[pos_++];
+}
+
+Program Parser::parse() {
+  Program prog;
+  while (peek().kind != TokenKind::Eof) {
+    auto stmt = parseLine();
+    prog.statements.push_back(std::move(stmt));
+    match(TokenKind::Newline);
+  }
+  return prog;
+}
+
+std::unique_ptr<Stmt> Parser::parseLine() {
+  int line = 0;
+  support::SourceLoc loc = peek().loc;
+  if (peek().kind == TokenKind::Integer) {
+    line = consume(TokenKind::Integer).int_value;
+    loc = peek().loc;
+  }
+  auto stmt = parseStmt();
+  stmt->line = line;
+  stmt->loc = loc;
+  return stmt;
+}
+
+std::unique_ptr<Stmt> Parser::parseStmt() {
+  switch (peek().kind) {
+  case TokenKind::KeywordPrint: {
+    consume(TokenKind::KeywordPrint);
+    auto expr = parseExpr();
+    return std::make_unique<PrintStmt>(std::move(expr), 0, peek().loc);
+  }
+  case TokenKind::KeywordLet: {
+    consume(TokenKind::KeywordLet);
+    std::string name = consume(TokenKind::Identifier).text;
+    consume(TokenKind::Equals);
+    auto expr = parseExpr();
+    return std::make_unique<LetStmt>(name, std::move(expr), 0, peek().loc);
+  }
+  case TokenKind::KeywordIf: {
+    consume(TokenKind::KeywordIf);
+    auto cond = parseExpr();
+    consume(TokenKind::KeywordThen);
+    auto then_stmt = parseInlineStmt();
+    std::unique_ptr<Stmt> else_stmt;
+    if (match(TokenKind::KeywordElse)) {
+      else_stmt = parseInlineStmt();
+    }
+    return std::make_unique<IfStmt>(std::move(cond), std::move(then_stmt),
+                                    std::move(else_stmt), 0, peek().loc);
+  }
+  case TokenKind::KeywordWhile: {
+    consume(TokenKind::KeywordWhile);
+    auto cond = parseExpr();
+    consume(TokenKind::Newline);
+    std::vector<std::unique_ptr<Stmt>> body;
+    while (true) {
+      if (peek().kind == TokenKind::KeywordWend) break;
+      if (peek().kind == TokenKind::Integer && tokens_[pos_ + 1].kind == TokenKind::KeywordWend) {
+        consume(TokenKind::Integer);
+        break;
+      }
+      auto st = parseLine();
+      body.push_back(std::move(st));
+      match(TokenKind::Newline);
+    }
+    consume(TokenKind::KeywordWend);
+    return std::make_unique<WhileStmt>(std::move(cond), std::move(body), 0,
+                                       peek().loc);
+  }
+  case TokenKind::KeywordGoto: {
+    consume(TokenKind::KeywordGoto);
+    int tgt = consume(TokenKind::Integer).int_value;
+    return std::make_unique<GotoStmt>(tgt, 0, peek().loc);
+  }
+  case TokenKind::KeywordEnd: {
+    consume(TokenKind::KeywordEnd);
+    return std::make_unique<EndStmt>(0, peek().loc);
+  }
+  default:
+    throw std::runtime_error("unknown statement");
+  }
+}
+
+std::unique_ptr<Stmt> Parser::parseInlineStmt() {
+  switch (peek().kind) {
+  case TokenKind::KeywordPrint:
+  case TokenKind::KeywordLet:
+  case TokenKind::KeywordIf:
+  case TokenKind::KeywordWhile:
+  case TokenKind::KeywordGoto:
+  case TokenKind::KeywordEnd:
+    return parseStmt();
+  default:
+    throw std::runtime_error("invalid inline statement");
+  }
+}
+
+int Parser::getPrecedence(TokenKind kind) const {
+  switch (kind) {
+  case TokenKind::Equals:
+  case TokenKind::NotEqual:
+  case TokenKind::Less:
+  case TokenKind::LessEqual:
+  case TokenKind::Greater:
+  case TokenKind::GreaterEqual:
+    return 1;
+  case TokenKind::Plus:
+  case TokenKind::Minus:
+    return 2;
+  case TokenKind::Star:
+  case TokenKind::Slash:
+    return 3;
+  default:
+    return 0;
+  }
+}
+
+std::unique_ptr<Expr> Parser::parseExpr(int prec) {
+  auto lhs = parsePrimary();
+  while (true) {
+    int p = getPrecedence(peek().kind);
+    if (p <= prec) break;
+    Token op = consume(peek().kind);
+    auto rhs = parseExpr(p);
+    auto bin = std::make_unique<BinaryExpr>("", std::move(lhs), std::move(rhs), op.loc);
+    switch (op.kind) {
+    case TokenKind::Plus: bin->op = "+"; break;
+    case TokenKind::Minus: bin->op = "-"; break;
+    case TokenKind::Star: bin->op = "*"; break;
+    case TokenKind::Slash: bin->op = "/"; break;
+    case TokenKind::Equals: bin->op = "="; break;
+    case TokenKind::NotEqual: bin->op = "<>"; break;
+    case TokenKind::Less: bin->op = "<"; break;
+    case TokenKind::LessEqual: bin->op = "<="; break;
+    case TokenKind::Greater: bin->op = ">"; break;
+    case TokenKind::GreaterEqual: bin->op = ">="; break;
+    default: break;
+    }
+    lhs = std::move(bin);
+  }
+  return lhs;
+}
+
+std::unique_ptr<Expr> Parser::parsePrimary() {
+  const Token &tok = peek();
+  switch (tok.kind) {
+  case TokenKind::Integer:
+    consume(TokenKind::Integer);
+    return std::make_unique<IntExpr>(tok.int_value, tok.loc);
+  case TokenKind::String:
+    consume(TokenKind::String);
+    return std::make_unique<StringExpr>(tok.text, tok.loc);
+  case TokenKind::Identifier: {
+    consume(TokenKind::Identifier);
+    if (match(TokenKind::LParen)) {
+      std::vector<std::unique_ptr<Expr>> args;
+      if (!match(TokenKind::RParen)) {
+        do {
+          args.push_back(parseExpr());
+        } while (match(TokenKind::Comma));
+        consume(TokenKind::RParen);
+      }
+      return std::make_unique<CallExpr>(tok.text, std::move(args), tok.loc);
+    }
+    return std::make_unique<VarExpr>(tok.text, tok.loc);
+  }
+  case TokenKind::LParen: {
+    consume(TokenKind::LParen);
+    auto e = parseExpr();
+    consume(TokenKind::RParen);
+    return e;
+  }
+  default:
+    throw std::runtime_error("bad primary");
+  }
+}
+
+} // namespace il::basic

--- a/src/frontends/basic/Parser.h
+++ b/src/frontends/basic/Parser.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <memory>
+#include <vector>
+#include "frontends/basic/AST.h"
+#include "frontends/basic/Token.h"
+
+namespace il::basic {
+
+class Parser {
+public:
+  explicit Parser(std::vector<Token> tokens);
+  Program parse();
+
+private:
+  const Token &peek() const;
+  bool match(TokenKind kind);
+  const Token &consume(TokenKind kind);
+
+  std::unique_ptr<Stmt> parseLine();
+  std::unique_ptr<Stmt> parseStmt();
+  std::unique_ptr<Stmt> parseInlineStmt();
+  std::unique_ptr<Expr> parseExpr(int prec = 0);
+  std::unique_ptr<Expr> parsePrimary();
+
+  int getPrecedence(TokenKind kind) const;
+
+  std::vector<Token> tokens_;
+  size_t pos_ = 0;
+};
+
+} // namespace il::basic

--- a/src/frontends/basic/Token.cpp
+++ b/src/frontends/basic/Token.cpp
@@ -1,0 +1,4 @@
+#include "frontends/basic/Token.h"
+namespace il::basic {
+// no-op
+}

--- a/src/frontends/basic/Token.h
+++ b/src/frontends/basic/Token.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <string>
+#include "support/source_manager.h"
+namespace il::basic {
+
+enum class TokenKind {
+  Eof,
+  Newline,
+  Identifier,
+  Integer,
+  String,
+  Plus,
+  Minus,
+  Star,
+  Slash,
+  Equals,
+  Less,
+  LessEqual,
+  Greater,
+  GreaterEqual,
+  NotEqual,
+  LParen,
+  RParen,
+  Comma,
+  KeywordPrint,
+  KeywordLet,
+  KeywordIf,
+  KeywordThen,
+  KeywordElse,
+  KeywordWhile,
+  KeywordWend,
+  KeywordGoto,
+  KeywordEnd,
+};
+
+struct Token {
+  TokenKind kind;
+  support::SourceLoc loc;
+  std::string text; // for identifiers/strings
+  int int_value = 0;
+};
+
+} // namespace il::basic

--- a/src/tools/basic-ast/main.cpp
+++ b/src/tools/basic-ast/main.cpp
@@ -1,0 +1,30 @@
+#include "frontends/basic/AstPrinter.h"
+#include "frontends/basic/Lexer.h"
+#include "frontends/basic/Parser.h"
+#include "support/source_manager.h"
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cerr << "usage: basic-ast <file>\n";
+    return 1;
+  }
+  std::ifstream ifs(argv[1]);
+  if (!ifs) {
+    std::cerr << "could not open file\n";
+    return 1;
+  }
+  std::stringstream buffer;
+  buffer << ifs.rdbuf();
+  std::string src = buffer.str();
+  il::support::SourceManager sm;
+  uint32_t fid = sm.addFile(argv[1]);
+  il::basic::Lexer lex(src, fid);
+  auto toks = lex.lex();
+  il::basic::Parser parser(std::move(toks));
+  auto prog = parser.parse();
+  std::cout << il::basic::AstPrinter::print(prog);
+  return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,22 @@ add_test(NAME vm_strings_example COMMAND ${CMAKE_COMMAND}
   -DSRC_DIR=${CMAKE_SOURCE_DIR}
   -P ${CMAKE_CURRENT_SOURCE_DIR}/e2e/test_vm_strings.cmake)
 
+add_executable(test_basic_lexer unit/test_basic_lexer.cpp)
+target_link_libraries(test_basic_lexer PRIVATE basic_frontend support)
+add_test(NAME test_basic_lexer COMMAND test_basic_lexer)
+
+set(BASIC_AST ${CMAKE_BINARY_DIR}/src/tools/basic-ast/basic-ast)
+add_test(NAME basic_ast_ex1 COMMAND ${CMAKE_COMMAND}
+  -DBASIC_AST=${BASIC_AST}
+  -DFILE=${CMAKE_SOURCE_DIR}/docs/examples/basic/ex1_hello_cond.bas
+  -DGOLDEN=${CMAKE_SOURCE_DIR}/tests/golden/basic_ast/ex1_hello_cond.ast
+  -P ${CMAKE_SOURCE_DIR}/tests/golden/basic_ast/check_ast.cmake)
+add_test(NAME basic_ast_ex2 COMMAND ${CMAKE_COMMAND}
+  -DBASIC_AST=${BASIC_AST}
+  -DFILE=${CMAKE_SOURCE_DIR}/docs/examples/basic/ex2_sum_1_to_10.bas
+  -DGOLDEN=${CMAKE_SOURCE_DIR}/tests/golden/basic_ast/ex2_sum_1_to_10.ast
+  -P ${CMAKE_SOURCE_DIR}/tests/golden/basic_ast/check_ast.cmake)
+
 set(IL_VERIFY ${CMAKE_BINARY_DIR}/src/tools/il-verify/il-verify)
 add_test(NAME il_verify_invalid_bad_types
   COMMAND ${CMAKE_COMMAND}

--- a/tests/golden/basic_ast/ex1_hello_cond.ast
+++ b/tests/golden/basic_ast/ex1_hello_cond.ast
@@ -1,0 +1,3 @@
+10:LET(X, Int(5))
+20:IF(Bin(=, Var(X), Int(5)), PRINT(Str("Hello")), PRINT(Str("Bye")))
+30:END

--- a/tests/golden/basic_ast/ex2_sum_1_to_10.ast
+++ b/tests/golden/basic_ast/ex2_sum_1_to_10.ast
@@ -1,0 +1,5 @@
+10:LET(S, Int(0))
+20:LET(I, Int(1))
+30:WHILE(Bin(<=, Var(I), Int(10)))[40:LET(S, Bin(+, Var(S), Var(I))); 50:LET(I, Bin(+, Var(I), Int(1)))]
+70:PRINT(Var(S))
+80:END

--- a/tests/unit/test_basic_lexer.cpp
+++ b/tests/unit/test_basic_lexer.cpp
@@ -1,0 +1,19 @@
+#include "frontends/basic/Lexer.h"
+#include <cassert>
+#include <string>
+
+int main() {
+  il::basic::Lexer lex("10 PRINT \"hi there\"\n", 1);
+  auto toks = lex.lex();
+  assert(toks[0].kind == il::basic::TokenKind::Integer && toks[0].int_value == 10);
+  assert(toks[1].kind == il::basic::TokenKind::KeywordPrint);
+  assert(toks[2].kind == il::basic::TokenKind::String && toks[2].text == "hi there");
+  assert(toks[3].kind == il::basic::TokenKind::Newline);
+  assert(toks[4].kind == il::basic::TokenKind::Eof);
+
+  il::basic::Lexer lex2("pRiNt 1\n", 1);
+  auto toks2 = lex2.lex();
+  assert(toks2[0].kind == il::basic::TokenKind::KeywordPrint);
+  assert(toks2[1].kind == il::basic::TokenKind::Integer);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- implement BASIC frontend tokens, lexer, parser, AST and printer
- add tool `basic-ast` and BASIC example programs
- golden tests for AST dumps of BASIC examples and lexer unit tests

## Testing
- `cmake -S . -B build && cmake --build build -j`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b13bbd99d8832495444d85d1adf749