### PR TITLE
feat(loc): propagate source locations through AST, IR, and VM

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(il_verify PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(il_vm STATIC vm/VM.cpp vm/RuntimeBridge.cpp)
 target_include_directories(il_vm PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(il_vm PUBLIC il_core rt)
+target_link_libraries(il_vm PUBLIC il_core rt support)
 
 add_library(il_codegen_x86_64 STATIC codegen/x86_64/placeholder.cpp)
 set_target_properties(il_codegen_x86_64 PROPERTIES LINKER_LANGUAGE CXX)

--- a/src/frontends/basic/Lowerer.h
+++ b/src/frontends/basic/Lowerer.h
@@ -72,6 +72,7 @@ private:
   std::unordered_map<std::string, unsigned> varSlots;
   std::unordered_map<std::string, std::string> strings;
   std::unordered_set<std::string> vars;
+  il::support::SourceLoc curLoc{}; ///< current source location for emitted IR
 };
 
 } // namespace il::frontends::basic

--- a/src/il/build/IRBuilder.cc
+++ b/src/il/build/IRBuilder.cc
@@ -50,32 +50,36 @@ bool IRBuilder::isTerminator(Opcode op) const {
   return op == Opcode::Br || op == Opcode::CBr || op == Opcode::Ret || op == Opcode::Trap;
 }
 
-Value IRBuilder::emitConstStr(const std::string &globalName) {
+Value IRBuilder::emitConstStr(const std::string &globalName, il::support::SourceLoc loc) {
   unsigned id = nextTemp++;
   Instr instr;
   instr.result = id;
   instr.op = Opcode::ConstStr;
   instr.type = Type(Type::Kind::Str);
   instr.operands.push_back(Value::global(globalName));
+  instr.loc = loc;
   append(std::move(instr));
   return Value::temp(id);
 }
 
-void IRBuilder::emitCall(const std::string &callee, const std::vector<Value> &args) {
+void IRBuilder::emitCall(const std::string &callee, const std::vector<Value> &args,
+                         il::support::SourceLoc loc) {
   Instr instr;
   instr.op = Opcode::Call;
   instr.type = Type(Type::Kind::Void);
   instr.callee = callee;
   instr.operands = args;
+  instr.loc = loc;
   append(std::move(instr));
 }
 
-void IRBuilder::emitRet(const std::optional<Value> &v) {
+void IRBuilder::emitRet(const std::optional<Value> &v, il::support::SourceLoc loc) {
   Instr instr;
   instr.op = Opcode::Ret;
   instr.type = Type(Type::Kind::Void);
   if (v)
     instr.operands.push_back(*v);
+  instr.loc = loc;
   append(std::move(instr));
 }
 

--- a/src/il/build/IRBuilder.h
+++ b/src/il/build/IRBuilder.h
@@ -9,6 +9,7 @@
 #include "il/core/Module.h"
 #include "il/core/Opcode.h"
 #include "il/core/Value.h"
+#include "support/source_manager.h"
 #include <optional>
 #include <vector>
 
@@ -56,16 +57,17 @@ public:
   /// @brief Emit reference to global string @p globalName.
   /// @param globalName Name of global string.
   /// @return Value representing constant string pointer.
-  Value emitConstStr(const std::string &globalName);
+  Value emitConstStr(const std::string &globalName, il::support::SourceLoc loc);
 
   /// @brief Emit call to function @p callee with arguments @p args.
   /// @param callee Name of function to call.
   /// @param args Argument values.
-  void emitCall(const std::string &callee, const std::vector<Value> &args);
+  void emitCall(const std::string &callee, const std::vector<Value> &args,
+                il::support::SourceLoc loc);
 
   /// @brief Emit return from current function.
   /// @param v Optional return value.
-  void emitRet(const std::optional<Value> &v = std::nullopt);
+  void emitRet(const std::optional<Value> &v, il::support::SourceLoc loc);
 
 private:
   Module &mod;                   ///< Module being constructed

--- a/src/il/core/Instr.h
+++ b/src/il/core/Instr.h
@@ -7,6 +7,7 @@
 #include "il/core/Opcode.h"
 #include "il/core/Type.h"
 #include "il/core/Value.h"
+#include "support/source_manager.h"
 #include <optional>
 #include <string>
 #include <vector>
@@ -21,6 +22,7 @@ struct Instr {
   std::vector<Value> operands;
   std::string callee;              ///< for call
   std::vector<std::string> labels; ///< for branch targets
+  il::support::SourceLoc loc;      ///< source location
 };
 
 } // namespace il::core

--- a/src/tools/il-dis/main.cpp
+++ b/src/tools/il-dis/main.cpp
@@ -16,9 +16,9 @@ int main() {
   auto &fn = builder.startFunction("main", il::core::Type(il::core::Type::Kind::I64), {});
   auto &bb = builder.addBlock(fn, "entry");
   builder.setInsertPoint(bb);
-  il::core::Value s0 = builder.emitConstStr(".L0");
-  builder.emitCall("rt_print_str", {s0});
-  builder.emitRet(il::core::Value::constInt(0));
+  il::core::Value s0 = builder.emitConstStr(".L0", {});
+  builder.emitCall("rt_print_str", {s0}, {});
+  builder.emitRet(il::core::Value::constInt(0), {});
   il::io::Serializer::write(m, std::cout);
   return 0;
 }

--- a/src/vm/RuntimeBridge.cpp
+++ b/src/vm/RuntimeBridge.cpp
@@ -6,6 +6,7 @@
 #include "vm/RuntimeBridge.h"
 #include "vm/VM.h"
 #include <cassert>
+#include <sstream>
 
 namespace il::vm {
 
@@ -29,6 +30,14 @@ Slot RuntimeBridge::call(const std::string &name, const std::vector<Slot> &args)
     assert(false && "unknown runtime call");
   }
   return res;
+}
+
+void RuntimeBridge::trap(const std::string &msg, const il::support::SourceLoc &loc,
+                         const std::string &fn, const std::string &block) {
+  std::ostringstream os;
+  os << msg << " in " << fn << ":" << block << " at " << loc.file_id << ":" << loc.line << ":"
+     << loc.column;
+  rt_trap(os.str().c_str());
 }
 
 } // namespace il::vm

