### PR TITLE
docs: reformat markdown files for consistent style and readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
 # ilc
 
 ## Overview
-ilc is an experimental compiler stack centered on a small, well-specified intermediate language (IL). The IL serves as a "thin waist" between source language front ends and eventual native code generation, keeping the core reusable across many languages and targets.
 
-The system is organized as front ends that lower programs into IL, the IL libraries and tools that parse and verify it, and a stack-based virtual machine (VM) that executes IL. Future work will add code generators that translate IL to native code.
+ilc is an experimental compiler stack centered on a small, well-specified intermediate
+language (IL). The IL acts as a “thin waist” between source language front ends and
+eventual native code generation, keeping the core reusable across many languages and
+targets.
 
-Currently the VM and a prototype BASIC front end are functional and can run small examples. Native code generation backends are planned but not yet implemented.
+The system is organized as front ends that lower programs into IL, the IL libraries and
+tools that parse and verify it, and a stack-based virtual machine (VM) that executes IL.
+Future work will add code generators that translate IL to native code.
+
+Currently the VM and a prototype BASIC front end are functional and can run small
+examples. Native code generation backends are planned but not yet implemented.
 
 ## Quickstart
+
 ```sh
 cmake -S . -B build && cmake --build build -j
 ./build/src/tools/il-verify/il-verify docs/examples/il/ex1_hello_cond.il
@@ -24,7 +32,8 @@ ctest --test-dir build -L Docs --output-on-failure
 ```
 
 ## Directory layout
-```
+
+```text
 .
 ├── src/il              # IL core libraries, parser, and verifier
 ├── src/vm              # stack-based virtual machine for IL
@@ -35,6 +44,7 @@ ctest --test-dir build -L Docs --output-on-failure
 ```
 
 ## Documentation
+
 - [Docs overview](docs/README.md)
 - [IL v0.1.1 specification](docs/il-spec.md)
 - [BASIC v0.1 Language Reference](docs/basic-language-reference.md)
@@ -43,7 +53,10 @@ ctest --test-dir build -L Docs --output-on-failure
 - [Examples](docs/examples/)
 
 ## Contributing
-See [AGENTS.md](AGENTS.md) for contribution guidelines and workflow. Architecture changes should start with an ADR as described there.
+
+See [AGENTS.md](AGENTS.md) for contribution guidelines and workflow. Architecture changes
+should start with an ADR as described there.
 
 ## License
+
 Licensed under the [MIT License](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,35 +1,26 @@
-#Documentation Index
+# Documentation Index
 
-This directory hosts specifications, plans, and examples for the IL-based
-compiler stack. Start here for a quick tour of the project and how to
-navigate the available materials. For an overview of the project itself, see
-the [root README](../README.md). Automation and contribution guidelines live
-in [AGENTS.md](../AGENTS.md). Standardized error codes keep diagnostics
-consistent across tools;
-examples live in the BASIC language reference.
+This directory hosts specifications, plans, and examples for the IL-based compiler stack. Start here for a quick tour of the project and how to navigate the available materials. For an overview of the project itself, see the [root README](../README.md). Automation and contribution guidelines live in [AGENTS.md](../AGENTS.md). Standardized error codes keep diagnostics consistent across tools; examples live in the BASIC language reference.
 
-        ##Quick links
+## Quick links
 
-        - [IL v0.1.1 specification](il - spec.md) -
-        [BASIC v0.1 Language Reference](basic - language - reference.md) -
-        [Class catalog](class - catalog.md) - [Project roadmap](roadmap.md) -
-        [Style guide](style - guide.md) - [Examples:BASIC](examples / basic) -
-        [Examples:IL](examples / il) - `ilc il -
-        opt` — run IL optimization passes on a module
+- [IL v0.1.1 specification](il-spec.md)
+- [BASIC v0.1 Language Reference](basic-language-reference.md)
+- [Class catalog](class-catalog.md)
+- [Project roadmap](roadmap.md)
+- [Style guide](style-guide.md)
+- [Examples: BASIC](examples/basic)
+- [Examples: IL](examples/il)
+- `ilc -opt` — run IL optimization passes on a module
 
-        ##Contributing to docs
+## Contributing to docs
 
-        Name new files in `kebab
-        - case.md` and place them under `docs /` or
-    an appropriate subdirectory.Use Markdown and wrap lines at roughly
-    100 characters.To validate changes locally,
-    build and test the project:
+Name new files in `kebab-case.md` and place them under `docs/` or an appropriate subdirectory. Use Markdown and wrap lines at roughly 100 characters. To validate changes locally, build and test the project:
 
-``` cmake - S.- B build cmake-- build build ctest-- output - on -
-    failure
+```sh
+cmake -S . -B build
+cmake --build build
+ctest --output-on-failure
 ```
 
-    Changes to the IL specification require an Architecture Decision
-    Record(ADR)
-before implementation;
-use the template in `adr / 000 - template.md` if available.
+Changes to the IL specification require an Architecture Decision Record (ADR) before implementation; use the template in `adr/000-template.md` if available.

--- a/docs/basic-language-reference.md
+++ b/docs/basic-language-reference.md
@@ -1,75 +1,118 @@
-BASIC v0.1 Language Reference (for this project)
+# BASIC v0.1 Language Reference
+
 Status: Implemented subset for front-end bring-up
 Back end: Lowers to IL v0.1.1 → VM interpreter (native codegen WIP)
-1. Goals & Scope
-Small, predictable BASIC subset suitable for early IDE/compiler bring-up.
-Deterministic semantics that map cleanly to IL and runtime calls.
-Feature set chosen to cover: variables, arithmetic, strings, conditionals, loops, simple I/O.
-2. Programs & Structure
-A program is a sequence of statements separated by newlines or ':' on the same line.
-Line numbers are optional; when present they act as labels (targets for GOTO).
-Execution starts at the first line (or the first statement if no numbers).
-Comments start with ' and run to end of line.
+
+## Goals & Scope
+
+- Small, predictable BASIC subset suitable for early IDE/compiler bring-up.
+- Deterministic semantics that map cleanly to IL and runtime calls.
+- Feature set covering variables, arithmetic, strings, conditionals, loops, and simple I/O.
+
+## Programs & Structure
+
+A program is a sequence of statements separated by newlines or `:` on the same line. Line
+numbers are optional; when present they act as labels (targets for `GOTO`). Execution
+starts at the first line (or the first statement if no numbers). Comments start with `'`
+and run to the end of the line.
+
+```basic
 10 PRINT "HELLO"
 20 LET X = 2 + 3
 30 IF X > 4 THEN PRINT X ELSE PRINT 4
 40 END
-3. Types
-Integer: 64-bit signed (i64 in IL). Literal examples: 0, -12, 42.
-Float (optional in v0.1; produced via VAL of string): 64-bit IEEE (f64).
-String: UTF-8 sequences. Literal: "text", escapes \" \\ \n \t \xNN.
-Boolean: expression result TRUE/FALSE (internally i1), accepted in conditions.
-Coercions
-Integer + Integer → Integer (wraps on overflow in IL).
-LEN, VAL, MID$ provide string↔numeric operations via runtime.
-PRINT chooses rt_print_str for strings, rt_print_i64 for integers, rt_print_f64 for floats.
-4. Expressions
-Precedence (high→low):
-()
-Unary: NOT, + -
-* /
-+ - (binary)
-Comparisons: = <> < <= > >= (yield Boolean)
-AND
-OR
+```
+
+## Types
+
+- **Integer:** 64-bit signed (`i64` in IL). Literal examples: `0`, `-12`, `42`.
+- **Float:** optional in v0.1; produced via `VAL` of string; 64-bit IEEE (`f64`).
+- **String:** UTF-8 sequences. Literal: `"text"`, escapes `\"` `\\` `\n` `\t` `\xNN`.
+- **Boolean:** expression result `TRUE`/`FALSE` (internally `i1`), accepted in conditions.
+
+### Coercions
+
+- Integer + Integer → Integer (wraps on overflow in IL).
+- `LEN`, `VAL`, `MID$` provide string↔numeric operations via runtime.
+- `PRINT` chooses `rt_print_str` for strings, `rt_print_i64` for integers,
+  `rt_print_f64` for floats.
+
+## Expressions
+
+Precedence (high → low):
+
+1. `()`
+1. Unary: `NOT`, `+`, `-`
+1. `*`, `/`
+1. `+`, `-` (binary)
+1. Comparisons: `= <> < <= > >=` (yield Boolean)
+1. `AND`
+1. `OR`
+
 Operators:
-Arithmetic on integers; / is integer division (traps on div/0).
-Comparisons allowed between like types (int with int, str with str using =/<> only).
-Logical operators AND/OR/NOT use short-circuit evaluation and return Boolean.
+
+- Arithmetic on integers; `/` is integer division (traps on div/0).
+- Comparisons allowed between like types (int with int, str with str using `=`/`<>` only).
+- Logical operators `AND`/`OR`/`NOT` use short-circuit evaluation and return Boolean.
+
 Built-ins (all map to runtime; see §10):
-LEN(s$) -> integer
-MID$(s$, start, length) -> string (1-based indices; clamped)
-VAL(s$) -> integer (traps on invalid; VALF$ for float optional later)
-5. Statements
-LET var = expr — assign (vars auto-declared on first use)
-PRINT expr — output value
-IF cond THEN stmt {ELSEIF cond THEN stmt}* [ELSE stmt]
-Multi-stmt THEN/ELSE blocks: chain multiple PRINT/LET/... on subsequent lines or use ':' separators.
-WHILE cond ... WEND
-FOR var = start TO end [STEP s] ... NEXT var
-GOTO lineNumber
-END — terminate program
-INPUT var$ | INPUT var — read a line from stdin. For NAME$ variables the line is stored
-as-is (leading/trailing spaces kept). For integer variables the line is trimmed and
-converted via VAL; invalid numbers trap.
-6. Variables & Names
-Names: [A-Za-z][A-Za-z0-9_]* with optional $ suffix for strings (NAME$).
+
+- `LEN(s$) -> integer`
+- `MID$(s$, start, length) -> string` (1-based indices; clamped)
+- `VAL(s$) -> integer` (traps on invalid; `VALF$` for float optional later)
+
+## Statements
+
+- `LET var = expr` — assign (vars auto-declared on first use).
+- `PRINT expr` — output value.
+- `IF cond THEN stmt {ELSEIF cond THEN stmt}* [ELSE stmt]`.
+- Multi-statement THEN/ELSE blocks: chain multiple statements on subsequent lines or use
+  `:` separators.
+- `WHILE cond ... WEND`.
+- `FOR var = start TO end [STEP s] ... NEXT var`.
+- `GOTO lineNumber`.
+- `END` — terminate program.
+- `INPUT var$ | INPUT var` — read a line from stdin. For `NAME$` variables the line is
+  stored as-is (leading/trailing spaces kept). For integer variables the line is trimmed
+  and converted via `VAL`; invalid numbers trap.
+
+## Variables & Names
+
+Names: `[A-Za-z][A-Za-z0-9_]*` with optional `$` suffix for strings (`NAME$`).
+
 Type inference:
