### PR TITLE
docs: format markdown files

### DIFF
--- a/docs/basic-language-reference.md
+++ b/docs/basic-language-reference.md
@@ -1,18 +1,20 @@
-#BASIC v0.1 Language Reference
+# BASIC v0.1 Language Reference
 
-BASIC programs lower to [IL v0.1.1](./il-spec.md) and run on the VM interpreter.  This document describes the subset implemented in v0.1.
+BASIC programs lower to [IL v0.1.1](./il-spec.md) and run on the VM interpreter. This document describes the subset implemented in v0.1.
 
 ## Goals & scope
+
 - Deterministic subset for early IDE/compiler bring-up.
-- VM-first design: source lowers to IL;
-native codegen is future work.- Includes variables, arithmetic, strings, conditionals, loops,
-    simple I / O.
+- VM-first design: source lowers to IL; native codegen is future work.
+- Includes variables, arithmetic, strings, conditionals, loops, simple I/O.
 
 ## Program structure & line numbers
+
 A program is a sequence of statements separated by newlines. Line numbers are optional labels (`GOTO` targets);
 execution starts at the first statement. Comments begin with `'` and continue to end of line.
 
 ### Multi-statement lines with `:`
+
 Multiple statements on the same line separated by `:` execute left-to-right.
 
 ```basic
@@ -34,15 +36,18 @@ prints:
 ```
 
 ## Types
-| Type    | IL type | Literal examples                    | Notes                            |
-|---------|---------|-------------------------------------|----------------------------------|
-| Integer | `i64`   | `0`, `-12`, `42`                    | default numeric type, wraps      |
-| Float   | `f64`   | produced via `VAL`                  | optional in v0.1                 |
-| String  | `str`   | `"text"`, escape `\\" \\ \n \t \xNN` | UTF-8                            |
-| Boolean | `i1`    | `TRUE`, `FALSE`                     | results of comparisons           |
+
+| Type    | IL type | Literal examples                     | Notes                       |
+| ------- | ------- | ------------------------------------ | --------------------------- |
+| Integer | `i64`   | `0`, `-12`, `42`                     | default numeric type, wraps |
+| Float   | `f64`   | produced via `VAL`                   | optional in v0.1            |
+| String  | `str`   | `"text"`, escape `\\" \\ \n \t \xNN` | UTF-8                       |
+| Boolean | `i1`    | `TRUE`, `FALSE`                      | results of comparisons      |
 
 ## Expressions
+
 ### Operators & precedence (high → low)
+
 1. `()`
 2. Unary `NOT`, `+`, `-`
 3. `*`, `/`
@@ -82,15 +87,17 @@ compile-time error:
 ```
 
 ### Built-in functions
-| Function          | Signature               | Notes                    |
-|-------------------|-------------------------|--------------------------|
-| `LEN(s$)`         | `str → i64`             | length in bytes          |
-| `MID$(s$, i, l)`  | `str × i64 × i64 → str` | 1-based index;
-length clamped | | `VAL(s$)` | `str → i64` | traps on invalid numeric |
+
+| Function         | Signature               | Notes           |
+| ---------------- | ----------------------- | --------------- | ----------- | ------------------------ |
+| `LEN(s$)`        | `str → i64`             | length in bytes |
+| `MID$(s$, i, l)` | `str × i64 × i64 → str` | 1-based index;  |
+| length clamped   |                         | `VAL(s$)`       | `str → i64` | traps on invalid numeric |
 
     ##Statements | Statement | Meaning | | -- -- -- -- -- -| -- -- -- -- -|
     | `LET v = expr` | assign to variable `v` (auto - declare) |
                | `PRINT items` | write values to stdout;
+
 separators : `,` inserts space, `;
 ` inserts nothing;
 newline appended unless statement ends with `;` |
@@ -112,20 +119,23 @@ The prompt must be a literal string for now.
 
 ### PRINT separators
 
-| Separator | Effect |
-|-----------|--------|
+| Separator | Effect      |
+| --------- | ----------- |
 | `,`       | print space |
+
 | `;
 ` | print nothing;
 if last
-    , suppress newline |
+, suppress newline |
 
           An example with trailing `;
