### PR TITLE
feat(frontend/basic+cli): add INPUT stmt and stdin redirection

### DIFF
--- a/docs/basic-language-reference.md
+++ b/docs/basic-language-reference.md
@@ -49,7 +49,9 @@ WHILE cond ... WEND
 FOR var = start TO end [STEP s] ... NEXT var
 GOTO lineNumber
 END — terminate program
-INPUT var$ (optional if runtime wired) — reads a line into a string variable
+INPUT var$ | INPUT var — read a line from stdin. For NAME$ variables the line is stored
+as-is (leading/trailing spaces kept). For integer variables the line is trimmed and
+converted via VAL; invalid numbers trap.
 6. Variables & Names
 Names: [A-Za-z][A-Za-z0-9_]* with optional $ suffix for strings (NAME$).
 Type inference:
@@ -92,6 +94,7 @@ LEN(S$) | call @rt_len(%s) | rt_len(str)->i64
 MID$(S$,i,l) | call @rt_substr(%s, i-1, l) | rt_substr(str,i64,i64)->str
 VAL(S$) | call @rt_to_int(%s) | rt_to_int(str)->i64
 INPUT A$ | %s = call @rt_input_line(); store A$, %s | rt_input_line()->str
+INPUT N | %s = call @rt_input_line(); %n = call @rt_to_int(%s); store N, %n | rt_input_line()->str; rt_to_int(str)->i64
 Indexing: BASIC’s 1-based indices are lowered to 0-based for runtime calls (subtract 1).
 11. Examples
 See /docs/examples/basic/ and the IL equivalents in /docs/examples/il/.

--- a/docs/examples/basic/ex5_input_echo.bas
+++ b/docs/examples/basic/ex5_input_echo.bas
@@ -1,0 +1,3 @@
+10 INPUT A$
+20 PRINT A$
+30 END

--- a/src/frontends/basic/AST.h
+++ b/src/frontends/basic/AST.h
@@ -98,6 +98,10 @@ struct GotoStmt : Stmt {
   int target;
 };
 struct EndStmt : Stmt {};