-$ suffix → string
-otherwise integer unless assigned from VALF$(…) (future).
-All variables are function-local to @main in v0.1.
-Arrays: DIM A(N) allocates N i64 elements and must appear before A is used.
-Indices are 0-based; only integer arrays are supported. Out-of-bounds access is undefined (no checks yet).
-7. Errors
-Division by zero, invalid VAL, out-of-bounds MID$ length/start after clamping → runtime trap with message.
-Type mismatch in comparisons/operations → compile-time (lowering) error.
-8. Diagnostics
-Errors use standardized codes prefixed with B. Messages show the source line and a caret.
+
+- `$` suffix → string.
+- otherwise integer unless assigned from `VALF$(…)` (future).
+
+All variables are function-local to `@main` in v0.1.
+
+Arrays: `DIM A(N)` allocates `N` `i64` elements and must appear before `A` is used.
+Indices are 0-based; only integer arrays are supported. Out-of-bounds access is undefined
+(no checks yet).
+
+## Errors
+
+- Division by zero, invalid `VAL`, out-of-bounds `MID$` length/start after clamping →
+  runtime trap with message.
+- Type mismatch in comparisons/operations → compile-time (lowering) error.
+
+## Diagnostics
+
+Errors use standardized codes prefixed with `B`. Messages show the source line and a
+caret.
+
+```text
 10 LET X = 1 +
             ^
 B0001: expected expression.
-Runtime traps use codes like B0002 for division by zero.
-9. Grammar (informal)
+```
+
+Runtime traps use codes like `B0002` for division by zero.
+
+## Grammar (informal)
+
+```text
 program     ::= (line | stmt)* EOF
 line        ::= (NUMBER)? stmt (":" stmt)* NEWLINE
 stmt        ::= "LET" ident "=" expr
@@ -85,22 +128,28 @@ expr        ::= term (("+"|"-") term)*
 term        ::= factor (("*"|"/") factor)*
 factor      ::= NUMBER | STRING | ident | ident "(" expr ")" | "(" expr ")" | ("+"|"-") factor | "NOT" factor
 ident       ::= NAME | NAME "$"
-10. Mapping to IL & Runtime
-BASIC | IL pattern | Runtime
----- | ---- | ----
-PRINT "X" | %s = const_str @.L; call @rt_print_str(%s) | rt_print_str(str)
-PRINT X | %v = load i64, %slotX; call @rt_print_i64(%v) | rt_print_i64(i64)
-LET X = A + B | load A; load B; %c = add %a,%b; store X,%c | —
-IF C THEN … ELSE … | %p = …cmp…; cbr %p, then, else | —
-WHILE C … WEND | br loop_head; cbr cond, loop_body, done | —
-LEN(S$) | call @rt_len(%s) | rt_len(str)->i64
-MID$(S$,i,l) | call @rt_substr(%s, i-1, l) | rt_substr(str,i64,i64)->str
-VAL(S$) | call @rt_to_int(%s) | rt_to_int(str)->i64
-INPUT A$ | %s = call @rt_input_line(); store A$, %s | rt_input_line()->str
-INPUT N | %s = call @rt_input_line(); %n = call @rt_to_int(%s); store N, %n | rt_input_line()->str; rt_to_int(str)->i64
-DIM A(N) | %bytes = mul N,8; %p = call @rt_alloc(%bytes); store ptr %p, %A | rt_alloc(i64)->ptr
-A(I) | %base = load ptr, %A; %off = shl I,3; %ptr = gep %base,%off; %v = load i64,%ptr | —
-LET A(I) = X | compute %ptr as above; store i64,%ptr,X | —
+```
+
+## Mapping to IL & Runtime
+
+| BASIC | IL pattern | Runtime |
+| :----------- | :------------------------------------------------------ | :---------------------------------- |
+| `PRINT "X"` | `%s = const_str @.L; call @rt_print_str(%s)` | `rt_print_str(str)` |
+| `PRINT X` | `%v = load i64, %slotX; call @rt_print_i64(%v)` | `rt_print_i64(i64)` |
+| `LET X = A + B` | `load A; load B; %c = add %a,%b; store X,%c` | — |
+| `IF C THEN … ELSE …` | `%p = …cmp…; cbr %p, then, else` | — |
+| `WHILE C … WEND` | `br loop_head; cbr cond, loop_body, done` | — |
+| `LEN(S$)` | `call @rt_len(%s)` | `rt_len(str)->i64` |
+| `MID$(S$,i,l)` | `call @rt_substr(%s, i-1, l)` | `rt_substr(str,i64,i64)->str` |
+| `VAL(S$)` | `call @rt_to_int(%s)` | `rt_to_int(str)->i64` |
+| `INPUT A$` | `%s = call @rt_input_line(); store A$, %s` | `rt_input_line()->str` |
+| `INPUT N` | `%s = call @rt_input_line(); %n = call @rt_to_int(%s); store N, %n` | `rt_input_line()->str; rt_to_int(str)->i64` |
+| `DIM A(N)` | `%bytes = mul N,8; %p = call @rt_alloc(%bytes); store ptr %p, %A` | `rt_alloc(i64)->ptr` |
+| `A(I)` | `%base = load ptr, %A; %off = shl I,3; %ptr = gep %base,%off; %v = load i64,%ptr` | — |
+| `LET A(I) = X` | `compute %ptr as above; store i64,%ptr,X` | — |
+
 Indexing: BASIC’s 1-based indices are lowered to 0-based for runtime calls (subtract 1).
-11. Examples
-See /docs/examples/basic/ and the IL equivalents in /docs/examples/il/.
+
+## Examples
+
+See `/docs/examples/basic/` and the IL equivalents in `/docs/examples/il/`.

--- a/docs/basic-to-il-examples.md
+++ b/docs/basic-to-il-examples.md
@@ -1,11 +1,17 @@
-Below are six small BASIC programs (≈10–20 lines each) and their complete IL equivalents. Each IL module is self‑contained and conforms to the IL v0.1 spec we drafted (textual format, strict terminators, typed loads/stores, runtime calls for I/O & strings).
+# BASIC to IL Examples
 
-	Legend used below
-		○ Locals are modeled with alloca 8 + load/store.
-		○ String literals use global const str @.Lk = "..." then const_str @.Lk.
-		○ Conditions use scmp_* / icmp_* / fcmp_* producing i1.
-		○ Branches always explicit: br / cbr.
-		○ Printing uses runtime: @rt_print_str, @rt_print_i64, @rt_print_f64.
+Below are six small BASIC programs (≈10–20 lines each) and their complete IL equivalents.
+Each IL module is self-contained and conforms to the IL v0.1 spec we drafted (textual
+format, strict terminators, typed loads/stores, runtime calls for I/O & strings).
+
+```
+Legend used below
+	○ Locals are modeled with alloca 8 + load/store.
+	○ String literals use global const str @.Lk = "..." then const_str @.Lk.
+	○ Conditions use scmp_* / icmp_* / fcmp_* producing i1.
+	○ Branches always explicit: br / cbr.
+	○ Printing uses runtime: @rt_print_str, @rt_print_i64, @rt_print_f64.
+```
 
 Example 1 — Hello, arithmetic, and conditional branch
 BASIC (10 lines)
@@ -29,44 +35,44 @@ global const str @.L0 = "HELLO"
 global const str @.L1 = "READY"
 func @main() -> i32 {
 entry:
-  ; locals
-  %x_slot = alloca 8
-  %y_slot = alloca 8
+; locals
+%x_slot = alloca 8
+%y_slot = alloca 8
 ; X = 2 + 3
-  %t0 = add 2, 3
-  store i64, %x_slot, %t0
+%t0 = add 2, 3
+store i64, %x_slot, %t0
 ; Y = X * 2
-  %xv = load i64, %x_slot
-  %t1 = mul %xv, 2
-  store i64, %y_slot, %t1
+%xv = load i64, %x_slot
+%t1 = mul %xv, 2
+store i64, %y_slot, %t1
 ; PRINT "HELLO"
-  %s0 = const_str @.L0
-  call @rt_print_str(%s0)
+%s0 = const_str @.L0
+call @rt_print_str(%s0)
 ; PRINT "READY"
-  %s1 = const_str @.L1
-  call @rt_print_str(%s1)
+%s1 = const_str @.L1
+call @rt_print_str(%s1)
 ; PRINT Y
-  %yv0 = load i64, %y_slot
-  call @rt_print_i64(%yv0)
+%yv0 = load i64, %y_slot
+call @rt_print_i64(%yv0)
 ; IF Y > 8 THEN GOTO 80 ELSE fallthrough
-  %yv1 = load i64, %y_slot
-  %cond = scmp_gt %yv1, 8
-  cbr %cond, label then80, label else60
+%yv1 = load i64, %y_slot
+%cond = scmp_gt %yv1, 8
+cbr %cond, label then80, label else60
 else60:
-  ; PRINT 4
-  call @rt_print_i64(4)
-  br label after
+; PRINT 4
+call @rt_print_i64(4)
+br label after
 then80:
-  ; PRINT Y
-  %yv2 = load i64, %y_slot
-  call @rt_print_i64(%yv2)
-  br label after
+; PRINT Y
+%yv2 = load i64, %y_slot
+call @rt_print_i64(%yv2)
+br label after
 after:
-  ret 0
+ret 0
 }
 Notes:
-	• LET lowers to alloca + store; reads use load.
-	• The GOTO 80 maps to br label then80.
+• LET lowers to alloca + store; reads use load.
+• The GOTO 80 maps to br label then80.
 
 Example 2 — Sum 1..10 with a WHILE loop
 BASIC (10 lines)
@@ -74,9 +80,9 @@ BASIC (10 lines)
 10 PRINT "SUM 1..10"
 20 LET I = 1
 30 LET S = 0
-40 WHILE I <= 10
-50   LET S = S + I
-60   LET I = I + 1
+40 WHILE I \<= 10
+50 LET S = S + I
+60 LET I = I + 1
 70 WEND
 80 PRINT S
 90 PRINT "DONE"
@@ -90,35 +96,35 @@ global const str @.L0 = "SUM 1..10"
 global const str @.L1 = "DONE"
 func @main() -> i32 {
 entry:
-  %i_slot = alloca 8
-  %s_slot = alloca 8
+%i_slot = alloca 8
+%s_slot = alloca 8
 ; PRINT "SUM 1..10"
-  %h = const_str @.L0
-  call @rt_print_str(%h)
+%h = const_str @.L0
+call @rt_print_str(%h)
 ; I = 1, S = 0
-  store i64, %i_slot, 1
-  store i64, %s_slot, 0
+store i64, %i_slot, 1
+store i64, %s_slot, 0
 br label loop_head
 loop_head:
-  %i0 = load i64, %i_slot
-  %c  = scmp_le %i0, 10
-  cbr %c, label loop_body, label done
+%i0 = load i64, %i_slot
+%c = scmp_le %i0, 10
+cbr %c, label loop_body, label done
 loop_body:
-  %s0 = load i64, %s_slot
-  %s1 = add %s0, %i0
-  store i64, %s_slot, %s1
+%s0 = load i64, %s_slot
+%s1 = add %s0, %i0
+store i64, %s_slot, %s1
 %i1 = add %i0, 1
-  store i64, %i_slot, %i1
+store i64, %i_slot, %i1
 br label loop_head
 done:
-  %s2 = load i64, %s_slot
-  call @rt_print_i64(%s2)
+%s2 = load i64, %s_slot
+call @rt_print_i64(%s2)
 %d = const_str @.L1
-  call @rt_print_str(%d)
+call @rt_print_str(%d)
 ret 0
 }
 Notes:
-	• Classic while lowering: entry → loop_head (cbr) → loop_body → loop_head → done.
+• Classic while lowering: entry → loop_head (cbr) → loop_body → loop_head → done.
 
 Example 3 — Nested loops: 5×5 multiplication table
 BASIC (12 lines)
@@ -126,13 +132,13 @@ BASIC (12 lines)
 10 PRINT "TABLE 5x5"
 20 LET N = 5
 30 LET I = 1
-40 WHILE I <= N
-50   LET J = 1
-60   WHILE J <= N
-70     PRINT I * J
-80     LET J = J + 1
-90   WEND
-100  LET I = I + 1
+40 WHILE I \<= N
+50 LET J = 1
+60 WHILE J \<= N
+70 PRINT I * J
+80 LET J = J + 1
+90 WEND
+100 LET I = I + 1
 110 WEND
 120 END
 IL
@@ -143,47 +149,47 @@ extern @rt_print_i64(i64) -> void
 global const str @.L0 = "TABLE 5x5"
 func @main() -> i32 {
 entry:
-  %n_slot = alloca 8
-  %i_slot = alloca 8
-  %j_slot = alloca 8
+%n_slot = alloca 8
+%i_slot = alloca 8
+%j_slot = alloca 8
 ; heading
-  %h = const_str @.L0
-  call @rt_print_str(%h)
+%h = const_str @.L0
+call @rt_print_str(%h)
 ; N=5, I=1
-  store i64, %n_slot, 5
-  store i64, %i_slot, 1
-  br label outer_head
+store i64, %n_slot, 5
+store i64, %i_slot, 1
+br label outer_head
 outer_head:
-  %i0 = load i64, %i_slot
-  %n0 = load i64, %n_slot
-  %oc = scmp_le %i0, %n0
-  cbr %oc, label outer_body, label outer_done
+%i0 = load i64, %i_slot
+%n0 = load i64, %n_slot
+%oc = scmp_le %i0, %n0
+cbr %oc, label outer_body, label outer_done
 outer_body:
-  ; J=1
-  store i64, %j_slot, 1
-  br label inner_head
+; J=1
+store i64, %j_slot, 1
+br label inner_head
 inner_head:
-  %j0 = load i64, %j_slot
-  %n1 = load i64, %n_slot
-  %ic = scmp_le %j0, %n1
-  cbr %ic, label inner_body, label inner_done
+%j0 = load i64, %j_slot
+%n1 = load i64, %n_slot
+%ic = scmp_le %j0, %n1
+cbr %ic, label inner_body, label inner_done
 inner_body:
-  %i1 = load i64, %i_slot
-  %prod = mul %i1, %j0
-  call @rt_print_i64(%prod)
+%i1 = load i64, %i_slot
+%prod = mul %i1, %j0
+call @rt_print_i64(%prod)
 %j1 = add %j0, 1
-  store i64, %j_slot, %j1
-  br label inner_head
+store i64, %j_slot, %j1
+br label inner_head
 inner_done:
-  %i2 = add %i0, 1
-  store i64, %i_slot, %i2
-  br label outer_head
+%i2 = add %i0, 1
+store i64, %i_slot, %i2
+br label outer_head
 outer_done:
-  ret 0
+ret 0
 }
 Notes:
