### PR TITLE
feat(fe/basic): add lowering context and name mangler

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,9 @@ add_library(fe_basic STATIC
   frontends/basic/Lexer.cpp
   frontends/basic/AST.cpp
   frontends/basic/AstPrinter.cpp
-  frontends/basic/Parser.cpp)
+  frontends/basic/Parser.cpp
+  frontends/basic/NameMangler.cpp
+  frontends/basic/LoweringContext.cpp)
 target_link_libraries(fe_basic PUBLIC support)
 target_include_directories(fe_basic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/frontends/basic/LoweringContext.cpp
+++ b/src/frontends/basic/LoweringContext.cpp
@@ -1,0 +1,39 @@
+#include "frontends/basic/LoweringContext.h"
+#include "il/build/IRBuilder.h"
+#include "il/core/BasicBlock.h"
+#include "il/core/Function.h"
+
+namespace il::frontends::basic {
+
+LoweringContext::LoweringContext(build::IRBuilder &builder, core::Function &func)
+    : builder(builder), function(func) {}
+
+std::string LoweringContext::getOrCreateSlot(const std::string &name) {
+  auto it = varSlots.find(name);
+  if (it != varSlots.end())
+    return it->second;
+  std::string slot = "%" + name + "_slot";
+  varSlots[name] = slot;
+  return slot;
+}
+
+core::BasicBlock *LoweringContext::getOrCreateBlock(int line) {
+  auto it = blocks.find(line);
+  if (it != blocks.end())
+    return it->second;
+  std::string label = mangler.block("L" + std::to_string(line));
+  core::BasicBlock &bb = builder.addBlock(function, label);
+  blocks[line] = &bb;
+  return &bb;
+}
+
+std::string LoweringContext::getOrAddString(const std::string &value) {
+  auto it = strings.find(value);
+  if (it != strings.end())
+    return it->second;
+  std::string name = ".L" + std::to_string(nextStringId++);
+  strings[value] = name;
+  return name;
+}
+
+} // namespace il::frontends::basic

--- a/src/frontends/basic/LoweringContext.h
+++ b/src/frontends/basic/LoweringContext.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "frontends/basic/NameMangler.h"
+#include <string>
+#include <unordered_map>
+
+namespace il {
+namespace core {
+struct BasicBlock;
+class Function;
+} // namespace core
+namespace build {
+class IRBuilder;
+} // namespace build
+} // namespace il
+
+namespace il::frontends::basic {
+
+/// @brief Tracks mappings needed during BASIC lowering.
+/// @invariant Each variable, line, and string literal is unique in its map.
+/// @ownership Holds references to IR structures owned elsewhere.
+class LoweringContext {
+public:
+  LoweringContext(build::IRBuilder &builder, core::Function &func);
+
+  /// @brief Get or create stack slot name for BASIC variable @p name.
+  std::string getOrCreateSlot(const std::string &name);
+
+  /// @brief Get or create a block for the given BASIC line number.
+  core::BasicBlock *getOrCreateBlock(int line);
+
+  /// @brief Get deterministic name for string literal @p value.
+  std::string getOrAddString(const std::string &value);
+
+private:
+  build::IRBuilder &builder;
+  core::Function &function;
+  NameMangler mangler;
+  std::unordered_map<std::string, std::string> varSlots;
+  std::unordered_map<int, core::BasicBlock *> blocks;
+  std::unordered_map<std::string, std::string> strings;
+  unsigned nextStringId{0};
+};
+
+} // namespace il::frontends::basic

--- a/src/frontends/basic/NameMangler.cpp
+++ b/src/frontends/basic/NameMangler.cpp
@@ -1,0 +1,16 @@
+#include "frontends/basic/NameMangler.h"
+
+namespace il::frontends::basic {
+
+std::string NameMangler::nextTemp() { return "%t" + std::to_string(tempCounter++); }
+
+std::string NameMangler::block(const std::string &hint) {
+  auto &count = blockCounters[hint];
+  std::string name = hint;
+  if (count > 0)
+    name += std::to_string(count);
+  ++count;
+  return name;
+}
+
+} // namespace il::frontends::basic

--- a/src/frontends/basic/NameMangler.h
+++ b/src/frontends/basic/NameMangler.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <string>
+#include <unordered_map>
+
+namespace il::frontends::basic {
+
+/// @brief Generates deterministic names for temporaries and blocks.
+/// @invariant Temp IDs increase sequentially; block names gain numeric suffixes on collision.
+/// @ownership Pure utility; no external ownership.
+class NameMangler {
+public:
+  /// @brief Return next temporary name ("%t0", "%t1", ...).
+  std::string nextTemp();
+
+  /// @brief Return a block label based on @p hint ("entry", "then", ...).
+  /// If the hint was used before, a numeric suffix is appended.
+  std::string block(const std::string &hint);
+
+private:
+  unsigned tempCounter{0};
+  std::unordered_map<std::string, unsigned> blockCounters;
+};
+
+} // namespace il::frontends::basic

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,10 @@ add_executable(test_basic_lexer unit/test_basic_lexer.cpp)
 target_link_libraries(test_basic_lexer PRIVATE fe_basic support)
 add_test(NAME test_basic_lexer COMMAND test_basic_lexer)
 
+add_executable(test_basic_lowering unit/test_basic_lowering.cpp)
+target_link_libraries(test_basic_lowering PRIVATE fe_basic il_build il_core support)
+add_test(NAME test_basic_lowering COMMAND test_basic_lowering)
+
 set(BASIC_AST_DUMP $<TARGET_FILE:basic-ast-dump>)
 add_test(NAME basic_ast_ex1 COMMAND ${CMAKE_COMMAND}
   -DBASIC_AST_DUMP=${BASIC_AST_DUMP}

--- a/tests/unit/test_basic_lowering.cpp
+++ b/tests/unit/test_basic_lowering.cpp
@@ -1,0 +1,41 @@
+#include "frontends/basic/LoweringContext.h"
+#include "frontends/basic/NameMangler.h"
+#include "il/build/IRBuilder.h"
+#include "il/core/Module.h"
+#include <cassert>
+
+using namespace il::frontends::basic;
+using namespace il::build;
+using namespace il::core;
+
+int main() {
+  // NameMangler tests
+  NameMangler nm;
+  assert(nm.nextTemp() == "%t0");
+  assert(nm.nextTemp() == "%t1");
+  assert(nm.block("entry") == "entry");
+  assert(nm.block("entry") == "entry1");
+  assert(nm.block("then") == "then");
+
+  // LoweringContext tests
+  Module m;
+  IRBuilder builder(m);
+  Function &fn = builder.startFunction("main", Type(Type::Kind::Void), {});
+  LoweringContext ctx(builder, fn);
+
+  std::string slot = ctx.getOrCreateSlot("x");
+  assert(slot == "%x_slot");
+  assert(ctx.getOrCreateSlot("x") == slot);
+
+  BasicBlock *b1 = ctx.getOrCreateBlock(10);
+  BasicBlock *b2 = ctx.getOrCreateBlock(10);
+  assert(b1 == b2);
+
+  std::string s0 = ctx.getOrAddString("hello");
+  std::string s1 = ctx.getOrAddString("world");
+  assert(s0 == ".L0");
+  assert(s1 == ".L1");
+  assert(ctx.getOrAddString("hello") == s0);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add NameMangler for `%t0` temp names and unique block labels
- introduce LoweringContext to track variables, blocks, and string literals during BASIC lowering
- unit tests for mangling and lowering context utilities

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68b23369f6548324913b598e990168ef