+/// @brief INPUT statement to read from stdin into a variable.
+struct InputStmt : Stmt {
+  std::string var; ///< Target variable name (may end with '$').
+};
 
 struct Program {
   std::vector<StmtPtr> statements;

--- a/src/frontends/basic/Lexer.cpp
+++ b/src/frontends/basic/Lexer.cpp
@@ -79,6 +79,8 @@ Token Lexer::lexIdentifierOrKeyword() {
     return {TokenKind::KeywordGoto, s, loc};
   if (s == "END")
     return {TokenKind::KeywordEnd, s, loc};
+  if (s == "INPUT")
+    return {TokenKind::KeywordInput, s, loc};
   if (s == "AND")
     return {TokenKind::KeywordAnd, s, loc};
   if (s == "OR")

--- a/src/frontends/basic/Lowerer.h
+++ b/src/frontends/basic/Lowerer.h
@@ -47,6 +47,7 @@ private:
   void lowerNext(const NextStmt &stmt);
   void lowerGoto(const GotoStmt &stmt);
   void lowerEnd(const EndStmt &stmt);
+  void lowerInput(const InputStmt &stmt);
 
   // helpers
   Value emitAlloca(int bytes);

--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -65,6 +65,8 @@ StmtPtr Parser::parseStatement(int line) {
     return parseGoto();
   if (check(TokenKind::KeywordEnd))
     return parseEnd();
+  if (check(TokenKind::KeywordInput))
+    return parseInput();
   auto stmt = std::make_unique<EndStmt>();
   stmt->loc = current_.loc;
   return stmt;
@@ -236,6 +238,17 @@ StmtPtr Parser::parseEnd() {
   advance(); // END
   auto stmt = std::make_unique<EndStmt>();
   stmt->loc = loc;
+  return stmt;
+}
+
+StmtPtr Parser::parseInput() {
+  il::support::SourceLoc loc = current_.loc;
+  advance(); // INPUT
+  std::string name = current_.lexeme;
+  consume(TokenKind::Identifier);
+  auto stmt = std::make_unique<InputStmt>();
+  stmt->loc = loc;
+  stmt->var = name;
   return stmt;
 }
 

--- a/src/frontends/basic/Parser.h
+++ b/src/frontends/basic/Parser.h
@@ -33,6 +33,7 @@ private:
   StmtPtr parseNext();
   StmtPtr parseGoto();
   StmtPtr parseEnd();
+  StmtPtr parseInput();
 
   ExprPtr parseExpression(int min_prec = 0);
   ExprPtr parsePrimary();

--- a/src/frontends/basic/SemanticAnalyzer.cpp
+++ b/src/frontends/basic/SemanticAnalyzer.cpp
@@ -101,6 +101,12 @@ void SemanticAnalyzer::visitStmt(const Stmt &s) {
     }
   } else if (dynamic_cast<const EndStmt *>(&s)) {
     // nothing
+  } else if (auto *inp = dynamic_cast<const InputStmt *>(&s)) {
+    symbols_.insert(inp->var);
+    if (!inp->var.empty() && inp->var.back() == '$')
+      varTypes_[inp->var] = Type::String;
+    else
+      varTypes_[inp->var] = Type::Int;
   }
 }
 

--- a/src/frontends/basic/Token.cpp
+++ b/src/frontends/basic/Token.cpp
@@ -47,6 +47,8 @@ const char *tokenKindToString(TokenKind k) {
     return "GOTO";
   case TokenKind::KeywordEnd:
     return "END";
+  case TokenKind::KeywordInput:
+    return "INPUT";
   case TokenKind::KeywordAnd:
     return "AND";
   case TokenKind::KeywordOr:

--- a/src/frontends/basic/Token.h
+++ b/src/frontends/basic/Token.h
@@ -29,6 +29,7 @@ enum class TokenKind {
   KeywordNext,
   KeywordGoto,
   KeywordEnd,
+  KeywordInput,
   KeywordAnd,
   KeywordOr,
   KeywordNot,

--- a/src/vm/RuntimeBridge.cpp
+++ b/src/vm/RuntimeBridge.cpp
@@ -40,6 +40,8 @@ Slot RuntimeBridge::call(const std::string &name, const std::vector<Slot> &args,
     res.str = rt_substr(args[0].str, args[1].i64, args[2].i64);
   } else if (name == "rt_str_eq") {
     res.i64 = rt_str_eq(args[0].str, args[1].str);
+  } else if (name == "rt_input_line") {
+    res.str = rt_input_line();
   } else if (name == "rt_to_int") {
     res.i64 = rt_to_int(args[0].str);
   } else {

--- a/tests/data/input1.txt
+++ b/tests/data/input1.txt
@@ -1,0 +1,1 @@
+hello world

--- a/tests/e2e/test_front_basic.cmake
+++ b/tests/e2e/test_front_basic.cmake
@@ -47,3 +47,31 @@ string(REGEX MATCH "45" _s3 "${R2}")
 if(NOT _s3)
   message(FATAL_ERROR "missing 45")
 endif()
+
+# test INPUT string echo
+execute_process(COMMAND ${ILC} front basic -run ${SRC_DIR}/docs/examples/basic/ex5_input_echo.bas --stdin-from ${SRC_DIR}/tests/data/input1.txt
+                OUTPUT_FILE run3.txt RESULT_VARIABLE r4)
+if(NOT r4 EQUAL 0)
+  message(FATAL_ERROR "execution ex5 failed")
+endif()
+file(READ run3.txt R3)
+string(REGEX MATCH "hello world" _e1 "${R3}")
+if(NOT _e1)
+  message(FATAL_ERROR "missing echoed input")
+endif()
+
+# test integer INPUT addition
+set(tmp_bas "${CMAKE_BINARY_DIR}/input_add.bas")
+file(WRITE ${tmp_bas} "10 INPUT A\n20 INPUT B\n30 PRINT A + B\n")
+set(tmp_in "${CMAKE_BINARY_DIR}/input_nums.txt")
+file(WRITE ${tmp_in} "3\n4\n")
+execute_process(COMMAND ${ILC} front basic -run ${tmp_bas} --stdin-from ${tmp_in}
+                OUTPUT_FILE run4.txt RESULT_VARIABLE r5)
+if(NOT r5 EQUAL 0)
+  message(FATAL_ERROR "execution add failed")
+endif()
+file(READ run4.txt R4)
+string(REGEX MATCH "7" _n1 "${R4}")
+if(NOT _n1)
+  message(FATAL_ERROR "missing numeric sum")
+endif()


### PR DESCRIPTION
## Summary
- parse and lower BASIC `INPUT` for strings and integers
- allow `ilc -run` to feed VM stdin from a file via `--stdin-from`
- document INPUT, add echo example, and exercise INPUT via e2e tests

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68b4b2ff6978832488eefc109601a540