-	• Nested while translates to two head/body/done trios.
-	• Each PRINT is an IL call to the runtime.
+• Nested while translates to two head/body/done trios.
+• Each PRINT is an IL call to the runtime.
 
 Example 4 — Read input and compute factorial
 BASIC (11 lines)
@@ -194,8 +200,8 @@ BASIC (11 lines)
 40 LET N = VAL(S$)
 50 LET R = 1
 60 WHILE N > 1
-70   LET R = R * N
-80   LET N = N - 1
+70 LET R = R * N
+80 LET N = N - 1
 90 WEND
 100 PRINT R
 110 END
@@ -210,43 +216,43 @@ global const str @.L0 = "FACTORIAL"
 global const str @.L1 = "ENTER N:"
 func @main() -> i32 {
 entry:
-  %s_slot = alloca 8    ; str handle
-  %n_slot = alloca 8
-  %r_slot = alloca 8
+%s_slot = alloca 8 ; str handle
+%n_slot = alloca 8
+%r_slot = alloca 8
 ; headings
-  %h0 = const_str @.L0
-  call @rt_print_str(%h0)
-  %h1 = const_str @.L1
-  call @rt_print_str(%h1)
+%h0 = const_str @.L0
+call @rt_print_str(%h0)
+%h1 = const_str @.L1
+call @rt_print_str(%h1)
 ; S$ = INPUT$
-  %line = call @rt_input_line()
-  store str, %s_slot, %line
+%line = call @rt_input_line()
+store str, %s_slot, %line
 ; N = VAL(S$)
-  %sval = load str, %s_slot
-  %n0 = call @rt_to_int(%sval)
-  store i64, %n_slot, %n0
+%sval = load str, %s_slot
+%n0 = call @rt_to_int(%sval)
+store i64, %n_slot, %n0
 ; R = 1
-  store i64, %r_slot, 1
+store i64, %r_slot, 1
 br label loop_head
 loop_head:
-  %n1 = load i64, %n_slot
-  %c  = scmp_gt %n1, 1
-  cbr %c, label loop_body, label done
+%n1 = load i64, %n_slot
+%c = scmp_gt %n1, 1
+cbr %c, label loop_body, label done
 loop_body:
-  %r0 = load i64, %r_slot
-  %r1 = mul %r0, %n1
-  store i64, %r_slot, %r1
+%r0 = load i64, %r_slot
+%r1 = mul %r0, %n1
+store i64, %r_slot, %r1
 %n2 = sub %n1, 1
-  store i64, %n_slot, %n2
-  br label loop_head
+store i64, %n_slot, %n2
+br label loop_head
 done:
-  %r2 = load i64, %r_slot
-  call @rt_print_i64(%r2)
-  ret 0
+%r2 = load i64, %r_slot
+call @rt_print_i64(%r2)
+ret 0
 }
 Notes:
-	• Input uses rt_input_line; conversion uses rt_to_int.
-	• On invalid numeric text, rt_to_int (by spec) may trap; that’s OK for v0.1.
+• Input uses rt_input_line; conversion uses rt_to_int.
+• On invalid numeric text, rt_to_int (by spec) may trap; that’s OK for v0.1.
 
 Example 5 — String concat, length, substring, equality
 BASIC (10 lines)
@@ -276,66 +282,66 @@ global const str @.L2 = " "
 global const str @.L3 = "JOHN DOE"
 func @main() -> i32 {
 entry:
-  %a_slot = alloca 8  ; str
-  %b_slot = alloca 8  ; str
-  %c_slot = alloca 8  ; str
-  %l_slot = alloca 8  ; i64
+%a_slot = alloca 8 ; str
+%b_slot = alloca 8 ; str
+%c_slot = alloca 8 ; str
+%l_slot = alloca 8 ; i64
 ; A$ = "JOHN", B$ = "DOE"
-  %sA = const_str @.L0
-  %sB = const_str @.L1
-  store str, %a_slot, %sA
-  store str, %b_slot, %sB
+%sA = const_str @.L0
+%sB = const_str @.L1
+store str, %a_slot, %sA
+store str, %b_slot, %sB
 ; C$ = A$ + " "
-  %sSp = const_str @.L2
-  %a0 = load str, %a_slot
-  %c0 = call @rt_concat(%a0, %sSp)
-  store str, %c_slot, %c0
+%sSp = const_str @.L2
+%a0 = load str, %a_slot
+%c0 = call @rt_concat(%a0, %sSp)
+store str, %c_slot, %c0
 ; C$ = C$ + B$
-  %c1 = load str, %c_slot
-  %b0 = load str, %b_slot
-  %c2 = call @rt_concat(%c1, %b0)
-  store str, %c_slot, %c2
+%c1 = load str, %c_slot
+%b0 = load str, %b_slot
+%c2 = call @rt_concat(%c1, %b0)
+store str, %c_slot, %c2
 ; PRINT C$
-  %c3 = load str, %c_slot
-  call @rt_print_str(%c3)
+%c3 = load str, %c_slot
+call @rt_print_str(%c3)
 ; L = LEN(C$) ; PRINT L
-  %len = call @rt_len(%c3)
-  store i64, %l_slot, %len
-  call @rt_print_i64(%len)
+%len = call @rt_len(%c3)
+store i64, %l_slot, %len
+call @rt_print_i64(%len)
 ; PRINT first char: MID$(C$,1,1) => substr(C$, 0, 1) (front end adjusts 1-based to 0-based)
-  %first = call @rt_substr(%c3, 0, 1)
-  call @rt_print_str(%first)
+%first = call @rt_substr(%c3, 0, 1)
+call @rt_print_str(%first)
 ; IF C$ == "JOHN DOE" THEN PRINT 1 ELSE PRINT 0
-  %target = const_str @.L3
-  %eq = call @rt_str_eq(%c3, %target)
-  cbr %eq, label then1, label else0
+%target = const_str @.L3
+%eq = call @rt_str_eq(%c3, %target)
+cbr %eq, label then1, label else0
 then1:
-  call @rt_print_i64(1)
-  br label exit
+call @rt_print_i64(1)
+br label exit
 else0:
-  call @rt_print_i64(0)
-  br label exit
+call @rt_print_i64(0)
+br label exit
 exit:
-  ret 0
+ret 0
 }
 Notes:
-	• All string operations are via runtime calls.
-	• Equality uses rt_str_eq returning an i1.
+• All string operations are via runtime calls.
+• Equality uses rt_str_eq returning an i1.
 
 Example 6 — Heap “array” via rt_alloc, fill with squares, print average as float
 BASIC (13 lines)
 
 10 LET N = 5
-20 DIM A(N)          ' conceptual; lowered to a heap block of N * 8 bytes
+20 DIM A(N) ' conceptual; lowered to a heap block of N * 8 bytes
 30 LET I = 0
 40 LET SUM = 0
 50 WHILE I < N
-60   LET A(I) = I * I
-70   LET SUM = SUM + A(I)
-80   LET I = I + 1
+60 LET A(I) = I * I
+70 LET SUM = SUM + A(I)
+80 LET I = I + 1
 90 WEND
 100 LET AVG = SUM / N
-110 PRINT AVG         ' print as floating average
+110 PRINT AVG ' print as floating average
 120 PRINT "DONE"
 130 END
 IL
@@ -347,61 +353,60 @@ extern @rt_print_str(str) -> void
 global const str @.L0 = "DONE"
 func @main() -> i32 {
 entry:
-  %n_slot   = alloca 8
-  %i_slot   = alloca 8
-  %sum_slot = alloca 8
-  %a_slot   = alloca 8   ; ptr to heap block
+%n_slot = alloca 8
+%i_slot = alloca 8
+%sum_slot = alloca 8
+%a_slot = alloca 8 ; ptr to heap block
 ; N = 5, I = 0, SUM = 0
-  store i64, %n_slot, 5
-  store i64, %i_slot, 0
-  store i64, %sum_slot, 0
+store i64, %n_slot, 5
+store i64, %i_slot, 0
+store i64, %sum_slot, 0
 ; A = rt_alloc(N * 8)
-  %n0 = load i64, %n_slot
-  %bytes = mul %n0, 8
-  %abase = call @rt_alloc(%bytes)
-  store ptr, %a_slot, %abase
+%n0 = load i64, %n_slot
+%bytes = mul %n0, 8
+%abase = call @rt_alloc(%bytes)
+store ptr, %a_slot, %abase
 br label loop_head
 loop_head:
-  %i0 = load i64, %i_slot
-  %n1 = load i64, %n_slot
-  %c  = scmp_lt %i0, %n1
-  cbr %c, label loop_body, label done
+%i0 = load i64, %i_slot
+%n1 = load i64, %n_slot
+%c = scmp_lt %i0, %n1
+cbr %c, label loop_body, label done
 loop_body:
-  ; compute address A + i*8
-  %a0 = load ptr, %a_slot
-  %off = shl %i0, 3         ; i * 8
-  %elem_ptr = gep %a0, %off
+; compute address A + i\*8
+%a0 = load ptr, %a_slot
+%off = shl %i0, 3 ; i * 8
+%elem_ptr = gep %a0, %off
 ; A(i) = i * i
-  %sq = mul %i0, %i0
-  store i64, %elem_ptr, %sq
+%sq = mul %i0, %i0
+store i64, %elem_ptr, %sq
 ; SUM += A(i)
-  %val = load i64, %elem_ptr
-  %sum0 = load i64, %sum_slot
-  %sum1 = add %sum0, %val
-  store i64, %sum_slot, %sum1
+%val = load i64, %elem_ptr
+%sum0 = load i64, %sum_slot
+%sum1 = add %sum0, %val
+store i64, %sum_slot, %sum1
 ; i++
-  %i1 = add %i0, 1
-  store i64, %i_slot, %i1
+%i1 = add %i0, 1
+store i64, %i_slot, %i1
 br label loop_head
 done:
-  ; AVG = (float)SUM / (float)N
-  %sum2 = load i64, %sum_slot
-  %n2   = load i64, %n_slot
-  %fsum = sitofp %sum2
-  %fn   = sitofp %n2
-  %avg  = fdiv %fsum, %fn
-  call @rt_print_f64(%avg)
+; AVG = (float)SUM / (float)N
+%sum2 = load i64, %sum_slot
+%n2 = load i64, %n_slot
+%fsum = sitofp %sum2
+%fn = sitofp %n2
+%avg = fdiv %fsum, %fn
+call @rt_print_f64(%avg)
 ; "DONE"
-  %d = const_str @.L0
-  call @rt_print_str(%d)
+%d = const_str @.L0
+call @rt_print_str(%d)
 ret 0
 }
 Notes:
-	• Arrays are modeled as a heap block (ptr) with manual addressing via gep.
-	• Average printed as f64, demonstrating sitofp and fdiv.
+• Arrays are modeled as a heap block (ptr) with manual addressing via gep.
+• Average printed as f64, demonstrating sitofp and fdiv.
 
 How to Use These Examples
-	• Golden tests: Keep each BASIC + IL pair together; your front end should emit IL text identical (or equivalent modulo temporary names/labels).
-	• VM vs Native: Run IL on the interpreter and compare to native output from the IL→ASM backend.
-	• Coverage: These six cover arithmetic, control flow, nested loops, input, strings, heap, and float math.
-
+• Golden tests: Keep each BASIC + IL pair together; your front end should emit IL text identical (or equivalent modulo temporary names/labels).
+• VM vs Native: Run IL on the interpreter and compare to native output from the IL→ASM backend.
+• Coverage: These six cover arithmetic, control flow, nested loops, input, strings, heap, and float math.

--- a/docs/class-catalog.md
+++ b/docs/class-catalog.md
@@ -1,22 +1,32 @@
 # Class Catalog
 
 ## Support layer
+
 Utility classes for symbols, memory arenas, diagnostics, and other shared helpers.
 
 ## IL Core
-Types, values, instructions, blocks, and modules that make up the in-memory IL ([IL spec](il-spec.md)).
+
+Types, values, instructions, blocks, and modules that make up the in-memory IL
+([IL spec](il-spec.md)).
 
 ## IL build/IO/verify
-Builders, parsers, serializers, and the verifier used to construct and check modules.
+
+Builders, parsers, serializers, and the verifier used to construct and check
+modules.
 
 ## Front end (BASIC)
+
 Lexer, parser, AST, and lowering logic that turns BASIC source into IL.
 
 ## VM
-Runtime structures like slots and frames plus the dispatch loop that interprets IL.
+
+Runtime structures like slots and frames plus the dispatch loop that interprets
+IL.
 
 ## Codegen
+
 Placeholder for future native backends and register allocation work.
 
 ## Tools
+
 Command-line utilities for invoking the compiler, verifier, and runtime tests.

