### PR TITLE
docs: add BASIC language reference and update IL spec

### DIFF
--- a/docs/basic-language-reference.md
+++ b/docs/basic-language-reference.md
@@ -1,0 +1,86 @@
+BASIC v0.1 Language Reference (for this project)
+Status: Implemented subset for front-end bring-up
+Back end: Lowers to IL v0.1.1 → VM interpreter (native codegen WIP)
+1. Goals & Scope
+Small, predictable BASIC subset suitable for early IDE/compiler bring-up.
+Deterministic semantics that map cleanly to IL and runtime calls.
+Feature set chosen to cover: variables, arithmetic, strings, conditionals, loops, simple I/O.
+2. Programs & Structure
+A program is a sequence of statements.
+Line numbers are optional; when present they act as labels (targets for GOTO).
+Execution starts at the first line (or the first statement if no numbers).
+Comments start with ' and run to end of line.
+10 PRINT "HELLO"
+20 LET X = 2 + 3
+30 IF X > 4 THEN PRINT X ELSE PRINT 4
+40 END
+3. Types
+Integer: 64-bit signed (i64 in IL). Literal examples: 0, -12, 42.
+Float (optional in v0.1; produced via VAL of string): 64-bit IEEE (f64).
+String: UTF-8 sequences. Literal: "text", escapes \" \\ \n \t \xNN.
+Boolean: expression result TRUE/FALSE (internally i1), accepted in conditions.
+Coercions
+Integer + Integer → Integer (wraps on overflow in IL).
+LEN, VAL, MID$ provide string↔numeric operations via runtime.
+PRINT chooses rt_print_str for strings, rt_print_i64 for integers, rt_print_f64 for floats.
+4. Expressions
+Precedence (high→low):
+()
+Unary: + -
+* /
++ - (binary)
+Comparisons: = <> < <= > >= (yield Boolean)
+Operators:
+Arithmetic on integers; / is integer division (traps on div/0).
+Comparisons allowed between like types (int with int, str with str using =/<> only).
+Built-ins (all map to runtime; see §9):
+LEN(s$) -> integer
+MID$(s$, start, length) -> string (1-based indices; clamped)
+VAL(s$) -> integer (traps on invalid; VALF$ for float optional later)
+5. Statements
+LET var = expr — assign (vars auto-declared on first use)
+PRINT expr — output value
+IF cond THEN stmt [ELSE stmt]
+Multi-stmt THEN/ELSE blocks: chain multiple PRINT/LET/... on subsequent lines or use line numbers to branch.
+WHILE cond ... WEND
+GOTO lineNumber
+END — terminate program
+INPUT var$ (optional if runtime wired) — reads a line into a string variable
+6. Variables & Names
+Names: [A-Za-z][A-Za-z0-9_]* with optional $ suffix for strings (NAME$).
+Type inference:
+$ suffix → string
+otherwise integer unless assigned from VALF$(…) (future).
+All variables are function-local to @main in v0.1.
+7. Errors
+Division by zero, invalid VAL, out-of-bounds MID$ length/start after clamping → runtime trap with message.
+Type mismatch in comparisons/operations → compile-time (lowering) error.
+8. Grammar (informal)
+program     ::= (line | stmt)* EOF
+line        ::= (NUMBER)? stmt NEWLINE
+stmt        ::= "LET" ident "=" expr
+             | "PRINT" expr
+             | "IF" expr "THEN" stmt ("ELSE" stmt)?
+             | "WHILE" expr NEWLINE stmt* "WEND"
+             | "GOTO" NUMBER
+             | "END"
+             | "INPUT" ident
+expr        ::= term (("+"|"-") term)*
+term        ::= factor (("*"|"/") factor)*
+factor      ::= NUMBER | STRING | ident | "(" expr ")" | ("+"|"-") factor
+ident       ::= NAME | NAME "$"
+9. Mapping to IL & Runtime
+BASIC | IL pattern | Runtime
+---- | ---- | ----
+PRINT "X" | %s = const_str @.L; call @rt_print_str(%s) | rt_print_str(str)
+PRINT X | %v = load i64, %slotX; call @rt_print_i64(%v) | rt_print_i64(i64)
+LET X = A + B | load A; load B; %c = add %a,%b; store X,%c | —
+IF C THEN … ELSE … | %p = …cmp…; cbr %p, then, else | —
+WHILE C … WEND | br loop_head; cbr cond, loop_body, done | —
+LEN(S$) | call @rt_len(%s) | rt_len(str)->i64
+MID$(S$,i,l) | call @rt_substr(%s, i-1, l) | rt_substr(str,i64,i64)->str
+VAL(S$) | call @rt_to_int(%s) | rt_to_int(str)->i64
+INPUT A$ | %s = call @rt_input_line(); store A$, %s | rt_input_line()->str
+Indexing: BASIC’s 1-based indices are lowered to 0-based for runtime calls (subtract 1).
+10. Examples
+See /docs/examples/basic/ and the IL equivalents in /docs/examples/il/.

