### PR TITLE
Add target-aware options and labels for x86_64 asm tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,31 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_compile_options(-Wall -Wextra -Wpedantic)
 
+option(IL_ENABLE_X64_ASM_SYNTAX_CHECK "Check generated x86_64 asm syntax" ON)
+option(IL_ENABLE_X64_ASM_ASSEMBLE_LINK "Assemble+link x86_64 asm" ON)
+option(IL_ENABLE_X64_NATIVE_RUN "Run x86_64 binaries" ON)
+
+if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+  set(IL_ENABLE_X64_NATIVE_RUN OFF CACHE BOOL "" FORCE)
+endif()
+
+if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+  set(IL_ENABLE_X64_ASM_ASSEMBLE_LINK OFF CACHE BOOL "" FORCE)
+endif()
+
+set(IL_X64_ASM_FLAGS "" CACHE STRING "Extra flags for assembling x86_64")
+set(IL_X64_LD_FLAGS  "" CACHE STRING "Extra flags for linking x86_64")
+if(APPLE)
+  set(IL_X64_ASM_FLAGS "-arch x86_64 -mmacosx-version-min=12.0" CACHE STRING "" FORCE)
+  set(IL_X64_LD_FLAGS  "-arch x86_64 -mmacosx-version-min=12.0" CACHE STRING "" FORCE)
+endif()
+
+message(STATUS "IL_ENABLE_X64_ASM_SYNTAX_CHECK=${IL_ENABLE_X64_ASM_SYNTAX_CHECK}")
+message(STATUS "IL_ENABLE_X64_ASM_ASSEMBLE_LINK=${IL_ENABLE_X64_ASM_ASSEMBLE_LINK}")
+message(STATUS "IL_ENABLE_X64_NATIVE_RUN=${IL_ENABLE_X64_NATIVE_RUN}")
+message(STATUS "IL_X64_ASM_FLAGS=${IL_X64_ASM_FLAGS}")
+message(STATUS "IL_X64_LD_FLAGS=${IL_X64_LD_FLAGS}")
+
 enable_testing()
 
 add_subdirectory(runtime)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_test(NAME vm_examples COMMAND ${CMAKE_COMMAND}
   -DILC=$<TARGET_FILE:ilc>
   -DSRC_DIR=${CMAKE_SOURCE_DIR}
   -P ${CMAKE_CURRENT_SOURCE_DIR}/e2e/test_vm_examples.cmake)
+set_tests_properties(vm_examples PROPERTIES LABELS VM)
 
 add_executable(test_rt_string unit/test_rt_string.cpp)
 target_link_libraries(test_rt_string PRIVATE rt)
@@ -37,6 +38,7 @@ add_test(NAME vm_strings_example COMMAND ${CMAKE_COMMAND}
   -DILC=$<TARGET_FILE:ilc>
   -DSRC_DIR=${CMAKE_SOURCE_DIR}
   -P ${CMAKE_CURRENT_SOURCE_DIR}/e2e/test_vm_strings.cmake)