+
 `:
 
 ```basic 10 PRINT "A";
 20 PRINT "B"
 ```
+
 prints `AB` on one line. The semicolon after `"A"` suppresses the newline so the next
 `PRINT` continues on the same line.
 
@@ -143,11 +153,12 @@ Multi-statement `THEN`/`ELSE` blocks may appear on new lines or be separated by 
 prints `TWO`.
 
 ## Variables & naming conventions
+
 Identifiers match `[A-Za-z][A-Za-z0-9_]*` with optional `$` suffix for strings.
 Without `$` the variable defaults to integer;
 all variables are local to `@main`.
 `DIM` arrays store `i64` elements with 0 -
-        based indices.
+based indices.
 
         ##Errors &diagnostics Compile -
         time errors report syntax or
@@ -157,9 +168,11 @@ all variables are local to `@main`.
         bounds `MID$`.Diagnostics use codes prefixed with `B` and show source line with a caret.
 
 ```text 10 LET X = 1 + ^B0001 : expected expression
+
 ```
 
                                  ##Grammar
+
 ```bnf program :: =
                         (line | stmt) *EOF line :: = (NUMBER)
     ? stmt(":" stmt) *NEWLINE stmt :: =
@@ -175,43 +188,43 @@ all variables are local to `@main`.
 
                   ##IL mapping The front end lowers BASIC to IL; see the [IL v0.1.1 spec](./il-spec.md) for instruction semantics.
 
-| BASIC snippet       | IL pattern                                                | Runtime |
-|---------------------|-----------------------------------------------------------|---------|
-| `PRINT "X"`         | `%s = const_str @.L;
-call @rt_print_str(% s)` | `rt_print_str(str)` | | `PRINT X` | `% v = load i64, % slotX;
-call @rt_print_i64(% v)` | `rt_print_i64(i64)` | | `PRINT "A";
-` | `call @rt_print_str("A")` | `rt_print_str(str)` | | `PRINT "A", 1` | `call @rt_print_str("A");
+| BASIC snippet            | IL pattern                | Runtime             |
+| ------------------------ | ------------------------- | ------------------- | ----------- | ------------------------- | ------------------------- |
+| `PRINT "X"`              | `%s = const_str @.L;      |
+| call @rt_print_str(% s)` | `rt_print_str(str)`       |                     | `PRINT X`   | `% v = load i64, % slotX; |
+| call @rt_print_i64(% v)` | `rt_print_i64(i64)`       |                     | `PRINT "A"; |
+| `                        | `call @rt_print_str("A")` | `rt_print_str(str)` |             | `PRINT "A", 1`            | `call @rt_print_str("A"); |
+
 call @rt_print_str(" ");
 call @rt_print_i64(1);
-call @rt_print_str("\n")` | `rt_print_str(str)`, `rt_print_i64(i64)` | | `PRINT "A";
-1` | `call @rt_print_str("A");
+call @rt_print_str("\n")`|`rt_print_str(str)`, `rt_print_i64(i64)`| |`PRINT "A";
+1`|`call @rt_print_str("A");
 call @rt_print_i64(1);
-call @rt_print_str("\n")` | `rt_print_str(str)`, `rt_print_i64(i64)` | | `LET X = A + B` | `load A;
+call @rt_print_str("\n")`|`rt_print_str(str)`, `rt_print_i64(i64)`| |`LET X = A + B`|`load A;
 load B;
 % c = add % a, % b;
