### PR TITLE
feat(vm): propagate instruction locations in traps

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -5,13 +5,17 @@
 #include <stdlib.h>
 #include <string.h>
 
-void rt_trap(const char *msg) {
+void rt_abort(const char *msg) {
   if (msg)
     fprintf(stderr, "runtime trap: %s\n", msg);
   else
     fprintf(stderr, "runtime trap\n");
   exit(1);
 }
+
+__attribute__((weak)) void vm_trap(const char *msg) { rt_abort(msg); }
+
+void rt_trap(const char *msg) { vm_trap(msg); }
 
 void *rt_alloc(int64_t bytes) {
   void *p = malloc((size_t)bytes);

--- a/runtime/rt.h
+++ b/runtime/rt.h
@@ -20,6 +20,10 @@ typedef struct rt_str_impl {
 /// @param msg Null-terminated message string.
 void rt_trap(const char *msg);
 
+/// @brief Print trap message and terminate process.
+/// @param msg Null-terminated message string.
+void rt_abort(const char *msg);
+
 /// @brief Print string @p s to stdout.
 /// @param s Reference-counted string.
 void rt_print_str(rt_str s);

--- a/src/vm/RuntimeBridge.h
+++ b/src/vm/RuntimeBridge.h
@@ -19,8 +19,13 @@ public:
   /// @brief Invoke runtime function @p name with arguments @p args.
   /// @param name Runtime function symbol.
   /// @param args Evaluated argument slots.
+  /// @param loc Source location of call instruction.
+  /// @param fn Calling function name.
+  /// @param block Calling block label.
   /// @return Result slot from runtime call.
-  static Slot call(const std::string &name, const std::vector<Slot> &args);
+  static Slot call(const std::string &name, const std::vector<Slot> &args,
+                   const il::support::SourceLoc &loc, const std::string &fn,
+                   const std::string &block);
 
   /// @brief Report a trap with source location @p loc within function @p fn and
   /// block @p block.

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -187,7 +187,7 @@ int64_t VM::execFunction(const Function &fn) {
       std::vector<Slot> args;
       for (const auto &op : in.operands)
         args.push_back(eval(fr, op));
-      Slot res = RuntimeBridge::call(in.callee, args);
+      Slot res = RuntimeBridge::call(in.callee, args, in.loc, fr.func->name, bb->label);
       if (in.result) {
         if (fr.regs.size() <= *in.result)
           fr.regs.resize(*in.result + 1);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,6 +103,10 @@ add_executable(test_vm_trap_loc unit/test_vm_trap_loc.cpp)
 target_link_libraries(test_vm_trap_loc PRIVATE il_build il_vm support)
 add_test(NAME test_vm_trap_loc COMMAND test_vm_trap_loc)
 
+add_executable(test_vm_rt_trap_loc unit/test_vm_rt_trap_loc.cpp)
+target_link_libraries(test_vm_rt_trap_loc PRIVATE il_build il_vm support)
+add_test(NAME test_vm_rt_trap_loc COMMAND test_vm_rt_trap_loc)
+
 
 set(BASIC_AST_DUMP $<TARGET_FILE:basic-ast-dump>)
 add_test(NAME basic_ast_ex1 COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
## Summary
- forward call source locations through `RuntimeBridge` so runtime traps know the calling function and block
- format trap messages as `function: block (file:line:col)` and surface them in VM
- add unit tests covering VM and runtime-originated traps with location info

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b2942313d883248fa17f72c194993d