### PR TITLE
feat(analysis): add CFG and dominator utilities

### DIFF
--- a/docs/dev/analysis.md
+++ b/docs/dev/analysis.md
@@ -1,0 +1,28 @@
+# Analysis Utilities
+
+Provides basic control-flow and dominance analyses for IL functions.
+
+## CFG
+
+`analysis::CFG` builds predecessor and successor lists for each block and
+produces a deterministic postorder of blocks. Construction visits each block and
+edge once (O(N + E)). The object only references existing blocks and must not
+outlive the function.
+
+## Dominator Tree
+
+`analysis::DominatorTree` uses the algorithm by Cooper et al. to compute
+immediate dominators. The implementation iterates until convergence and is
+nearly linear for typical graphs. Query `dominates(A, B)` to test dominance or
+`idom(B)` for the immediate dominator.
+
+## IL Utils
+
+The `il::util` helpers relate instructions to blocks:
+
+- `isInBlock(bb, inst)` checks whether an instruction resides in a block.
+- `findBlock(fn, inst)` finds the block containing an instruction.
+
+Both helpers run in linear time with respect to the number of inspected
+instructions.
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(il_core STATIC
   il/core/Global.cpp
   il/core/Extern.cpp
   il/core/Module.cpp
+  il/Utils.cpp
 )
 target_include_directories(il_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -30,6 +31,12 @@ add_library(il_transform STATIC
   il/transform/ConstFold.cpp)
 target_link_libraries(il_transform PUBLIC il_core il_verify)
 target_include_directories(il_transform PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(il_analysis STATIC
+  analysis/CFG.cpp
+  analysis/Dominators.cpp)
+target_link_libraries(il_analysis PUBLIC il_core)
+target_include_directories(il_analysis PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(il_vm STATIC vm/VM.cpp vm/RuntimeBridge.cpp)
 target_include_directories(il_vm PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/analysis/CFG.cpp
+++ b/src/analysis/CFG.cpp
@@ -1,0 +1,79 @@
+// File: src/analysis/CFG.cpp
+// Purpose: Builds basic control-flow graph information.
+// Key invariants: Predecessor/successor lists mirror terminator labels.
+// Ownership/Lifetime: Operates on existing function; no ownership.
+// Links: docs/dev/analysis.md
+
+#include "analysis/CFG.hpp"
+#include "il/core/Instr.hpp"
+#include <functional>
+#include <unordered_set>
+
+using namespace il::core;
+
+namespace il::analysis
+{
+
+CFG::CFG(const Function &fn)
+{
+    compute(fn);
+}
+
+void CFG::compute(const Function &fn)
+{
+    std::unordered_map<std::string, const BasicBlock *> labelMap;
+    for (const auto &bb : fn.blocks)
+    {
+        labelMap[bb.label] = &bb;
+        succ[&bb];
+        pred[&bb];
+    }
+
+    for (const auto &bb : fn.blocks)
+    {
+        if (bb.instructions.empty())
+            continue;
+        const Instr &term = bb.instructions.back();
+        for (const auto &lbl : term.labels)
+        {
+            auto it = labelMap.find(lbl);
+            if (it != labelMap.end())
+            {
+                succ[&bb].push_back(it->second);
+                pred[it->second].push_back(&bb);
+            }
+        }
+    }
+
+    std::unordered_set<const BasicBlock *> visited;
+    std::function<void(const BasicBlock *)> dfs = [&](const BasicBlock *b)
+    {
+        if (!visited.insert(b).second)
+            return;
+        for (const BasicBlock *s : succ[b])
+            dfs(s);
+        postIndex[b] = postorder.size();
+        postorder.push_back(b);
+    };
+
+    if (!fn.blocks.empty())
+        dfs(&fn.blocks.front());
+}
+
+const std::vector<const BasicBlock *> &CFG::successors(const BasicBlock &bb) const
+{
+    return succ.at(&bb);
+}
+
+const std::vector<const BasicBlock *> &CFG::predecessors(const BasicBlock &bb) const
+{
+    return pred.at(&bb);
+}
+
+size_t CFG::postorderIndex(const BasicBlock &bb) const
+{
+    auto it = postIndex.find(&bb);
+    return it == postIndex.end() ? static_cast<size_t>(-1) : it->second;
+}
+
+} // namespace il::analysis

--- a/src/analysis/CFG.hpp
+++ b/src/analysis/CFG.hpp
@@ -1,0 +1,51 @@
+// File: src/analysis/CFG.hpp
+// Purpose: Basic control-flow graph utilities for IL functions.
+// Key invariants: Graph reflects explicit terminators; postorder is deterministic.
+// Ownership/Lifetime: Views into existing function; does not own blocks.
+// Links: docs/dev/analysis.md
+#pragma once
+
+#include "il/core/Function.hpp"
+#include <unordered_map>
+#include <vector>
+
+namespace il::analysis
+{
+
+/// @brief Control-flow graph for a function.
+/// Provides predecessor/successor queries and postorder numbering.
+class CFG
+{
+  public:
+    /// @brief Build CFG for function @p fn.
+    explicit CFG(const il::core::Function &fn);
+
+    /// @brief Successors of block @p bb.
+    const std::vector<const il::core::BasicBlock *> &successors(
+        const il::core::BasicBlock &bb) const;
+
+    /// @brief Predecessors of block @p bb.
+    const std::vector<const il::core::BasicBlock *> &predecessors(
+        const il::core::BasicBlock &bb) const;
+
+    /// @brief Postorder index of @p bb (0-based, root has highest index).
+    size_t postorderIndex(const il::core::BasicBlock &bb) const;
+
+    /// @brief Blocks in postorder (leaves first, entry last).
+    const std::vector<const il::core::BasicBlock *> &postorderBlocks() const
+    {
+        return postorder;
+    }
+
+  private:
+    std::unordered_map<const il::core::BasicBlock *, std::vector<const il::core::BasicBlock *>>
+        succ;
+    std::unordered_map<const il::core::BasicBlock *, std::vector<const il::core::BasicBlock *>>
+        pred;
+    std::vector<const il::core::BasicBlock *> postorder;
+    std::unordered_map<const il::core::BasicBlock *, size_t> postIndex;
+
+    void compute(const il::core::Function &fn);
+};
+
+} // namespace il::analysis

--- a/src/analysis/Dominators.cpp
+++ b/src/analysis/Dominators.cpp
@@ -1,0 +1,102 @@
+// File: src/analysis/Dominators.cpp
+// Purpose: Implements simple Cooper et al. dominator algorithm.
+// Key invariants: Root dominates all; idom map stable.
+// Ownership/Lifetime: Uses CFG; no ownership of blocks.
+// Links: docs/dev/analysis.md
+
+#include "analysis/Dominators.hpp"
+#include <vector>
+
+using namespace il::core;
+
+namespace il::analysis
+{
+namespace
+{
+const BasicBlock *intersect(const BasicBlock *b1,
+                            const BasicBlock *b2,
+                            const std::unordered_map<const BasicBlock *, const BasicBlock *> &idom,
+                            const std::unordered_map<const BasicBlock *, size_t> &rpoIdx)
+{
+    while (b1 != b2)
+    {
+        while (rpoIdx.at(b1) > rpoIdx.at(b2))
+            b1 = idom.at(b1);
+        while (rpoIdx.at(b2) > rpoIdx.at(b1))
+            b2 = idom.at(b2);
+    }
+    return b1;
+}
+} // namespace
+
+DominatorTree::DominatorTree(const CFG &cfg)
+{
+    const auto &po = cfg.postorderBlocks();
+    if (po.empty())
+        return;
+    std::vector<const BasicBlock *> rpo(po.rbegin(), po.rend());
+    std::unordered_map<const BasicBlock *, size_t> rpoIdx;
+    for (size_t i = 0; i < rpo.size(); ++i)
+        rpoIdx[rpo[i]] = i;
+
+    const BasicBlock *start = rpo.front();
+    idoms[start] = start;
+    bool changed = true;
+    while (changed)
+    {
+        changed = false;
+        for (size_t i = 1; i < rpo.size(); ++i)
+        {
+            const BasicBlock *b = rpo[i];
+            const auto &preds = cfg.predecessors(*b);
+            const BasicBlock *newIdom = nullptr;
+            for (const BasicBlock *p : preds)
+            {
+                if (idoms.count(p))
+                {
+                    newIdom = p;
+                    break;
+                }
+            }
+            if (!newIdom)
+                continue;
+            for (const BasicBlock *p : preds)
+            {
+                if (p == newIdom)
+                    continue;
+                if (idoms.count(p))
+                    newIdom = intersect(p, newIdom, idoms, rpoIdx);
+            }
+            if (idoms[b] != newIdom)
+            {
+                idoms[b] = newIdom;
+                changed = true;
+            }
+        }
+    }
+}
+
+const BasicBlock *DominatorTree::idom(const BasicBlock &bb) const
+{
+    auto it = idoms.find(&bb);
+    if (it == idoms.end())
+        return nullptr;
+    return it->second;
+}
+
+bool DominatorTree::dominates(const BasicBlock &a, const BasicBlock &b) const
+{
+    const BasicBlock *cur = &b;
+    while (cur)
+    {
+        if (cur == &a)
+            return true;
+        auto it = idoms.find(cur);
+        if (it == idoms.end() || it->second == cur)
+            break;
+        cur = it->second;
+    }
+    return false;
+}
+
+} // namespace il::analysis

--- a/src/analysis/Dominators.hpp
+++ b/src/analysis/Dominators.hpp
@@ -1,0 +1,31 @@
+// File: src/analysis/Dominators.hpp
+// Purpose: Construct dominator tree for a function.
+// Key invariants: Deterministic Cooper-style algorithm.
+// Ownership/Lifetime: References blocks owned elsewhere.
+// Links: docs/dev/analysis.md
+#pragma once
+
+#include "analysis/CFG.hpp"
+#include <unordered_map>
+
+namespace il::analysis
+{
+
+/// @brief Computes immediate dominators and dominance queries.
+class DominatorTree
+{
+  public:
+    /// @brief Build dominator tree from CFG @p cfg.
+    explicit DominatorTree(const CFG &cfg);
+
+    /// @brief Immediate dominator of block @p bb (nullptr for entry).
+    const il::core::BasicBlock *idom(const il::core::BasicBlock &bb) const;
+
+    /// @brief True if @p a dominates @p b.
+    bool dominates(const il::core::BasicBlock &a, const il::core::BasicBlock &b) const;
+
+  private:
+    std::unordered_map<const il::core::BasicBlock *, const il::core::BasicBlock *> idoms;
+};
+
+} // namespace il::analysis

--- a/src/il/Utils.cpp
+++ b/src/il/Utils.cpp
@@ -1,0 +1,32 @@
+// File: src/il/Utils.cpp
+// Purpose: Implements IL helper functions for instruction queries.
+// Key invariants: None.
+// Ownership/Lifetime: Non-owning views into existing structures.
+// Links: docs/dev/analysis.md
+
+#include "il/Utils.hpp"
+
+namespace il::util
+{
+
+bool isInBlock(const il::core::BasicBlock &bb, const il::core::Instr &inst)
+{
+    for (const auto &i : bb.instructions)
+    {
+        if (&i == &inst)
+            return true;
+    }
+    return false;
+}
+
+const il::core::BasicBlock *findBlock(const il::core::Function &fn, const il::core::Instr &inst)
+{
+    for (const auto &bb : fn.blocks)
+    {
+        if (isInBlock(bb, inst))
+            return &bb;
+    }
+    return nullptr;
+}
+
+} // namespace il::util

--- a/src/il/Utils.hpp
+++ b/src/il/Utils.hpp
@@ -1,0 +1,27 @@
+// File: src/il/Utils.hpp
+// Purpose: Helper functions for inspecting IL instruction placement.
+// Key invariants: None.
+// Ownership/Lifetime: Functions operate on existing structures.
+// Links: docs/dev/analysis.md
+#pragma once
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+
+namespace il::util
+{
+
+/// @brief Check if instruction @p inst resides in block @p bb.
+/// @param bb Basic block to search.
+/// @param inst Instruction to locate.
+/// @return True if @p inst is contained in @p bb.
+bool isInBlock(const il::core::BasicBlock &bb, const il::core::Instr &inst);
+
+/// @brief Find block containing instruction @p inst in function @p fn.
+/// @param fn Function to inspect.
+/// @param inst Instruction to find.
+/// @return Pointer to containing block, or nullptr if not found.
+const il::core::BasicBlock *findBlock(const il::core::Function &fn, const il::core::Instr &inst);
+
+} // namespace il::util

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,10 @@ target_link_libraries(test_il_parse_negative PRIVATE il_core il_io support)
 target_compile_definitions(test_il_parse_negative PRIVATE BAD_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse")
 add_test(NAME test_il_parse_negative COMMAND test_il_parse_negative)
 
+add_executable(test_analysis_cfg_dom unit/test_analysis_cfg_dominators.cpp)
+target_link_libraries(test_analysis_cfg_dom PRIVATE il_core il_build il_analysis support)
+add_test(NAME test_analysis_cfg_dom COMMAND test_analysis_cfg_dom)
+
 add_test(NAME il_verify_ex1 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex1_hello_cond.il)
 add_test(NAME il_verify_ex2 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex2_sum_1_to_10.il)
 add_test(NAME il_verify_ex3 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex3_table_5x5.il)

--- a/tests/unit/test_analysis_cfg_dominators.cpp
+++ b/tests/unit/test_analysis_cfg_dominators.cpp
@@ -1,0 +1,92 @@
+// File: tests/unit/test_analysis_cfg_dominators.cpp
+// Purpose: Exercise CFG and dominator analyses on small graphs.
+// Key invariants: Dominator relationships follow graph structure.
+// Ownership/Lifetime: Builds temporary modules via IRBuilder.
+// Links: docs/dev/analysis.md
+
+#include "analysis/CFG.hpp"
+#include "analysis/Dominators.hpp"
+#include "il/Utils.hpp"
+#include "il/build/IRBuilder.hpp"
+#include <cassert>
+#include <optional>
+
+using namespace il::core;
+
+void testDiamond()
+{
+    Module m;
+    il::build::IRBuilder b(m);
+    Function &fn = b.startFunction("diamond", Type(Type::Kind::Void), {});
+    b.createBlock(fn, "entry");
+    b.createBlock(fn, "t");
+    b.createBlock(fn, "f");
+    b.createBlock(fn, "join");
+    BasicBlock &entry = fn.blocks[0];
+    BasicBlock &t = fn.blocks[1];
+    BasicBlock &f = fn.blocks[2];
+    BasicBlock &join = fn.blocks[3];
+
+    b.setInsertPoint(entry);
+    b.cbr(Value::constInt(1), t, {}, f, {});
+
+    b.setInsertPoint(t);
+    b.br(join);
+
+    b.setInsertPoint(f);
+    b.br(join);
+
+    b.setInsertPoint(join);
+    b.emitRet(std::nullopt, {});
+
+    il::analysis::CFG cfg(fn);
+    il::analysis::DominatorTree dom(cfg);
+
+    assert(dom.dominates(entry, t));
+    assert(dom.dominates(entry, f));
+    assert(!dom.dominates(t, f));
+    assert(dom.idom(t) == &entry);
+    assert(dom.idom(f) == &entry);
+    assert(dom.idom(join) == &entry);
+
+    const Instr &br = entry.instructions.back();
+    assert(il::util::isInBlock(entry, br));
+    assert(il::util::findBlock(fn, br) == &entry);
+}
+
+void testLoop()
+{
+    Module m;
+    il::build::IRBuilder b(m);
+    Function &fn = b.startFunction("loop", Type(Type::Kind::Void), {});
+    b.createBlock(fn, "entry");
+    b.createBlock(fn, "loop");
+    b.createBlock(fn, "exit");
+    BasicBlock &entry = fn.blocks[0];
+    BasicBlock &loop = fn.blocks[1];
+    BasicBlock &exit = fn.blocks[2];
+
+    b.setInsertPoint(entry);
+    b.br(loop);
+
+    b.setInsertPoint(loop);
+    b.cbr(Value::constInt(0), loop, {}, exit, {});
+
+    b.setInsertPoint(exit);
+    b.emitRet(std::nullopt, {});
+
+    il::analysis::CFG cfg(fn);
+    il::analysis::DominatorTree dom(cfg);
+
+    assert(dom.dominates(entry, loop));
+    assert(dom.dominates(entry, exit));
+    assert(dom.idom(loop) == &entry);
+    assert(dom.idom(exit) == &loop);
+}
+
+int main()
+{
+    testDiamond();
+    testLoop();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add control-flow graph builder with postorder numbering
- compute dominator tree using Cooper algorithm
- expose IL helpers for instruction/block queries and document analysis APIs

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b7ce40aff88324a57f75ce8b2d3711