-store X, % c` | — | | `IF C THEN … ELSE …`| `% p = …cmp…;
-cbr % p, then, else ` | — | | `WHILE C … WEND` | `br loop_head;
+store X, % c`| — | |`IF C THEN … ELSE …`| `% p = …cmp…;
+cbr % p, then, else `| — | |`WHILE C … WEND`|`br loop_head;
 cbr cond, loop_body,
-    done` | — | | `LEN(S$)` | `call @rt_len(% s)` | `rt_len(str)→i64` | | `MID$(S$, i, l)` | `call
+done`| — | |`LEN(S$)` | `call @rt_len(% s)` | `rt_len(str)→i64` | | `MID$(S$, i, l)` | `call
         @rt_substr(% s, i - 1, l)` | `rt_substr(str, i64, i64)→str` |
-        | `VAL(S$)` | `call @rt_to_int(% s)` | `rt_to_int(str)→i64` |
-        | `INPUT A$` | `% s = call @rt_input_line();
-store A$, % s` | `rt_input_line()→str` | | `INPUT N` | `% s = call @rt_input_line();
+        | `VAL(S$)`|`call @rt_to_int(% s)`|`rt_to_int(str)→i64`|
+        |`INPUT A$` | `% s = call @rt_input_line();
+store A$, % s`|`rt_input_line()→str`| |`INPUT N`|`% s = call @rt_input_line();
 % n = call @rt_to_int(% s);
-store N, % n` | `rt_input_line()→str;
-rt_to_int(str)→i64` | | `INPUT "N=", N` | `call @rt_print_str("N=");
+store N, % n`|`rt_input_line()→str;
+rt_to_int(str)→i64`| |`INPUT "N=", N`|`call @rt_print_str("N=");
 % s = call @rt_input_line();
 % n = call @rt_to_int(% s);
-store N, % n` | `rt_print_str(str);
+store N, % n`|`rt_print_str(str);
 rt_input_line()→str;
-rt_to_int(str)→i64` | | `DIM A(N)` | `% bytes = mul N, 8;
+rt_to_int(str)→i64`| |`DIM A(N)`|`% bytes = mul N, 8;
 % p = call @rt_alloc(% bytes);
-store % A, % p` | `rt_alloc(i64)→ptr` | | `A(I)` | `% base = load ptr, % A;
+store % A, % p`|`rt_alloc(i64)→ptr`| |`A(I)`|`% base = load ptr, % A;
 % off = shl I, 3;
 % ptr = gep % base, % off;
-% v = load i64, % ptr` | — | | `LET A(I) = X` | compute `% ptr` as above;
-`store i64, % ptr,
-    X` | — |
+% v = load i64, % ptr`| — | |`LET A(I) = X`| compute`% ptr`as above;`store i64, % ptr,
+X` | — |
 
         BASIC's 1-based indices become 0-based for runtime calls.
 
@@ -223,6 +236,7 @@ store % A, % p` | `rt_alloc(i64)→ptr` | | `A(I)` | `% base = load ptr, % A;
 ```
 
     This aborts after five instructions and prints
+
 `VM : step limit exceeded(5);
 aborting.`
 

--- a/docs/basic-to-il-examples.md
+++ b/docs/basic-to-il-examples.md
@@ -18,7 +18,7 @@ BASIC (10 lines)
 
 10 PRINT "HELLO"
 20 LET X = 2 + 3
-30 LET Y = X * 2
+30 LET Y = X \* 2
 35 PRINT "READY"
 40 PRINT Y
 50 IF Y > 8 THEN GOTO 80
@@ -41,7 +41,7 @@ entry:
 ; X = 2 + 3
 %t0 = add 2, 3
 store i64, %x_slot, %t0
-; Y = X * 2
+; Y = X \* 2
 %xv = load i64, %x_slot
 %t1 = mul %xv, 2
 store i64, %y_slot, %t1
@@ -135,7 +135,7 @@ BASIC (12 lines)
 40 WHILE I \<= N
 50 LET J = 1
 60 WHILE J \<= N
