### PR TITLE
docs: add getting-started guide with 3 tiny BASIC programs and link from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ cmake --build build
 - [Docs index](docs/README.md)
 - [BASIC language reference](docs/basic-language-reference.md)
 - [IL specification](docs/il-spec.md)
+- [Getting Started](/docs/getting-started.md)
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,3 +53,7 @@ This mode ensures test diffs are stable and comparable across builds.
 - `--stdin-from <file>` — read program input from a file.
 - `--max-steps <N>` — abort after executing `N` instructions with the message
   `VM: step limit exceeded (N); aborting.`
+
+## Quick Links
+
+- [Getting Started](/docs/getting-started.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,66 @@
+# Getting Started: Build, Run, and Your First 3 BASIC Programs
+
+This guide shows you how to build the project, run the interpreter, and write three tiny BASIC programs.
+
+---
+
+## 1) Prerequisites
+
+- **Clang** (preferred) and **CMake**  
+  - macOS: Apple Clang is preinstalled.  
+  - Ubuntu: `sudo apt-get update && sudo apt-get install -y clang cmake`
+
+---
+
+## 2) Build the tools
+
+```bash
+CC=clang CXX=clang++ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build -j
+```
+
+This builds:
+ilc — compile/run driver (BASIC → IL → VM)
+il-verify — IL verifier
+
+## 3) Program #1 — Hello
+Create hello.bas:
+10 PRINT "HELLO"
+20 END
+Run:
+./build/src/tools/ilc/ilc front basic hello.bas -emit-il
+./build/src/tools/ilc/ilc front basic hello.bas -run
+Expected output:
+HELLO
+
+## 4) Program #2 — Sum 1..10 (loop)
+Create sum10.bas:
+10 PRINT "SUM 1..10"
+20 LET I = 1
+30 LET S = 0
+40 WHILE I <= 10
+50   LET S = S + I
+60   LET I = I + 1
+70 WEND
+80 PRINT S
+90 END
+Run:
+./build/src/tools/ilc/ilc front basic sum10.bas -run
+Expected output:
+SUM 1..10
+45
+
+## 5) Program #3 — Branching (IF/ELSE)
+Create branch.bas:
+10 LET X = 2
+20 IF X = 1 THEN PRINT "ONE" ELSE PRINT "NOT ONE"
+30 END
+Run:
+./build/src/tools/ilc/ilc front basic branch.bas -run
+Expected output:
+NOT ONE
+
+## 6) Tips & Troubleshooting
+Verify IL: for .il files, use ./build/src/tools/il-verify/il-verify path/to/file.il.
+Paths: if your build tree differs, adjust the ./build/src/tools/... paths accordingly.
+Docs: BASIC reference → /docs/basic-language-reference.md, IL spec → /docs/il-spec.md.


### PR DESCRIPTION
## Summary
- add getting-started guide outlining build steps and 3 BASIC sample programs
- link new guide from project and docs READMEs for quick access

## Testing
- `./scripts/check_docs_exist` *(fails: No such file or directory)*
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b788ff39b88324817a928687cdb5f2