--- a/docs/cpp-overview.md
+++ b/docs/cpp-overview.md
@@ -1,309 +1,341 @@
-here’s a high‑level but extensive blueprint for turning the IL + VM + codegen + front end design into a clean, maintainable C++20 project. It’s written to be “handable” to an assistant like Codex and to keep you out of the mess that VC drifted into.
+# C++ Project Overview
 
-1) Guiding principles
-	• Single thin‑waist IL: all front ends target it; both the VM and codegen consume it.
-	• Small core, strong boundaries: each layer compiles to its own library; no cross‑layer reach‑through.
-	• Determinism first: the VM is the semantic oracle; native code must match it.
-	• Testable units: verifier, serializer, VM, and backend have dedicated golden/e2e tests.
-	• Solo‑friendly: minimal dependencies; predictable build; clear incremental milestones.
+Here’s a high-level but extensive blueprint for turning the IL + VM + codegen + front end
+design into a clean, maintainable C++20 project. It’s written to be “handable” to an
+assistant like Codex and to keep you out of the mess that VC drifted into.
 
-2) Repository layout (CMake, modular)
+1. Guiding principles
+
+- Single thin‑waist IL: all front ends target it; both the VM and codegen consume it.
+- Small core, strong boundaries: each layer compiles to its own library; no cross‑layer reach‑through.
+- Determinism first: the VM is the semantic oracle; native code must match it.
+- Testable units: verifier, serializer, VM, and backend have dedicated golden/e2e tests.
+- Solo‑friendly: minimal dependencies; predictable build; clear incremental milestones.
+
+1. Repository layout (CMake, modular)
 
 /CMakeLists.txt
-/cmake/                      # compiler flags, toolchain helpers
-/docs/                       # IL spec, developer docs, ADRs
-/runtime/                    # C runtime (librt.a): rt_*.c, rt_*.h
+/cmake/ # compiler flags, toolchain helpers
+/docs/ # IL spec, developer docs, ADRs
+/runtime/ # C runtime (librt.a): rt\_*.c, rt\_*.h
 /src/
-  /support/                  # small utilities shared across libs
-  /il/                       # IL core: types, IR, builder, verifier, I/O
-  /vm/                       # IL interpreter
-  /codegen/
-    /x86_64/                 # x86-64 SysV backend
-  /frontends/
-    /basic/                  # BASIC lexer, parser, AST, lowering
-  /tools/                    # CLI tools: ilc, il-dis, il-verify
+/support/ # small utilities shared across libs
+/il/ # IL core: types, IR, builder, verifier, I/O
+/vm/ # IL interpreter
+/codegen/
+/x86_64/ # x86-64 SysV backend
+/frontends/
+/basic/ # BASIC lexer, parser, AST, lowering
+/tools/ # CLI tools: ilc, il-dis, il-verify
 /tests/
-  /unit/                     # gtest/catch2 unit tests
-  /golden/                   # text-based golden tests (IL, diagnostics)
-  /e2e/                      # compile & run comparisons (VM vs native)
-/scripts/                    # dev scripts (format, lint, build, test)
+/unit/ # gtest/catch2 unit tests
+/golden/ # text-based golden tests (IL, diagnostics)
+/e2e/ # compile & run comparisons (VM vs native)
+/scripts/ # dev scripts (format, lint, build, test)
 Top-level CMake targets
-	• il_core (static lib)
-	• il_vm (static lib)
-	• il_codegen_x86_64 (static lib)
-	• frontend_basic (static lib)
-	• librt (static lib from /runtime)
-	• ilc, il-dis, il-verify (executables)
-	• tests_* (test executables)
 
-3) Tooling & Build
-	• C++ standard: C++20 (-std=c++20)
-	• Warnings: -Wall -Wextra -Wpedantic -Werror
-	• Sanitizers (dev/CI): -fsanitize=address,undefined
-	• Dependencies (small, vendorable):
-		○ fmt (formatted printing)
-		○ CLI11 or lyra (CLI parsing), or roll a tiny one
-		○ gtest or Catch2 (tests)
-	• Style: clang-format, clang-tidy with a minimal config
-	• CI: GitHub Actions matrix (Linux, macOS), caches build, runs sanitizers + tests
+- il_core (static lib)
+- il_vm (static lib)
+- il_codegen_x86_64 (static lib)
+- frontend_basic (static lib)
+- librt (static lib from /runtime)
+- ilc, il-dis, il-verify (executables)
+- tests\_\* (test executables)
 
-4) Namespaces and libraries
-	• il::core — types, values, instructions, module, symbol tables
-	• il::build — IRBuilder helpers
-	• il::io — text parser/serializer
-	• il::verify — structural/type verifier
-	• il::vm — interpreter engine
-	• il::codegen::x86_64 — instruction selection, regalloc, asm emitter
-	• fe::basic — BASIC front end (lexer/parser/AST/lowering)
-	• rt — C ABI runtime (no namespace; C headers)
+3. Tooling & Build
 
-5) Core IL library (C++)
-5.1 Data model (lightweight, cache‑friendly)
-	• Type system
+- C++ standard: C++20 (-std=c++20)
+- Warnings: -Wall -Wextra -Wpedantic -Werror
+- Sanitizers (dev/CI): -fsanitize=address,undefined
+- Dependencies (small, vendorable):
+  ○ fmt (formatted printing)
+  ○ CLI11 or lyra (CLI parsing), or roll a tiny one
+  ○ gtest or Catch2 (tests)
+- Style: clang-format, clang-tidy with a minimal config
+- CI: GitHub Actions matrix (Linux, macOS), caches build, runs sanitizers + tests
+
+1. Namespaces and libraries
+
+- il::core — types, values, instructions, module, symbol tables
+- il::build — IRBuilder helpers
+- il::io — text parser/serializer
+- il::verify — structural/type verifier
+- il::vm — interpreter engine
+- il::codegen::x86_64 — instruction selection, regalloc, asm emitter
+- fe::basic — BASIC front end (lexer/parser/AST/lowering)
+- rt — C ABI runtime (no namespace; C headers)
+
+1. Core IL library (C++)
+   5.1 Data model (lightweight, cache‑friendly)
+
+- Type system
 
 enum class TypeKind { Void, I1, I64, F64, Ptr, Str };
-struct Type { TypeKind kind; /* eq, hash */ };
-	• Value hierarchy (flat, tagged)
+struct Type { TypeKind kind; /\* eq, hash \*/ };
+
+- Value hierarchy (flat, tagged)
 
 enum class ValueKind { Temp, ConstInt, ConstFloat, ConstStr, GlobalAddr };
-struct Value { ValueKind kind; Type type; uint32_t id; /* payload via union */ };
+struct Value { ValueKind kind; Type type; uint32_t id; /\* payload via union \*/ };
 
 Rationale: a small tagged struct beats deep inheritance for speed and simplicity.
-	• Instruction
+
+- Instruction
 
 enum class Opcode { Add, Sub, Mul, SDiv, UDiv, ... , Load, Store, Call, Br, CBr, Ret, Alloca, GEP, ... };
 struct Instr {
-  Opcode op;
-  Type   type;        // result type if any (void for stores, branches)
-  Value  dst;         // optional (invalid for void)
-  small_vector<Value, 4> ops;  // operands
-  SourceLoc loc;      // optional metadata
+Opcode op;
+Type type; // result type if any (void for stores, branches)
+Value dst; // optional (invalid for void)
+small_vector\<Value, 4> ops; // operands
+SourceLoc loc; // optional metadata
 };
-	• BasicBlock / Function / Module
+
+- BasicBlock / Function / Module
 
 struct BasicBlock { Symbol name; std::vector<Instr> instrs; };
 struct Param { Symbol name; Type type; };
 struct Function {
-  Symbol name; std::vector<Param> params; Type ret;
-  std::vector<BasicBlock> blocks; AttrMask attrs; Visibility vis;
-  SymbolTable locals; // temps, slots if named
+Symbol name; std::vector<Param> params; Type ret;
+std::vector<BasicBlock> blocks; AttrMask attrs; Visibility vis;
+SymbolTable locals; // temps, slots if named
 };
 struct Global { Symbol name; Type type; GlobalInit init; bool isConst; Visibility vis; };
 struct Module { Target triple; vector<ExternDecl> externs; vector<Global> globals; vector<Function> funcs; StrTable strlits; };
-	• Symbol table & interning
-		○ Symbol is an interned string handle (uint32 id → string table).
-		○ All names (@main, labels, params) live in a per‑module interner.
-	• Memory management
-		○ Use arenas (monotonic buffers) for IR nodes; IR is long‑lived and mostly append‑only.
-5.2 IRBuilder (ergonomic construction)
-	• Fluent helpers that guarantee well‑formedness locally:
+
+- Symbol table & interning
+  ○ Symbol is an interned string handle (uint32 id → string table).
+  ○ All names (@main, labels, params) live in a per‑module interner.
+- Memory management
+  ○ Use arenas (monotonic buffers) for IR nodes; IR is long‑lived and mostly append‑only.
+  5.2 IRBuilder (ergonomic construction)
+- Fluent helpers that guarantee well‑formedness locally:
 
 class IRBuilder {
-  Function* f_;
-  BasicBlock* bb_;
-  // ...
-  Value const_i64(int64_t);
-  Value add(Value a, Value b);
-  void  br(Label dst);
-  void  cbr(Value cond, Label t, Label f);
-  // ...
+Function\* f\_;
+BasicBlock\* bb\_;
+// ...
+Value const_i64(int64_t);
+Value add(Value a, Value b);
+void br(Label dst);
+void cbr(Value cond, Label t, Label f);
+// ...
 };
-	• Enforces “exactly one terminator per block”, operand typing, and records source locations from front ends.
-5.3 IL I/O (text format)
-	• Serializer: pretty, deterministic (sorted externs/globals, stable temp numbering).
-	• Parser: Pratt‑style for expressions inside instructions isn’t needed; use a small hand‑rolled tokenizer and recursive descent for the grammar in your spec.
-	• Round‑trip tests: parse→print→parse equivalence (modulo whitespace).
-5.4 Verifier
-	• Structural checks (one terminator per block; labels defined/used).
-	• Type checks (operand and result types per opcode).
-	• Call signature checks.
-	• Memory ops alignment rules (load/store size vs natural alignment).
-Deliverable: il_verify(Module&) -> std::vector<Diagnostic>.
 
-6) Runtime library (/runtime, C, stable ABI)
-	• Files: rt_print.c, rt_string.c, rt_input.c, rt_mem.c, rt_math.c
-	• Headers: rt.h with declarations:
+- Enforces “exactly one terminator per block”, operand typing, and records source locations from front ends.
+  5.3 IL I/O (text format)
+- Serializer: pretty, deterministic (sorted externs/globals, stable temp numbering).
+- Parser: Pratt‑style for expressions inside instructions isn’t needed; use a small hand‑rolled tokenizer and recursive descent for the grammar in your spec.
+- Round‑trip tests: parse→print→parse equivalence (modulo whitespace).
+  5.4 Verifier
+- Structural checks (one terminator per block; labels defined/used).
+- Type checks (operand and result types per opcode).
+- Call signature checks.
+- Memory ops alignment rules (load/store size vs natural alignment).
+  Deliverable: il_verify(Module&) -> std::vector<Diagnostic>.
 
-void  rt_print_str(rt_str s);
-void  rt_print_i64(int64_t v);
-void  rt_print_f64(double v);
+6. Runtime library (/runtime, C, stable ABI)
+
+- Files: rt_print.c, rt_string.c, rt_input.c, rt_mem.c, rt_math.c
+- Headers: rt.h with declarations:
+
+void rt_print_str(rt_str s);
+void rt_print_i64(int64_t v);
+void rt_print_f64(double v);
 rt_str rt_input_line(void);
 int64_t rt_len(rt_str s);
 rt_str rt_concat(rt_str a, rt_str b);
 // ...
-void* rt_alloc(int64_t bytes); // simple wrapper on malloc for v1
-	• String representation: ref‑counted heap blocks (len + capacity + UTF‑8 bytes).
-	• Build: static library librt.a, linked by native binaries; callable from VM through host‑function table.
+void\* rt_alloc(int64_t bytes); // simple wrapper on malloc for v1
 
-7) Interpreter (il::vm)
-7.1 Execution engine
-	• VM types
+- String representation: ref‑counted heap blocks (len + capacity + UTF‑8 bytes).
+- Build: static library librt.a, linked by native binaries; callable from VM through host‑function table.
 
