### PR TITLE
feat(fe/basic): add diagnostic emitter with caret formatting

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,7 +52,8 @@ add_library(fe_basic STATIC
   frontends/basic/NameMangler.cpp
   frontends/basic/LoweringContext.cpp
   frontends/basic/Lowerer.cpp
-  frontends/basic/SemanticAnalyzer.cpp)
+  frontends/basic/SemanticAnalyzer.cpp
+  frontends/basic/DiagnosticEmitter.cpp)
 target_link_libraries(fe_basic PUBLIC support il_build il_core)
 target_include_directories(fe_basic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/frontends/basic/DiagnosticEmitter.cpp
+++ b/src/frontends/basic/DiagnosticEmitter.cpp
@@ -1,0 +1,71 @@
+// File: src/frontends/basic/DiagnosticEmitter.cpp
+// Purpose: Implements BASIC diagnostic formatting with codes and carets.
+// Key invariants: Diagnostics printed in emission order.
+// Ownership/Lifetime: Holds copies of source text; borrows engine and manager.
+// Links: docs/class-catalog.md
+#include "frontends/basic/DiagnosticEmitter.h"
+#include <algorithm>
+#include <sstream>
+
+namespace il::frontends::basic {
+
+DiagnosticEmitter::DiagnosticEmitter(il::support::DiagnosticEngine &de,
+                                     const il::support::SourceManager &sm)
+    : de_(de), sm_(sm) {}
+
+void DiagnosticEmitter::addSource(uint32_t fileId, std::string source) {
+  sources_[fileId] = std::move(source);
+}
+
+void DiagnosticEmitter::emit(il::support::Severity sev, std::string code,
+                             il::support::SourceLoc loc, uint32_t length, std::string message) {
+  de_.report({sev, message, loc});
+  entries_.push_back({sev, std::move(code), std::move(message), loc, length});
+}
+
+static const char *toString(il::support::Severity s) {
+  using il::support::Severity;
+  switch (s) {
+  case Severity::Note:
+    return "note";
+  case Severity::Warning:
+    return "warning";
+  case Severity::Error:
+    return "error";
+  }
+  return "";
+}
+
+std::string DiagnosticEmitter::getLine(uint32_t fileId, uint32_t line) const {
+  auto it = sources_.find(fileId);
+  if (it == sources_.end())
+    return {};
+  const std::string &src = it->second;
+  size_t start = 0;
+  for (uint32_t l = 1; l < line; ++l) {
+    size_t pos = src.find('\n', start);
+    if (pos == std::string::npos)
+      return {};
+    start = pos + 1;
+  }
+  size_t end = src.find('\n', start);
+  if (end == std::string::npos)
+    end = src.size();
+  return src.substr(start, end - start);
+}
+
+void DiagnosticEmitter::printAll(std::ostream &os) const {
+  for (const auto &e : entries_) {
+    auto path = sm_.getPath(e.loc.file_id);
+    os << path << ':' << e.loc.line << ':' << e.loc.column << ": " << toString(e.severity) << '['
+       << e.code << "]: " << e.message << '\n';
+    std::string line = getLine(e.loc.file_id, e.loc.line);
+    if (!line.empty()) {
+      os << line << '\n';
+      uint32_t caretLen = e.length == 0 ? 1 : e.length;
+      os << std::string(e.loc.column - 1, ' ') << std::string(caretLen, '^') << '\n';
+    }
+  }
+}
+
+} // namespace il::frontends::basic

--- a/src/frontends/basic/DiagnosticEmitter.cpp
+++ b/src/frontends/basic/DiagnosticEmitter.cpp
@@ -23,6 +23,9 @@ void DiagnosticEmitter::emit(il::support::Severity sev, std::string code,
   entries_.push_back({sev, std::move(code), std::move(message), loc, length});
 }
 
+/// @brief Convert severity enum to human-readable string.
+/// @param s Severity to convert.
+/// @return Null-terminated severity name.
 static const char *toString(il::support::Severity s) {
   using il::support::Severity;
   switch (s) {
@@ -36,6 +39,10 @@ static const char *toString(il::support::Severity s) {
   return "";
 }
 
+/// @brief Retrieve a specific line from stored source text.
+/// @param fileId Source file identifier.
+/// @param line 1-based line number to fetch.
+/// @return Line contents or empty string if unavailable.
 std::string DiagnosticEmitter::getLine(uint32_t fileId, uint32_t line) const {
   auto it = sources_.find(fileId);
   if (it == sources_.end())

--- a/src/frontends/basic/DiagnosticEmitter.h
+++ b/src/frontends/basic/DiagnosticEmitter.h
@@ -48,6 +48,7 @@ public:
   size_t warningCount() const { return de_.warningCount(); }
 
 private:
+  /// @brief Diagnostic record captured for later printing.
   struct Entry {
     il::support::Severity severity; ///< Diagnostic severity.
     std::string code;               ///< Error code like B1001.
@@ -56,12 +57,16 @@ private:
     uint32_t length;                ///< Number of characters to mark.
   };
 
+  /// @brief Retrieve full line text for @p fileId at @p line.
+  /// @param fileId Identifier from SourceManager.
+  /// @param line 1-based line number to fetch.
+  /// @return Line contents without trailing newline; empty if unavailable.
   std::string getLine(uint32_t fileId, uint32_t line) const;
 
-  il::support::DiagnosticEngine &de_;
-  const il::support::SourceManager &sm_;
-  std::vector<Entry> entries_;
-  std::unordered_map<uint32_t, std::string> sources_;
+  il::support::DiagnosticEngine &de_;                 ///< Underlying diagnostic engine.
+  const il::support::SourceManager &sm_;              ///< Source manager for file paths.
+  std::vector<Entry> entries_;                        ///< Diagnostics in emission order.
+  std::unordered_map<uint32_t, std::string> sources_; ///< Source text per file id.
 };
 
 } // namespace il::frontends::basic

--- a/src/frontends/basic/DiagnosticEmitter.h
+++ b/src/frontends/basic/DiagnosticEmitter.h
@@ -1,0 +1,67 @@
+// File: src/frontends/basic/DiagnosticEmitter.h
+// Purpose: Wraps DiagnosticEngine to format BASIC diagnostics with codes and carets.
+// Key invariants: Stored diagnostics maintain emission order.
+// Ownership/Lifetime: Borrows DiagnosticEngine and SourceManager; owns source copies.
+// Links: docs/class-catalog.md
+#pragma once
+#include "support/diagnostics.h"
+#include "support/source_manager.h"
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace il::frontends::basic {
+
+/// @brief Formats BASIC diagnostics with error codes and caret ranges.
+/// @invariant Diagnostics are emitted in order and printed with original source line.
+/// @ownership Borrows DiagnosticEngine and SourceManager; copies source text per file id.
+class DiagnosticEmitter {
+public:
+  /// @brief Create emitter forwarding counts to @p de and using @p sm for file paths.
+  /// @param de Diagnostic engine collecting counts.
+  /// @param sm Source manager providing file paths.
+  DiagnosticEmitter(il::support::DiagnosticEngine &de, const il::support::SourceManager &sm);
+
+  /// @brief Register source text for a file id.
+  /// @param fileId Identifier from SourceManager.
+  /// @param source Full contents of the source file.
+  void addSource(uint32_t fileId, std::string source);
+
+  /// @brief Emit diagnostic with @p code at @p loc covering @p length characters.
+  /// @param sev Severity level.
+  /// @param code BASIC error code (e.g., B1001).
+  /// @param loc Start location of the diagnostic.
+  /// @param length Number of characters to underline (0 -> 1 caret).
+  /// @param message Human-readable explanation.
+  void emit(il::support::Severity sev, std::string code, il::support::SourceLoc loc,
+            uint32_t length, std::string message);
+
+  /// @brief Print all diagnostics to @p os with source snippets.
+  /// @param os Output stream.
+  void printAll(std::ostream &os) const;
+
+  /// @brief Number of errors reported.
+  size_t errorCount() const { return de_.errorCount(); }
+
+  /// @brief Number of warnings reported.
+  size_t warningCount() const { return de_.warningCount(); }
+
+private:
+  struct Entry {
+    il::support::Severity severity; ///< Diagnostic severity.
+    std::string code;               ///< Error code like B1001.
+    std::string message;            ///< Description text.
+    il::support::SourceLoc loc;     ///< Start source location.
+    uint32_t length;                ///< Number of characters to mark.
+  };
+
+  std::string getLine(uint32_t fileId, uint32_t line) const;
+
+  il::support::DiagnosticEngine &de_;
+  const il::support::SourceManager &sm_;
+  std::vector<Entry> entries_;
+  std::unordered_map<uint32_t, std::string> sources_;
+};
+
+} // namespace il::frontends::basic

--- a/src/frontends/basic/SemanticAnalyzer.h
+++ b/src/frontends/basic/SemanticAnalyzer.h
@@ -3,11 +3,11 @@
 //          basic validation, and rudimentary type checking.
 // Key invariants: Analyzer tracks defined symbols and reports unknown
 //                 references.
-// Ownership/Lifetime: Analyzer borrows DiagnosticEngine; no AST ownership.
+// Ownership/Lifetime: Analyzer borrows DiagnosticEmitter; no AST ownership.
 // Links: docs/class-catalog.md
 #pragma once
 #include "frontends/basic/AST.h"
-#include "support/diagnostics.h"
+#include "frontends/basic/DiagnosticEmitter.h"
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -19,11 +19,11 @@ namespace il::frontends::basic {
 ///        references, and verify FOR/NEXT nesting.
 /// @invariant Symbol table only contains definitions; unknown uses report
 ///            diagnostics.
-/// @ownership Borrows DiagnosticEngine; AST not owned.
+/// @ownership Borrows DiagnosticEmitter; AST not owned.
 class SemanticAnalyzer {
 public:
   /// @brief Create analyzer reporting to @p de.
-  explicit SemanticAnalyzer(il::support::DiagnosticEngine &de) : de(de) {}
+  explicit SemanticAnalyzer(DiagnosticEmitter &de) : de(de) {}
 
   /// @brief Analyze @p prog collecting symbols and labels.
   /// @param prog Program AST to walk.
@@ -51,7 +51,7 @@ private:
   /// @return Inferred type of the expression.
   Type visitExpr(const Expr &e);
 
-  il::support::DiagnosticEngine &de; ///< Diagnostic sink.
+  DiagnosticEmitter &de; ///< Diagnostic sink.
   std::unordered_set<std::string> symbols_;
   std::unordered_map<std::string, Type> varTypes_;
   std::unordered_set<int> labels_;

--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -3,6 +3,7 @@
 // Key invariants: None.
 // Ownership/Lifetime: Tool owns loaded modules.
 // Links: docs/class-catalog.md
+#include "frontends/basic/DiagnosticEmitter.h"
 #include "frontends/basic/Lowerer.h"
 #include "frontends/basic/Parser.h"
 #include "frontends/basic/SemanticAnalyzer.h"
@@ -103,10 +104,12 @@ int main(int argc, char **argv) {
       Parser p(src, fid);
       auto prog = p.parseProgram();
       support::DiagnosticEngine de;
-      SemanticAnalyzer sema(de);
+      DiagnosticEmitter em(de, sm);
+      em.addSource(fid, src);
+      SemanticAnalyzer sema(em);
       sema.analyze(*prog);
-      if (de.errorCount() > 0) {
-        de.printAll(std::cerr, &sm);
+      if (em.errorCount() > 0) {
+        em.printAll(std::cerr);
         return 1;
       }
       Lowerer lower;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,6 +95,10 @@ add_executable(test_basic_semantic unit/test_basic_semantic.cpp)
 target_link_libraries(test_basic_semantic PRIVATE fe_basic support)
 add_test(NAME test_basic_semantic COMMAND test_basic_semantic)
 
+add_executable(test_basic_diagnostic unit/test_basic_diagnostic.cpp)
+target_link_libraries(test_basic_diagnostic PRIVATE fe_basic support)
+add_test(NAME test_basic_diagnostic COMMAND test_basic_diagnostic)
+
 add_executable(test_vm_trap_loc unit/test_vm_trap_loc.cpp)
 target_link_libraries(test_vm_trap_loc PRIVATE il_build il_vm support)
 add_test(NAME test_vm_trap_loc COMMAND test_vm_trap_loc)

--- a/tests/unit/test_basic_diagnostic.cpp
+++ b/tests/unit/test_basic_diagnostic.cpp
@@ -1,6 +1,6 @@
-// File: tests/unit/test_basic_semantic.cpp
-// Purpose: Unit test verifying BASIC semantic analyzer runs without diagnostics.
-// Key invariants: Analyzer collects symbols and labels without emitting messages.
+// File: tests/unit/test_basic_diagnostic.cpp
+// Purpose: Ensure DiagnosticEmitter formats BASIC diagnostics with carets and codes.
+// Key invariants: Output contains error code and caret underlined range.
 // Ownership/Lifetime: Test owns all objects locally.
 // Links: docs/class-catalog.md
 
@@ -9,13 +9,14 @@
 #include "frontends/basic/SemanticAnalyzer.h"
 #include "support/source_manager.h"
 #include <cassert>
+#include <sstream>
 #include <string>
 
 using namespace il::frontends::basic;
 using namespace il::support;
 
 int main() {
-  std::string src = "10 LET X = 1\n20 END\n";
+  std::string src = "10 PRINT X\n20 END\n";
   SourceManager sm;
   uint32_t fid = sm.addFile("test.bas");
   Parser p(src, fid);
@@ -26,11 +27,13 @@ int main() {
   em.addSource(fid, src);
   SemanticAnalyzer sema(em);
   sema.analyze(*prog);
-  assert(em.errorCount() == 0);
-  assert(em.warningCount() == 0);
-  assert(sema.symbols().count("X") == 1);
-  assert(sema.labels().count(10) == 1);
-  assert(sema.labels().count(20) == 1);
-  assert(sema.labelRefs().empty());
+
+  std::ostringstream oss;
+  em.printAll(oss);
+  std::string out = oss.str();
+  assert(em.errorCount() == 1);
+  assert(out.find("error[B1001]") != std::string::npos);
+  assert(out.find("unknown variable 'X'") != std::string::npos);
+  assert(out.find("^") != std::string::npos);
   return 0;
 }


### PR DESCRIPTION
## Summary
- add `DiagnosticEmitter` to format BASIC diagnostics with codes and caret ranges
- switch BASIC semantic analyzer and `ilc` to use `DiagnosticEmitter`
- cover diagnostic formatting with new unit test

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b290cdbf348324bd566e0242f788de