### PR TITLE
feat(basic/print): suppress final newline when PRINT ends with a trailing semicolon

### DIFF
--- a/docs/basic-language-reference.md
+++ b/docs/basic-language-reference.md
@@ -52,7 +52,7 @@ Logical operators short-circuit and return Boolean.
 | Statement | Meaning |
 |-----------|---------|
 | `LET v = expr` | assign to variable `v` (auto-declare) |
-| `PRINT items` | write values to stdout; separators: `,` inserts space, `;` inserts nothing; newline appended |
+| `PRINT items` | write values to stdout; separators: `,` inserts space, `;` inserts nothing; newline appended unless statement ends with `;` |
 | `IF c THEN … [ELSEIF …]* [ELSE …]` | conditional execution |
 | `WHILE c … WEND` | loop while condition `c` is true |
 | `FOR v = start TO end [STEP s] … NEXT v` | counted loop |
@@ -67,7 +67,16 @@ Logical operators short-circuit and return Boolean.
 | Separator | Effect |
 |-----------|--------|
 | `,`       | print space |
-| `;`       | print nothing |
+| `;`       | print nothing; if last, suppress newline |
+
+An example with trailing `;`:
+
+```basic
+10 PRINT "A";
+20 PRINT "B"
+```
+prints `AB` on one line. The semicolon after `"A"` suppresses the newline so the next
+`PRINT` continues on the same line.
 
 Multi-statement `THEN`/`ELSE` blocks may appear on new lines or be separated by `:`.
 
@@ -114,6 +123,7 @@ The front end lowers BASIC to IL; see the [IL v0.1.1 spec](./il-spec.md) for ins
 |---------------------|-----------------------------------------------------------|---------|
 | `PRINT "X"`         | `%s = const_str @.L; call @rt_print_str(%s)`              | `rt_print_str(str)` |
 | `PRINT X`           | `%v = load i64, %slotX; call @rt_print_i64(%v)`           | `rt_print_i64(i64)` |
+| `PRINT "A";`       | `call @rt_print_str("A")`                               | `rt_print_str(str)` |
 | `PRINT "A", 1`     | `call @rt_print_str("A"); call @rt_print_str(" "); call @rt_print_i64(1); call @rt_print_str("\n")` | `rt_print_str(str)`, `rt_print_i64(i64)` |
 | `PRINT "A"; 1`     | `call @rt_print_str("A"); call @rt_print_i64(1); call @rt_print_str("\n")` | `rt_print_str(str)`, `rt_print_i64(i64)` |
 | `LET X = A + B`     | `load A; load B; %c = add %a,%b; store X,%c`              | — |

--- a/docs/examples/basic/ex_print_newline_control.bas
+++ b/docs/examples/basic/ex_print_newline_control.bas
@@ -1,0 +1,2 @@
+10 PRINT "A";
+20 PRINT "B"

--- a/src/frontends/basic/AST.hpp
+++ b/src/frontends/basic/AST.hpp
@@ -111,10 +111,12 @@ struct PrintItem
 };
 
 /// @brief PRINT statement outputting a sequence of expressions and separators.
+/// Trailing semicolon suppresses the automatic newline.
 /// @invariant items.size() > 0
 struct PrintStmt : Stmt
 {
-    std::vector<PrintItem> items; ///< Items printed in order; final newline appended.
+    std::vector<PrintItem> items; ///< Items printed in order; unless the last item is
+                                  ///< a semicolon, a newline is appended.
 };
 
 /// @brief Assignment statement to variable or array element.

--- a/src/frontends/basic/Lowerer.cpp
+++ b/src/frontends/basic/Lowerer.cpp
@@ -435,10 +435,15 @@ void Lowerer::lowerPrint(const PrintStmt &stmt)
                 break;
         }
     }
-    std::string nlLbl = getStringLabel("\n");
-    Value nl = emitConstStr(nlLbl);
-    curLoc = stmt.loc;
-    emitCall("rt_print_str", {nl});
+
+    bool suppress_nl = !stmt.items.empty() && stmt.items.back().kind == PrintItem::Kind::Semicolon;
+    if (!suppress_nl)
+    {
+        std::string nlLbl = getStringLabel("\n");
+        Value nl = emitConstStr(nlLbl);
+        curLoc = stmt.loc;
+        emitCall("rt_print_str", {nl});
+    }
 }
 
 void Lowerer::lowerIf(const IfStmt &stmt)