-struct Slot { uint64_t u64; double f64; void* ptr; /* tagged by Type at use */ };
+7. Interpreter (il::vm)
+   7.1 Execution engine
+
+- VM types
+
+struct Slot { uint64_t u64; double f64; void\* ptr; /\* tagged by Type at use */ };
 struct Frame {
-  Function* f;
-  std::vector<Slot> regs;       // virtual regs / temps
-  std::vector<uint8_t> stack;   // for alloca
-  size_t ip_block, ip_index;    // current block, instr index
+Function* f;
+std::vector<Slot> regs; // virtual regs / temps
+std::vector\<uint8_t> stack; // for alloca
+size_t ip_block, ip_index; // current block, instr index
 };
 struct VM {
-  Module* m;
-  HostFuncs host;               // C ABI shims to runtime
-  std::vector<Frame> callstack;
+Module\* m;
+HostFuncs host; // C ABI shims to runtime
+std::vector<Frame> callstack;
 };
-	• Dispatch: classic switch(opcode) on Instr; computed goto optional later.
-	• Alloca: bump pointer in Frame::stack, zero‑initialized.
-	• Load/store: check null + alignment, then memcpy by size (8 for i64/f64).
-	• Calls: if callee is IL function → push new frame; if extern → call host C function with marshalled args and result.
-	• Traps: throw VMTrap (or return error) with location; top‑level converts to diagnostic + non‑zero exit.
-7.2 Tracing & diagnostics
-	• --trace: dump func:label:instr and value states.
-	• --trace-calls: show call/ret push/pop frames.
-	• Include source metadata from IL when available.
 
-8) Codegen (il::codegen::x86_64)
-8.1 Pipeline
-	1. Lowering: turn IL instructions into a simple target‑agnostic MIR (optional) or go direct.
-	2. Liveness: compute live intervals of virtual regs within each function (linear time scan).
-	3. Regalloc (linear scan):
-		○ Register classes: GP (RAX…R15), FP (XMM0…XMM15).
-		○ Spill to fixed stack slots; reuse spills when possible.
-	4. Instruction selection: greedy patterns:
-		○ add i64 → addq
-		○ compares → cmp + setcc/cmovcc/conditional branches
-		○ load/store → mov with [base + disp]
-	5. Prologue/Epilogue:
-		○ Preserve RBX, RBP, R12–R15 if used.
-		○ 16‑byte stack alignment at call sites.
-	6. Calling convention (SysV x86‑64):
-		○ Int/pointers: RDI, RSI, RDX, RCX, R8, R9; floats: XMM0–7.
-		○ Return: RAX (int/pointer) or XMM0 (float).
-		○ i1 zero‑extended in EDI/EAX when passed/returned.
-	7. Asm emitter:
-		○ Output .text, .globl, labels, comments with IL source refs.
-		○ Choice of AT&T vs Intel syntax via flag (default AT&T on *nix).
-8.2 Toolchain integration
-	• Assembler/linker: call cc/clang to assemble .s → .o and link with librt.a.
-	• Output: a.out by default or -o <path>.
-	• Windows: add MS x64 or SysV for mingw in a later milestone.
+- Dispatch: classic switch(opcode) on Instr; computed goto optional later.
+- Alloca: bump pointer in Frame::stack, zero‑initialized.
+- Load/store: check null + alignment, then memcpy by size (8 for i64/f64).
+- Calls: if callee is IL function → push new frame; if extern → call host C function with marshalled args and result.
+- Traps: throw VMTrap (or return error) with location; top‑level converts to diagnostic + non‑zero exit.
+  7.2 Tracing & diagnostics
+- --trace: dump func:label:instr and value states.
+- --trace-calls: show call/ret push/pop frames.
+- Include source metadata from IL when available.
 
-9) BASIC front end (fe::basic)
-9.1 Lexer (hand‑rolled)
-	• Tokens: identifiers (A‑Z$, %), numbers (ints, floats), strings ("..."), keywords (PRINT, LET, IF, THEN, ELSE, WHILE, WEND, GOTO, GOSUB, RETURN, END), newlines/line numbers.
-	• Keep track of line labels (10, 20, …) → map to synthetic labels in IL.
-9.2 Parser
-	• Approach: recursive descent with a Pratt expression parser for precedence.
-	• AST: small node set (Expr, Stmt subclasses).
-	• Desugaring:
-		○ ELSEIF → IF nesting
-		○ WHILE/WEND → blocks and conditional branches
-		○ 1‑based string indexes → 0‑based IL/runtime calls
-9.3 Semantic analysis
-	• Symbol table for variables (global vs function‑local).
-	• Type coercions: numeric to i64/f64, string ops via runtime.
-	• Built‑ins mapping to runtime calls (e.g., PRINT routes to rt_print_*).
-9.4 Lowering to IL
-	• One IRBuilder instance per function.
-	• Variables → alloca 8 in entry + load/store.
-	• Branching and labels: maintain a map from BASIC line numbers to IL labels.
-	• Attach SourceLoc to each emitted instruction for diagnostics.
+8. Codegen (il::codegen::x86_64)
+   8.1 Pipeline
 
-10) CLI tools (/src/tools)
-	• ilc: the driver
-		○ ilc front basic file.bas -emit-il → stdout IL
-		○ ilc front basic file.bas -run → VM execution
-		○ ilc front basic file.bas -S → emit assembly
-		○ ilc front basic file.bas -o a.out → compile & link
-		○ --trace, --verify
-	• il-verify: reads IL, runs verifier, prints diagnostics.
-	• il-dis: pretty prints IL (for .il or binary form if added later).
+   1. Lowering: turn IL instructions into a simple target‑agnostic MIR (optional) or go direct.
+   1. Liveness: compute live intervals of virtual regs within each function (linear time scan).
+   1. Regalloc (linear scan):
+      ○ Register classes: GP (RAX…R15), FP (XMM0…XMM15).
+      ○ Spill to fixed stack slots; reuse spills when possible.
+   1. Instruction selection: greedy patterns:
+      ○ add i64 → addq
+      ○ compares → cmp + setcc/cmovcc/conditional branches
+      ○ load/store → mov with [base + disp]
+   1. Prologue/Epilogue:
+      ○ Preserve RBX, RBP, R12–R15 if used.
+      ○ 16‑byte stack alignment at call sites.
+   1. Calling convention (SysV x86‑64):
+      ○ Int/pointers: RDI, RSI, RDX, RCX, R8, R9; floats: XMM0–7.
+      ○ Return: RAX (int/pointer) or XMM0 (float).
+      ○ i1 zero‑extended in EDI/EAX when passed/returned.
+   1. Asm emitter:
+      ○ Output .text, .globl, labels, comments with IL source refs.
+      ○ Choice of AT&T vs Intel syntax via flag (default AT&T on \*nix).
+      8.2 Toolchain integration
 
-11) Testing strategy
-	• Unit tests:
-		○ Types, symbol tables, IRBuilder basic use.
-		○ Verifier: valid/invalid cases per rule.
-		○ VM arithmetic/branches/calls/traps.
-		○ Codegen snippets (e.g., add, cmp+jcc, call sequences) with assembler roundtrip.
-	• Golden tests:
-		○ BASIC → expected IL text (stable names/labels).
-		○ IL → expected pretty‑printed IL (round‑trip).
-	• End‑to‑end:
-		○ Run IL on VM vs compiled native; compare stdout and exit code.
-		○ Include edge cases: INT64_MIN/-1, div 0 trap, fptosi NaN trap.
-	• Fuzz (lightweight):
-		○ Randomized expressions in BASIC; ensure VM and native match.
+- Assembler/linker: call cc/clang to assemble .s → .o and link with librt.a.
+- Output: a.out by default or -o <path>.
+- Windows: add MS x64 or SysV for mingw in a later milestone.
 
-12) Diagnostics & developer UX
-	• Diagnostic object
+1. BASIC front end (fe::basic)
+   9.1 Lexer (hand‑rolled)
+
+- Tokens: identifiers (A‑Z$, %), numbers (ints, floats), strings ("..."), keywords (PRINT, LET, IF, THEN, ELSE, WHILE, WEND, GOTO, GOSUB, RETURN, END), newlines/line numbers.
+- Keep track of line labels (10, 20, …) → map to synthetic labels in IL.
+  9.2 Parser
+- Approach: recursive descent with a Pratt expression parser for precedence.
+- AST: small node set (Expr, Stmt subclasses).
+- Desugaring:
+  ○ ELSEIF → IF nesting
+  ○ WHILE/WEND → blocks and conditional branches
+  ○ 1‑based string indexes → 0‑based IL/runtime calls
+  9.3 Semantic analysis
+- Symbol table for variables (global vs function‑local).
+- Type coercions: numeric to i64/f64, string ops via runtime.
+- Built‑ins mapping to runtime calls (e.g., PRINT routes to rt_print\_\*).
+  9.4 Lowering to IL
+- One IRBuilder instance per function.
+- Variables → alloca 8 in entry + load/store.
+- Branching and labels: maintain a map from BASIC line numbers to IL labels.
+- Attach SourceLoc to each emitted instruction for diagnostics.
+
+1. CLI tools (/src/tools)
+
+- ilc: the driver
+  ○ ilc front basic file.bas -emit-il → stdout IL
+  ○ ilc front basic file.bas -run → VM execution
+  ○ ilc front basic file.bas -S → emit assembly
+  ○ ilc front basic file.bas -o a.out → compile & link
+  ○ --trace, --verify
+- il-verify: reads IL, runs verifier, prints diagnostics.
+- il-dis: pretty prints IL (for .il or binary form if added later).
+
+1. Testing strategy
+
+- Unit tests:
+  ○ Types, symbol tables, IRBuilder basic use.
+  ○ Verifier: valid/invalid cases per rule.
+  ○ VM arithmetic/branches/calls/traps.
+  ○ Codegen snippets (e.g., add, cmp+jcc, call sequences) with assembler roundtrip.
+- Golden tests:
+  ○ BASIC → expected IL text (stable names/labels).
+  ○ IL → expected pretty‑printed IL (round‑trip).
+- End‑to‑end:
+  ○ Run IL on VM vs compiled native; compare stdout and exit code.
+  ○ Include edge cases: INT64_MIN/-1, div 0 trap, fptosi NaN trap.
+- Fuzz (lightweight):
+  ○ Randomized expressions in BASIC; ensure VM and native match.
+
+1. Diagnostics & developer UX
+
+- Diagnostic object
 
 struct Diagnostic { Severity sev; std::string msg; SourceLoc loc; };
-	• Pretty printer: show source lines with carets; color in TTY.
-	• Trace modes: --trace, --trace-calls, --trace-regalloc (backend), --trace-asm.
 
-13) Performance & memory
-	• Arenas for IR nodes and string interning → low allocation overhead.
-	• VM fast path:
-		○ Cache frequently used runtime function pointers.
-		○ Optional direct‑threaded dispatch (compile‑time flag).
-	• Backend:
-		○ Peephole pass to remove redundant moves and combine cmp/jcc.
-		○ Linear‑scan with interval splitting once basic is stable.
+- Pretty printer: show source lines with carets; color in TTY.
+- Trace modes: --trace, --trace-calls, --trace-regalloc (backend), --trace-asm.
 
-14) Portability plan
-	• Phase 1: Linux/macOS x86‑64 SysV.
-	• Phase 2: Windows x64 (different calling convention + prologue rules).
-	• Phase 3: ARM64 (Apple M‑series + Linux aarch64) with a sibling backend.
+13. Performance & memory
 
-15) Documentation & governance
-	• /docs/il-spec.md — the spec you wrote (versioned, with change log).
-	• /docs/adr/ — short Architecture Decision Records (e.g., “no φ in v0.1”).
-	• /docs/dev/ — build/run instructions, backend ABI notes, coding standards.
-	• Auto‑generated API docs with Doxygen (optional).
+- Arenas for IR nodes and string interning → low allocation overhead.
+- VM fast path:
+  ○ Cache frequently used runtime function pointers.
+  ○ Optional direct‑threaded dispatch (compile‑time flag).
+- Backend:
+  ○ Peephole pass to remove redundant moves and combine cmp/jcc.
+  ○ Linear‑scan with interval splitting once basic is stable.
 
-16) Milestones (project plan)
-M0 — Scaffolding (1–2 days)
-	• CMake skeleton, il_core stubs, librt hello‑world, CI, clang‑format.
-M1 — IL Core + Verifier
-	• Types/values/instructions, builder, serializer/parser, verifier, unit tests.
-M2 — VM
-	• Minimal interpreter executing arithmetic, branches, calls; host C runtime bridge; tracing.
-M3 — BASIC Front End (subset)
-	• Lexer/parser for LET, PRINT, IF/THEN/ELSE, GOTO, WHILE/WEND.
-	• Lowering to IL with source locations.
-	• Golden tests (BASIC→IL) + VM e2e.
-M4 — Codegen x86‑64 v1
-	• Greedy selection, simple linear‑scan, prologue/epilogue, runtime calls, link.
-	• Differential tests (VM vs native) for the conformance suite.
-M5 — Quality pass
-	• Peephole fixes, better diagnostics, more runtime funcs (strings/math), docs polish.
+1. Portability plan
 
