### PR TITLE
feat(vm): add --max-steps guard to prevent infinite loops in tests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,3 +36,14 @@ Tools that produce IL for golden tests emit a canonical form:
 - constants rendered deterministically with minimal formatting.
 
 This mode ensures test diffs are stable and comparable across builds.
+
+## Tools
+
+### VM flags
+
+`ilc -run <file.il>` accepts additional debugging flags:
+
+- `--trace` — print executed instructions.
+- `--stdin-from <file>` — read program input from a file.
+- `--max-steps <N>` — abort after executing `N` instructions with the message
+  `VM: step limit exceeded (N); aborting.`

--- a/docs/basic-language-reference.md
+++ b/docs/basic-language-reference.md
@@ -148,5 +148,15 @@ The front end lowers BASIC to IL; see the [IL v0.1.1 spec](./il-spec.md) for ins
 
 BASIC's 1-based indices become 0-based for runtime calls.
 
+## Debugging the interpreter
+When a program hangs due to an infinite loop, run it with a step limit:
+
+```sh
+ilc -run tests/data/loop.il --max-steps 5
+```
+
+This aborts after five instructions and prints
+`VM: step limit exceeded (5); aborting.`
+
 ## Examples
 See the [BASIC examples](./examples/basic/) and their IL counterparts.

--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -17,6 +17,7 @@
 #include "il/verify/Verifier.hpp"
 #include "support/source_manager.hpp"
 #include "vm/VM.hpp"
+#include <cstdint>
 #include <cstdio>
 #include <fstream>
 #include <iostream>
@@ -31,9 +32,10 @@ using namespace il::support;
 static void usage()
 {
     std::cerr << "ilc v0.1.0\n"
-              << "Usage: ilc -run <file.il> [--trace] [--stdin-from <file>]\n"
+              << "Usage: ilc -run <file.il> [--trace] [--stdin-from <file>] [--max-steps N]\n"
               << "       ilc front basic -emit-il <file.bas>\n"
-              << "       ilc front basic -run <file.bas> [--trace] [--stdin-from <file>]\n"
+              << "       ilc front basic -run <file.bas> [--trace] [--stdin-from <file>] "
+                 "[--max-steps N]\n"
               << "       ilc il-opt <in.il> -o <out.il> --passes p1,p2\n";
 }
 
@@ -57,6 +59,7 @@ int main(int argc, char **argv)
         }
         std::string ilFile = argv[2];
         std::string stdinPath;
+        uint64_t maxSteps = 0;
         for (int i = 3; i < argc; ++i)
         {
             std::string arg = argv[i];
@@ -67,6 +70,10 @@ int main(int argc, char **argv)
             else if (arg == "--stdin-from" && i + 1 < argc)
             {
                 stdinPath = argv[++i];
+            }
+            else if (arg == "--max-steps" && i + 1 < argc)
+            {
+                maxSteps = std::stoull(argv[++i]);
             }
             else
             {
@@ -93,7 +100,7 @@ int main(int argc, char **argv)
                 return 1;
             }
         }
-        vm::VM vm(m, trace);
+        vm::VM vm(m, trace, maxSteps);
         return static_cast<int>(vm.run());
     }
 
@@ -170,6 +177,7 @@ int main(int argc, char **argv)
             bool run = false;
             std::string file;
             std::string stdinPath;
+            uint64_t maxSteps = 0;
             for (int i = 3; i < argc; ++i)
             {
                 std::string arg = argv[i];
@@ -190,6 +198,10 @@ int main(int argc, char **argv)
                 else if (arg == "--stdin-from" && i + 1 < argc)
                 {
                     stdinPath = argv[++i];
+                }
+                else if (arg == "--max-steps" && i + 1 < argc)
+                {
+                    maxSteps = std::stoull(argv[++i]);
                 }
                 else
                 {
@@ -246,7 +258,7 @@ int main(int argc, char **argv)
                     return 1;
                 }
             }