--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -114,6 +114,7 @@ StmtPtr Parser::parsePrint()
         }
         stmt->items.push_back(PrintItem{PrintItem::Kind::Expr, parseExpression()});
     }
+    // A trailing ';' produces a final Semicolon item, suppressing the newline.
     return stmt;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -165,6 +165,11 @@ add_test(NAME basic_to_il_print_semicolons COMMAND ${CMAKE_COMMAND}
   -DBAS_FILE=${CMAKE_SOURCE_DIR}/docs/examples/basic/ex_print_semicolons.bas
   -DGOLDEN=${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/print_semicolons.il
   -P ${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/check_il.cmake)
+add_test(NAME basic_to_il_print_newline_control COMMAND ${CMAKE_COMMAND}
+  -DILC=${BASIC_ILC}
+  -DBAS_FILE=${CMAKE_SOURCE_DIR}/docs/examples/basic/ex_print_newline_control.bas
+  -DGOLDEN=${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/print_newline_control.il
+  -P ${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/check_il.cmake)
 add_test(NAME basic_to_il_loc COMMAND ${CMAKE_COMMAND}
   -DILC=${BASIC_ILC}
   -DBAS_FILE=${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/loc_add.bas

--- a/tests/e2e/test_front_basic.cmake
+++ b/tests/e2e/test_front_basic.cmake
@@ -70,6 +70,17 @@ if(NOT RS STREQUAL "A1B\n")
   message(FATAL_ERROR "unexpected print_semicolons output: ${RS}")
 endif()
 
+# test PRINT newline control with trailing ';'
+execute_process(COMMAND ${ILC} front basic -run ${SRC_DIR}/docs/examples/basic/ex_print_newline_control.bas
+                OUTPUT_FILE run_nl.txt RESULT_VARIABLE rn)
+if(NOT rn EQUAL 0)
+  message(FATAL_ERROR "execution print_newline_control failed")
+endif()
+file(READ run_nl.txt RN)
+if(NOT RN STREQUAL "AB\n")
+  message(FATAL_ERROR "unexpected print_newline_control output: ${RN}")
+endif()
+
 # test INPUT string echo
 execute_process(COMMAND ${ILC} front basic -run ${SRC_DIR}/docs/examples/basic/ex5_input_echo.bas --stdin-from ${SRC_DIR}/tests/data/input1.txt
                 OUTPUT_FILE run3.txt RESULT_VARIABLE r4)

--- a/tests/golden/basic_to_il/print_newline_control.il
+++ b/tests/golden/basic_to_il/print_newline_control.il
@@ -1,0 +1,34 @@
+il 0.1
+extern @rt_print_str(str) -> void
+extern @rt_print_i64(i64) -> void
+extern @rt_print_f64(f64) -> void
+extern @rt_len(str) -> i64
+extern @rt_substr(str, i64, i64) -> str
+global const str @.L0 = "A"
+global const str @.L1 = "B"
+global const str @.L2 = "
+"
+func @main() -> i64 {
+entry:
+  br label L10
+L10:
+  .loc 1 1 10
+  %t0 = const_str @.L0
+  .loc 1 1 4
+  call @rt_print_str(%t0)
+  .loc 1 1 4
+  br label L20
+L20:
+  .loc 1 2 10
+  %t1 = const_str @.L1
+  .loc 1 2 4
+  call @rt_print_str(%t1)
+  .loc 1 2 4
+  %t2 = const_str @.L2
+  .loc 1 2 4
+  call @rt_print_str(%t2)
+  .loc 1 2 4
+  br label exit
+exit:
+  ret 0
+}


### PR DESCRIPTION
## Summary
- honor trailing `;` in BASIC `PRINT` by skipping the automatic newline
- document newline suppression and add example coverage

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b763c28fd88324a51ea42d2a967656