-17) Extension hooks
-	• Pass framework: add a tiny pass manager (il::pass::run(Module&, PassPipeline)), even if you only do verify and peephole initially.
-	• Plugin points:
-		○ New front ends register with ilc via a factory.
-		○ Backends: il::codegen::Backend interface so ARM64 can slot in later.
-	• Optional SSA: add an “IL→SSA→IL” pass later if you want classic data‑flow opts.
+- Phase 1: Linux/macOS x86‑64 SysV.
+- Phase 2: Windows x64 (different calling convention + prologue rules).
+- Phase 3: ARM64 (Apple M‑series + Linux aarch64) with a sibling backend.
 
-18) Risk controls (to avoid VC‑style sprawl)
-	• Keep runtime and compiler strictly separate; communicate only over the C ABI.
-	• No front end is allowed to emit target‑specific hints; everything goes through IL.
-	• Verifier is always run in debug builds (and via ilc --verify).
-	• Each new feature ships with:
-		1. unit test(s),
-		2. golden IL (if front end),
-		3. VM vs native differential test.
+1. Documentation & governance
 
-19) What to implement first (files checklist)
-	• /src/il/Type.h/.cc — Type, equality, helpers
-	• /src/il/IR.h/.cc — Value, Instr, BasicBlock, Function, Module
-	• /src/il/IRBuilder.h/.cc — helpers
-	• /src/il/Serialize.h/.cc — text I/O
-	• /src/il/Verify.h/.cc — verifier
-	• /src/vm/VM.h/.cc — engine, run(Module&, entry)
-	• /runtime/rt.h, rt_print.c, rt_string.c, rt_input.c — minimal runtime
-	• /src/tools/ilc.cc — driver with -emit-il and -run
-	• Tests: unit + two e2e samples (e.g., “HELLO”, “sum 1..10”)
-This gives you a walking skeleton: end‑to‑end from BASIC → IL → VM run, with verify and text I/O, ready for codegen to slot in.
+- /docs/il-spec.md — the spec you wrote (versioned, with change log).
+- /docs/adr/ — short Architecture Decision Records (e.g., “no φ in v0.1”).
+- /docs/dev/ — build/run instructions, backend ABI notes, coding standards.
+- Auto‑generated API docs with Doxygen (optional).
+
+1. Milestones (project plan)
+   M0 — Scaffolding (1–2 days)
+
+- CMake skeleton, il_core stubs, librt hello‑world, CI, clang‑format.
+  M1 — IL Core + Verifier
+- Types/values/instructions, builder, serializer/parser, verifier, unit tests.
+  M2 — VM
+- Minimal interpreter executing arithmetic, branches, calls; host C runtime bridge; tracing.
+  M3 — BASIC Front End (subset)
+- Lexer/parser for LET, PRINT, IF/THEN/ELSE, GOTO, WHILE/WEND.
+- Lowering to IL with source locations.
+- Golden tests (BASIC→IL) + VM e2e.
+  M4 — Codegen x86‑64 v1
+- Greedy selection, simple linear‑scan, prologue/epilogue, runtime calls, link.
+- Differential tests (VM vs native) for the conformance suite.
+  M5 — Quality pass
+- Peephole fixes, better diagnostics, more runtime funcs (strings/math), docs polish.
+
+1. Extension hooks
+
+- Pass framework: add a tiny pass manager (il::pass::run(Module&, PassPipeline)), even if you only do verify and peephole initially.
+- Plugin points:
+  ○ New front ends register with ilc via a factory.
+  ○ Backends: il::codegen::Backend interface so ARM64 can slot in later.
+- Optional SSA: add an “IL→SSA→IL” pass later if you want classic data‑flow opts.
+
+1. Risk controls (to avoid VC‑style sprawl)
+
+- Keep runtime and compiler strictly separate; communicate only over the C ABI.
+- No front end is allowed to emit target‑specific hints; everything goes through IL.
+- Verifier is always run in debug builds (and via ilc --verify).
+- Each new feature ships with:
+  1\. unit test(s),
+  2\. golden IL (if front end),
+  3\. VM vs native differential test.
+
+1. What to implement first (files checklist)
+
+- /src/il/Type.h/.cc — Type, equality, helpers
+- /src/il/IR.h/.cc — Value, Instr, BasicBlock, Function, Module
+- /src/il/IRBuilder.h/.cc — helpers
+- /src/il/Serialize.h/.cc — text I/O
+- /src/il/Verify.h/.cc — verifier
+- /src/vm/VM.h/.cc — engine, run(Module&, entry)
+- /runtime/rt.h, rt_print.c, rt_string.c, rt_input.c — minimal runtime
+- /src/tools/ilc.cc — driver with -emit-il and -run
+- Tests: unit + two e2e samples (e.g., “HELLO”, “sum 1..10”)
+  This gives you a walking skeleton: end‑to‑end from BASIC → IL → VM run, with verify and text I/O, ready for codegen to slot in.
 
 Closing thought
 This structure keeps each layer crisp and independently testable. You can develop methodically: lock IL + verifier, bring up the VM (semantic oracle), then add the BASIC front end (golden tests), and finally land x86‑64 codegen with differential tests. Each milestone is small enough for a single dev and friendly to a coding assistant working off this plan.

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -1,161 +1,170 @@
-here’s a concrete, end‑to‑end design you can use as a blueprint. It assumes a two-layer architecture with a “thin waist” Intermediate Language (IL) that everything revolves around. You’ll start with a BASIC front end, run IL via an interpreter, and add an IL→assembly backend as a separate module.
+# Project Overview
 
-0) Project Goals
-	1. Multi-language front ends (start with BASIC; later add others) that all lower to a common IL.
-	2. Backend interpreter that executes IL directly (great for fast bring‑up, tests, and debugging).
-	3. Backend compiler that translates IL to assembly (x86‑64 SysV first), assembled and linked into native binaries.
-	4. Small, solo‑friendly codebase with clear module boundaries, strong tests, and an extensible runtime ABI.
+Here’s a concrete, end-to-end design you can use as a blueprint. It assumes a two-layer
+architecture with a “thin waist” Intermediate Language (IL) that everything revolves
+around. You’ll start with a BASIC front end, run IL via an interpreter, and add an
+IL→assembly backend as a separate module.
 
-1) High-Level Architecture
+0. Project Goals
 
-        +-----------------------+      +-----------------------+
-        |   Frontends (N)       |      |   Tools               |
-        |  - BASIC (v1)         |      |  - CLI (driver)       |
-        |  - Future: Tiny C,    |      |  - IL verifier        |
-        |    Pascal, …          |      |  - Disassembler       |
-        +-----------+-----------+      +-----------+-----------+
-                    |                              |
-                    v                              |
-        +-----------------------+                  |
-        |   IL Builder          |                  |
-        |  (in-memory IR)       |                  |
-        +-----------+-----------+                  |
-                    |                              |
-           +--------v---------+            +-------v----------+
-           |   IL Optimizer   |   (opt)    |   IL Serializer  |
-           |  (optional)      | ---------->|  .il text/bc     |
-           +--------+---------+            +-------+----------+
-                    |                              |
-                    +------------------------------+  
-                    |
-     +--------------+--------------------+
-     |                                   |
-     v                                   v
-+------------+                    +--------------------+
-| IL VM      |                    | Codegen Backend    |
-| (Interpreter)                   | IL -> Assembly     |
-| run .il in-process             | emit .s , assemble |
-+------------+                    +--------------------+
-        |                                   |
-        v                                   v
-     Program                             Native Binary
-Thin waist: All languages produce the same IL; both the VM and codegen consume the same IL.
+   1. Multi-language front ends (start with BASIC; later add others) that all lower to a common IL.
+   1. Backend interpreter that executes IL directly (great for fast bring‑up, tests, and debugging).
+   1. Backend compiler that translates IL to assembly (x86‑64 SysV first), assembled and linked into native binaries.
+   1. Small, solo‑friendly codebase with clear module boundaries, strong tests, and an extensible runtime ABI.
 
-2) Components & Responsibilities
-2.1 Front Ends (start with BASIC)
-	• Purpose: Translate source to IL while enforcing language rules (syntax + semantics).
-	• Subcomponents:
-		○ Lexer: tokens (identifiers, numbers, strings, keywords).
-		○ Parser: builds an AST for a subset of BASIC (e.g., LET, PRINT, IF/THEN/ELSE, WHILE/WEND, GOTO, GOSUB/RETURN, function calls if present).
-		○ Semantic Analysis: symbol tables (variables, functions), simple type handling (integer, float, string), constant folding for literals.
-		○ Desugaring: normalize constructs (e.g., ELSEIF → nested IF).
-		○ Lowering to IL: walk the AST and emit IL instructions via an IR Builder.
-	• Output: an in-memory IL Module (functions, global variables, string constants).
-	Why this separation: It keeps language-specific work isolated. To add a new language later, you reuse IR Builder and runtime ABI.
+1. High-Level Architecture
+
+   ```
+    +-----------------------+      +-----------------------+
+    |   Frontends (N)       |      |   Tools               |
+    |  - BASIC (v1)         |      |  - CLI (driver)       |
+    |  - Future: Tiny C,    |      |  - IL verifier        |
+    |    Pascal, …          |      |  - Disassembler       |
+    +-----------+-----------+      +-----------+-----------+
+                |                              |
+                v                              |
+    +-----------------------+                  |
+    |   IL Builder          |                  |
+    |  (in-memory IR)       |                  |
+    +-----------+-----------+                  |
+                |                              |
+       +--------v---------+            +-------v----------+
+       |   IL Optimizer   |   (opt)    |   IL Serializer  |
+       |  (optional)      | ---------->|  .il text/bc     |
+       +--------+---------+            +-------+----------+
+                |                              |
+                +------------------------------+  
+                |
+   ```
+
+   +--------------+--------------------+
+   | |
+   v v
+   +------------+ +--------------------+
+   | IL VM | | Codegen Backend |
+   | (Interpreter) | IL -> Assembly |
+   | run .il in-process | emit .s , assemble |
+   +------------+ +--------------------+
+   | |
+   v v
+   Program Native Binary
+   Thin waist: All languages produce the same IL; both the VM and codegen consume the same IL.
+
+1. Components & Responsibilities
+   2.1 Front Ends (start with BASIC)
+   • Purpose: Translate source to IL while enforcing language rules (syntax + semantics).
+   • Subcomponents:
+   ○ Lexer: tokens (identifiers, numbers, strings, keywords).
+   ○ Parser: builds an AST for a subset of BASIC (e.g., LET, PRINT, IF/THEN/ELSE, WHILE/WEND, GOTO, GOSUB/RETURN, function calls if present).
+   ○ Semantic Analysis: symbol tables (variables, functions), simple type handling (integer, float, string), constant folding for literals.
+   ○ Desugaring: normalize constructs (e.g., ELSEIF → nested IF).
+   ○ Lowering to IL: walk the AST and emit IL instructions via an IR Builder.
+   • Output: an in-memory IL Module (functions, global variables, string constants).
+   Why this separation: It keeps language-specific work isolated. To add a new language later, you reuse IR Builder and runtime ABI.
 
 2.2 Intermediate Language (IL)