+set_tests_properties(vm_strings_example PROPERTIES LABELS VM)
 
 add_test(NAME front_basic_example COMMAND ${CMAKE_COMMAND}
   -DILC=$<TARGET_FILE:ilc>
@@ -103,3 +105,29 @@ add_test(NAME basic_to_il_ex2 COMMAND ${CMAKE_COMMAND}
   -DBAS_FILE=${CMAKE_SOURCE_DIR}/docs/examples/basic/ex2_sum_1_to_10.bas
   -DGOLDEN=${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/ex2_sum_1_to_10.il
   -P ${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/check_il.cmake)
+
+set(CODEGEN_E2E ${CMAKE_CURRENT_SOURCE_DIR}/e2e/test_codegen.cmake)
+if(IL_ENABLE_X64_ASM_SYNTAX_CHECK)
+  add_test(NAME codegen_syntax_only COMMAND ${CMAKE_COMMAND}
+    "-DASM_FLAGS=${IL_X64_ASM_FLAGS}"
+    "-DLD_FLAGS=${IL_X64_LD_FLAGS}"
+    -DMODE=syntax
+    -P ${CODEGEN_E2E})
+  set_tests_properties(codegen_syntax_only PROPERTIES LABELS CodegenSyntaxOnly)
+endif()
+if(IL_ENABLE_X64_ASM_ASSEMBLE_LINK)
+  add_test(NAME codegen_assemble_link COMMAND ${CMAKE_COMMAND}
+    "-DASM_FLAGS=${IL_X64_ASM_FLAGS}"
+    "-DLD_FLAGS=${IL_X64_LD_FLAGS}"
+    -DMODE=assemble_link
+    -P ${CODEGEN_E2E})
+  set_tests_properties(codegen_assemble_link PROPERTIES LABELS CodegenAssembleLink)
+endif()
+if(IL_ENABLE_X64_NATIVE_RUN)
+  add_test(NAME codegen_native_run COMMAND ${CMAKE_COMMAND}
+    "-DASM_FLAGS=${IL_X64_ASM_FLAGS}"
+    "-DLD_FLAGS=${IL_X64_LD_FLAGS}"
+    -DMODE=run
+    -P ${CODEGEN_E2E})
+  set_tests_properties(codegen_native_run PROPERTIES LABELS NativeX64Run)
+endif()

--- a/tests/e2e/test_codegen.cmake
+++ b/tests/e2e/test_codegen.cmake
@@ -1,0 +1,42 @@
+separate_arguments(ASM_FLAGS_LIST NATIVE_COMMAND "${ASM_FLAGS}")
+separate_arguments(LD_FLAGS_LIST  NATIVE_COMMAND "${LD_FLAGS}")
+
+file(WRITE out.s ".text\n.globl main\nmain:\n  mov $0, %eax\n  ret\n")
+
+if(MODE STREQUAL "syntax")
+  execute_process(
+    COMMAND clang ${ASM_FLAGS_LIST} -x assembler -fsyntax-only out.s
+    RESULT_VARIABLE r)
+  if(NOT r EQUAL 0)
+    message(FATAL_ERROR "syntax check failed")
+  endif()
+elseif(MODE STREQUAL "assemble_link")
+  execute_process(COMMAND clang ${ASM_FLAGS_LIST} -c out.s -o out.o
+                  RESULT_VARIABLE r1)
+  if(NOT r1 EQUAL 0)
+    message(FATAL_ERROR "assembly failed")
+  endif()
+  execute_process(COMMAND clang ${LD_FLAGS_LIST} out.o -o a.out
+                  RESULT_VARIABLE r2)
+  if(NOT r2 EQUAL 0)
+    message(FATAL_ERROR "link failed")
+  endif()
+elseif(MODE STREQUAL "run")
+  execute_process(COMMAND clang ${ASM_FLAGS_LIST} -c out.s -o out.o
+                  RESULT_VARIABLE r1)
+  if(NOT r1 EQUAL 0)
+    message(FATAL_ERROR "assembly failed")
+  endif()
+  execute_process(COMMAND clang ${LD_FLAGS_LIST} out.o -o a.out
+                  RESULT_VARIABLE r2)
+  if(NOT r2 EQUAL 0)
+    message(FATAL_ERROR "link failed")
+  endif()
+  execute_process(COMMAND ./a.out RESULT_VARIABLE r3)
+  if(NOT r3 EQUAL 0)
+    message(FATAL_ERROR "run failed")
+  endif()
+else()
+  message(FATAL_ERROR "unknown MODE ${MODE}")
+endif()
+


### PR DESCRIPTION
## Summary
- add build options to control x86_64 asm syntax check, assemble+link, and native run
- gate x86_64 native run to actual x86_64 hosts and set cross flags for macOS
- add CTest labels and conditional codegen tests for syntax, assemble+link, and native run

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b26468b010832497715431e1b39fa6