### PR TITLE
feat(basic): support ':' multi-statement lines with left-to-right execution; docs+tests

### DIFF
--- a/docs/basic-language-reference.md
+++ b/docs/basic-language-reference.md
@@ -8,10 +8,23 @@ BASIC programs lower to [IL v0.1.1](./il-spec.md) and run on the VM interpreter.
 native codegen is future work.- Includes variables, arithmetic, strings, conditionals, loops,
     simple I / O.
 
-               ##Program structure &line numbers A program is a sequence of statements separated by
-                   newlines or `:`.Line numbers are optional labels(`GOTO` targets);
-execution starts at the first statement.
-Comments begin with `'` and continue to end of line.
+## Program structure & line numbers
+A program is a sequence of statements separated by newlines. Line numbers are optional labels (`GOTO` targets);
+execution starts at the first statement. Comments begin with `'` and continue to end of line.
+
+### Multi-statement lines with `:`
+Multiple statements on the same line separated by `:` execute left-to-right.
+
+```basic
+10 LET A = 1 : PRINT A : LET A = A + 1 : PRINT A
+```
+
+prints:
+
+```
+1
+2
+```
 
 ```basic
 10 PRINT "HELLO"

--- a/docs/examples/basic/ex_colon.bas
+++ b/docs/examples/basic/ex_colon.bas
@@ -1,0 +1,2 @@
+10 LET A = 1 : PRINT A : LET A = A + 1 : PRINT A
+

--- a/src/frontends/basic/AST.hpp
+++ b/src/frontends/basic/AST.hpp
@@ -179,6 +179,12 @@ struct InputStmt : Stmt
     std::string var; ///< Target variable name (may end with '$').
 };
 
+/// @brief Sequence of statements executed left-to-right on one BASIC line.
+struct StmtList : Stmt
+{
+    std::vector<StmtPtr> stmts; ///< Ordered statements sharing the same line.
+};
+
 struct Program
 {
     std::vector<StmtPtr> statements;

--- a/src/frontends/basic/AstPrinter.cpp
+++ b/src/frontends/basic/AstPrinter.cpp
@@ -22,7 +22,15 @@ std::string AstPrinter::dump(const Program &prog)
 
 std::string AstPrinter::dump(const Stmt &stmt)
 {
-    if (auto *p = dynamic_cast<const PrintStmt *>(&stmt))
+    if (auto *lst = dynamic_cast<const StmtList *>(&stmt))
+    {
+        std::string res = "(SEQ";
+        for (auto &s : lst->stmts)
+            res += " " + dump(*s);
+        res += ")";
+        return res;
+    }
+    else if (auto *p = dynamic_cast<const PrintStmt *>(&stmt))
     {
         std::string res = "(PRINT";
         for (const auto &it : p->items)

--- a/src/frontends/basic/ConstFolder.cpp
+++ b/src/frontends/basic/ConstFolder.cpp
@@ -187,7 +187,12 @@ static void foldStmt(StmtPtr &s)
 {
     if (!s)
         return;
-    if (auto *p = dynamic_cast<PrintStmt *>(s.get()))
+    if (auto *lst = dynamic_cast<StmtList *>(s.get()))
+    {
+        for (auto &st : lst->stmts)
+            foldStmt(st);
+    }
+    else if (auto *p = dynamic_cast<PrintStmt *>(s.get()))
     {
         for (auto &it : p->items)
             if (it.kind == PrintItem::Kind::Expr)

--- a/src/frontends/basic/Lowerer.cpp
+++ b/src/frontends/basic/Lowerer.cpp
@@ -151,7 +151,12 @@ void Lowerer::collectVars(const Program &prog)
     };
     std::function<void(const Stmt &)> st = [&](const Stmt &s)
     {
-        if (auto *p = dynamic_cast<const PrintStmt *>(&s))
+        if (auto *lst = dynamic_cast<const StmtList *>(&s))
+        {
+            for (const auto &sub : lst->stmts)
+                st(*sub);
+        }
+        else if (auto *p = dynamic_cast<const PrintStmt *>(&s))
         {
             for (const auto &it : p->items)
                 if (it.kind == PrintItem::Kind::Expr)
@@ -203,7 +208,16 @@ void Lowerer::collectVars(const Program &prog)
 void Lowerer::lowerStmt(const Stmt &stmt)
 {
     curLoc = stmt.loc;
-    if (auto *p = dynamic_cast<const PrintStmt *>(&stmt))
+    if (auto *lst = dynamic_cast<const StmtList *>(&stmt))
+    {
+        for (const auto &s : lst->stmts)
+        {
+            if (cur->terminated)
+                break;
+            lowerStmt(*s);
+        }
+    }
+    else if (auto *p = dynamic_cast<const PrintStmt *>(&stmt))
         lowerPrint(*p);
     else if (auto *l = dynamic_cast<const LetStmt *>(&stmt))
         lowerLet(*l);

--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -45,17 +45,31 @@ std::unique_ptr<Program> Parser::parseProgram()
             line = std::atoi(current_.lexeme.c_str());
             advance();
         }
+        std::vector<StmtPtr> stmts;
         while (true)
         {
             auto stmt = parseStatement(line);
             stmt->line = line;
-            prog->statements.push_back(std::move(stmt));
+            stmts.push_back(std::move(stmt));
             if (check(TokenKind::Colon))
             {
                 advance();
                 continue;
             }
             break;
+        }
+        if (stmts.size() == 1)
+        {
+            prog->statements.push_back(std::move(stmts.front()));
+        }
+        else
+        {
+            il::support::SourceLoc loc = stmts.front()->loc;
+            auto list = std::make_unique<StmtList>();
+            list->line = line;
+            list->loc = loc;
+            list->stmts = std::move(stmts);
+            prog->statements.push_back(std::move(list));
         }
         if (check(TokenKind::EndOfLine))
             advance();

--- a/src/frontends/basic/SemanticAnalyzer.cpp
+++ b/src/frontends/basic/SemanticAnalyzer.cpp
@@ -57,7 +57,13 @@ void SemanticAnalyzer::analyze(const Program &prog)
 
 void SemanticAnalyzer::visitStmt(const Stmt &s)
 {
-    if (auto *p = dynamic_cast<const PrintStmt *>(&s))
+    if (auto *lst = dynamic_cast<const StmtList *>(&s))
+    {
+        for (const auto &st : lst->stmts)
+            if (st)
+                visitStmt(*st);
+    }
+    else if (auto *p = dynamic_cast<const PrintStmt *>(&s))
     {
         for (const auto &it : p->items)
             if (it.kind == PrintItem::Kind::Expr && it.expr)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -181,6 +181,11 @@ add_test(NAME basic_to_il_print_newline_control COMMAND ${CMAKE_COMMAND}
   -DBAS_FILE=${CMAKE_SOURCE_DIR}/docs/examples/basic/ex_print_newline_control.bas
   -DGOLDEN=${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/print_newline_control.il
   -P ${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/check_il.cmake)
+add_test(NAME basic_to_il_colon COMMAND ${CMAKE_COMMAND}
+  -DILC=${BASIC_ILC}
+  -DBAS_FILE=${CMAKE_SOURCE_DIR}/docs/examples/basic/ex_colon.bas
+  -DGOLDEN=${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/ex_colon.il
+  -P ${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/check_il.cmake)
 add_test(NAME basic_to_il_loc COMMAND ${CMAKE_COMMAND}
   -DILC=${BASIC_ILC}
   -DBAS_FILE=${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/loc_add.bas

--- a/tests/e2e/test_front_basic.cmake
+++ b/tests/e2e/test_front_basic.cmake
@@ -134,6 +134,17 @@ if(NOT _n2)
   message(FATAL_ERROR "missing array sum")
 endif()
 
+# test multi-statement lines with ':'
+execute_process(COMMAND ${ILC} front basic -run ${SRC_DIR}/docs/examples/basic/ex_colon.bas
+                OUTPUT_FILE run_colon.txt RESULT_VARIABLE rcol)
+if(NOT rcol EQUAL 0)
+  message(FATAL_ERROR "execution ex_colon failed")
+endif()
+file(READ run_colon.txt RCOL)
+if(NOT RCOL STREQUAL "1\n2\n")
+  message(FATAL_ERROR "unexpected ex_colon output: ${RCOL}")
+endif()
+
 # test unary NOT
 execute_process(COMMAND ${ILC} front basic -run ${SRC_DIR}/docs/examples/basic/ex_not.bas
                 OUTPUT_FILE run_not.txt RESULT_VARIABLE rn)

--- a/tests/golden/basic_to_il/ex_colon.il
+++ b/tests/golden/basic_to_il/ex_colon.il
@@ -1,0 +1,42 @@
+il 0.1
+extern @rt_print_str(str) -> void
+extern @rt_print_i64(i64) -> void
+extern @rt_print_f64(f64) -> void
+extern @rt_len(str) -> i64
+extern @rt_substr(str, i64, i64) -> str
+global const str @.L0 = "
+"
+func @main() -> i64 {
+entry:
+  %t0 = alloca 8
+  br label L10
+L10:
+  .loc 1 1 4
+  store i64, %t0, 1
+  .loc 1 1 22
+  %t1 = load i64, %t0
+  .loc 1 1 16
+  call @rt_print_i64(%t1)
+  .loc 1 1 16
+  %t2 = const_str @.L0
+  .loc 1 1 16
+  call @rt_print_str(%t2)
+  .loc 1 1 34
+  %t3 = load i64, %t0
+  .loc 1 1 36
+  %t4 = add %t3, 1
+  .loc 1 1 26
+  store i64, %t0, %t4
+  .loc 1 1 48
+  %t5 = load i64, %t0
+  .loc 1 1 42
+  call @rt_print_i64(%t5)
+  .loc 1 1 42
+  %t6 = const_str @.L0
+  .loc 1 1 42
+  call @rt_print_str(%t6)
+  .loc 1 1 4
+  br label exit
+exit:
+  ret 0
+}


### PR DESCRIPTION
## Summary
- allow `:` to chain BASIC statements on one line; parsed into `StmtList` and lowered sequentially
- document multi-statement lines and add example
- add golden BASIC→IL and e2e tests for colon chaining

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b7755854608324a7c90e5c089bb430