--- a/src/vm/RuntimeBridge.h
+++ b/src/vm/RuntimeBridge.h
@@ -5,6 +5,7 @@
 // Links: docs/il-spec.md
 #pragma once
 #include "rt.h"
+#include "support/source_manager.h"
 #include <string>
 #include <vector>
 
@@ -20,6 +21,11 @@ public:
   /// @param args Evaluated argument slots.
   /// @return Result slot from runtime call.
   static Slot call(const std::string &name, const std::vector<Slot> &args);
+
+  /// @brief Report a trap with source location @p loc within function @p fn and
+  /// block @p block.
+  static void trap(const std::string &msg, const il::support::SourceLoc &loc, const std::string &fn,
+                   const std::string &block);
 };
 
 } // namespace il::vm

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -195,6 +195,10 @@ int64_t VM::execFunction(const Function &fn) {
       }
       break;
     }
+    case Opcode::Trap: {
+      RuntimeBridge::trap("trap", in.loc, fr.func->name, bb->label);
+      return 0; // unreachable
+    }
     default:
       assert(false && "unimplemented opcode");
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,6 +87,14 @@ add_executable(test_basic_lexer unit/test_basic_lexer.cpp)
 target_link_libraries(test_basic_lexer PRIVATE fe_basic support)
 add_test(NAME test_basic_lexer COMMAND test_basic_lexer)
 