-	• Purpose: A simple, SSA-optional, three-address style IR that’s easy to interpret and easy to lower to assembly.
-	• Form: In-memory graph of Functions → BasicBlocks → Instructions; optionally serializable to a human-readable text format (.il) and to a compact bytecode (.ilbc) later.
-	• Types (minimal v1):
-		○ i1 (bool), i32, i64, f64, ptr, str (handle to runtime-managed string).
-	• Values:
-		○ Virtual registers (temporaries), constants, globals, function symbols.
-	• Instructions (v1 set, intentionally small):
-		○ Arithmetic: add, sub, mul, div, mod (integers), fadd, fsub, fmul, fdiv (floats).
-		○ Bitwise: and, or, xor, shl, shr.
-		○ Compare: cmp_eq, cmp_ne, cmp_lt, cmp_le, cmp_gt, cmp_ge (int/float variants).
-		○ Control: br label, cbr cond, tlabel, flabel, ret [val].
-		○ Memory: load ptr, store ptr, val, alloca size (stack slot), gep base, offset (simple pointer arithmetic).
-		○ Call: call func_symbol, arg1, ... (conforms to runtime ABI).
-		○ Const: const_i64, const_f64, const_str, const_ptr.
-		○ Cast (minimal): sitofp, fptosi, zext/trunc as needed.
-	• Metadata:
-		○ Source locations (file:line:col) attached to instructions for diagnostics and debugging.
-		○ Function attributes (e.g., noreturn, pure) later.
-	• Control Flow: Basic blocks end with exactly one terminator (br, cbr, or ret).
-	• Calling convention (IL-level):
-		○ Simple: by-value scalars; pointers for strings/arrays; return via register or implicit out‑param if larger than a machine word.
-	SSA? Start without SSA to keep it simple. You can add an SSA pass later (with Φ nodes) if you want classic dataflow optimizations.
+• Purpose: A simple, SSA-optional, three-address style IR that’s easy to interpret and easy to lower to assembly.
+• Form: In-memory graph of Functions → BasicBlocks → Instructions; optionally serializable to a human-readable text format (.il) and to a compact bytecode (.ilbc) later.
+• Types (minimal v1):
+○ i1 (bool), i32, i64, f64, ptr, str (handle to runtime-managed string).
+• Values:
+○ Virtual registers (temporaries), constants, globals, function symbols.
+• Instructions (v1 set, intentionally small):
+○ Arithmetic: add, sub, mul, div, mod (integers), fadd, fsub, fmul, fdiv (floats).
+○ Bitwise: and, or, xor, shl, shr.
+○ Compare: cmp_eq, cmp_ne, cmp_lt, cmp_le, cmp_gt, cmp_ge (int/float variants).
+○ Control: br label, cbr cond, tlabel, flabel, ret [val].
+○ Memory: load ptr, store ptr, val, alloca size (stack slot), gep base, offset (simple pointer arithmetic).
+○ Call: call func_symbol, arg1, ... (conforms to runtime ABI).
+○ Const: const_i64, const_f64, const_str, const_ptr.
+○ Cast (minimal): sitofp, fptosi, zext/trunc as needed.
+• Metadata:
+○ Source locations (file:line:col) attached to instructions for diagnostics and debugging.
+○ Function attributes (e.g., noreturn, pure) later.
+• Control Flow: Basic blocks end with exactly one terminator (br, cbr, or ret).
+• Calling convention (IL-level):
+○ Simple: by-value scalars; pointers for strings/arrays; return via register or implicit out‑param if larger than a machine word.
+SSA? Start without SSA to keep it simple. You can add an SSA pass later (with Φ nodes) if you want classic dataflow optimizations.
 
 2.3 Runtime Library & ABI
-	• Purpose: Provide I/O and utilities as normal functions callable from IL (and later, from compiled code), so front ends don’t hardcode behavior.
-	• Initial surface (prefixed rt_):
-		○ Console: rt_print_str(str), rt_print_i64(i64), rt_print_f64(f64), rt_input_line() -> str.
-		○ Strings: rt_len(str)->i64, rt_concat(str,str)->str, rt_substr(str,i64,i64)->str, rt_to_int(str)->i64, rt_to_float(str)->f64.
-		○ Math (optional): rt_sin(f64), rt_cos, rt_pow, etc., often thin wrappers on libc.
-		○ Memory: rt_alloc(size)->ptr, rt_free(ptr). Strings use internal ref-count or arena.
-	• Implementation: C for portability; expose a stable C ABI.
-	• Memory/Strings: Start with ref-counted strings (simpler than GC). Later you can swap to a small, precise GC without changing IL.
-	The compiler lowers BASIC built-ins like PRINT → call rt_print_*. The interpreter and native code both call the same functions.
+• Purpose: Provide I/O and utilities as normal functions callable from IL (and later, from compiled code), so front ends don’t hardcode behavior.
+• Initial surface (prefixed rt\_):
+○ Console: rt_print_str(str), rt_print_i64(i64), rt_print_f64(f64), rt_input_line() -> str.
+○ Strings: rt_len(str)->i64, rt_concat(str,str)->str, rt_substr(str,i64,i64)->str, rt_to_int(str)->i64, rt_to_float(str)->f64.
+○ Math (optional): rt_sin(f64), rt_cos, rt_pow, etc., often thin wrappers on libc.
+○ Memory: rt_alloc(size)->ptr, rt_free(ptr). Strings use internal ref-count or arena.
+• Implementation: C for portability; expose a stable C ABI.
+• Memory/Strings: Start with ref-counted strings (simpler than GC). Later you can swap to a small, precise GC without changing IL.
+The compiler lowers BASIC built-ins like PRINT → call rt_print\_\*. The interpreter and native code both call the same functions.
 
 2.4 IL VM (Interpreter)
-	• Purpose: Execute IL quickly for development, testing, and “script-like” usage.
-	• Execution model: Register-based interpreter over decoded instructions (no need for a separate bytecode in v1; interpret the in-memory IR).
-	• State:
-		○ Frame: local virtual-register array, stack slots (for alloca), a call stack of frames.
-		○ Heap: managed by runtime (for strings/arrays).
-		○ Globals: addresses bound at module load time.
-	• Main loop (sketch):
+• Purpose: Execute IL quickly for development, testing, and “script-like” usage.
+• Execution model: Register-based interpreter over decoded instructions (no need for a separate bytecode in v1; interpret the in-memory IR).
+• State:
+○ Frame: local virtual-register array, stack slots (for alloca), a call stack of frames.
+○ Heap: managed by runtime (for strings/arrays).
+○ Globals: addresses bound at module load time.
+• Main loop (sketch):
 
 for (;;) {
-  switch (instr.opcode) {
-    case OP_ADD: regs[d] = regs[a] + regs[b]; ip++; break;
-    case OP_CBR: ip = regs[cond] ? then_bb->first : else_bb->first; break;
-    case OP_CALL: regs[dst] = call_runtime_or_fn(fsym, args...); ip++; break;
-    case OP_RET:  return regs[retv];
-    // ...
-  }
+switch (instr.opcode) {
+case OP_ADD: regs[d] = regs[a] + regs[b]; ip++; break;
+case OP_CBR: ip = regs[cond] ? then_bb->first : else_bb->first; break;
+case OP_CALL: regs[dst] = call_runtime_or_fn(fsym, args...); ip++; break;
+case OP_RET: return regs[retv];
+// ...
 }
-	• Diagnostics:
-		○ On runtime error (e.g., wrong type to rt_len), report with source location metadata from the IL and a short backtrace of IL call frames.
-	• Performance: Plenty for early stages. If you need more speed, add:
-		○ A compact bytecode encoder (.ilbc) to optimize dispatch.
-		○ Direct-threaded dispatch (computed gotos) in C/C++.
-		○ Simple hot-path inliner in the VM.
+}
+• Diagnostics:
+○ On runtime error (e.g., wrong type to rt_len), report with source location metadata from the IL and a short backtrace of IL call frames.
+• Performance: Plenty for early stages. If you need more speed, add:
+○ A compact bytecode encoder (.ilbc) to optimize dispatch.
+○ Direct-threaded dispatch (computed gotos) in C/C++.
+○ Simple hot-path inliner in the VM.
 
 2.5 Codegen Backend (IL → Assembly)
-	• Purpose: Produce native binaries from IL.
-	• Targets: Start with x86‑64 SysV (Linux/macOS); later add Windows x64 and ARM64.
-	• Pipeline:
-		1. Instruction Selection: Greedy mapping of IL ops to asm patterns (no need for DAG selector at first).
-		2. Register Allocation: Start with linear-scan over virtual registers; spill to the stack as needed.
-		3. Prologue/Epilogue: Set up call frame, preserve callee-saved registers, align stack.
-		4. Calling Convention: Map IL calls to native ABI (SysV: integer args in rdi, rsi, rdx, rcx, r8, r9; float args in xmm0..).
-		5. Emitting Assembly: Generate .s (AT&T or Intel syntax); invoke the system assembler and linker.
-	• Files:
-		○ module.s → assemble → module.o → link with librt.a → a.out.
-	• Debug Info (optional in v1):
-		○ Emit comments with source line info, later expand to DWARF if desired.
+• Purpose: Produce native binaries from IL.
+• Targets: Start with x86‑64 SysV (Linux/macOS); later add Windows x64 and ARM64.
+• Pipeline:
+1\. Instruction Selection: Greedy mapping of IL ops to asm patterns (no need for DAG selector at first).
+2\. Register Allocation: Start with linear-scan over virtual registers; spill to the stack as needed.
+3\. Prologue/Epilogue: Set up call frame, preserve callee-saved registers, align stack.
+4\. Calling Convention: Map IL calls to native ABI (SysV: integer args in rdi, rsi, rdx, rcx, r8, r9; float args in xmm0..).
+5\. Emitting Assembly: Generate .s (AT&T or Intel syntax); invoke the system assembler and linker.
+• Files:
+○ module.s → assemble → module.o → link with librt.a → a.out.
+• Debug Info (optional in v1):
+○ Emit comments with source line info, later expand to DWARF if desired.
 
 2.6 Tools / Driver
-	• CLI (ilc as example):
-		○ ilc front basic file.bas -emit-il (print IL)
-		○ ilc front basic file.bas -run (front → IL → run on VM)
-		○ ilc front basic file.bas -S (front → IL → asm)
-		○ ilc front basic file.bas -o a.out (front → IL → asm → link)
-		○ ilc il-opt file.il -o file.opt.il (optional)
-		○ ilc il-verify file.il (structure/type checks)
-	• Verifier: Ensures each block ends with a terminator, types of operands match, calls match signatures, etc.
-	• Disassembler: Pretty-print IL from binary form (if you add .ilbc).
+• CLI (ilc as example):
+○ ilc front basic file.bas -emit-il (print IL)
+○ ilc front basic file.bas -run (front → IL → run on VM)
+○ ilc front basic file.bas -S (front → IL → asm)
+○ ilc front basic file.bas -o a.out (front → IL → asm → link)
+○ ilc il-opt file.il -o file.opt.il (optional)
+○ ilc il-verify file.il (structure/type checks)
+• Verifier: Ensures each block ends with a terminator, types of operands match, calls match signatures, etc.
+• Disassembler: Pretty-print IL from binary form (if you add .ilbc).
 
-3) Implementation Language & Structure
-	• Language choice:
-		○ C++20 is a sweet spot for ASTs, IR graph, and RAII management (smart pointers, std::vector, std::unordered_map).
-		○ Keep the runtime in C with a stable ABI.
-	• Repo layout:
+3. Implementation Language & Structure
+   • Language choice:
+   ○ C++20 is a sweet spot for ASTs, IR graph, and RAII management (smart pointers, std::vector, std::unordered_map).
+   ○ Keep the runtime in C with a stable ABI.
+   • Repo layout:
 
-/runtime/        (C)   rt_*.c, rt_*.h, build to librt.a
-/il/             (C++) IL core: types, module, builder, verifier, serializer
-/vm/             (C++) IL interpreter
-/codegen/        (C++) x86_64 backend, regalloc, asm emitter
+/runtime/ (C) rt\_*.c, rt\_*.h, build to librt.a
+/il/ (C++) IL core: types, module, builder, verifier, serializer
+/vm/ (C++) IL interpreter
+/codegen/ (C++) x86_64 backend, regalloc, asm emitter
 /frontends/
-    /basic/      (C++) lexer, parser, AST, lowering
-    /common/     (C++) shared front-end utils
-/tools/          (C++) CLI driver, disassembler
-/tests/          (mixed) unit + golden + e2e
+/basic/ (C++) lexer, parser, AST, lowering
+/common/ (C++) shared front-end utils
+/tools/ (C++) CLI driver, disassembler
+/tests/ (mixed) unit + golden + e2e
 
-4) BASIC v1: Source → IL Example
-BASIC (subset):
+4. BASIC v1: Source → IL Example
+   BASIC (subset):
 
 10 PRINT "HELLO"
 20 LET X = 2 + 3
@@ -164,68 +173,69 @@ BASIC (subset):
 Lowered IL (textual sketch):
 
 module {
-  global str @.L0 = "HELLO"
+global str @.L0 = "HELLO"
 func @main() -> i32 {
-  entry:
-    %t0 = const_str @.L0
-    call @rt_print_str(%t0)
+entry:
+%t0 = const_str @.L0
+call @rt_print_str(%t0)
 %t1 = const_i64 2
-    %t2 = const_i64 3
-    %t3 = add %t1, %t2
-    store &X, %t3
+%t2 = const_i64 3
+%t3 = add %t1, %t2
+store &X, %t3
 %t4 = load &X
-    %t5 = cmp_gt %t4, const_i64 4
-    cbr %t5, then, else
+%t5 = cmp_gt %t4, const_i64 4
+cbr %t5, then, else
 then:
-    call @rt_print_i64(%t4)
-    br exit
+call @rt_print_i64(%t4)
+br exit
 else:
-    call @rt_print_i64(const_i64 4)
-    br exit
+call @rt_print_i64(const_i64 4)
+br exit
 exit:
-    ret const_i32 0
-  }
+ret const_i32 0
 }
-	Note: &X can be modeled as a function‑local stack slot created via alloca in entry.
+}
+Note: &X can be modeled as a function‑local stack slot created via alloca in entry.
 
-5) Testing Strategy (solo‑friendly)
-	1. Golden tests for front ends: source → expected IL text.
-	2. VM e2e tests: run IL on interpreter; assert stdout/return code.
-	3. Backend e2e tests: same programs compiled to native; compare output to VM.
-	4. Differential testing: VM result vs. native result for each sample.
-	5. IL verifier unit tests: deliberately malformed IR to ensure verifier catches issues.
-	6. Fuzz lite: fuzz front-end lexer/parser (strings, numbers, nesting) with small seeds.
+5. Testing Strategy (solo‑friendly)
 