--- a/docs/il-spec.md
+++ b/docs/il-spec.md
@@ -1,38 +1,196 @@
-# IL Specification
+IL v0.1.1 — Specification
+Status: Normative for VM + codegen MVP
+Compatibility: Supersedes v0.1 (tightened typing & traps; no breaking syntax changes)
+1. Design Goals
+Thin waist between multiple front ends and multiple back ends.
+Deterministic semantics so VM and native agree.
+Simple, explicit control flow (no fallthrough; one terminator per block).
+Small type system (i64, f64, i1, ptr, str).
+2. Module Structure (text)
+il 0.1.1
+target "x86_64-sysv"      ; optional; VM ignores
 
-## Introduction & design goals
-Overview of the intermediate language and the small, portable design goals.
+extern @rt_print_str(str) -> void
+global const str @.L0 = "HELLO"
 
-## Types
-Primitive and opaque types defined by the IL (see the [class catalog](class-catalog.md)).
+func @main() -> i32 {
+entry:
+  %s = const_str @.L0
+  call @rt_print_str(%s)
+  ret 0
+}
+Symbols: functions/globals @name, temporaries %tN, labels label:.
+Visibility: extern, global [const], func (public by default), internal (optional attribute).
+3. Types
+Kind | Meaning | Notes
+---- | ------- | -----
+void | no value | only as function return
+i1 | boolean | produced by comparisons & trunc1
+i64 | 64-bit signed int | wrap-on-overflow in add/sub/mul
+f64 | 64-bit IEEE | NaN/Inf propagate
+ptr | untyped pointer | byte-addressed
+str | opaque string handle | managed by runtime
+4. Constants & Literals
+Integers: -?[0-9]+
+Floats: -?[0-9]+(\.[0-9]+)? plus NaN, Inf, -Inf
+Bools: true/false (sugar for i1 1/0)
+Strings: "..." with escapes \" \\ \n \t \xNN
+Null pointer: const_null (ptr)
+5. Functions & Basic Blocks
+A function has parameters, return type, 1+ blocks.
+Exactly one terminator per block and none elsewhere.
+No implicit fallthrough; control flow uses br/cbr/ret.
+6. Instruction Set (typing & traps)
+Legend: ⟶ result type, Trap: runtime error condition.
+6.1 Integer arithmetic (wrap on overflow)
+%d = add %a:i64, %b:i64 ⟶ i64
+%d = sub %a:i64, %b:i64 ⟶ i64
+%d = mul %a:i64, %b:i64 ⟶ i64
+%d = sdiv %a:i64, %b:i64 ⟶ i64 Trap: b=0 or a=INT64_MIN, b=-1
+%d = udiv %a:i64, %b:i64 ⟶ i64 Trap: b=0
+%d = srem %a:i64, %b:i64 ⟶ i64 Trap: b=0
+%d = urem %a:i64, %b:i64 ⟶ i64 Trap: b=0
+Bitwise & shifts
+and/or/xor: i64 × i64 ⟶ i64
+shl/lshr/ashr: i64 × i64 ⟶ i64 (shift count masked mod 64)
+6.2 Floating arithmetic (IEEE-754)
+fadd/fsub/fmul/fdiv: f64 × f64 ⟶ f64 (NaN/Inf per IEEE)
+6.3 Comparisons (result i1)
+Integer equality: icmp_eq/icmp_ne (i64,i64)
+Signed: scmp_lt/le/gt/ge (i64,i64)
+Unsigned: ucmp_lt/le/gt/ge (i64,i64)
+Float: fcmp_lt/le/gt/ge/eq/ne (f64,f64) (NaN: eq false, ne true)
+6.4 Conversions
+sitofp (i64) ⟶ f64
+fptosi (f64) ⟶ i64 Trap: NaN or out-of-range
+zext1 (i1) ⟶ i64 (0/1 → 0/1)
+trunc1 (i64) ⟶ i1 (0 → 0, non-zero → 1)
+6.5 Memory & pointers
+%p = alloca %n:i64 ⟶ ptr (n ≥ 0; zero-initialized; frame-local)
+%q = gep %base:ptr, %off:i64 ⟶ ptr (q = base + off, no bounds checks)
+%v = load ty, %p:ptr ⟶ ty Trap: %p=null or misaligned for ty
+store ty, %p:ptr, %v:ty Trap: %p=null or misaligned
+%p = addr_of @global ⟶ ptr
+%p = const_null ⟶ ptr
+Alignment: natural alignment: i64/f64 → 8 bytes; str/ptr → pointer-size (8). Misaligned load/store trap.
+6.6 Calls & returns
+%r = call @f(arg1,…): (T1,…)->Tr
+ret (for void), ret %v:Tr otherwise.
+Arity and types must match the callee’s signature (verified).
+6.7 Control flow (terminators)
+br label %dst
+cbr %cond:i1, label %t, label %f
+ret [val]
+6.8 String & misc
+%s = const_str @.Lk ⟶ str
+trap — unconditional runtime error with diagnostic; abort program.
+7. Runtime ABI (minimum surface)
+C ABI functions (extern):
+@rt_print_str(str)->void
+@rt_print_i64(i64)->void
+@rt_print_f64(f64)->void
+@rt_input_line()->str
+@rt_len(str)->i64
+@rt_concat(str,str)->str
+@rt_substr(str,i64,i64)->str
+@rt_to_int(str)->i64
+@rt_to_float(str)->f64
+@rt_str_eq(str,str)->i1
+@rt_alloc(i64)->ptr
+@rt_free(ptr)->void         (optional in v0.1.1)
+Strings are ref-counted (implementation detail). rt_substr clamps to valid range; invalid (negative) parameters trap.
+8. Memory Model
+IL exposes no data races or concurrency primitives in v0.1.1.
+Pointers are plain addresses; no aliasing rules beyond type of load/store.
+alloca memory lives until function returns; zero-initialized.
+Null/misaligned load/store → trap.
+9. Verifier Rules
+Structure: each block ends with one terminator; entry is first block; labels referenced are defined in same function.
+Typing: operand and result types must match opcode signature.
+Calls: arity/types match callee signature; destination present only when return type ≠ void.
+Memory: load/store use ptr operand; data type not void.
+Alloca: size is i64 (non-negative if constant).
+Use-before-def (intra-block): a temp must be defined earlier in the same block. (Dominance across blocks deferred to later SSA pass.)
+10. Text Format Grammar (EBNF)
+module      ::= "il" version (target_decl)? (decl_or_def)*
+version     ::= number "." number
+target_decl ::= "target" string
 