+add_executable(test_basic_loc unit/test_basic_loc.cpp)
+target_link_libraries(test_basic_loc PRIVATE fe_basic il_build il_core support)
+add_test(NAME test_basic_loc COMMAND test_basic_loc)
+
+add_executable(test_vm_trap_loc unit/test_vm_trap_loc.cpp)
+target_link_libraries(test_vm_trap_loc PRIVATE il_build il_vm support)
+add_test(NAME test_vm_trap_loc COMMAND test_vm_trap_loc)
+
 
 set(BASIC_AST_DUMP $<TARGET_FILE:basic-ast-dump>)
 add_test(NAME basic_ast_ex1 COMMAND ${CMAKE_COMMAND}

--- a/tests/unit/test_basic_loc.cpp
+++ b/tests/unit/test_basic_loc.cpp
@@ -1,3 +1,9 @@
+// File: tests/unit/test_basic_loc.cpp
+// Purpose: Ensure BASIC AST and IL instructions retain source locations.
+// Key invariants: Locations must match expected columns.
+// Ownership: Test owns constructed AST and module.
+// Links: docs/class-catalog.md
+
 #include "frontends/basic/Lowerer.h"
 #include "frontends/basic/Parser.h"
 #include "support/source_manager.h"

--- a/tests/unit/test_basic_loc.cpp
+++ b/tests/unit/test_basic_loc.cpp
@@ -1,0 +1,43 @@
+#include "frontends/basic/Lowerer.h"
+#include "frontends/basic/Parser.h"
+#include "support/source_manager.h"
+#include <cassert>
+
+using namespace il::frontends::basic;
+using il::support::SourceManager;
+
+int main() {
+  SourceManager sm;
+  uint32_t fid = sm.addFile("test.bas");
+  std::string src = "PRINT 1+2\n";
+  Parser p(src, fid);
+  auto prog = p.parseProgram();
+  assert(prog->statements.size() == 1);
+  auto *ps = dynamic_cast<PrintStmt *>(prog->statements[0].get());
+  assert(ps);
+  assert(ps->loc.file_id == fid && ps->loc.line == 1 && ps->loc.column == 1);
+  auto *bin = dynamic_cast<BinaryExpr *>(ps->expr.get());
+  assert(bin);
+  assert(bin->loc.column == 8);
+  auto *lhs = dynamic_cast<IntExpr *>(bin->lhs.get());
+  auto *rhs = dynamic_cast<IntExpr *>(bin->rhs.get());
+  assert(lhs && rhs);
+  assert(lhs->loc.column == 7);
+  assert(rhs->loc.column == 9);
+
+  Lowerer low;
+  il::core::Module m = low.lower(*prog);
+  bool foundAdd = false;
+  for (const auto &fn : m.functions) {
+    for (const auto &bb : fn.blocks) {
+      for (const auto &in : bb.instructions) {
+        if (in.op == il::core::Opcode::Add) {
+          assert(in.loc.line == 1 && in.loc.column == 8);
+          foundAdd = true;
+        }
+      }
+    }
+  }
+  assert(foundAdd);
+  return 0;
+}

--- a/tests/unit/test_il_serialize.cpp
+++ b/tests/unit/test_il_serialize.cpp
@@ -13,9 +13,9 @@ int main() {
   auto &fn = builder.startFunction("main", il::core::Type(il::core::Type::Kind::I64), {});
   auto &bb = builder.addBlock(fn, "entry");
   builder.setInsertPoint(bb);
-  il::core::Value s0 = builder.emitConstStr(".L0");
-  builder.emitCall("rt_print_str", {s0});
-  builder.emitRet(il::core::Value::constInt(0));
+  il::core::Value s0 = builder.emitConstStr(".L0", {});
+  builder.emitCall("rt_print_str", {s0}, {});
+  builder.emitRet(il::core::Value::constInt(0), {});
   std::string out = il::io::Serializer::toString(m);
   std::ifstream in(std::string(TESTS_DIR) + "/golden/hello_expected.il");
   std::stringstream buf;

--- a/tests/unit/test_vm_trap_loc.cpp
+++ b/tests/unit/test_vm_trap_loc.cpp
@@ -1,3 +1,9 @@
+// File: tests/unit/test_vm_trap_loc.cpp
+// Purpose: Verify VM trap messages include instruction source locations.
+// Key invariants: Trap output must reference function, block, and location.
+// Ownership: Test constructs IL module and executes VM.
+// Links: docs/class-catalog.md
+
 #include "il/build/IRBuilder.h"
 #include "vm/VM.h"
 #include <cassert>

--- a/tests/unit/test_vm_trap_loc.cpp
+++ b/tests/unit/test_vm_trap_loc.cpp
@@ -1,0 +1,43 @@
+#include "il/build/IRBuilder.h"
+#include "vm/VM.h"
+#include <cassert>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main() {
+  il::core::Module m;
+  il::build::IRBuilder b(m);
+  auto &fn = b.startFunction("main", il::core::Type(il::core::Type::Kind::I64), {});
+  auto &bb = b.addBlock(fn, "entry");
+  b.setInsertPoint(bb);
+  il::core::Instr in;
+  in.op = il::core::Opcode::Trap;
+  in.type = il::core::Type(il::core::Type::Kind::Void);
+  in.loc = {1, 1, 1};
+  bb.instructions.push_back(in);
+  int fds[2];
+  assert(pipe(fds) == 0);
+  pid_t pid = fork();
+  assert(pid >= 0);
+  if (pid == 0) {
+    close(fds[0]);
+    dup2(fds[1], 2);
+    il::vm::VM vm(m);
+    vm.run();
+    _exit(0);
+  }
+  close(fds[1]);
+  char buf[256];
+  ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
+  if (n > 0)
+    buf[n] = '\0';
+  else
+    buf[0] = '\0';
+  int status = 0;
+  waitpid(pid, &status, 0);
+  std::string out(buf);
+  bool ok = out.find("trap in main:entry at 1:1:1") != std::string::npos;
+  assert(ok);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- record `SourceLoc` on BASIC AST nodes during parsing
- extend IL instructions and builder APIs to carry source locations
- plumb locations through lowering and VM traps with contextual messages
- add tests ensuring AST, IL, and VM keep correct line/column info

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --output-on-failure` *(fails: codegen_syntax_only, codegen_assemble_link, codegen_native_run)*

------
https://chatgpt.com/codex/tasks/task_e_68b28154a02883249b451696bca3d905