-6) Extensibility: Adding New Languages
-	• Contract: New front end just needs to produce valid IL and adhere to the runtime ABI for I/O and strings.
-	• BASIC specifics:
-		○ Keywords map to simple control flow and runtime calls.
-		○ Dynamic-ish typing can be handled by front-end coercions to a small IL type set (i64, f64, str) plus runtime helpers.
-Later front ends (Tiny C / Pascal):
-	• Reuse symbol tables and type checker utilities where possible.
-	• Keep desugaring consistent (loops → blocks and branches).
-	• Avoid pushing complexity into IL: keep IL small and orthogonal.
+   1. Golden tests for front ends: source → expected IL text.
+   1. VM e2e tests: run IL on interpreter; assert stdout/return code.
+   1. Backend e2e tests: same programs compiled to native; compare output to VM.
+   1. Differential testing: VM result vs. native result for each sample.
+   1. IL verifier unit tests: deliberately malformed IR to ensure verifier catches issues.
+   1. Fuzz lite: fuzz front-end lexer/parser (strings, numbers, nesting) with small seeds.
 
-7) IL Details Worth Nailing Early
-	• Integer width: choose i64 as the canonical integer; i32 only if you need it for external ABIs.
-	• Floats: f64 only at first.
-	• Strings: opaque str handle; only manipulated via runtime calls.
-	• Booleans: i1 for branch conditions.
-	• Undefined behavior: define it narrowly—e.g., division by zero triggers a runtime error with a diagnostic.
-	• Verifier rules (non-exhaustive):
-		○ All operands dominate their uses.
-		○ Every block has exactly one terminator.
-		○ Types of operands match opcode expectations.
-		○ Calls match callee signatures (arity + types).
-		○ No fallthrough between blocks without a br.
+1. Extensibility: Adding New Languages
+   • Contract: New front end just needs to produce valid IL and adhere to the runtime ABI for I/O and strings.
+   • BASIC specifics:
+   ○ Keywords map to simple control flow and runtime calls.
+   ○ Dynamic-ish typing can be handled by front-end coercions to a small IL type set (i64, f64, str) plus runtime helpers.
+   Later front ends (Tiny C / Pascal):
+   • Reuse symbol tables and type checker utilities where possible.
+   • Keep desugaring consistent (loops → blocks and branches).
+   • Avoid pushing complexity into IL: keep IL small and orthogonal.
 
-8) Interpreter vs Codegen: Division of Labor
-	• Interpreter is your oracle for semantics and the fastest path to a working system.
-	• Backend focuses purely on performance and binary output, not language behavior.
-	• When a test fails in native, compare to VM output to isolate codegen bugs.
+1. IL Details Worth Nailing Early
+   • Integer width: choose i64 as the canonical integer; i32 only if you need it for external ABIs.
+   • Floats: f64 only at first.
+   • Strings: opaque str handle; only manipulated via runtime calls.
+   • Booleans: i1 for branch conditions.
+   • Undefined behavior: define it narrowly—e.g., division by zero triggers a runtime error with a diagnostic.
+   • Verifier rules (non-exhaustive):
+   ○ All operands dominate their uses.
+   ○ Every block has exactly one terminator.
+   ○ Types of operands match opcode expectations.
+   ○ Calls match callee signatures (arity + types).
+   ○ No fallthrough between blocks without a br.
 
-9) Minimal Code Sketches
-IR Builder (C++-ish)
+1. Interpreter vs Codegen: Division of Labor
+   • Interpreter is your oracle for semantics and the fastest path to a working system.
+   • Backend focuses purely on performance and binary output, not language behavior.
+   • When a test fails in native, compare to VM output to isolate codegen bugs.
+
+1. Minimal Code Sketches
+   IR Builder (C++-ish)
 
 Value v1 = b.const_i64(2);
 Value v2 = b.const_i64(3);
@@ -235,71 +245,75 @@ b.ret(b.const_i32(0));
 Interpreter dispatch (C-like)
 
 for (;;) {
-  Instr *i = ip++;
-  switch (i->op) {
-    case OP_ADD: regs[i->dst] = regs[i->a].i64 + regs[i->b].i64; break;
-    case OP_CBR: ip = regs[i->cond].i1 ? i->tgt : i->ftgt; break;
-    case OP_CALL: regs[i->dst] = call_host(i->callee, regs, i->argc); break;
-    case OP_RET:  return regs[i->retv];
-    // ...
-  }
+Instr \*i = ip++;
+switch (i->op) {
+case OP_ADD: regs[i->dst] = regs[i->a].i64 + regs[i->b].i64; break;
+case OP_CBR: ip = regs[i->cond].i1 ? i->tgt : i->ftgt; break;
+case OP_CALL: regs[i->dst] = call_host(i->callee, regs, i->argc); break;
+case OP_RET: return regs[i->retv];
+// ...
+}
 }
 Assembly emission (x86‑64 SysV, sketch)
 
 # prologue
+
 push %rbp
-mov  %rsp, %rbp
-sub  $32, %rsp           # spill area
+mov %rsp, %rbp
+sub $32, %rsp # spill area
+
 # ... instructions mapped from IL ...
+
 # epilogue
-mov  %rbp, %rsp
-pop  %rbp
+
+mov %rbp, %rsp
+pop %rbp
 ret
 
-10) Diagnostics & Developer UX
-	• Source mapping: carry file/line/col through AST → IL → VM/native for clear errors.
-	• Pretty errors: show source snippet with a caret.
-	• Tracing (optional): VM flag --trace-il to print each executed IL instruction with values.
-	• ** REPL (nice-to-have)**: ilc repl runs a BASIC prompt backed by the VM.
+10. Diagnostics & Developer UX
+    • Source mapping: carry file/line/col through AST → IL → VM/native for clear errors.
+    • Pretty errors: show source snippet with a caret.
+    • Tracing (optional): VM flag --trace-il to print each executed IL instruction with values.
+    • \*\* REPL (nice-to-have)\*\*: ilc repl runs a BASIC prompt backed by the VM.
 
-11) Performance (when you’re ready)
-	• Interpreter:
-		○ Switch → direct-threaded dispatch (computed goto).
-		○ Intern strings; cache common constant strings.
-	• Backend:
-		○ Peephole pass (remove redundant moves, combine cmp+jcc).
-		○ Simple constant folding at IL build time (you’ll get many wins “for free”).
-		○ Linear-scan regalloc with live-interval splitting.
+01. Performance (when you’re ready)
+    • Interpreter:
+    ○ Switch → direct-threaded dispatch (computed goto).
+    ○ Intern strings; cache common constant strings.
+    • Backend:
+    ○ Peephole pass (remove redundant moves, combine cmp+jcc).
+    ○ Simple constant folding at IL build time (you’ll get many wins “for free”).
+    ○ Linear-scan regalloc with live-interval splitting.
 
-12) Risks & Mitigations
-	• Scope creep → Strict v1 feature set; milestone-based roadmap.
-	• Type system complexity → Keep IL types minimal; push conversions into front end and runtime helpers.
-	• String/heap bugs → Start with refcounted strings and a small test suite around them; add ASAN/UBSAN in CI.
-	• Codegen pitfalls → Lean on VM-oracle differential tests; begin with a single platform/ABI.
+01. Risks & Mitigations
+    • Scope creep → Strict v1 feature set; milestone-based roadmap.
+    • Type system complexity → Keep IL types minimal; push conversions into front end and runtime helpers.
+    • String/heap bugs → Start with refcounted strings and a small test suite around them; add ASAN/UBSAN in CI.
+    • Codegen pitfalls → Lean on VM-oracle differential tests; begin with a single platform/ABI.
 
-13) Roadmap (suggested)
-Milestone A (bring-up)
-	• BASIC front end for PRINT, LET, IF, GOTO.
-	• IL core + verifier + textual serializer.
-	• Runtime: rt_print_*, basic string support.
-	• VM executes small programs; golden tests.
-Milestone B (control & funcs)
-	• WHILE/WEND, FOR/NEXT (desugared), simple functions/procedures.
-	• Calls in IL + runtime input (rt_input_line).
-	• CLI flags: -emit-il, -run.
-Milestone C (codegen v1)
-	• x86‑64 SysV codegen, linear-scan regalloc, emit .s, assemble+link with librt.a.
-	• Differential tests (VM vs native).
-Milestone D (quality)
-	• Peephole optimizer, better diagnostics, small library expansion (strings/math/file I/O).
-	• Optional: bytecode encoding for faster VM.
+01. Roadmap (suggested)
+    Milestone A (bring-up)
+    • BASIC front end for PRINT, LET, IF, GOTO.
+    • IL core + verifier + textual serializer.
+    • Runtime: rt_print\_\*, basic string support.
+    • VM executes small programs; golden tests.
+    Milestone B (control & funcs)
+    • WHILE/WEND, FOR/NEXT (desugared), simple functions/procedures.
+    • Calls in IL + runtime input (rt_input_line).
+    • CLI flags: -emit-il, -run.
+    Milestone C (codegen v1)
+    • x86‑64 SysV codegen, linear-scan regalloc, emit .s, assemble+link with librt.a.
+    • Differential tests (VM vs native).
+    Milestone D (quality)
+    • Peephole optimizer, better diagnostics, small library expansion (strings/math/file I/O).
+    • Optional: bytecode encoding for faster VM.
 
-14) What’s “Done” for v1
-	• BASIC subset compiles to IL, runs correctly on the VM, and compiles to native with matching outputs.
-	• Clear CLI, docs, and tests.
-	• Clean separation of: front end ↔ IL ↔ VM/Codegen ↔ runtime.
+01. What’s “Done” for v1
+    • BASIC subset compiles to IL, runs correctly on the VM, and compiles to native with matching outputs.
+    • Clear CLI, docs, and tests.
+    • Clean separation of: front end ↔ IL ↔ VM/Codegen ↔ runtime.
 
 Final Notes
-	• This design stays intentionally small and orthogonal so you can build it solo without it turning into another sprawling VC.
-	• The IL is your stable contract: it keeps language work and machine work independent.
-	• The interpreter-first approach gives you immediate feedback and a rock-solid oracle for codegen.
+• This design stays intentionally small and orthogonal so you can build it solo without it turning into another sprawling VC.
+• The IL is your stable contract: it keeps language work and machine work independent.
+• The interpreter-first approach gives you immediate feedback and a rock-solid oracle for codegen.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,24 +1,30 @@
 # Roadmap
 
 ## Milestone A – Bring-up
+
 Bootstrap the build system and seed the core [class catalog](class-catalog.md).
 
 ## Milestone B – VM
+
 Establish the interpreter and runtime interface per the [IL spec](il-spec.md).
 
 ## Milestone C – BASIC front end
+
 Provide a lexer, parser, and lowering path from BASIC source to IL.
 
 ## Milestone D – Codegen prep
+
 Lay the groundwork for native code emission and register allocation.
 
 ### Status checklist
+
 - [ ] Milestone A complete
 - [ ] Milestone B complete
 - [ ] Milestone C complete
 - [ ] Milestone D complete
 
 ### Out of scope for v0.1
+
 - Optimizing code generation beyond basic correctness
 - Alternative language front ends
 - Parallel or concurrent execution models

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -9,7 +9,7 @@ adding new code or updating existing files.
 Every source and header file begins with a short block comment that
 explains the file's role. Use this template:
 
-```
+```cpp
 // File: <path/to/file>
 // Purpose: <one line>
 // Key invariants: <state what must hold>
@@ -41,7 +41,7 @@ Keep comments under ~100 characters per line.
 Member variables have short trailing comments focusing on meaning
 or units:
 
-```
+```cpp
 int count; ///< Number of active users.
 ```
 
@@ -58,7 +58,7 @@ Avoid repeating type information or restating obvious details.
 
 ### Class
 
-```
+```cpp
 // foo/Bar.h
 /// @brief Manages frobnications.
 /// @invariant ID is unique per instance.
@@ -76,7 +76,7 @@ private:
 
 ### Function
 
-```
+```cpp
 /// @brief Adds two integers.
 /// @param a First operand.
 /// @param b Second operand.
@@ -86,7 +86,7 @@ int add(int a, int b);
 
 ### Enum
 
-```
+```cpp
 /// @brief Token categories.
 /// @note Must align with the IL lexer.
 enum class TokenKind {


### PR DESCRIPTION
## Summary
- standardize spacing, headings, and lists across project markdown files
- add missing top-level headings and language tags for code examples
- tidy links and code fences in docs index and specification

## Testing
- `cmake -S . -B build && cmake --build build -j`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68b4bc2b804c8324bfd2720254845e5e