-70 PRINT I * J
+70 PRINT I \* J
 80 LET J = J + 1
 90 WEND
 100 LET I = I + 1
@@ -200,7 +200,7 @@ BASIC (11 lines)
 40 LET N = VAL(S$)
 50 LET R = 1
 60 WHILE N > 1
-70 LET R = R * N
+70 LET R = R \* N
 80 LET N = N - 1
 90 WEND
 100 PRINT R
@@ -332,11 +332,11 @@ Example 6 — Heap “array” via rt_alloc, fill with squares, print average as
 BASIC (13 lines)
 
 10 LET N = 5
-20 DIM A(N) ' conceptual; lowered to a heap block of N * 8 bytes
+20 DIM A(N) ' conceptual; lowered to a heap block of N _ 8 bytes
 30 LET I = 0
 40 LET SUM = 0
 50 WHILE I < N
-60 LET A(I) = I * I
+60 LET A(I) = I _ I
 70 LET SUM = SUM + A(I)
 80 LET I = I + 1
 90 WEND
@@ -347,7 +347,7 @@ BASIC (13 lines)
 IL
 
 il 0.1
-extern @rt_alloc(i64) -> ptr
+extern @rt*alloc(i64) -> ptr
 extern @rt_print_f64(f64) -> void
 extern @rt_print_str(str) -> void
 global const str @.L0 = "DONE"
@@ -362,7 +362,7 @@ store i64, %n_slot, 5
 store i64, %i_slot, 0
 store i64, %sum_slot, 0
 ; A = rt_alloc(N * 8)
-%n0 = load i64, %n_slot
+%n0 = load i64, %n*slot
 %bytes = mul %n0, 8
 %abase = call @rt_alloc(%bytes)
 store ptr, %a_slot, %abase
@@ -377,7 +377,7 @@ loop_body:
 %a0 = load ptr, %a_slot
 %off = shl %i0, 3 ; i * 8
 %elem_ptr = gep %a0, %off
-; A(i) = i * i
+; A(i) = i \* i
 %sq = mul %i0, %i0
 store i64, %elem_ptr, %sq
 ; SUM += A(i)

--- a/docs/class-catalog.md
+++ b/docs/class-catalog.md
@@ -6,78 +6,78 @@ All headers use `.hpp` and sources use `.cpp`.
 
 ## Support
 
-| Class | Description |
-| --- | --- |
-| Arena | Bump allocator for temporary objects |
+| Class            | Description                            |
+| ---------------- | -------------------------------------- |
+| Arena            | Bump allocator for temporary objects   |
 | DiagnosticEngine | Records and prints errors and warnings |
-| Options | Global compiler flags |
-| Result<T> | Minimal expected-like container |
-| SourceManager | Maps file IDs to paths |
-| StringInterner | Interns strings into Symbols |
-| Symbol | Opaque handle for interned strings |
+| Options          | Global compiler flags                  |
+| Result<T>        | Minimal expected-like container        |
+| SourceManager    | Maps file IDs to paths                 |
+| StringInterner   | Interns strings into Symbols           |
+| Symbol           | Opaque handle for interned strings     |
 
 ## IL
 
 ### Core
 
-| Class | Description |
-| --- | --- |
-| Module | Top-level container for functions and globals |
-| Function | Sequence of blocks forming a procedure |
-| BasicBlock | Linear list of instructions with a label |
-| Instr | Single IL instruction |
-| Value | Operand or constant |
-| Type | IL type descriptor |
-| Global | Named global variable |
-| Extern | External function declaration |
-| Param | Function parameter |
+| Class      | Description                                   |
+| ---------- | --------------------------------------------- |
+| Module     | Top-level container for functions and globals |
+| Function   | Sequence of blocks forming a procedure        |
+| BasicBlock | Linear list of instructions with a label      |
+| Instr      | Single IL instruction                         |
+| Value      | Operand or constant                           |
+| Type       | IL type descriptor                            |
+| Global     | Named global variable                         |
+| Extern     | External function declaration                 |
+| Param      | Function parameter                            |
 
 ### Build / IO / Verify
 