-            vm::VM vm(m, trace);
+            vm::VM vm(m, trace, maxSteps);
             return static_cast<int>(vm.run());
         }
     }

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -17,7 +17,7 @@ using namespace il::core;
 namespace il::vm
 {
 
-VM::VM(const Module &m, bool tr) : mod(m), trace(tr)
+VM::VM(const Module &m, bool tr, uint64_t ms) : mod(m), trace(tr), maxSteps(ms)
 {
     for (const auto &f : m.functions)
         fnMap[f.name] = &f;
@@ -72,9 +72,15 @@ int64_t VM::execFunction(const Function &fn)
     size_t ip = 0;
     while (bb && ip < bb->instructions.size())
     {
+        if (maxSteps && steps >= maxSteps)
+        {
+            std::cerr << "VM: step limit exceeded (" << maxSteps << "); aborting.\n";
+            return 1;
+        }
         const Instr &in = bb->instructions[ip];
         if (trace)
             std::cerr << fn.name << ":" << bb->label << ":" << toString(in.op) << "\n";
+        ++steps;
         switch (in.op)
         {
             case Opcode::Alloca:

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -43,7 +43,8 @@ class VM
     /// @brief Create VM for module @p m.
     /// @param m IL module to execute.
     /// @param trace Enable instruction tracing.
-    VM(const il::core::Module &m, bool trace = false);
+    /// @param maxSteps Abort after executing @p maxSteps instructions (0 = unlimited).
+    VM(const il::core::Module &m, bool trace = false, uint64_t maxSteps = 0);
 
     /// @brief Execute the module's entry function.
     /// @return Exit code from main function.
@@ -52,6 +53,8 @@ class VM
   private:
     const il::core::Module &mod; ///< Module to execute
     bool trace;                  ///< Whether to print executed instructions
+    uint64_t maxSteps;           ///< Step limit; 0 means unlimited
+    uint64_t steps = 0;          ///< Executed instruction count
     std::unordered_map<std::string, const il::core::Function *> fnMap; ///< Name lookup
     std::unordered_map<std::string, rt_str> strMap;                    ///< String pool
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,12 @@ add_test(NAME vm_strings_example COMMAND ${CMAKE_COMMAND}
   -P ${CMAKE_CURRENT_SOURCE_DIR}/e2e/test_vm_strings.cmake)
 set_tests_properties(vm_strings_example PROPERTIES LABELS VM)
 
+add_test(NAME vm_step_limit COMMAND ${CMAKE_COMMAND}
+  -DILC=$<TARGET_FILE:ilc>
+  -DSRC_DIR=${CMAKE_SOURCE_DIR}
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/e2e/test_vm_step_limit.cmake)
+set_tests_properties(vm_step_limit PROPERTIES LABELS VM)
+
 add_test(NAME front_basic_example COMMAND ${CMAKE_COMMAND}
   -DILC=$<TARGET_FILE:ilc>
   -DSRC_DIR=${CMAKE_SOURCE_DIR}

--- a/tests/data/loop.il
+++ b/tests/data/loop.il
@@ -1,0 +1,8 @@
+il 0.1
+
+func @main() -> i64 {
+entry:
+  br label loop
+loop:
+  br label loop
+}

--- a/tests/e2e/test_vm_step_limit.cmake
+++ b/tests/e2e/test_vm_step_limit.cmake
@@ -1,0 +1,10 @@
+execute_process(COMMAND ${ILC} -run ${SRC_DIR}/tests/data/loop.il --max-steps 5
+                OUTPUT_FILE out.txt ERROR_FILE err.txt RESULT_VARIABLE r)
+if(r EQUAL 0)
+  message(FATAL_ERROR "expected non-zero exit")
+endif()
+file(READ err.txt E)
+string(FIND "${E}" "VM: step limit exceeded (5); aborting." pos)
+if(pos EQUAL -1)
+  message(FATAL_ERROR "missing step limit message")
+endif()


### PR DESCRIPTION
## Summary
- add instruction step limit to VM and abort with message when exceeded
- expose --max-steps flag in ilc CLI and update documentation
- include loop fixture and e2e test for the new guard

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b769de2c0c8324b50cff6fa6a42f4d