### PR TITLE
docs(code): add file headers to all source/runtime files per style guide

### DIFF
--- a/runtime/rt.h
+++ b/runtime/rt.h
@@ -1,3 +1,8 @@
+// File: runtime/rt.h
+// Purpose: Declares C runtime utilities for strings and I/O.
+// Key invariants: Reference counts remain non-negative.
+// Ownership/Lifetime: Caller manages returned strings.
+// Links: docs/class-catalog.md
 #pragma once
 #include <stdint.h>
 #ifdef __cplusplus

--- a/src/codegen/x86_64/placeholder.cpp
+++ b/src/codegen/x86_64/placeholder.cpp
@@ -1,4 +1,8 @@
-// TODO: implement x86_64 codegen library
+// File: src/codegen/x86_64/placeholder.cpp
+// Purpose: Stub implementation for x86_64 code generation library.
+// Key invariants: None.
+// Ownership/Lifetime: Not applicable.
+// Links: docs/class-catalog.md
 namespace il::codegen::x86_64 {
 int placeholder() { return 0; }
 } // namespace il::codegen::x86_64

--- a/src/frontends/basic/AST.cpp
+++ b/src/frontends/basic/AST.cpp
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/AST.cpp
+// Purpose: Provides out-of-line definitions for BASIC AST nodes.
+// Key invariants: None.
+// Ownership/Lifetime: Nodes owned via std::unique_ptr.
+// Links: docs/class-catalog.md
 #include "frontends/basic/AST.h"
 
 namespace il::frontends::basic {

--- a/src/frontends/basic/AST.h
+++ b/src/frontends/basic/AST.h
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/AST.h
+// Purpose: Declares BASIC front-end abstract syntax tree nodes.
+// Key invariants: Nodes carry source locations.
+// Ownership/Lifetime: Caller owns nodes via std::unique_ptr.
+// Links: docs/class-catalog.md
 #pragma once
 #include "support/source_manager.h"
 #include <memory>

--- a/src/frontends/basic/AstPrinter.cpp
+++ b/src/frontends/basic/AstPrinter.cpp
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/AstPrinter.cpp
+// Purpose: Implements BASIC AST printer for debugging.
+// Key invariants: None.
+// Ownership/Lifetime: Printer does not own AST nodes.
+// Links: docs/class-catalog.md
 #include "frontends/basic/AstPrinter.h"
 #include <sstream>
 

--- a/src/frontends/basic/AstPrinter.h
+++ b/src/frontends/basic/AstPrinter.h
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/AstPrinter.h
+// Purpose: Declares utilities to print BASIC AST nodes.
+// Key invariants: None.
+// Ownership/Lifetime: Functions do not take ownership of nodes.
+// Links: docs/class-catalog.md
 #pragma once
 #include "frontends/basic/AST.h"
 #include <string>

--- a/src/frontends/basic/Lexer.cpp
+++ b/src/frontends/basic/Lexer.cpp
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/Lexer.cpp
+// Purpose: Implements lexer for the BASIC frontend.
+// Key invariants: None.
+// Ownership/Lifetime: Lexer views input managed externally.
+// Links: docs/class-catalog.md
 #include "frontends/basic/Lexer.h"
 #include <cctype>
 #include <string>

--- a/src/frontends/basic/Lexer.h
+++ b/src/frontends/basic/Lexer.h
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/Lexer.h
+// Purpose: Declares BASIC token lexer.
+// Key invariants: Current position always within source buffer.
+// Ownership/Lifetime: Lexer does not own the source buffer.
+// Links: docs/class-catalog.md
 #pragma once
 #include "frontends/basic/Token.h"
 #include <string_view>

--- a/src/frontends/basic/Lowerer.cpp
+++ b/src/frontends/basic/Lowerer.cpp
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/Lowerer.cpp
+// Purpose: Lowers BASIC AST to IL.
+// Key invariants: None.
+// Ownership/Lifetime: Uses contexts managed externally.
+// Links: docs/class-catalog.md
 #include "frontends/basic/Lowerer.h"
 #include "il/core/BasicBlock.h"
 #include "il/core/Function.h"

--- a/src/frontends/basic/Lowerer.h
+++ b/src/frontends/basic/Lowerer.h
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/Lowerer.h
+// Purpose: Declares lowering from BASIC AST to IL.
+// Key invariants: None.
+// Ownership/Lifetime: Lowerer does not own AST or module.
+// Links: docs/class-catalog.md
 #pragma once
 #include "frontends/basic/AST.h"
 #include "frontends/basic/NameMangler.h"

--- a/src/frontends/basic/LoweringContext.cpp
+++ b/src/frontends/basic/LoweringContext.cpp
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/LoweringContext.cpp
+// Purpose: Implements state used during BASIC-to-IL lowering.
+// Key invariants: None.
+// Ownership/Lifetime: Context references module owned externally.
+// Links: docs/class-catalog.md
 #include "frontends/basic/LoweringContext.h"
 #include "il/build/IRBuilder.h"
 #include "il/core/BasicBlock.h"

--- a/src/frontends/basic/LoweringContext.h
+++ b/src/frontends/basic/LoweringContext.h
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/LoweringContext.h
+// Purpose: Declares state container used in BASIC-to-IL lowering.
+// Key invariants: None.
+// Ownership/Lifetime: Does not own referenced module.
+// Links: docs/class-catalog.md
 #pragma once
 #include "frontends/basic/NameMangler.h"
 #include <string>

--- a/src/frontends/basic/NameMangler.cpp
+++ b/src/frontends/basic/NameMangler.cpp
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/NameMangler.cpp
+// Purpose: Implements symbol mangling for BASIC frontend.
+// Key invariants: None.
+// Ownership/Lifetime: Uses strings managed externally.
+// Links: docs/class-catalog.md
 #include "frontends/basic/NameMangler.h"
 
 namespace il::frontends::basic {

--- a/src/frontends/basic/NameMangler.h
+++ b/src/frontends/basic/NameMangler.h
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/NameMangler.h
+// Purpose: Declares symbol mangling helpers for BASIC frontend.
+// Key invariants: None.
+// Ownership/Lifetime: Functions allocate strings for caller.
+// Links: docs/class-catalog.md
 #pragma once
 #include <string>
 #include <unordered_map>

--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/Parser.cpp
+// Purpose: Implements BASIC parser converting tokens to AST.
+// Key invariants: None.
+// Ownership/Lifetime: Parser references tokens managed externally.
+// Links: docs/class-catalog.md
 #include "frontends/basic/Parser.h"
 #include <cstdlib>
 

--- a/src/frontends/basic/Parser.h
+++ b/src/frontends/basic/Parser.h
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/Parser.h
+// Purpose: Declares BASIC parser that builds an AST.
+// Key invariants: Parser state tracks current token.
+// Ownership/Lifetime: Parser does not own token buffer.
+// Links: docs/class-catalog.md
 #pragma once
 #include "frontends/basic/AST.h"
 #include "frontends/basic/Lexer.h"

--- a/src/frontends/basic/Token.cpp
+++ b/src/frontends/basic/Token.cpp
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/Token.cpp
+// Purpose: Provides token utilities for BASIC frontend.
+// Key invariants: None.
+// Ownership/Lifetime: Tokens passed by value.
+// Links: docs/class-catalog.md
 #include "frontends/basic/Token.h"
 
 namespace il::frontends::basic {

--- a/src/frontends/basic/Token.h
+++ b/src/frontends/basic/Token.h
@@ -1,3 +1,8 @@
+// File: src/frontends/basic/Token.h
+// Purpose: Defines token types for BASIC lexer.
+// Key invariants: Tokens carry source locations.
+// Ownership/Lifetime: Tokens are value types.
+// Links: docs/class-catalog.md
 #pragma once
 #include "support/source_manager.h"
 #include <string>

--- a/src/il/build/IRBuilder.cc
+++ b/src/il/build/IRBuilder.cc
@@ -1,3 +1,8 @@
+// File: src/il/build/IRBuilder.cc
+// Purpose: Implements helpers to construct IL modules.
+// Key invariants: None.
+// Ownership/Lifetime: Builder references module owned externally.
+// Links: docs/il-spec.md
 #include "il/build/IRBuilder.h"
 #include <cassert>
 

--- a/src/il/build/IRBuilder.h
+++ b/src/il/build/IRBuilder.h
@@ -1,3 +1,8 @@
+// File: src/il/build/IRBuilder.h
+// Purpose: Declares helper class for building IL modules.
+// Key invariants: None.
+// Ownership/Lifetime: Does not own the module it modifies.
+// Links: docs/il-spec.md
 #pragma once
 #include "il/core/BasicBlock.h"
 #include "il/core/Function.h"

--- a/src/il/core/BasicBlock.cc
+++ b/src/il/core/BasicBlock.cc
@@ -1,3 +1,8 @@
+// File: src/il/core/BasicBlock.cc
+// Purpose: Defines out-of-line methods for BasicBlock.
+// Key invariants: None.
+// Ownership/Lifetime: Blocks owned by functions.
+// Links: docs/il-spec.md
 #include "il/core/BasicBlock.h"
 
 namespace il::core {

--- a/src/il/core/BasicBlock.h
+++ b/src/il/core/BasicBlock.h
@@ -1,3 +1,8 @@
+// File: src/il/core/BasicBlock.h
+// Purpose: Represents a sequence of IL instructions.
+// Key invariants: terminated is true when block ends with control flow.
+// Ownership/Lifetime: Functions own blocks by value.
+// Links: docs/il-spec.md
 #pragma once
 #include "il/core/Instr.h"
 #include <string>

--- a/src/il/core/Extern.cc
+++ b/src/il/core/Extern.cc
@@ -1,3 +1,8 @@
+// File: src/il/core/Extern.cc
+// Purpose: Provides out-of-line helpers for Extern.
+// Key invariants: None.
+// Ownership/Lifetime: Module owns extern declarations.
+// Links: docs/il-spec.md
 #include "il/core/Extern.h"
 
 namespace il::core {

--- a/src/il/core/Extern.h
+++ b/src/il/core/Extern.h
@@ -1,3 +1,8 @@
+// File: src/il/core/Extern.h
+// Purpose: Represents external function declarations in IL modules.
+// Key invariants: Parameter count matches signature.
+// Ownership/Lifetime: Module owns extern declarations.
+// Links: docs/il-spec.md
 #pragma once
 #include "il/core/Type.h"
 #include <string>

--- a/src/il/core/Function.cc
+++ b/src/il/core/Function.cc
@@ -1,3 +1,8 @@
+// File: src/il/core/Function.cc
+// Purpose: Implements IL function manipulation helpers.
+// Key invariants: None.
+// Ownership/Lifetime: Module owns functions.
+// Links: docs/il-spec.md
 #include "il/core/Function.h"
 
 namespace il::core {

--- a/src/il/core/Function.h
+++ b/src/il/core/Function.h
@@ -1,3 +1,8 @@
+// File: src/il/core/Function.h
+// Purpose: Defines IL function structure.
+// Key invariants: Parameters match function type.
+// Ownership/Lifetime: Module owns functions and their blocks.
+// Links: docs/il-spec.md
 #pragma once
 #include "il/core/BasicBlock.h"
 #include "il/core/Param.h"

--- a/src/il/core/Global.cc
+++ b/src/il/core/Global.cc
@@ -1,3 +1,8 @@
+// File: src/il/core/Global.cc
+// Purpose: Provides helpers for global variables.
+// Key invariants: None.
+// Ownership/Lifetime: Module owns global declarations.
+// Links: docs/il-spec.md
 #include "il/core/Global.h"
 
 namespace il::core {

--- a/src/il/core/Global.h
+++ b/src/il/core/Global.h
@@ -1,3 +1,8 @@
+// File: src/il/core/Global.h
+// Purpose: Represents global variables in IL modules.
+// Key invariants: Initialized values match declared type.
+// Ownership/Lifetime: Module owns global variables.
+// Links: docs/il-spec.md
 #pragma once
 #include "il/core/Type.h"
 #include <string>

--- a/src/il/core/Instr.cc
+++ b/src/il/core/Instr.cc
@@ -1,3 +1,8 @@
+// File: src/il/core/Instr.cc
+// Purpose: Provides helper methods for IL instructions.
+// Key invariants: None.
+// Ownership/Lifetime: Instructions stored by value in blocks.
+// Links: docs/il-spec.md
 #include "il/core/Instr.h"
 
 namespace il::core {

--- a/src/il/core/Instr.h
+++ b/src/il/core/Instr.h
@@ -1,3 +1,8 @@
+// File: src/il/core/Instr.h
+// Purpose: Defines IL instruction representation.
+// Key invariants: Opcode determines operand layout.
+// Ownership/Lifetime: Instructions stored by value in basic blocks.
+// Links: docs/il-spec.md
 #pragma once
 #include "il/core/Opcode.h"
 #include "il/core/Type.h"

--- a/src/il/core/Module.cc
+++ b/src/il/core/Module.cc
@@ -1,3 +1,8 @@
+// File: src/il/core/Module.cc
+// Purpose: Implements IL module utilities.
+// Key invariants: None.
+// Ownership/Lifetime: Module owns functions, globals, and externs.
+// Links: docs/il-spec.md
 #include "il/core/Module.h"
 
 namespace il::core {

--- a/src/il/core/Module.h
+++ b/src/il/core/Module.h
@@ -1,3 +1,8 @@
+// File: src/il/core/Module.h
+// Purpose: Container for IL externs, globals, and functions.
+// Key invariants: Names are unique within a module.
+// Ownership/Lifetime: Module owns contained objects by value.
+// Links: docs/il-spec.md
 #pragma once
 #include "il/core/Extern.h"
 #include "il/core/Function.h"

--- a/src/il/core/Opcode.h
+++ b/src/il/core/Opcode.h
@@ -1,3 +1,8 @@
+// File: src/il/core/Opcode.h
+// Purpose: Enumerates IL instruction opcodes.
+// Key invariants: Enumeration values match IL spec.
+// Ownership/Lifetime: Not applicable.
+// Links: docs/il-spec.md
 #pragma once
 #include <string>
 

--- a/src/il/core/Param.h
+++ b/src/il/core/Param.h
@@ -1,3 +1,8 @@
+// File: src/il/core/Param.h
+// Purpose: Defines function parameter representation.
+// Key invariants: Type matches function signature.
+// Ownership/Lifetime: Parameters stored by value.
+// Links: docs/il-spec.md
 #pragma once
 #include "il/core/Type.h"
 #include <string>

--- a/src/il/core/Type.cc
+++ b/src/il/core/Type.cc
@@ -1,3 +1,8 @@
+// File: src/il/core/Type.cc
+// Purpose: Implements helpers for IL type system.
+// Key invariants: None.
+// Ownership/Lifetime: Types are value objects.
+// Links: docs/il-spec.md
 #include "il/core/Type.h"
 
 namespace il::core {

--- a/src/il/core/Type.h
+++ b/src/il/core/Type.h
@@ -1,3 +1,8 @@
+// File: src/il/core/Type.h
+// Purpose: Declares IL type representation.
+// Key invariants: Kind field determines payload.
+// Ownership/Lifetime: Types are lightweight values.
+// Links: docs/il-spec.md
 #pragma once
 #include <string>
 

--- a/src/il/core/Value.cc
+++ b/src/il/core/Value.cc
@@ -1,3 +1,8 @@
+// File: src/il/core/Value.cc
+// Purpose: Implements helpers for IL values.
+// Key invariants: None.
+// Ownership/Lifetime: Values are owned by their users.
+// Links: docs/il-spec.md
 #include "il/core/Value.h"
 
 namespace il::core {

--- a/src/il/core/Value.h
+++ b/src/il/core/Value.h
@@ -1,3 +1,8 @@
+// File: src/il/core/Value.h
+// Purpose: Defines IL value variants.
+// Key invariants: Discriminant matches stored payload.
+// Ownership/Lifetime: Values are passed by value.
+// Links: docs/il-spec.md
 #pragma once
 #include <string>
 

--- a/src/il/io/Parser.cc
+++ b/src/il/io/Parser.cc
@@ -1,3 +1,8 @@
+// File: src/il/io/Parser.cc
+// Purpose: Implements parser for IL textual format.
+// Key invariants: None.
+// Ownership/Lifetime: Parser operates on externally managed strings.
+// Links: docs/il-spec.md
 #include "il/io/Parser.h"
 #include "il/core/Opcode.h"
 #include "il/core/Value.h"

--- a/src/il/io/Parser.h
+++ b/src/il/io/Parser.h
@@ -1,3 +1,8 @@
+// File: src/il/io/Parser.h
+// Purpose: Declares parser for IL textual representation.
+// Key invariants: None.
+// Ownership/Lifetime: Parser views input string without owning.
+// Links: docs/il-spec.md
 #pragma once
 #include "il/core/Module.h"
 #include <istream>

--- a/src/il/io/Serializer.cc
+++ b/src/il/io/Serializer.cc
@@ -1,3 +1,8 @@
+// File: src/il/io/Serializer.cc
+// Purpose: Implements serializer for IL modules to text.
+// Key invariants: None.
+// Ownership/Lifetime: Serializer does not own modules.
+// Links: docs/il-spec.md
 #include "il/io/Serializer.h"
 #include "il/core/Opcode.h"
 #include "il/core/Value.h"

--- a/src/il/io/Serializer.h
+++ b/src/il/io/Serializer.h
@@ -1,3 +1,8 @@
+// File: src/il/io/Serializer.h
+// Purpose: Declares text serializer for IL modules.
+// Key invariants: None.
+// Ownership/Lifetime: Serializer operates on provided modules.
+// Links: docs/il-spec.md
 #pragma once
 #include "il/core/Module.h"
 #include <ostream>

--- a/src/il/verify/Verifier.cc
+++ b/src/il/verify/Verifier.cc
@@ -1,3 +1,8 @@
+// File: src/il/verify/Verifier.cc
+// Purpose: Implements IL verifier checking module correctness.
+// Key invariants: None.
+// Ownership/Lifetime: Verifier does not own modules.
+// Links: docs/il-spec.md
 #include "il/verify/Verifier.h"
 #include "il/core/Opcode.h"
 #include <sstream>

--- a/src/il/verify/Verifier.h
+++ b/src/il/verify/Verifier.h
@@ -1,3 +1,8 @@
+// File: src/il/verify/Verifier.h
+// Purpose: Declares IL verifier that checks modules.
+// Key invariants: None.
+// Ownership/Lifetime: Verifier does not own modules.
+// Links: docs/il-spec.md
 #pragma once
 #include "il/core/Module.h"
 #include <ostream>

--- a/src/support/arena.cpp
+++ b/src/support/arena.cpp
@@ -1,3 +1,8 @@
+// File: src/support/arena.cpp
+// Purpose: Implements bump allocator for short-lived objects.
+// Key invariants: None.
+// Ownership/Lifetime: Arena owns allocated memory until reset.
+// Links: docs/class-catalog.md
 #include "arena.h"
 namespace il::support {
 Arena::Arena(size_t size) : buffer_(size) {}

--- a/src/support/arena.h
+++ b/src/support/arena.h
@@ -1,3 +1,8 @@
+// File: src/support/arena.h
+// Purpose: Declares bump allocator for temporary objects.
+// Key invariants: None.
+// Ownership/Lifetime: Arena owns all allocated memory.
+// Links: docs/class-catalog.md
 #pragma once
 #include <cstddef>
 #include <vector>

--- a/src/support/diagnostics.cpp
+++ b/src/support/diagnostics.cpp
@@ -1,3 +1,8 @@
+// File: src/support/diagnostics.cpp
+// Purpose: Implements diagnostic reporting utilities.
+// Key invariants: None.
+// Ownership/Lifetime: Diagnostic engine owns stored messages.
+// Links: docs/class-catalog.md
 #include "diagnostics.h"
 namespace il::support {
 void DiagnosticEngine::report(Diagnostic d) {

--- a/src/support/diagnostics.h
+++ b/src/support/diagnostics.h
@@ -1,3 +1,8 @@
+// File: src/support/diagnostics.h
+// Purpose: Declares diagnostic engine for errors and warnings.
+// Key invariants: None.
+// Ownership/Lifetime: Engine owns collected diagnostics.
+// Links: docs/class-catalog.md
 #pragma once
 #include "source_manager.h"
 #include <ostream>

--- a/src/support/options.h
+++ b/src/support/options.h
@@ -1,3 +1,8 @@
+// File: src/support/options.h
+// Purpose: Declares command-line option parsing helpers.
+// Key invariants: None.
+// Ownership/Lifetime: Caller owns option values.
+// Links: docs/class-catalog.md
 #pragma once
 #include <string>
 /// @brief Global options controlling compiler behavior.

--- a/src/support/result.h
+++ b/src/support/result.h
@@ -1,3 +1,8 @@
+// File: src/support/result.h
+// Purpose: Provides a simple Result type for error handling.
+// Key invariants: None.
+// Ownership/Lifetime: Result owns contained value or error.
+// Links: docs/class-catalog.md
 #pragma once
 #include <string>
 #include <utility>

--- a/src/support/source_manager.cpp
+++ b/src/support/source_manager.cpp
@@ -1,3 +1,8 @@
+// File: src/support/source_manager.cpp
+// Purpose: Implements utilities to manage source buffers.
+// Key invariants: None.
+// Ownership/Lifetime: SourceManager owns loaded buffers.
+// Links: docs/class-catalog.md
 #include "source_manager.h"
 namespace il::support {
 uint32_t SourceManager::addFile(std::string path) {

--- a/src/support/source_manager.h
+++ b/src/support/source_manager.h
@@ -1,3 +1,8 @@
+// File: src/support/source_manager.h
+// Purpose: Declares manager for source file identifiers.
+// Key invariants: File ID 0 is invalid.
+// Ownership/Lifetime: Manager owns file path strings.
+// Links: docs/class-catalog.md
 #pragma once
 #include <cstdint>
 #include <string>

--- a/src/support/string_interner.cpp
+++ b/src/support/string_interner.cpp
@@ -1,3 +1,8 @@
+// File: src/support/string_interner.cpp
+// Purpose: Implements string interning facility.
+// Key invariants: Symbol id 0 is reserved.
+// Ownership/Lifetime: Interner owns interned strings.
+// Links: docs/class-catalog.md
 #include "string_interner.h"
 namespace il::support {
 Symbol StringInterner::intern(std::string_view str) {

--- a/src/support/string_interner.h
+++ b/src/support/string_interner.h
@@ -1,3 +1,8 @@
+// File: src/support/string_interner.h
+// Purpose: Declares string interning and symbol types.
+// Key invariants: Symbol id 0 is invalid.
+// Ownership/Lifetime: Interner owns stored strings.
+// Links: docs/class-catalog.md
 #pragma once
 #include "symbol.h"
 #include <string>

--- a/src/support/symbol.h
+++ b/src/support/symbol.h
@@ -1,3 +1,8 @@
+// File: src/support/symbol.h
+// Purpose: Defines Symbol handle type for interned strings.
+// Key invariants: Value 0 denotes an invalid symbol.
+// Ownership/Lifetime: Symbols are value types.
+// Links: docs/class-catalog.md
 #pragma once
 #include <cstdint>
 #include <functional>

--- a/src/tools/basic-ast-dump/main.cpp
+++ b/src/tools/basic-ast-dump/main.cpp
@@ -1,3 +1,8 @@
+// File: src/tools/basic-ast-dump/main.cpp
+// Purpose: Command-line tool to dump BASIC AST.
+// Key invariants: None.
+// Ownership/Lifetime: Tool owns loaded source.
+// Links: docs/class-catalog.md
 #include "frontends/basic/AstPrinter.h"
 #include "frontends/basic/Parser.h"
 #include "support/source_manager.h"

--- a/src/tools/il-dis/main.cpp
+++ b/src/tools/il-dis/main.cpp
@@ -1,3 +1,8 @@
+// File: src/tools/il-dis/main.cpp
+// Purpose: Example tool emitting IL for a simple program.
+// Key invariants: None.
+// Ownership/Lifetime: Tool owns constructed module.
+// Links: docs/class-catalog.md
 #include "il/build/IRBuilder.h"
 #include "il/io/Serializer.h"
 #include <iostream>

--- a/src/tools/il-verify/il-verify.cpp
+++ b/src/tools/il-verify/il-verify.cpp
@@ -1,3 +1,8 @@
+// File: src/tools/il-verify/il-verify.cpp
+// Purpose: Command-line tool verifying IL modules.
+// Key invariants: None.
+// Ownership/Lifetime: Tool owns parsed module.
+// Links: docs/class-catalog.md
 #include "il/io/Parser.h"
 #include "il/verify/Verifier.h"
 #include <fstream>

--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -1,3 +1,8 @@
+// File: src/tools/ilc/main.cpp
+// Purpose: Main driver for IL compiler and runner.
+// Key invariants: None.
+// Ownership/Lifetime: Tool owns loaded modules.
+// Links: docs/class-catalog.md
 #include "frontends/basic/Lowerer.h"
 #include "frontends/basic/Parser.h"
 #include "il/io/Parser.h"

--- a/src/vm/RuntimeBridge.cpp
+++ b/src/vm/RuntimeBridge.cpp
@@ -1,3 +1,8 @@
+// File: src/vm/RuntimeBridge.cpp
+// Purpose: Bridges VM to C runtime functions.
+// Key invariants: None.
+// Ownership/Lifetime: Bridge does not own VM or runtime resources.
+// Links: docs/il-spec.md
 #include "vm/RuntimeBridge.h"
 #include "vm/VM.h"
 #include <cassert>

--- a/src/vm/RuntimeBridge.h
+++ b/src/vm/RuntimeBridge.h
@@ -1,3 +1,8 @@
+// File: src/vm/RuntimeBridge.h
+// Purpose: Declares adapter between VM and runtime library.
+// Key invariants: None.
+// Ownership/Lifetime: VM owns the bridge.
+// Links: docs/il-spec.md
 #pragma once
 #include "rt.h"
 #include <string>

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -1,3 +1,8 @@
+// File: src/vm/VM.cpp
+// Purpose: Implements stack-based virtual machine for IL.
+// Key invariants: None.
+// Ownership/Lifetime: VM references module owned externally.
+// Links: docs/il-spec.md
 #include "vm/VM.h"
 #include "il/core/Instr.h"
 #include "il/core/Opcode.h"

--- a/src/vm/VM.h
+++ b/src/vm/VM.h
@@ -1,3 +1,8 @@
+// File: src/vm/VM.h
+// Purpose: Declares stack-based virtual machine executing IL.
+// Key invariants: None.
+// Ownership/Lifetime: VM does not own module or runtime bridge.
+// Links: docs/il-spec.md
 #pragma once
 #include "il/core/Module.h"
 #include "rt.h"


### PR DESCRIPTION
## Summary
- document purpose, invariants, ownership, and related docs at top of all source/runtime files

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --output-on-failure`
- `scripts/check_comments.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2716a58ac8324b751c1994f353fd8