### PR TITLE
docs(readme): rewrite root README with overview, quickstart, layout, and doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,46 @@
-# ilc
+# Viper
 
-## Overview
+**IL Compiler & BASIC Frontend (VM-first)**
 
-ilc is an experimental compiler stack centered on a small, well-specified intermediate
-language (IL). The IL acts as a “thin waist” between source language front ends and
-eventual native code generation, keeping the core reusable across many languages and
-targets.
-
-The system is organized as front ends that lower programs into IL, the IL libraries and
-tools that parse and verify it, and a stack-based virtual machine (VM) that executes IL.
-Future work will add code generators that translate IL to native code.
-
-Currently the VM and a prototype BASIC front end are functional and can run small
-examples. Native code generation backends are planned but not yet implemented.
+Viper is an experimental compiler stack centered on a small, well-specified Intermediate Language (IL).
+Language frontends (currently a tiny BASIC) lower source programs to IL, IL libraries parse and verify modules, and a stack-based virtual machine executes IL today.
+The architecture flows from frontends → IL → VM, with native code generators planned for future phases.
 
 ## Quickstart
 
 ```sh
-cmake -S . -B build && cmake --build build -j
-./build/src/tools/il-verify/il-verify docs/examples/il/ex1_hello_cond.il
-./build/src/tools/ilc/ilc -run docs/examples/il/ex2_sum_1_to_10.il
-```
+# Configure and build with Clang
+cmake -S . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+cmake --build build
 
-## Documentation checks
-
-To verify file headers and public API comments locally, run:
-
-```sh
-cmake -S . -B build
-ctest --test-dir build -L Docs --output-on-failure
+# Run a BASIC example on the VM
+./build/src/tools/ilc/ilc front basic -run docs/examples/basic/ex1_hello_cond.bas
 ```
 
 ## Directory layout
 
 ```text
 .
-├── src/il              # IL core libraries, parser, and verifier
-├── src/vm              # stack-based virtual machine for IL
-├── src/frontends/basic # tiny BASIC front end lowering to IL
-├── runtime             # C runtime support for the VM
-├── docs                # specifications, design notes, and examples
-└── tests               # unit, golden, and end-to-end tests
+├── src/               # C++ sources: IL core, VM, frontends
+│   ├── il/            # IL core libraries, parser, verifier
+│   ├── vm/            # Stack-based virtual machine
+│   └── frontends/     # Language frontends (BASIC implemented)
+├── runtime/           # C runtime support for the VM
+├── docs/              # Specifications, guides, and examples
+├── tests/             # Unit, golden, and end-to-end tests
+├── scripts/           # Build and utility helpers
+└── CMakeLists.txt     # Top-level build configuration
 ```
 
 ## Documentation
 
-- [Docs overview](docs/README.md)
-- [IL v0.1.1 specification](docs/il-spec.md)
-- [BASIC v0.1 Language Reference](docs/basic-language-reference.md)
-- [Class catalog](docs/class-catalog.md)
-- [Project roadmap](docs/roadmap.md)
-- [Examples](docs/examples/)
+- [Docs index](docs/README.md)
+- [BASIC language reference](docs/basic-language-reference.md)
+- [IL specification](docs/il-spec.md)
 
 ## Contributing
 
-See [AGENTS.md](AGENTS.md) for contribution guidelines and workflow. Architecture changes
-should start with an ADR as described there.
+See [AGENTS.md](AGENTS.md) for contribution workflow and the [style guide](docs/style-guide.md) for formatting rules.
 
 ## License
 


### PR DESCRIPTION
## Summary
- replace root README with clear title, overview, and architecture description
- add Clang-based quickstart and directory layout tree
- link key docs plus contributing and style guide references

## Testing
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`
- `./build/src/tools/ilc/ilc front basic -run docs/examples/basic/ex1_hello_cond.bas`


------
https://chatgpt.com/codex/tasks/task_e_68b4c10d8e788324a9b406ea4ab8c6f1