-| Class | Description |
-| --- | --- |
-| IRBuilder | Fluent builder for IL modules |
-| Parser | Parses textual IL |
-| Serializer | Prints modules as text |
-| Verifier | Checks structural correctness |
-| PassManager | Runs transformation passes |
-| ConstFold | Constant folding pass |
-| Peephole | Peephole optimization pass |
+| Class       | Description                   |
+| ----------- | ----------------------------- |
+| IRBuilder   | Fluent builder for IL modules |
+| Parser      | Parses textual IL             |
+| Serializer  | Prints modules as text        |
+| Verifier    | Checks structural correctness |
+| PassManager | Runs transformation passes    |
+| ConstFold   | Constant folding pass         |
+| Peephole    | Peephole optimization pass    |
 
 ## Frontend (BASIC)
 
-| Class | Description |
-| --- | --- |
-| Token | Lexical token representation |
-| Lexer | Converts source text to tokens |
-| Parser | Builds AST from tokens |
-| AST nodes | Expression and statement hierarchy |
-| SemanticAnalyzer | Validates and annotates AST |
-| ConstFolder | Evaluates constant expressions |
-| Lowerer | Lowers AST to IL |
-| LoweringContext | Shared state for lowering |
-| NameMangler | Transforms identifiers for IL |
-| DiagnosticEmitter | Emits front-end diagnostics |
-| AstPrinter | Dumps AST for debugging |
+| Class             | Description                        |
+| ----------------- | ---------------------------------- |
+| Token             | Lexical token representation       |
+| Lexer             | Converts source text to tokens     |
+| Parser            | Builds AST from tokens             |
+| AST nodes         | Expression and statement hierarchy |
+| SemanticAnalyzer  | Validates and annotates AST        |
+| ConstFolder       | Evaluates constant expressions     |
+| Lowerer           | Lowers AST to IL                   |
+| LoweringContext   | Shared state for lowering          |
+| NameMangler       | Transforms identifiers for IL      |
+| DiagnosticEmitter | Emits front-end diagnostics        |
+| AstPrinter        | Dumps AST for debugging            |
 
 ## VM
 
-| Class | Description |
-| --- | --- |
-| VM | Stack-based interpreter |
+| Class         | Description              |
+| ------------- | ------------------------ |
+| VM            | Stack-based interpreter  |
 | RuntimeBridge | Calls into the C runtime |
 
 ## Codegen
 
-| Class | Description |
-| --- | --- |
+| Class         | Description            |
+| ------------- | ---------------------- |
 | (placeholder) | Planned x86_64 backend |
 
 ## Tools
 
-| Tool | Description |
-| --- | --- |
-| basic-ast-dump | Dumps BASIC ASTs |
-| il-dis | Disassembles IL modules |
-| il-verify | Verifies IL modules |
-| ilc | Driver for compilation and execution |
+| Tool           | Description                          |
+| -------------- | ------------------------------------ |
+| basic-ast-dump | Dumps BASIC ASTs                     |
+| il-dis         | Disassembles IL modules              |
+| il-verify      | Verifies IL modules                  |
+| ilc            | Driver for compilation and execution |

--- a/docs/cpp-overview.md
+++ b/docs/cpp-overview.md
@@ -17,7 +17,7 @@ assistant like Codex and to keep you out of the mess that VC drifted into.
 /CMakeLists.txt
 /cmake/ # compiler flags, toolchain helpers
 /docs/ # IL spec, developer docs, ADRs
-/runtime/ # C runtime (librt.a): rt\_*.c, rt\_*.hpp
+/runtime/ # C runtime (librt.a): rt\__.c, rt\__.hpp
 /src/
 /support/ # small utilities shared across libs
 /il/ # IL core: types, IR, builder, verifier, I/O
