### PR TITLE
style: add clang-format config and enforce in CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,16 @@
 BasedOnStyle: LLVM
-IndentWidth: 2
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+BreakBeforeBraces: Allman
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
 ColumnLimit: 100
+SpaceBeforeParens: ControlStatements
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeAssignmentOperators: true
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+IndentCaseLabels: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,21 @@ on:
   pull_request:
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install clang-format
+        run: sudo apt-get install -y clang-format
+      - name: Check formatting
+        run: |
+          git fetch origin main
+          CHANGED_FILES=$(git diff --name-only origin/main... | grep -E '\.(cpp|hpp)$' || true)
+          if [ -n "$CHANGED_FILES" ]; then
+            echo "$CHANGED_FILES" | xargs clang-format --dry-run --Werror
+          fi
   build:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ cmake --build build
 ## Contributing
 
 See [AGENTS.md](AGENTS.md) for contribution workflow and the [style guide](docs/style-guide.md) for formatting rules.
+Run `clang-format -i` on all `.cpp` and `.hpp` files before committing.
 
 ## License
 


### PR DESCRIPTION
## Summary
- configure clang-format for Allman braces and 4-space indentation
- document clang-format usage in README
- check formatting in CI for changed C++ sources

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b520ef46048324905e5c320ac2baf3