-## Values & constants
-Describes temporaries, literals, and how constants are represented.
+decl_or_def ::= extern_decl | global_decl | func_def
+extern_decl ::= "extern" symbol "(" type_list? ")" "->" type
+global_decl ::= "global" ("const")? type symbol "=" ginit
+ginit       ::= string | int | float | "null" | symbol
 
-## Instructions
-Grouped by behavior:
-- Arithmetic: `add`, `sub`, `mul`, `sdiv`, `udiv`, `srem`, `urem`
-- Bitwise: `and`, `or`, `xor`, `shl`, `lshr`, `ashr`
-- Comparison: `icmp_eq`, `icmp_ne`, `scmp_*`, `ucmp_*`, `fcmp_*`
-- Memory: `alloca`, `load`, `store`, `gep`, `addr_of`
-- Control: `br`, `cbr`, `ret`, `trap`
-- Calls & constants: `call`, `const_str`, `const_null`
-- Conversion: `sitofp`, `fptosi`, `zext1`, `trunc1`
+func_def    ::= "func" symbol "(" params? ")" "->" type attr_list? "{" block+ "}"
+params      ::= param ("," param)*
+param       ::= ident ":" type
+type_list   ::= type ("," type)*
 
-## Control flow & functions
-Outlines how basic blocks form functions and how calls and returns transfer control.
+block       ::= label ":" instr* term
+label       ::= ident
+instr       ::= named | bare
+named       ::= temp "=" op
+bare        ::= term | "store" type "," value "," value | "call" symbol "(" args? ")"
 
