### PR TITLE
style: reformat all source with clang-format (Allman, 4 spaces)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,15 @@ endif()
 add_compile_options(${IL_COMPILE_FLAGS})
 add_link_options(${IL_LINK_FLAGS})
 
+file(GLOB_RECURSE ALL_CXX_SOURCE_FILES
+     src/*.cpp src/*.hpp
+     runtime/*.cpp runtime/*.hpp)
+
+add_custom_target(format
+  COMMAND clang-format -i ${ALL_CXX_SOURCE_FILES}
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+
 option(IL_ENABLE_X64_ASM_SYNTAX_CHECK "Check generated x86_64 asm syntax" ON)
 option(IL_ENABLE_X64_ASM_ASSEMBLE_LINK "Assemble+link x86_64 asm" ON)
 option(IL_ENABLE_X64_NATIVE_RUN "Run x86_64 binaries" ON)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cmake --build build
 ## Contributing
 
 See [AGENTS.md](AGENTS.md) for contribution workflow and the [style guide](docs/style-guide.md) for formatting rules.
-Run `clang-format -i` on all `.cpp` and `.hpp` files before committing.
+Run `cmake --build build --target format` to apply clang-format to all `.cpp` and `.hpp` files before committing.
 
 ## License
 

--- a/src/codegen/x86_64/placeholder.cpp
+++ b/src/codegen/x86_64/placeholder.cpp
@@ -3,6 +3,10 @@
 // Key invariants: None.
 // Ownership/Lifetime: Not applicable.
 // Links: docs/class-catalog.md
-namespace il::codegen::x86_64 {
-int placeholder() { return 0; }
+namespace il::codegen::x86_64
+{
+int placeholder()
+{
+    return 0;
+}
 } // namespace il::codegen::x86_64


### PR DESCRIPTION
## Summary
- Run clang-format across all C++ sources using the existing Allman/4-space config.
- Add a `format` target to CMake to easily apply clang-format to the tree.
- Document formatting via `cmake --build build --target format` in README.

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cmake --build build --target format`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b524b8ddf483249035eda2c6039fe9