### PR TITLE
docs: polish roadmap, class catalog, and style guide for consistency and clarity

### DIFF
--- a/docs/class-catalog.md
+++ b/docs/class-catalog.md
@@ -1,32 +1,81 @@
 # Class Catalog
 
-## Support layer
+Classes grouped by subsystem.
 
-Utility classes for symbols, memory arenas, diagnostics, and other shared helpers.
+## Support
 
-## IL Core
+| Class | Description |
+| --- | --- |
+| Arena | Bump allocator for temporary objects |
+| DiagnosticEngine | Records and prints errors and warnings |
+| Options | Global compiler flags |
+| Result<T> | Minimal expected-like container |
+| SourceManager | Maps file IDs to paths |
+| StringInterner | Interns strings into Symbols |
+| Symbol | Opaque handle for interned strings |
 
-Types, values, instructions, blocks, and modules that make up the in-memory IL
-([IL spec](il-spec.md)).
+## IL
 
-## IL build/IO/verify
+### Core
 
-Builders, parsers, serializers, and the verifier used to construct and check
-modules.
+| Class | Description |
+| --- | --- |
+| Module | Top-level container for functions and globals |
+| Function | Sequence of blocks forming a procedure |
+| BasicBlock | Linear list of instructions with a label |
+| Instr | Single IL instruction |
+| Value | Operand or constant |
+| Type | IL type descriptor |
+| Global | Named global variable |
+| Extern | External function declaration |
+| Param | Function parameter |
 
-## Front end (BASIC)
+### Build / IO / Verify
 
-Lexer, parser, AST, and lowering logic that turns BASIC source into IL.
+| Class | Description |
+| --- | --- |
+| IRBuilder | Fluent builder for IL modules |
+| Parser | Parses textual IL |
+| Serializer | Prints modules as text |
+| Verifier | Checks structural correctness |
+| PassManager | Runs transformation passes |
+| ConstFold | Constant folding pass |
+| Peephole | Peephole optimization pass |
+
+## Frontend (BASIC)
+
+| Class | Description |
+| --- | --- |
+| Token | Lexical token representation |
+| Lexer | Converts source text to tokens |
+| Parser | Builds AST from tokens |
+| AST nodes | Expression and statement hierarchy |
+| SemanticAnalyzer | Validates and annotates AST |
+| ConstFolder | Evaluates constant expressions |
+| Lowerer | Lowers AST to IL |
+| LoweringContext | Shared state for lowering |
+| NameMangler | Transforms identifiers for IL |
+| DiagnosticEmitter | Emits front-end diagnostics |
+| AstPrinter | Dumps AST for debugging |
 
 ## VM
 
-Runtime structures like slots and frames plus the dispatch loop that interprets
-IL.
+| Class | Description |
+| --- | --- |
+| VM | Stack-based interpreter |
+| RuntimeBridge | Calls into the C runtime |
 
 ## Codegen
 
-Placeholder for future native backends and register allocation work.
+| Class | Description |
+| --- | --- |
+| (placeholder) | Planned x86_64 backend |
 
 ## Tools
 
-Command-line utilities for invoking the compiler, verifier, and runtime tests.
+| Tool | Description |
+| --- | --- |
+| basic-ast-dump | Dumps BASIC ASTs |
+| il-dis | Disassembles IL modules |
+| il-verify | Verifies IL modules |
+| ilc | Driver for compilation and execution |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,30 +1,26 @@
 # Roadmap
 
-## Milestone A – Bring-up
+## Milestones
 
-Bootstrap the build system and seed the core [class catalog](class-catalog.md).
-
-## Milestone B – VM
-
-Establish the interpreter and runtime interface per the [IL spec](il-spec.md).
-
-## Milestone C – BASIC front end
-
-Provide a lexer, parser, and lowering path from BASIC source to IL.
-
-## Milestone D – Codegen prep
-
-Lay the groundwork for native code emission and register allocation.
+| ID | Stage | Focus |
+|----|-------|-------|
+| M0 | Bootstrap | Build system and seed the [class catalog](class-catalog.md) |
+| M1 | IL core | Types, instructions, and module scaffolding |
+| M2 | VM | Stack-based interpreter and runtime interface from the [IL spec](il-spec.md) |
+| M3 | BASIC front end | Lexer, parser, and lowering from BASIC to IL |
+| M4 | Codegen prep | Groundwork for native emission and register allocation |
 
 ### Status checklist
 
-- [ ] Milestone A complete
-- [ ] Milestone B complete
-- [ ] Milestone C complete
-- [ ] Milestone D complete
+- [x] M0 Bootstrap
+- [x] M1 IL core
+- [ ] M2 VM
+- [ ] M3 BASIC front end
+- [ ] M4 Codegen prep
 
-### Out of scope for v0.1
+### Future items
 
-- Optimizing code generation beyond basic correctness
-- Alternative language front ends
-- Parallel or concurrent execution models
+- String functions
+- Arrays
+- GOSUB/RETURN
+- SSA-based optimizations

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,13 +1,13 @@
 # Style guide
 
-This guide defines comment conventions and file headers for the
-Viper codebase. All contributors must follow these rules when
-adding new code or updating existing files.
+See [AGENTS.md](../AGENTS.md) for project-wide policies. This guide defines
+comment conventions and file headers for the Viper codebase. All contributors
+must follow these rules when adding new code or updating existing files.
 
 ## File headers
 
-Every source and header file begins with a short block comment that
-explains the file's role. Use this template:
+Every source and header file begins with a short block comment that explains
+the file's role. Use this template:
 
 ```cpp
 // File: <path/to/file>
@@ -23,10 +23,20 @@ explains the file's role. Use this template:
 - Keep lines concise and factual.
 - Omit fields that do not apply rather than leaving placeholders.
 
+### Example
+
+```cpp
+// foo/Bar.h
+// Purpose: Declares the Bar helper.
+// Key invariants: ID remains unique.
+// Ownership/Lifetime: Caller frees instances.
+// Links: docs/class-catalog.md
+```
+
 ## Doxygen API comments
 
-Public classes, functions, and members use Doxygen comments with
-triple slashes. Common tags:
+Public classes, functions, and members use Doxygen comments with triple
+slashes. Common tags:
 
 - `@brief` – one line summary.
 - `@param` – describe each parameter.


### PR DESCRIPTION
## Summary
- Expand roadmap with milestone table, status tracking, and future items
- Organize class catalog by subsystem using markdown tables with descriptions
- Cross-link style guide to AGENTS and add header examples

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b51e92d13c8324a26ed0e93b45d7da