### PR TITLE
feat(frontend/basic): add DIM and A(i) arrays lowered via rt_alloc/gep

### DIFF
--- a/docs/examples/basic/ex6_array_sum.bas
+++ b/docs/examples/basic/ex6_array_sum.bas
@@ -1,0 +1,11 @@
+10 INPUT N
+20 DIM A(N)
+30 LET I = 0
+40 LET S = 0
+50 WHILE I < N
+60   LET A(I) = I * I
+70   LET S = S + A(I)
+80   LET I = I + 1
+90 WEND
+100 PRINT S
+110 END

--- a/src/frontends/basic/AST.h
+++ b/src/frontends/basic/AST.h
@@ -27,6 +27,12 @@ struct VarExpr : Expr {
   std::string name;
 };
 
+/// @brief Array element access A(i).
+struct ArrayExpr : Expr {
+  std::string name; ///< Array variable name.
+  ExprPtr index;    ///< Index expression (0-based).
+};
+
 /// @brief Unary expression (e.g., NOT).
 struct UnaryExpr : Expr {
   /// @brief Unary operators supported.
@@ -69,9 +75,15 @@ using StmtPtr = std::unique_ptr<Stmt>;
 struct PrintStmt : Stmt {
   ExprPtr expr;
 };
+/// @brief Assignment statement to variable or array element.
 struct LetStmt : Stmt {
-  std::string name;
-  ExprPtr expr;
+  ExprPtr target; ///< Variable or ArrayExpr on the left-hand side.
+  ExprPtr expr;   ///< Value expression to store.
+};
+/// @brief DIM statement allocating array storage.
+struct DimStmt : Stmt {
+  std::string name; ///< Array name.
+  ExprPtr size;     ///< Element count expression.
 };
 struct IfStmt : Stmt {
   ExprPtr cond;

--- a/src/frontends/basic/AstPrinter.cpp
+++ b/src/frontends/basic/AstPrinter.cpp
@@ -20,7 +20,9 @@ std::string AstPrinter::dump(const Stmt &stmt) {
   if (auto *p = dynamic_cast<const PrintStmt *>(&stmt)) {
     return "(PRINT " + dump(*p->expr) + ")";
   } else if (auto *l = dynamic_cast<const LetStmt *>(&stmt)) {
-    return "(LET " + l->name + " " + dump(*l->expr) + ")";
+    return "(LET " + dump(*l->target) + " " + dump(*l->expr) + ")";
+  } else if (auto *d = dynamic_cast<const DimStmt *>(&stmt)) {
+    return "(DIM " + d->name + " " + dump(*d->size) + ")";
   } else if (auto *i = dynamic_cast<const IfStmt *>(&stmt)) {
     std::string res = "(IF " + dump(*i->cond) + " THEN " + dump(*i->then_branch);
     if (i->else_branch)
@@ -119,6 +121,8 @@ std::string AstPrinter::dump(const Expr &expr) {
       res += " " + dump(*a);
     res += ")";
     return res;
+  } else if (auto *a = dynamic_cast<const ArrayExpr *>(&expr)) {
+    return a->name + "(" + dump(*a->index) + ")";
   }
   return "?";
 }

--- a/src/frontends/basic/ConstFolder.cpp
+++ b/src/frontends/basic/ConstFolder.cpp
@@ -141,6 +141,8 @@ static void foldExpr(ExprPtr &e) {
     foldBinary(e, b);
   } else if (auto *c = dynamic_cast<CallExpr *>(e.get())) {
     foldCall(e, c);
+  } else if (auto *a = dynamic_cast<ArrayExpr *>(e.get())) {
+    foldExpr(a->index);
   }
 }
 
@@ -150,6 +152,7 @@ static void foldStmt(StmtPtr &s) {
   if (auto *p = dynamic_cast<PrintStmt *>(s.get())) {
     foldExpr(p->expr);
   } else if (auto *l = dynamic_cast<LetStmt *>(s.get())) {
+    foldExpr(l->target);
     foldExpr(l->expr);
   } else if (auto *i = dynamic_cast<IfStmt *>(s.get())) {
     foldExpr(i->cond);
@@ -166,6 +169,8 @@ static void foldStmt(StmtPtr &s) {
       foldExpr(f->step);
     for (auto &b : f->body)
       foldStmt(b);
+  } else if (auto *d = dynamic_cast<DimStmt *>(s.get())) {
+    foldExpr(d->size);
   }
 }
 

--- a/src/frontends/basic/Lexer.cpp
+++ b/src/frontends/basic/Lexer.cpp
@@ -81,6 +81,8 @@ Token Lexer::lexIdentifierOrKeyword() {
     return {TokenKind::KeywordEnd, s, loc};
   if (s == "INPUT")
     return {TokenKind::KeywordInput, s, loc};
+  if (s == "DIM")
+    return {TokenKind::KeywordDim, s, loc};
   if (s == "AND")
     return {TokenKind::KeywordAnd, s, loc};
   if (s == "OR")

--- a/src/frontends/basic/Lowerer.h
+++ b/src/frontends/basic/Lowerer.h
@@ -48,6 +48,7 @@ private:
   void lowerGoto(const GotoStmt &stmt);
   void lowerEnd(const EndStmt &stmt);
   void lowerInput(const InputStmt &stmt);
+  void lowerDim(const DimStmt &stmt);
 
   // helpers
   Value emitAlloca(int bytes);
@@ -62,6 +63,7 @@ private:
   void emitRet(Value v);
   std::string getStringLabel(const std::string &s);
   unsigned nextTempId();
+  Value lowerArrayAddr(const ArrayExpr &expr);
 
   build::IRBuilder *builder{nullptr};
   Module *mod{nullptr};

--- a/src/frontends/basic/Parser.h
+++ b/src/frontends/basic/Parser.h
@@ -34,6 +34,7 @@ private:
   StmtPtr parseGoto();
   StmtPtr parseEnd();
   StmtPtr parseInput();
+  StmtPtr parseDim();
 
   ExprPtr parseExpression(int min_prec = 0);
   ExprPtr parsePrimary();

--- a/src/frontends/basic/SemanticAnalyzer.h
+++ b/src/frontends/basic/SemanticAnalyzer.h
@@ -54,6 +54,7 @@ private:
   DiagnosticEmitter &de; ///< Diagnostic sink.
   std::unordered_set<std::string> symbols_;
   std::unordered_map<std::string, Type> varTypes_;
+  std::unordered_map<std::string, long long> arrays_; ///< array sizes if known (-1 if dynamic)
   std::unordered_set<int> labels_;
   std::unordered_set<int> labelRefs_;
   std::vector<std::string> forStack_; ///< Active FOR loop variables.

--- a/src/frontends/basic/Token.cpp
+++ b/src/frontends/basic/Token.cpp
@@ -49,6 +49,8 @@ const char *tokenKindToString(TokenKind k) {
     return "END";
   case TokenKind::KeywordInput:
     return "INPUT";
+  case TokenKind::KeywordDim:
+    return "DIM";
   case TokenKind::KeywordAnd:
     return "AND";
   case TokenKind::KeywordOr:

--- a/src/frontends/basic/Token.h
+++ b/src/frontends/basic/Token.h
@@ -30,6 +30,7 @@ enum class TokenKind {
   KeywordGoto,
   KeywordEnd,
   KeywordInput,
+  KeywordDim,
   KeywordAnd,
   KeywordOr,
   KeywordNot,

--- a/src/vm/RuntimeBridge.cpp
+++ b/src/vm/RuntimeBridge.cpp
@@ -44,6 +44,8 @@ Slot RuntimeBridge::call(const std::string &name, const std::vector<Slot> &args,
     res.str = rt_input_line();
   } else if (name == "rt_to_int") {
     res.i64 = rt_to_int(args[0].str);
+  } else if (name == "rt_alloc") {
+    res.ptr = rt_alloc(args[0].i64);
   } else {
     assert(false && "unknown runtime call");
   }

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -91,6 +91,8 @@ int64_t VM::execFunction(const Function &fn) {
         res.i64 = *reinterpret_cast<int64_t *>(ptr);
       else if (in.type.kind == Type::Kind::Str)
         res.str = *reinterpret_cast<rt_str *>(ptr);
+      else if (in.type.kind == Type::Kind::Ptr)
+        res.ptr = *reinterpret_cast<void **>(ptr);
       if (in.result) {
         if (fr.regs.size() <= *in.result)
           fr.regs.resize(*in.result + 1);
@@ -106,6 +108,8 @@ int64_t VM::execFunction(const Function &fn) {
         *reinterpret_cast<int64_t *>(ptr) = val.i64;
       else if (in.type.kind == Type::Kind::Str)
         *reinterpret_cast<rt_str *>(ptr) = val.str;
+      else if (in.type.kind == Type::Kind::Ptr)
+        *reinterpret_cast<void **>(ptr) = val.ptr;
       break;
     }
     case Opcode::Add: {
@@ -132,11 +136,47 @@ int64_t VM::execFunction(const Function &fn) {
       }
       break;
     }
+    case Opcode::Shl: {
+      Slot a = eval(fr, in.operands[0]);
+      Slot b = eval(fr, in.operands[1]);
+      Slot res{};
+      res.i64 = a.i64 << b.i64;
+      if (in.result) {
+        if (fr.regs.size() <= *in.result)
+          fr.regs.resize(*in.result + 1);
+        fr.regs[*in.result] = res;
+      }
+      break;
+    }
+    case Opcode::GEP: {
+      Slot base = eval(fr, in.operands[0]);
+      Slot off = eval(fr, in.operands[1]);
+      Slot res{};
+      res.ptr = static_cast<char *>(base.ptr) + off.i64;
+      if (in.result) {
+        if (fr.regs.size() <= *in.result)
+          fr.regs.resize(*in.result + 1);
+        fr.regs[*in.result] = res;
+      }
+      break;
+    }
     case Opcode::SCmpGT: {
       Slot a = eval(fr, in.operands[0]);
       Slot b = eval(fr, in.operands[1]);
       Slot res{};
       res.i64 = (a.i64 > b.i64) ? 1 : 0;
+      if (in.result) {
+        if (fr.regs.size() <= *in.result)
+          fr.regs.resize(*in.result + 1);
+        fr.regs[*in.result] = res;
+      }
+      break;
+    }
+    case Opcode::SCmpLT: {
+      Slot a = eval(fr, in.operands[0]);
+      Slot b = eval(fr, in.operands[1]);
+      Slot res{};
+      res.i64 = (a.i64 < b.i64) ? 1 : 0;
       if (in.result) {
         if (fr.regs.size() <= *in.result)
           fr.regs.resize(*in.result + 1);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -150,6 +150,11 @@ add_test(NAME basic_to_il_ex4 COMMAND ${CMAKE_COMMAND}
   -DBAS_FILE=${CMAKE_SOURCE_DIR}/docs/examples/basic/ex4_if_elseif.bas
   -DGOLDEN=${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/ex4_if_elseif.il
   -P ${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/check_il.cmake)
+add_test(NAME basic_to_il_ex6 COMMAND ${CMAKE_COMMAND}
+  -DILC=${BASIC_ILC}
+  -DBAS_FILE=${CMAKE_SOURCE_DIR}/docs/examples/basic/ex6_array_sum.bas
+  -DGOLDEN=${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/ex6_array_sum.il
+  -P ${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/check_il.cmake)
 add_test(NAME basic_to_il_loc COMMAND ${CMAKE_COMMAND}
   -DILC=${BASIC_ILC}
   -DBAS_FILE=${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/loc_add.bas

--- a/tests/e2e/test_front_basic.cmake
+++ b/tests/e2e/test_front_basic.cmake
@@ -75,3 +75,17 @@ string(REGEX MATCH "7" _n1 "${R4}")
 if(NOT _n1)
   message(FATAL_ERROR "missing numeric sum")
 endif()
+
+# test array DIM and element access
+set(tmp_arr_in "${CMAKE_BINARY_DIR}/array_n.txt")
+file(WRITE ${tmp_arr_in} "5\n")
+execute_process(COMMAND ${ILC} front basic -run ${SRC_DIR}/docs/examples/basic/ex6_array_sum.bas --stdin-from ${tmp_arr_in}
+                OUTPUT_FILE run5.txt RESULT_VARIABLE r6)
+if(NOT r6 EQUAL 0)
+  message(FATAL_ERROR "execution ex6 failed")
+endif()
+file(READ run5.txt R5)
+string(REGEX MATCH "30" _n2 "${R5}")
+if(NOT _n2)
+  message(FATAL_ERROR "missing array sum")
+endif()

--- a/tests/golden/basic_to_il/ex6_array_sum.il
+++ b/tests/golden/basic_to_il/ex6_array_sum.il
@@ -1,0 +1,114 @@
+il 0.1
+extern @rt_print_str(str) -> void
+extern @rt_print_i64(i64) -> void
+extern @rt_len(str) -> i64
+extern @rt_substr(str, i64, i64) -> str
+extern @rt_input_line() -> str
+extern @rt_to_int(str) -> i64
+extern @rt_alloc(i64) -> ptr
+func @main() -> i64 {
+entry:
+  %t0 = alloca 8
+  %t1 = alloca 8
+  %t2 = alloca 8
+  %t3 = alloca 8
+  br label L10
+L10:
+  .loc 1 1 4
+  %t4 = call @rt_input_line()
+  .loc 1 1 4
+  %t5 = call @rt_to_int(%t4)
+  .loc 1 1 4
+  store i64, %t3, %t5
+  .loc 1 1 4
+  br label L20
+L20:
+  .loc 1 2 10
+  %t6 = load i64, %t3
+  .loc 1 2 4
+  %t7 = mul %t6, 8
+  .loc 1 2 4
+  %t8 = call @rt_alloc(%t7)
+  .loc 1 2 4
+  store ptr, %t2, %t8
+  .loc 1 2 4
+  br label L30
+L30:
+  .loc 1 3 4
+  store i64, %t1, 0
+  .loc 1 3 4
+  br label L40
+L40:
+  .loc 1 4 4
+  store i64, %t0, 0
+  .loc 1 4 4
+  br label L50
+L50:
+  .loc 1 5 4
+  br label loop_head
+L100:
+  .loc 1 10 11
+  %t28 = load i64, %t0
+  .loc 1 10 5
+  call @rt_print_i64(%t28)
+  .loc 1 10 5
+  br label L110
+L110:
+  .loc 1 11 5
+  br label exit
+exit:
+  ret 0
+loop_head:
+  .loc 1 5 10
+  %t9 = load i64, %t1
+  .loc 1 5 14
+  %t10 = load i64, %t3
+  .loc 1 5 12
+  %t11 = scmp_lt %t9, %t10
+  .loc 1 5 4
+  cbr %t11, label loop_body, label done
+loop_body:
+  .loc 1 6 17
+  %t12 = load i64, %t1
+  .loc 1 6 21
+  %t13 = load i64, %t1
+  .loc 1 6 19
+  %t14 = mul %t12, %t13
+  .loc 1 6 19
+  %t15 = load ptr, %t2
+  .loc 1 6 12
+  %t16 = load i64, %t1
+  .loc 1 6 10
+  %t17 = shl %t16, 3
+  .loc 1 6 10
+  %t18 = gep %t15, %t17
+  .loc 1 6 6
+  store i64, %t18, %t14
+  .loc 1 7 14
+  %t19 = load i64, %t0
+  .loc 1 7 18
+  %t20 = load ptr, %t2
+  .loc 1 7 20
+  %t21 = load i64, %t1
+  .loc 1 7 18
+  %t22 = shl %t21, 3
+  .loc 1 7 18
+  %t23 = gep %t20, %t22
+  .loc 1 7 18
+  %t24 = load i64, %t23
+  .loc 1 7 16
+  %t25 = add %t19, %t24
+  .loc 1 7 6
+  store i64, %t0, %t25
+  .loc 1 8 14
+  %t26 = load i64, %t1
+  .loc 1 8 16
+  %t27 = add %t26, 1
+  .loc 1 8 6
+  store i64, %t1, %t27
+  .loc 1 5 4
+  br label loop_head
+done:
+  .loc 1 5 4
+  br label L100
+}


### PR DESCRIPTION
## Summary
- add DimStmt and ArrayExpr to BASIC AST, parser, and semantic analysis
- lower DIM via rt_alloc and array indexing via shl/gep
- extend VM runtime bridge and interpreter for pointers and new ops
- document DIM semantics and add array sum example with goldens and e2e

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b4b6cda6648324822b443d367422ea