### PR TITLE
docs: add /docs/README.md as an index and contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ilc is an experimental compiler stack built around a small intermediate language
 ## Layout
 - `src/` – libraries, VM, code generator, and tools.
 - `runtime/` – runtime libraries.
-- `docs/` – specifications and planning documents.
+- [docs/](docs/README.md) – specifications and planning documents.
 - `tests/` – unit, golden, and end-to-end tests.
 
 ## Building

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,31 @@
+# Documentation Index
+
+This directory hosts specifications, plans, and examples for the IL-based
+compiler stack. Start here for a quick tour of the project and how to
+navigate the available materials. For an overview of the project itself, see
+the [root README](../README.md). Automation and contribution guidelines live
+in [AGENTS.md](../AGENTS.md).
+
+## Quick links
+
+- [IL specification](il-spec.md)
+- [Class catalog](class-catalog.md)
+- [Project roadmap](roadmap.md)
+- [Examples: BASIC](examples/basic)
+- [Examples: IL](examples/il)
+
+## Contributing to docs
+
+Name new files in `kebab-case.md` and place them under `docs/` or an
+appropriate subdirectory. Use Markdown and wrap lines at roughly 100
+characters. To validate changes locally, build and test the project:
+
+```
+cmake -S . -B build
+cmake --build build
+ctest --output-on-failure
+```
+
+Changes to the IL specification require an Architecture Decision Record
+(ADR) before implementation; use the template in `adr/000-template.md` if
+available.


### PR DESCRIPTION
## Summary
- add a human-friendly `docs/README.md` with quick links and contribution guidelines
- link root `README.md` to the new docs index

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b25e61f3148324aa2b7ec3c9a62883