-## Memory model & alignment
-Notes on stack slots, pointer operations, and alignment rules enforced by the IL.
+term        ::= "ret" | "ret" value
+             | "br" "label" value
+             | "cbr" value "," "label" value "," "label" value
 
-## Runtime ABI
-Summarizes calling conventions and how the IL interacts with the runtime library.
+op          ::= "add" value "," value
+             | "sub" value "," value
+             | "mul" value "," value
+             | "sdiv" value "," value
+             | "udiv" value "," value
+             | "srem" value "," value
+             | "urem" value "," value
+             | "and" value "," value
+             | "or"  value "," value
+             | "xor" value "," value
+             | "shl" value "," value
+             | "lshr" value "," value
+             | "ashr" value "," value
+             | "fadd" value "," value
+             | "fsub" value "," value
+             | "fmul" value "," value
+             | "fdiv" value "," value
+             | "icmp_eq" value "," value
+             | "icmp_ne" value "," value
+             | "scmp_lt" value "," value | "scmp_le" value "," value
+             | "scmp_gt" value "," value | "scmp_ge" value "," value
+             | "ucmp_lt" value "," value | "ucmp_le" value "," value
+             | "ucmp_gt" value "," value | "ucmp_ge" value "," value
+             | "fcmp_lt" value "," value | "fcmp_le" value "," value
+             | "fcmp_gt" value "," value | "fcmp_ge" value "," value
+             | "fcmp_eq" value "," value | "fcmp_ne" value "," value
+             | "sitofp" value
+             | "fptosi" value
+             | "zext1"  value
+             | "trunc1" value
+             | "alloca" value
+             | "gep" value "," value
+             | "load" type "," value
+             | "addr_of" symbol
+             | "const_str" symbol
+             | "const_null"
+             | "call" symbol "(" args? ")"
+             | "trap"
 
-## Verifier rules
-Key structural and typing checks that ensure modules are well formed.
-
-## Text grammar
-High-level outline of the text format grammar used by the parser and serializer.
-
-## Examples
-See [IL examples](examples/il/) for sample modules used in tests.
+args        ::= value ("," value)*
+value       ::= temp | symbol | literal
+temp        ::= "%" ident
+symbol      ::= "@" ident
+type        ::= "void" | "i1" | "i64" | "f64" | "ptr" | "str"
+11. Calling Convention (native back end target)
+Default target: x86-64 System V (Linux/macOS).
+Args: integers/pointers in rdi, rsi, rdx, rcx, r8, r9; floats in xmm0..7.
+Return: integer/pointer in rax; float in xmm0.
+Stack: 16-byte alignment at call sites.
+i1 passing: zero-extend to 32 bits (in line with SysV).
+12. Versioning
+Files must start with il 0.1.1.
+Future versions must not change the meaning of existing opcodes; additions are backwards-compatible.
+13. Conformance
+A VM or backend is conformant if it:
+Accepts grammar & passes verifier.
+Produces identical observable behavior (stdout, exit code) on the official sample suite under /docs/examples/il/.
+Traps on the listed conditions.


### PR DESCRIPTION
## Summary
- document BASIC v0.1 features and mapping to IL
- update IL specification to version 0.1.1 with detailed semantics

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure` *(fails: codegen_syntax_only, codegen_assemble_link, codegen_native_run)*

------
https://chatgpt.com/codex/tasks/task_e_68b275dd1af08324b596b65ec85bcffd