### PR TITLE
feat(frontend/basic): add semantic analyzer skeleton

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,7 +51,8 @@ add_library(fe_basic STATIC
   frontends/basic/Parser.cpp
   frontends/basic/NameMangler.cpp
   frontends/basic/LoweringContext.cpp
-  frontends/basic/Lowerer.cpp)
+  frontends/basic/Lowerer.cpp
+  frontends/basic/SemanticAnalyzer.cpp)
 target_link_libraries(fe_basic PUBLIC support il_build il_core)
 target_include_directories(fe_basic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/frontends/basic/SemanticAnalyzer.cpp
+++ b/src/frontends/basic/SemanticAnalyzer.cpp
@@ -1,0 +1,84 @@
+// File: src/frontends/basic/SemanticAnalyzer.cpp
+// Purpose: Implements BASIC semantic analyzer that collects symbols and labels.
+// Key invariants: Analyzer mutates internal sets but emits no diagnostics yet.
+// Ownership/Lifetime: Borrowed DiagnosticEngine; AST nodes owned externally.
+// Links: docs/class-catalog.md
+#include "frontends/basic/SemanticAnalyzer.h"
+#include <functional>
+
+namespace il::frontends::basic {
+
+void SemanticAnalyzer::analyze(const Program &prog) {
+  symbols_.clear();
+  labels_.clear();
+  labelRefs_.clear();
+  for (const auto &stmt : prog.statements) {
+    if (stmt)
+      labels_.insert(stmt->line);
+    if (stmt)
+      visitStmt(*stmt);
+  }
+}
+
+void SemanticAnalyzer::visitStmt(const Stmt &s) {
+  if (auto *p = dynamic_cast<const PrintStmt *>(&s)) {
+    if (p->expr)
+      visitExpr(*p->expr);
+  } else if (auto *l = dynamic_cast<const LetStmt *>(&s)) {
+    symbols_.insert(l->name);
+    if (l->expr)
+      visitExpr(*l->expr);
+  } else if (auto *i = dynamic_cast<const IfStmt *>(&s)) {
+    if (i->cond)
+      visitExpr(*i->cond);
+    if (i->then_branch)
+      visitStmt(*i->then_branch);
+    if (i->else_branch)
+      visitStmt(*i->else_branch);
+  } else if (auto *w = dynamic_cast<const WhileStmt *>(&s)) {
+    if (w->cond)
+      visitExpr(*w->cond);
+    for (const auto &bs : w->body)
+      if (bs)
+        visitStmt(*bs);
+  } else if (auto *f = dynamic_cast<const ForStmt *>(&s)) {
+    symbols_.insert(f->var);
+    if (f->start)
+      visitExpr(*f->start);
+    if (f->end)
+      visitExpr(*f->end);
+    if (f->step)
+      visitExpr(*f->step);
+    for (const auto &bs : f->body)
+      if (bs)
+        visitStmt(*bs);
+  } else if (auto *n = dynamic_cast<const NextStmt *>(&s)) {
+    symbols_.insert(n->var);
+  } else if (auto *g = dynamic_cast<const GotoStmt *>(&s)) {
+    labelRefs_.insert(g->target);
+  } else if (dynamic_cast<const EndStmt *>(&s)) {
+    // nothing
+  }
+}
+
+void SemanticAnalyzer::visitExpr(const Expr &e) {
+  if (auto *v = dynamic_cast<const VarExpr *>(&e)) {
+    symbols_.insert(v->name);
+  } else if (auto *u = dynamic_cast<const UnaryExpr *>(&e)) {
+    if (u->expr)
+      visitExpr(*u->expr);
+  } else if (auto *b = dynamic_cast<const BinaryExpr *>(&e)) {
+    if (b->lhs)
+      visitExpr(*b->lhs);
+    if (b->rhs)
+      visitExpr(*b->rhs);
+  } else if (auto *c = dynamic_cast<const CallExpr *>(&e)) {
+    for (const auto &a : c->args)
+      if (a)
+        visitExpr(*a);
+  } else {
+    // IntExpr, StringExpr etc. have no symbols
+  }
+}
+
+} // namespace il::frontends::basic

--- a/src/frontends/basic/SemanticAnalyzer.h
+++ b/src/frontends/basic/SemanticAnalyzer.h
@@ -1,0 +1,46 @@
+// File: src/frontends/basic/SemanticAnalyzer.h
+// Purpose: Declares BASIC semantic analyzer for symbol and label tracking.
+// Key invariants: Analyzer only records symbols and labels; no validation yet.
+// Ownership/Lifetime: Analyzer borrows DiagnosticEngine; no AST ownership.
+// Links: docs/class-catalog.md
+#pragma once
+#include "frontends/basic/AST.h"
+#include "support/diagnostics.h"
+#include <string>
+#include <unordered_set>
+
+namespace il::frontends::basic {
+
+/// @brief Traverses BASIC AST to collect symbols and labels.
+/// @invariant Does not emit diagnostics for now.
+/// @ownership Borrows DiagnosticEngine; AST not owned.
+class SemanticAnalyzer {
+public:
+  /// @brief Create analyzer reporting to @p de.
+  explicit SemanticAnalyzer(il::support::DiagnosticEngine &de) : de(de) {}
+
+  /// @brief Analyze @p prog collecting symbols and labels.
+  /// @param prog Program AST to walk.
+  void analyze(const Program &prog);
+
+  /// @brief Collected variable names.
+  const std::unordered_set<std::string> &symbols() const { return symbols_; }
+
+  /// @brief Line numbers present in the program.
+  const std::unordered_set<int> &labels() const { return labels_; }
+
+  /// @brief GOTO targets referenced in the program.
+  const std::unordered_set<int> &labelRefs() const { return labelRefs_; }
+
+private:
+  void visitStmt(const Stmt &s);
+  void visitExpr(const Expr &e);
+
+  il::support::DiagnosticEngine &de; ///< Diagnostic sink (unused for now).
+  std::unordered_set<std::string> symbols_;
+  std::unordered_set<int> labels_;
+  std::unordered_set<int> labelRefs_;
+};
+
+} // namespace il::frontends::basic
+

--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -5,6 +5,7 @@
 // Links: docs/class-catalog.md
 #include "frontends/basic/Lowerer.h"
 #include "frontends/basic/Parser.h"
+#include "frontends/basic/SemanticAnalyzer.h"
 #include "il/io/Parser.h"
 #include "il/io/Serializer.h"
 #include "il/verify/Verifier.h"
@@ -101,6 +102,13 @@ int main(int argc, char **argv) {
       uint32_t fid = sm.addFile(file);
       Parser p(src, fid);
       auto prog = p.parseProgram();
+      support::DiagnosticEngine de;
+      SemanticAnalyzer sema(de);
+      sema.analyze(*prog);
+      if (de.errorCount() > 0) {
+        de.printAll(std::cerr, &sm);
+        return 1;
+      }
       Lowerer lower;
       core::Module m = lower.lower(*prog);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,6 +91,10 @@ add_executable(test_basic_loc unit/test_basic_loc.cpp)
 target_link_libraries(test_basic_loc PRIVATE fe_basic il_build il_core support)
 add_test(NAME test_basic_loc COMMAND test_basic_loc)
 
+add_executable(test_basic_semantic unit/test_basic_semantic.cpp)
+target_link_libraries(test_basic_semantic PRIVATE fe_basic support)
+add_test(NAME test_basic_semantic COMMAND test_basic_semantic)
+
 add_executable(test_vm_trap_loc unit/test_vm_trap_loc.cpp)
 target_link_libraries(test_vm_trap_loc PRIVATE il_build il_vm support)
 add_test(NAME test_vm_trap_loc COMMAND test_vm_trap_loc)

--- a/tests/unit/test_basic_semantic.cpp
+++ b/tests/unit/test_basic_semantic.cpp
@@ -1,0 +1,27 @@
+#include "frontends/basic/Parser.h"
+#include "frontends/basic/SemanticAnalyzer.h"
+#include "support/source_manager.h"
+#include <cassert>
+#include <string>
+
+using namespace il::frontends::basic;
+using namespace il::support;
+
+int main() {
+  std::string src = "10 LET X = 1\n20 END\n";
+  SourceManager sm;
+  uint32_t fid = sm.addFile("test.bas");
+  Parser p(src, fid);
+  auto prog = p.parseProgram();
+
+  DiagnosticEngine de;
+  SemanticAnalyzer sema(de);
+  sema.analyze(*prog);
+  assert(de.errorCount() == 0);
+  assert(de.warningCount() == 0);
+  assert(sema.symbols().count("X") == 1);
+  assert(sema.labels().count(10) == 1);
+  assert(sema.labels().count(20) == 1);
+  assert(sema.labelRefs().empty());
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add SemanticAnalyzer to BASIC front end to collect symbols and labels
- invoke semantic analyzer from `ilc` BASIC driver
- add unit test ensuring analyzer runs without diagnostics

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b285c9561083249185197e75d5ffcc