### PR TITLE
feat(analysis): add CFG and dominator utilities

### DIFF
--- a/docs/dev/analysis.md
+++ b/docs/dev/analysis.md
@@ -1,0 +1,32 @@
+# Analysis Utilities
+
+This module provides basic control-flow analyses used by optimization passes.
+
+## CFG
+
+`il::analysis::CFG` builds predecessor and successor lists for each basic block
+and assigns a post-order number. Construction runs a depth-first search from the
+function's entry block.
+
+- `succs(b)`: successor blocks of `b`.
+- `preds(b)`: predecessor blocks of `b`.
+- `postOrder(b)`: post-order index of `b` (0 is first visited).
+- `rpo()`: blocks in reverse post-order.
+
+Complexity: `O(B + E)` where `B` is number of blocks and `E` edges.
+
+## Dominator Tree
+
+`il::analysis::DominatorTree` computes immediate dominators using the
+Cooper–Harvey–Kennedy algorithm.
+
+- `idom(b)`: immediate dominator of `b` (`nullptr` for entry).
+- `dominates(a, b)`: true if `a` dominates `b`.
+
+Complexity: nearly linear in the size of the graph.
+
+## Utilities
+
+`il::util::inBlock(inst, block)` checks if an instruction resides in a block.
+It performs a linear scan over the block's instruction list.
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,16 @@ add_library(il_transform STATIC
 target_link_libraries(il_transform PUBLIC il_core il_verify)
 target_include_directories(il_transform PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_library(il_utils STATIC il/utils/Utils.cpp)
+target_link_libraries(il_utils PUBLIC il_core)
+target_include_directories(il_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(il_analysis STATIC
+  il/analysis/CFG.cpp
+  il/analysis/Dominators.cpp)
+target_link_libraries(il_analysis PUBLIC il_core)
+target_include_directories(il_analysis PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_library(il_vm STATIC vm/VM.cpp vm/RuntimeBridge.cpp)
 target_include_directories(il_vm PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(il_vm PUBLIC il_core rt support)

--- a/src/il/analysis/CFG.cpp
+++ b/src/il/analysis/CFG.cpp
@@ -1,0 +1,82 @@
+// File: src/il/analysis/CFG.cpp
+// Purpose: Implement basic control-flow graph utilities for functions.
+// Key invariants: Successor/predecessor lists are constructed from terminators.
+// Ownership/Lifetime: References remain valid as long as the function lives.
+// Links: docs/class-catalog.md
+
+#include "il/analysis/CFG.hpp"
+#include "il/core/Instr.hpp"
+#include <algorithm>
+#include <limits>
+
+using namespace il::core;
+
+namespace il::analysis
+{
+
+CFG::CFG(const Function &f)
+{
+    // Map labels to blocks for quick lookup.
+    std::unordered_map<std::string, const BasicBlock *> labelMap;
+    for (const auto &b : f.blocks)
+        labelMap[b.label] = &b;
+
+    // Build successors and predecessors.
+    for (const auto &b : f.blocks)
+    {
+        if (!b.terminated || b.instructions.empty())
+            continue;
+        const Instr &term = b.instructions.back();
+        for (const auto &lab : term.labels)
+        {
+            auto it = labelMap.find(lab);
+            if (it == labelMap.end())
+                continue;
+            succs_[&b].push_back(it->second);
+            preds_[it->second].push_back(&b);
+        }
+    }
+
+    // Depth-first search for post-order.
+    std::unordered_set<const BasicBlock *> visited;
+    if (!f.blocks.empty())
+        dfs(&f.blocks.front(), visited);
+    for (unsigned i = 0; i < postOrder_.size(); ++i)
+        postIndex_[postOrder_[i]] = i;
+    rpo_ = postOrder_;
+    std::reverse(rpo_.begin(), rpo_.end());
+}
+
+const std::vector<const BasicBlock *> &CFG::succs(const BasicBlock &b) const
+{
+    static const std::vector<const BasicBlock *> empty;
+    auto it = succs_.find(&b);
+    return it != succs_.end() ? it->second : empty;
+}
+
+const std::vector<const BasicBlock *> &CFG::preds(const BasicBlock &b) const
+{
+    static const std::vector<const BasicBlock *> empty;
+    auto it = preds_.find(&b);
+    return it != preds_.end() ? it->second : empty;
+}
+
+unsigned CFG::postOrder(const BasicBlock &b) const
+{
+    auto it = postIndex_.find(&b);
+    return it != postIndex_.end() ? it->second : std::numeric_limits<unsigned>::max();
+}
+
+void CFG::dfs(const BasicBlock *b, std::unordered_set<const BasicBlock *> &visited)
+{
+    if (visited.count(b))
+        return;
+    visited.insert(b);
+    auto it = succs_.find(b);
+    if (it != succs_.end())
+        for (const BasicBlock *s : it->second)
+            dfs(s, visited);
+    postOrder_.push_back(b);
+}
+
+} // namespace il::analysis

--- a/src/il/analysis/CFG.hpp
+++ b/src/il/analysis/CFG.hpp
@@ -1,0 +1,49 @@
+// File: src/il/analysis/CFG.hpp
+// Purpose: Build basic control-flow graph utilities for functions.
+// Key invariants: Blocks are reachable and uniquely labeled.
+// Ownership/Lifetime: Does not own the function or blocks.
+// Links: docs/class-catalog.md
+#pragma once
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace il::analysis
+{
+
+/// @brief Computes CFG information for a function.
+class CFG
+{
+  public:
+    /// @brief Construct CFG for function @p f.
+    explicit CFG(const core::Function &f);
+
+    /// @brief Successor blocks of @p b.
+    const std::vector<const core::BasicBlock *> &succs(const core::BasicBlock &b) const;
+
+    /// @brief Predecessor blocks of @p b.
+    const std::vector<const core::BasicBlock *> &preds(const core::BasicBlock &b) const;
+
+    /// @brief Post-order index of @p b (0-based).
+    unsigned postOrder(const core::BasicBlock &b) const;
+
+    /// @brief Blocks in reverse post-order.
+    const std::vector<const core::BasicBlock *> &rpo() const
+    {
+        return rpo_;
+    }
+
+  private:
+    std::unordered_map<const core::BasicBlock *, std::vector<const core::BasicBlock *>> succs_;
+    std::unordered_map<const core::BasicBlock *, std::vector<const core::BasicBlock *>> preds_;
+    std::vector<const core::BasicBlock *> postOrder_;
+    std::unordered_map<const core::BasicBlock *, unsigned> postIndex_;
+    std::vector<const core::BasicBlock *> rpo_;
+
+    void dfs(const core::BasicBlock *b, std::unordered_set<const core::BasicBlock *> &visited);
+};
+
+} // namespace il::analysis

--- a/src/il/analysis/Dominators.cpp
+++ b/src/il/analysis/Dominators.cpp
@@ -1,0 +1,91 @@
+// File: src/il/analysis/Dominators.cpp
+// Purpose: Implement dominator tree construction.
+// Key invariants: Follows Cooper et al.'s iterative algorithm.
+// Ownership/Lifetime: Uses CFG; no ownership transfer.
+// Links: docs/class-catalog.md
+
+#include "il/analysis/Dominators.hpp"
+
+using namespace il::core;
+
+namespace il::analysis
+{
+
+DominatorTree::DominatorTree(const CFG &cfg) : cfg_(cfg)
+{
+    const auto &order = cfg_.rpo();
+    if (order.empty())
+        return;
+    for (unsigned i = 0; i < order.size(); ++i)
+        rpoIndex_[order[i]] = i;
+    const BasicBlock *start = order.front();
+    idom_[start] = start;
+    bool changed = true;
+    while (changed)
+    {
+        changed = false;
+        for (size_t i = 1; i < order.size(); ++i)
+        {
+            const BasicBlock *b = order[i];
+            const BasicBlock *newIdom = nullptr;
+            for (const BasicBlock *p : cfg_.preds(*b))
+            {
+                if (idom_.count(p))
+                {
+                    newIdom = p;
+                    break;
+                }
+            }
+            if (!newIdom)
+                continue;
+            for (const BasicBlock *p : cfg_.preds(*b))
+            {
+                if (p == newIdom || !idom_.count(p))
+                    continue;
+                newIdom = intersect(p, newIdom);
+            }
+            if (!idom_.count(b) || idom_[b] != newIdom)
+            {
+                idom_[b] = newIdom;
+                changed = true;
+            }
+        }
+    }
+}
+
+const BasicBlock *DominatorTree::idom(const BasicBlock &b) const
+{
+    auto it = idom_.find(&b);
+    if (it == idom_.end() || it->second == &b)
+        return nullptr;
+    return it->second;
+}
+
+bool DominatorTree::dominates(const BasicBlock &a, const BasicBlock &b) const
+{
+    if (&a == &b)
+        return true;
+    const BasicBlock *cur = &b;
+    while (cur && cur != &a)
+    {
+        auto it = idom_.find(cur);
+        if (it == idom_.end() || it->second == cur)
+            return false;
+        cur = it->second;
+    }
+    return cur == &a;
+}
+
+const BasicBlock *DominatorTree::intersect(const BasicBlock *a, const BasicBlock *b) const
+{
+    while (a != b)
+    {
+        while (rpoIndex_.at(a) > rpoIndex_.at(b))
+            a = idom_.at(a);
+        while (rpoIndex_.at(b) > rpoIndex_.at(a))
+            b = idom_.at(b);
+    }
+    return a;
+}
+
+} // namespace il::analysis

--- a/src/il/analysis/Dominators.hpp
+++ b/src/il/analysis/Dominators.hpp
@@ -1,0 +1,35 @@
+// File: src/il/analysis/Dominators.hpp
+// Purpose: Compute dominator relationships for basic blocks.
+// Key invariants: Entry block dominates all others.
+// Ownership/Lifetime: Relies on CFG data; does not own blocks.
+// Links: docs/class-catalog.md
+#pragma once
+
+#include "il/analysis/CFG.hpp"
+#include <unordered_map>
+
+namespace il::analysis
+{
+
+/// @brief Simple dominator tree using Cooper et al.'s algorithm.
+class DominatorTree
+{
+  public:
+    /// @brief Build dominator tree for @p cfg.
+    explicit DominatorTree(const CFG &cfg);
+
+    /// @brief Immediate dominator of @p b; nullptr for entry.
+    const core::BasicBlock *idom(const core::BasicBlock &b) const;
+
+    /// @brief Whether @p a dominates @p b.
+    bool dominates(const core::BasicBlock &a, const core::BasicBlock &b) const;
+
+  private:
+    const CFG &cfg_;
+    std::unordered_map<const core::BasicBlock *, const core::BasicBlock *> idom_;
+    std::unordered_map<const core::BasicBlock *, unsigned> rpoIndex_;
+
+    const core::BasicBlock *intersect(const core::BasicBlock *a, const core::BasicBlock *b) const;
+};
+
+} // namespace il::analysis

--- a/src/il/utils/Utils.cpp
+++ b/src/il/utils/Utils.cpp
@@ -1,0 +1,20 @@
+// File: src/il/utils/Utils.cpp
+// Purpose: Implement miscellaneous IL helper routines.
+// Key invariants: Inputs reference valid instructions and blocks.
+// Ownership/Lifetime: No ownership transfer.
+// Links: docs/class-catalog.md
+
+#include "il/utils/Utils.hpp"
+
+namespace il::util
+{
+
+bool inBlock(const core::Instr &inst, const core::BasicBlock &block)
+{
+    for (const auto &i : block.instructions)
+        if (&i == &inst)
+            return true;
+    return false;
+}
+
+} // namespace il::util

--- a/src/il/utils/Utils.hpp
+++ b/src/il/utils/Utils.hpp
@@ -1,0 +1,20 @@
+// File: src/il/utils/Utils.hpp
+// Purpose: Miscellaneous IL helper routines.
+// Key invariants: Functions operate on existing instructions and blocks.
+// Ownership/Lifetime: Does not take ownership of inputs.
+// Links: docs/class-catalog.md
+#pragma once
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Instr.hpp"
+
+namespace il::util
+{
+
+/// @brief Check if instruction @p inst exists in @p block.
+/// @param inst Instruction to test.
+/// @param block Basic block to search.
+/// @return True if @p inst resides in @p block.
+bool inBlock(const core::Instr &inst, const core::BasicBlock &block);
+
+} // namespace il::util

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,14 @@ target_link_libraries(test_il_parse_negative PRIVATE il_core il_io support)
 target_compile_definitions(test_il_parse_negative PRIVATE BAD_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse")
 add_test(NAME test_il_parse_negative COMMAND test_il_parse_negative)
 
+add_executable(test_analysis_cfg unit/test_analysis_cfg.cpp)
+target_link_libraries(test_analysis_cfg PRIVATE il_core il_analysis il_utils support)
+add_test(NAME test_analysis_cfg COMMAND test_analysis_cfg)
+
+add_executable(test_analysis_dom unit/test_analysis_dominators.cpp)
+target_link_libraries(test_analysis_dom PRIVATE il_core il_analysis il_utils support)
+add_test(NAME test_analysis_dom COMMAND test_analysis_dom)
+
 add_test(NAME il_verify_ex1 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex1_hello_cond.il)
 add_test(NAME il_verify_ex2 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex2_sum_1_to_10.il)
 add_test(NAME il_verify_ex3 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex3_table_5x5.il)

--- a/tests/unit/test_analysis_cfg.cpp
+++ b/tests/unit/test_analysis_cfg.cpp
@@ -1,0 +1,71 @@
+// File: tests/unit/test_analysis_cfg.cpp
+// Purpose: Unit tests for CFG utilities.
+// Key invariants: Constructs synthetic graphs to validate analysis.
+// Ownership/Lifetime: Tests own all temporary graphs.
+// Links: docs/dev/analysis.md
+#include "il/analysis/CFG.hpp"
+#include "il/core/Type.hpp"
+#include "il/utils/Utils.hpp"
+#include <cassert>
+
+using namespace il::core;
+using namespace il::analysis;
+
+static Function makeDiamond()
+{
+    Function f;
+    f.name = "f";
+    f.retType = Type(Type::Kind::Void);
+
+    BasicBlock entry{};
+    entry.label = "entry";
+    Instr cbr;
+    cbr.op = Opcode::CBr;
+    cbr.labels = {"then", "else"};
+    entry.instructions.push_back(cbr);
+    entry.terminated = true;
+
+    BasicBlock thenB{};
+    thenB.label = "then";
+    Instr br1;
+    br1.op = Opcode::Br;
+    br1.labels = {"merge"};
+    thenB.instructions.push_back(br1);
+    thenB.terminated = true;
+
+    BasicBlock elseB{};
+    elseB.label = "else";
+    Instr br2;
+    br2.op = Opcode::Br;
+    br2.labels = {"merge"};
+    elseB.instructions.push_back(br2);
+    elseB.terminated = true;
+
+    BasicBlock merge{};
+    merge.label = "merge";
+    Instr ret;
+    ret.op = Opcode::Ret;
+    merge.instructions.push_back(ret);
+    merge.terminated = true;
+
+    f.blocks = {entry, thenB, elseB, merge};
+    return f;
+}
+
+int main()
+{
+    Function f = makeDiamond();
+    CFG cfg(f);
+    const auto &entry = f.blocks[0];
+    const auto &thenB = f.blocks[1];
+    const auto &elseB = f.blocks[2];
+    const auto &merge = f.blocks[3];
+
+    assert(cfg.succs(entry).size() == 2);
+    assert(cfg.preds(thenB).size() == 1 && cfg.preds(thenB)[0] == &entry);
+    assert(cfg.postOrder(merge) == 0);
+    assert(cfg.postOrder(entry) == 3);
+    assert(il::util::inBlock(thenB.instructions.front(), thenB));
+    assert(!il::util::inBlock(thenB.instructions.front(), elseB));
+    return 0;
+}

--- a/tests/unit/test_analysis_dominators.cpp
+++ b/tests/unit/test_analysis_dominators.cpp
@@ -1,0 +1,119 @@
+// File: tests/unit/test_analysis_dominators.cpp
+// Purpose: Unit tests for dominator tree construction.
+// Key invariants: Uses synthetic CFGs covering diamonds and loops.
+// Ownership/Lifetime: Tests manage temporary graphs.
+// Links: docs/dev/analysis.md
+#include "il/analysis/CFG.hpp"
+#include "il/analysis/Dominators.hpp"
+#include "il/core/Type.hpp"
+#include <cassert>
+
+using namespace il::core;
+using namespace il::analysis;
+
+static Function makeDiamond()
+{
+    Function f;
+    f.name = "f";
+    f.retType = Type(Type::Kind::Void);
+    BasicBlock entry{};
+    entry.label = "entry";
+    Instr cbr;
+    cbr.op = Opcode::CBr;
+    cbr.labels = {"then", "else"};
+    entry.instructions.push_back(cbr);
+    entry.terminated = true;
+    BasicBlock thenB{};
+    thenB.label = "then";
+    Instr br1;
+    br1.op = Opcode::Br;
+    br1.labels = {"merge"};
+    thenB.instructions.push_back(br1);
+    thenB.terminated = true;
+    BasicBlock elseB{};
+    elseB.label = "else";
+    Instr br2;
+    br2.op = Opcode::Br;
+    br2.labels = {"merge"};
+    elseB.instructions.push_back(br2);
+    elseB.terminated = true;
+    BasicBlock merge{};
+    merge.label = "merge";
+    Instr ret;
+    ret.op = Opcode::Ret;
+    merge.instructions.push_back(ret);
+    merge.terminated = true;
+    f.blocks = {entry, thenB, elseB, merge};
+    return f;
+}
+
+static Function makeLoop()
+{
+    Function f;
+    f.name = "loop";
+    f.retType = Type(Type::Kind::Void);
+    BasicBlock entry{};
+    entry.label = "entry";
+    Instr br;
+    br.op = Opcode::Br;
+    br.labels = {"hdr"};
+    entry.instructions.push_back(br);
+    entry.terminated = true;
+    BasicBlock hdr{};
+    hdr.label = "hdr";
+    Instr cbr;
+    cbr.op = Opcode::CBr;
+    cbr.labels = {"body", "exit"};
+    hdr.instructions.push_back(cbr);
+    hdr.terminated = true;
+    BasicBlock body{};
+    body.label = "body";
+    Instr br2;
+    br2.op = Opcode::Br;
+    br2.labels = {"hdr"};
+    body.instructions.push_back(br2);
+    body.terminated = true;
+    BasicBlock exit{};
+    exit.label = "exit";
+    Instr ret;
+    ret.op = Opcode::Ret;
+    exit.instructions.push_back(ret);
+    exit.terminated = true;
+    f.blocks = {entry, hdr, body, exit};
+    return f;
+}
+
+int main()
+{
+    {
+        Function f = makeDiamond();
+        CFG cfg(f);
+        DominatorTree dt(cfg);
+        const auto &entry = f.blocks[0];
+        const auto &thenB = f.blocks[1];
+        const auto &elseB = f.blocks[2];
+        const auto &merge = f.blocks[3];
+        assert(dt.idom(entry) == nullptr);
+        assert(dt.idom(thenB) == &entry);
+        assert(dt.idom(elseB) == &entry);
+        assert(dt.idom(merge) == &entry);
+        assert(dt.dominates(entry, merge));
+        assert(!dt.dominates(thenB, elseB));
+    }
+    {
+        Function f = makeLoop();
+        CFG cfg(f);
+        DominatorTree dt(cfg);
+        const auto &entry = f.blocks[0];
+        const auto &hdr = f.blocks[1];
+        const auto &body = f.blocks[2];
+        const auto &exit = f.blocks[3];
+        assert(dt.idom(entry) == nullptr);
+        assert(dt.idom(hdr) == &entry);
+        assert(dt.idom(body) == &hdr);
+        assert(dt.idom(exit) == &hdr);
+        assert(dt.dominates(hdr, body));
+        assert(!dt.dominates(body, exit));
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add CFG helper for successor/predecessor queries and post-order numbering
- compute dominator tree using Cooper et al.'s algorithm
- provide IL utility for checking instruction membership and document analyses

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b7ce40aff88324a57f75ce8b2d3711