@@ -156,9 +156,9 @@ void\* rt_alloc(int64_t bytes); // simple wrapper on malloc for v1
 
 - VM types
 
-struct Slot { uint64_t u64; double f64; void\* ptr; /\* tagged by Type at use */ };
+struct Slot { uint64_t u64; double f64; void\* ptr; /\* tagged by Type at use _/ };
 struct Frame {
-Function* f;
+Function_ f;
 std::vector<Slot> regs; // virtual regs / temps
 std::vector\<uint8_t> stack; // for alloca
 size_t ip_block, ip_index; // current block, instr index
@@ -181,7 +181,6 @@ std::vector<Frame> callstack;
 
 8. Codegen (il::codegen::x86_64)
    8.1 Pipeline
-
    1. Lowering: turn IL instructions into a simple target‑agnostic MIR (optional) or go direct.
    1. Liveness: compute live intervals of virtual regs within each function (linear time scan).
    1. Regalloc (linear scan):

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,8 +6,8 @@ This guide shows you how to build the project, run the interpreter, and write th
 
 ## 1) Prerequisites
 
-- **Clang** (preferred) and **CMake**  
-  - macOS: Apple Clang is preinstalled.  
+- **Clang** (preferred) and **CMake**
+  - macOS: Apple Clang is preinstalled.
   - Ubuntu: `sudo apt-get update && sudo apt-get install -y clang cmake`
 
 ---
@@ -24,6 +24,7 @@ ilc — compile/run driver (BASIC → IL → VM)
 il-verify — IL verifier
 
 ## 3) Program #1 — Hello
+
 Create hello.bas:
 10 PRINT "HELLO"
 20 END
@@ -34,13 +35,14 @@ Expected output:
 HELLO
 
 ## 4) Program #2 — Sum 1..10 (loop)
+
 Create sum10.bas:
 10 PRINT "SUM 1..10"
 20 LET I = 1
 30 LET S = 0
 40 WHILE I <= 10
-50   LET S = S + I
-60   LET I = I + 1
+50 LET S = S + I
+60 LET I = I + 1
 70 WEND
 80 PRINT S
 90 END
@@ -51,6 +53,7 @@ SUM 1..10
 45
 
 ## 5) Program #3 — Branching (IF/ELSE)
+
 Create branch.bas:
 10 LET X = 2
 20 IF X = 1 THEN PRINT "ONE" ELSE PRINT "NOT ONE"
@@ -61,6 +64,7 @@ Expected output:
 NOT ONE
 
 ## 6) Tips & Troubleshooting
+
 Verify IL: for .il files, use ./build/src/tools/il-verify/il-verify path/to/file.il.
 Paths: if your build tree differs, adjust the ./build/src/tools/... paths accordingly.
 Docs: BASIC reference → /docs/basic-language-reference.md, IL spec → /docs/il-spec.md.

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -6,7 +6,6 @@ around. You’ll start with a BASIC front end, run IL via an interpreter, and ad
 IL→assembly backend as a separate module.
 
 0. Project Goals
-
    1. Multi-language front ends (start with BASIC; later add others) that all lower to a common IL.
    1. Backend interpreter that executes IL directly (great for fast bring‑up, tests, and debugging).
    1. Backend compiler that translates IL to assembly (x86‑64 SysV first), assembled and linked into native binaries.
@@ -33,7 +32,7 @@ IL→assembly backend as a separate module.
        |  (optional)      | ---------->|  .il text/bc     |
        +--------+---------+            +-------+----------+
                 |                              |
-                +------------------------------+  
+                +------------------------------+
                 |
    ```
 
@@ -153,7 +152,7 @@ case OP_RET: return regs[retv];
    ○ Keep the runtime in C with a stable ABI.
    • Repo layout:
 
-/runtime/ (C) rt\_*.c, rt\_*.hpp, build to librt.a
+/runtime/ (C) rt\__.c, rt\__.hpp, build to librt.a
 /il/ (C++) IL core: types, module, builder, verifier, serializer
 /vm/ (C++) IL interpreter
 /codegen/ (C++) x86_64 backend, regalloc, asm emitter
@@ -198,7 +197,6 @@ ret const_i32 0
 Note: &X can be modeled as a function‑local stack slot created via alloca in entry.
 
 5. Testing Strategy (solo‑friendly)
-
    1. Golden tests for front ends: source → expected IL text.
    1. VM e2e tests: run IL on interpreter; assert stdout/return code.
    1. Backend e2e tests: same programs compiled to native; compare output to VM.
@@ -276,7 +274,7 @@ ret
     • Tracing (optional): VM flag --trace-il to print each executed IL instruction with values.
     • \*\* REPL (nice-to-have)\*\*: ilc repl runs a BASIC prompt backed by the VM.
 
-01. Performance (when you’re ready)
+1.  Performance (when you’re ready)
     • Interpreter:
     ○ Switch → direct-threaded dispatch (computed goto).
     ○ Intern strings; cache common constant strings.
@@ -285,13 +283,13 @@ ret
     ○ Simple constant folding at IL build time (you’ll get many wins “for free”).
     ○ Linear-scan regalloc with live-interval splitting.
 
-01. Risks & Mitigations
+1.  Risks & Mitigations
     • Scope creep → Strict v1 feature set; milestone-based roadmap.
     • Type system complexity → Keep IL types minimal; push conversions into front end and runtime helpers.
     • String/heap bugs → Start with refcounted strings and a small test suite around them; add ASAN/UBSAN in CI.
     • Codegen pitfalls → Lean on VM-oracle differential tests; begin with a single platform/ABI.
 
-01. Roadmap (suggested)
+1.  Roadmap (suggested)
     Milestone A (bring-up)
     • BASIC front end for PRINT, LET, IF, GOTO.
     • IL core + verifier + textual serializer.
@@ -308,7 +306,7 @@ ret
     • Peephole optimizer, better diagnostics, small library expansion (strings/math/file I/O).
     • Optional: bytecode encoding for faster VM.
 
-01. What’s “Done” for v1
+1.  What’s “Done” for v1
     • BASIC subset compiles to IL, runs correctly on the VM, and compiles to native with matching outputs.
     • Clear CLI, docs, and tests.
     • Clean separation of: front end ↔ IL ↔ VM/Codegen ↔ runtime.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,13 +4,13 @@ Note: implementation files use `.cpp`; headers use `.hpp`.
 
 ## Milestones
 
-| ID | Stage | Focus |
-|----|-------|-------|
-| M0 | Bootstrap | Build system and seed the [class catalog](class-catalog.md) |
-| M1 | IL core | Types, instructions, and module scaffolding |
-| M2 | VM | Stack-based interpreter and runtime interface from the [IL spec](il-spec.md) |
-| M3 | BASIC front end | Lexer, parser, and lowering from BASIC to IL |
-| M4 | Codegen prep | Groundwork for native emission and register allocation |
+| ID  | Stage           | Focus                                                                        |
+| --- | --------------- | ---------------------------------------------------------------------------- |
+| M0  | Bootstrap       | Build system and seed the [class catalog](class-catalog.md)                  |
+| M1  | IL core         | Types, instructions, and module scaffolding                                  |
+| M2  | VM              | Stack-based interpreter and runtime interface from the [IL spec](il-spec.md) |
+| M3  | BASIC front end | Lexer, parser, and lowering from BASIC to IL                                 |
+| M4  | Codegen prep    | Groundwork for native emission and register allocation                       |
 
 ### Status checklist
 


### PR DESCRIPTION
## Summary
- Normalize Markdown formatting across documentation with Prettier.

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b78abb37e48324ba295f0aef11121c