### PR TITLE
docs: add BASIC v0.1 reference and refine IL spec to v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ ctest --test-dir build -L Docs --output-on-failure
 
 ## Documentation
 - [Docs overview](docs/README.md)
-- [IL specification](docs/il-spec.md)
+- [IL v0.1.1 specification](docs/il-spec.md)
+- [BASIC v0.1 Language Reference](docs/basic-language-reference.md)
 - [Class catalog](docs/class-catalog.md)
 - [Project roadmap](docs/roadmap.md)
 - [Examples](docs/examples/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,8 @@ in [AGENTS.md](../AGENTS.md).
 
 ## Quick links
 
-- [IL specification](il-spec.md)
+- [IL v0.1.1 specification](il-spec.md)
+- [BASIC v0.1 Language Reference](basic-language-reference.md)
 - [Class catalog](class-catalog.md)
 - [Project roadmap](roadmap.md)
 - [Style guide](style-guide.md)


### PR DESCRIPTION
## Summary
- mention IL spec version 0.1.1 and add BASIC v0.1 language reference link in root README
- mirror those links in docs index for consistency

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build -E "codegen_.*" --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68b2779d35088324a3b8d83ece97bb73