### PR TITLE
feat(il/opt): peephole fold cbr(cond, L, L) into br L; add golden

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,12 @@ This mode ensures test diffs are stable and comparable across builds.
 
 ## Tools
 
+### il-opt
+
+`ilc il-opt` applies optimizer passes to IL modules.
+
+- `peephole`: folds `cbr %cond, label L, label L` into `br label L`.
+
 ### VM flags
 
 `ilc -run <file.il>` accepts additional debugging flags:

--- a/src/il/transform/Peephole.cpp
+++ b/src/il/transform/Peephole.cpp
@@ -65,6 +65,13 @@ void peephole(Module &m)
                 Instr &in = b.instructions[i];
                 if (in.op == Opcode::CBr)
                 {
+                    if (in.labels.size() == 2 && in.labels[0] == in.labels[1])
+                    {
+                        in.op = Opcode::Br;
+                        in.labels = {in.labels[0]};
+                        in.operands.clear();
+                        continue;
+                    }
                     long long v;
                     bool known = false;
                     size_t defIdx = static_cast<size_t>(-1);

--- a/tests/golden/CMakeLists.txt
+++ b/tests/golden/CMakeLists.txt
@@ -67,3 +67,10 @@ add_test(NAME il_opt_arith_id COMMAND ${CMAKE_COMMAND}
   -DIL_FILE=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/arith_id.in.il
   -DGOLDEN=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/arith_id.opt.il
   -P ${CMAKE_CURRENT_SOURCE_DIR}/il_opt/check_opt.cmake)
+add_test(NAME il_opt_cbr_same_target COMMAND ${CMAKE_COMMAND}
+  -DILC=${BASIC_ILC}
+  -DIL_FILE=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/cbr_same_target.in.il
+  -DGOLDEN=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/cbr_same_target.golden
+  -DPASSES=peephole
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/il_opt/check_opt.cmake)
+set_tests_properties(il_opt_cbr_same_target PROPERTIES LABELS Smoke)

--- a/tests/golden/il_opt/cbr_same_target.golden
+++ b/tests/golden/il_opt/cbr_same_target.golden
@@ -1,0 +1,7 @@
+il 0.1
+func @main(i1 %c) -> i64 {
+entry:
+  br label L1
+L1:
+  ret 0
+}

--- a/tests/golden/il_opt/cbr_same_target.in.il
+++ b/tests/golden/il_opt/cbr_same_target.in.il
@@ -1,0 +1,7 @@
+il 0.1
+func @main(i1 %c) -> i64 {
+entry:
+  cbr %c, label L1, label L1
+L1:
+  ret 0
+}


### PR DESCRIPTION
## Summary
- fold redundant conditional branches into an unconditional `br`
- document peephole in il-opt docs
- add golden test for `cbr %c, label L1, label L1`

## Testing
- `cmake -S . -B build`
- `cmake --build build --target format`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b77f1a13c483249fcd1b1f7d97aa1d