### PR TITLE
docs(readme): expand root README with overview, quickstart, and docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,39 @@
 # ilc
 
-ilc is an experimental compiler stack built around a small intermediate language (IL).
+## Overview
+ilc is an experimental compiler stack centered on a small, well-specified intermediate language (IL). The IL serves as a "thin waist" between source language front ends and eventual native code generation, keeping the core reusable across many languages and targets.
 
-## Goals
-- Define a simple, well-specified IL.
-- Provide tools and a virtual machine for executing IL.
-- Enable future front ends and native code generation.
+The system is organized as front ends that lower programs into IL, the IL libraries and tools that parse and verify it, and a stack-based virtual machine (VM) that executes IL. Future work will add code generators that translate IL to native code.
 
-## Layout
-- `src/` – libraries, VM, code generator, and tools.
-- `runtime/` – runtime libraries.
-- [docs/](docs/README.md) – specifications and planning documents.
-- `tests/` – unit, golden, and end-to-end tests.
+Currently the VM and a prototype BASIC front end are functional and can run small examples. Native code generation backends are planned but not yet implemented.
 
-## Building
-Requires a C++20 compiler and CMake.
-
-```
-cmake -S . -B build
-cmake --build build
-ctest --test-dir build --output-on-failure
+## Quickstart
+```sh
+cmake -S . -B build && cmake --build build -j
+./build/src/tools/il-verify/il-verify docs/examples/il/ex1_hello_cond.il
+./build/src/tools/ilc/ilc -run docs/examples/il/ex2_sum_1_to_10.il
 ```
 
-Executables will be in `build/src/tools`.
+## Directory layout
+```
+.
+├── src/il              # IL core libraries, parser, and verifier
+├── src/vm              # stack-based virtual machine for IL
+├── src/frontends/basic # tiny BASIC front end lowering to IL
+├── runtime             # C runtime support for the VM
+├── docs                # specifications, design notes, and examples
+└── tests               # unit, golden, and end-to-end tests
+```
+
+## Documentation
+- [Docs overview](docs/README.md)
+- [IL specification](docs/il-spec.md)
+- [Class catalog](docs/class-catalog.md)
+- [Project roadmap](docs/roadmap.md)
+- [Examples](docs/examples/)
+
+## Contributing
+See [AGENTS.md](AGENTS.md) for contribution guidelines and workflow. Architecture changes should start with an ADR as described there.
+
+## License
+Licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- outline thin-waist IL design and current components in README overview
- add quickstart build and sample usage commands
- document directory layout and link to key specs and guides

## Testing
- `cmake -S . -B build && cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b26162b0348324a34f694f06bcf0be