### PR TITLE
feat(analysis): add CFG and dominator utilities

### DIFF
--- a/docs/dev/analysis.md
+++ b/docs/dev/analysis.md
@@ -1,0 +1,25 @@
+# Analysis Utilities
+
+This module provides basic control-flow and dominance analyses for IL functions.
+
+## CFG
+
+`il::analysis::CFG` builds predecessor and successor lists for each basic block
+and computes a postorder numbering starting from the entry block. Construction
+runs in $O(N + E)$ time.
+
+## Dominator Tree
+
+`il::analysis::DominatorTree` implements the simple dominator tree algorithm by
+Cooper et al. using the CFG's postorder. Queries for immediate dominators and
+`dominates` checks execute in $O(h)$ where $h$ is the height of the dominator
+ tree.
+
+## IL Utils
+
+`il::utils::isInstrInBlock` tests whether a given instruction resides in a
+particular basic block. This performs a linear scan over the block's instruction
+list.
+
+These utilities underpin SSA construction and other transforms such as mem2reg.
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,14 @@ add_library(il_verify STATIC il/verify/Verifier.cpp)
 target_link_libraries(il_verify PUBLIC il_core)
 target_include_directories(il_verify PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_library(il_utils STATIC il/utils/Utils.cpp)
+target_link_libraries(il_utils PUBLIC il_core)
+target_include_directories(il_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(il_analysis STATIC analysis/CFG.cpp analysis/Dominators.cpp)
+target_link_libraries(il_analysis PUBLIC il_core)
+target_include_directories(il_analysis PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_library(il_transform STATIC
   il/transform/PassManager.cpp
   il/transform/Peephole.cpp

--- a/src/analysis/CFG.cpp
+++ b/src/analysis/CFG.cpp
@@ -1,0 +1,76 @@
+// File: src/analysis/CFG.cpp
+// Purpose: Implements construction of basic block predecessor/successor lists.
+// Key invariants: All branch targets map to known blocks.
+// Ownership/Lifetime: CFG stores non-owning pointers.
+// Links: docs/dev/analysis.md
+
+#include "analysis/CFG.hpp"
+#include <functional>
+#include <unordered_set>
+
+namespace il::analysis
+{
+
+CFG::CFG(const il::core::Function &f) : func(f)
+{
+    using Block = il::core::BasicBlock;
+    std::unordered_map<std::string, const Block *> labelToBlock;
+    for (const auto &b : f.blocks)
+    {
+        labelToBlock[b.label] = &b;
+        preds[&b];
+        succs[&b];
+    }
+    for (const auto &b : f.blocks)
+    {
+        if (!b.terminated || b.instructions.empty())
+            continue;
+        const auto &term = b.instructions.back();
+        if (term.op == il::core::Opcode::Br || term.op == il::core::Opcode::CBr)
+        {
+            for (const auto &lab : term.labels)
+            {
+                auto it = labelToBlock.find(lab);
+                if (it != labelToBlock.end())
+                {
+                    succs[&b].push_back(it->second);
+                    preds[it->second].push_back(&b);
+                }
+            }
+        }
+    }
+    const Block *entry = f.blocks.empty() ? nullptr : &f.blocks.front();
+    std::unordered_set<const Block *> visited;
+    std::function<void(const Block *)> dfs = [&](const Block *bb)
+    {
+        if (visited.count(bb))
+            return;
+        visited.insert(bb);
+        for (const Block *s : succs[bb])
+            dfs(s);
+        postOrder.push_back(bb);
+    };
+    if (entry)
+        dfs(entry);
+    for (std::size_t i = 0; i < postOrder.size(); ++i)
+        postNum[postOrder[i]] = i;
+}
+
+const std::vector<const il::core::BasicBlock *> &CFG::predecessors(
+    const il::core::BasicBlock *bb) const
+{
+    return preds.at(bb);
+}
+
+const std::vector<const il::core::BasicBlock *> &CFG::successors(
+    const il::core::BasicBlock *bb) const
+{
+    return succs.at(bb);
+}
+
+std::size_t CFG::postIndex(const il::core::BasicBlock *bb) const
+{
+    return postNum.at(bb);
+}
+
+} // namespace il::analysis

--- a/src/analysis/CFG.hpp
+++ b/src/analysis/CFG.hpp
@@ -1,0 +1,42 @@
+// File: src/analysis/CFG.hpp
+// Purpose: Builds predecessor/successor lists and postorder for functions.
+// Key invariants: Blocks referenced by labels must exist in the function.
+// Ownership/Lifetime: CFG holds non-owning pointers to blocks.
+// Links: docs/dev/analysis.md
+#pragma once
+
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include <unordered_map>
+#include <vector>
+
+namespace il::analysis
+{
+
+class CFG
+{
+  public:
+    explicit CFG(const il::core::Function &f);
+
+    const std::vector<const il::core::BasicBlock *> &predecessors(
+        const il::core::BasicBlock *bb) const;
+    const std::vector<const il::core::BasicBlock *> &successors(
+        const il::core::BasicBlock *bb) const;
+
+    const std::vector<const il::core::BasicBlock *> &postorder() const
+    {
+        return postOrder;
+    }
+
+    std::size_t postIndex(const il::core::BasicBlock *bb) const;
+
+  private:
+    using Block = il::core::BasicBlock;
+    const il::core::Function &func;
+    std::unordered_map<const Block *, std::vector<const Block *>> preds;
+    std::unordered_map<const Block *, std::vector<const Block *>> succs;
+    std::vector<const Block *> postOrder;
+    std::unordered_map<const Block *, std::size_t> postNum;
+};
+
+} // namespace il::analysis

--- a/src/analysis/Dominators.cpp
+++ b/src/analysis/Dominators.cpp
@@ -1,0 +1,81 @@
+// File: src/analysis/Dominators.cpp
+// Purpose: Implements dominator tree construction using Cooper's algorithm.
+// Key invariants: CFG must represent a single-entry graph.
+// Ownership/Lifetime: Uses pointers supplied by CFG.
+// Links: docs/dev/analysis.md
+
+#include "analysis/Dominators.hpp"
+
+namespace il::analysis
+{
+
+DominatorTree::DominatorTree(const CFG &cfg) : cfg(cfg)
+{
+    const auto &order = cfg.postorder();
+    for (auto *b : order)
+        idoms[b] = nullptr;
+    if (order.empty())
+        return;
+    const Block *start = order.back();
+    idoms[start] = start;
+    bool changed = true;
+    while (changed)
+    {
+        changed = false;
+        for (auto it = order.rbegin(); it != order.rend(); ++it)
+        {
+            const Block *b = *it;
+            if (b == start)
+                continue;
+            const auto &preds = cfg.predecessors(b);
+            const Block *newIdom = nullptr;
+            for (const Block *p : preds)
+            {
+                if (idoms[p])
+                    newIdom = newIdom ? intersect(p, newIdom) : p;
+            }
+            if (idoms[b] != newIdom)
+            {
+                idoms[b] = newIdom;
+                changed = true;
+            }
+        }
+    }
+}
+
+const il::core::BasicBlock *DominatorTree::idom(const il::core::BasicBlock *b) const
+{
+    auto it = idoms.find(b);
+    return it != idoms.end() ? it->second : nullptr;
+}
+
+bool DominatorTree::dominates(const il::core::BasicBlock *a, const il::core::BasicBlock *b) const
+{
+    if (a == b)
+        return true;
+    const Block *cur = b;
+    while (cur && cur != idoms.at(cur))
+    {
+        cur = idoms.at(cur);
+        if (cur == a)
+            return true;
+    }
+    return false;
+}
+
+const il::core::BasicBlock *DominatorTree::intersect(const il::core::BasicBlock *a,
+                                                     const il::core::BasicBlock *b) const
+{
+    const Block *x = a;
+    const Block *y = b;
+    while (x != y)
+    {
+        while (cfg.postIndex(x) < cfg.postIndex(y))
+            x = idoms.at(x);
+        while (cfg.postIndex(y) < cfg.postIndex(x))
+            y = idoms.at(y);
+    }
+    return x;
+}
+
+} // namespace il::analysis

--- a/src/analysis/Dominators.hpp
+++ b/src/analysis/Dominators.hpp
@@ -1,0 +1,30 @@
+// File: src/analysis/Dominators.hpp
+// Purpose: Declares dominator tree construction for functions.
+// Key invariants: Requires valid CFG postorder numbering.
+// Ownership/Lifetime: Holds non-owning pointers to blocks.
+// Links: docs/dev/analysis.md
+#pragma once
+
+#include "analysis/CFG.hpp"
+#include <unordered_map>
+
+namespace il::analysis
+{
+
+class DominatorTree
+{
+  public:
+    explicit DominatorTree(const CFG &cfg);
+
+    const il::core::BasicBlock *idom(const il::core::BasicBlock *b) const;
+    bool dominates(const il::core::BasicBlock *a, const il::core::BasicBlock *b) const;
+
+  private:
+    using Block = il::core::BasicBlock;
+    const CFG &cfg;
+    std::unordered_map<const Block *, const Block *> idoms;
+
+    const Block *intersect(const Block *a, const Block *b) const;
+};
+
+} // namespace il::analysis

--- a/src/il/utils/Utils.cpp
+++ b/src/il/utils/Utils.cpp
@@ -1,0 +1,20 @@
+// File: src/il/utils/Utils.cpp
+// Purpose: Implements small IL helper routines.
+// Key invariants: None.
+// Ownership/Lifetime: Does not assume ownership of IL objects.
+// Links: docs/dev/analysis.md
+
+#include "il/utils/Utils.hpp"
+#include <algorithm>
+
+namespace il::utils
+{
+
+bool isInstrInBlock(const il::core::Instr &instr, const il::core::BasicBlock &block)
+{
+    return std::any_of(block.instructions.begin(),
+                       block.instructions.end(),
+                       [&](const il::core::Instr &i) { return &i == &instr; });
+}
+
+} // namespace il::utils

--- a/src/il/utils/Utils.hpp
+++ b/src/il/utils/Utils.hpp
@@ -1,0 +1,16 @@
+// File: src/il/utils/Utils.hpp
+// Purpose: Miscellaneous helpers for inspecting IL structures.
+// Key invariants: None.
+// Ownership/Lifetime: Non-owning references to blocks and instructions.
+// Links: docs/dev/analysis.md
+#pragma once
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Instr.hpp"
+
+namespace il::utils
+{
+
+bool isInstrInBlock(const il::core::Instr &instr, const il::core::BasicBlock &block);
+
+} // namespace il::utils

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,10 @@ target_link_libraries(test_il_serialize PRIVATE il_core il_build il_io support)
 target_compile_definitions(test_il_serialize PRIVATE TESTS_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 add_test(NAME test_il_serialize COMMAND test_il_serialize)
 
+add_executable(test_analysis_dominators unit/test_analysis_dominators.cpp)
+target_link_libraries(test_analysis_dominators PRIVATE il_core il_analysis il_utils)
+add_test(NAME test_analysis_dominators COMMAND test_analysis_dominators)
+
 add_executable(test_il_roundtrip unit/test_il_roundtrip.cpp)
 target_link_libraries(test_il_roundtrip PRIVATE il_core il_io il_verify support)
 target_compile_definitions(test_il_roundtrip PRIVATE EXAMPLES_DIR="${CMAKE_SOURCE_DIR}/docs/examples" ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/roundtrip")

--- a/tests/unit/test_analysis_dominators.cpp
+++ b/tests/unit/test_analysis_dominators.cpp
@@ -1,0 +1,110 @@
+#include "analysis/CFG.hpp"
+#include "analysis/Dominators.hpp"
+#include "il/utils/Utils.hpp"
+#include <cassert>
+
+using namespace il;
+
+static core::Instr makeBr(const std::string &dst)
+{
+    core::Instr i;
+    i.op = core::Opcode::Br;
+    i.labels = {dst};
+    return i;
+}
+
+static core::Instr makeCBr(const std::string &t, const std::string &f)
+{
+    core::Instr i;
+    i.op = core::Opcode::CBr;
+    i.operands = {core::Value::temp(0)};
+    i.labels = {t, f};
+    return i;
+}
+
+static core::Instr makeRet()
+{
+    core::Instr i;
+    i.op = core::Opcode::Ret;
+    return i;
+}
+
+int main()
+{
+    // Diamond CFG
+    core::Function f;
+    core::BasicBlock a;
+    a.label = "A";
+    a.instructions = {makeCBr("B", "C")};
+    a.terminated = true;
+    core::BasicBlock b;
+    b.label = "B";
+    b.instructions = {makeBr("D")};
+    b.terminated = true;
+    core::BasicBlock c;
+    c.label = "C";
+    c.instructions = {makeBr("D")};
+    c.terminated = true;
+    core::BasicBlock d;
+    d.label = "D";
+    d.instructions = {makeRet()};
+    d.terminated = true;
+    f.blocks = {a, b, c, d};
+
+    analysis::CFG cfg(f);
+    assert(cfg.successors(&f.blocks[0]).size() == 2);
+    assert(cfg.predecessors(&f.blocks[3]).size() == 2);
+    assert(cfg.postorder().size() == 4);
+
+    analysis::DominatorTree dom(cfg);
+    const auto *A = &f.blocks[0];
+    const auto *B = &f.blocks[1];
+    const auto *C = &f.blocks[2];
+    const auto *D = &f.blocks[3];
+    assert(dom.dominates(A, B));
+    assert(dom.dominates(A, C));
+    assert(dom.dominates(A, D));
+    assert(dom.idom(B) == A);
+    assert(dom.idom(C) == A);
+    assert(dom.idom(D) == A);
+    const auto &instrB = f.blocks[1].instructions[0];
+    assert(utils::isInstrInBlock(instrB, f.blocks[1]));
+    assert(!utils::isInstrInBlock(instrB, f.blocks[2]));
+
+    // Loop CFG
+    core::Function lf;
+    core::BasicBlock e;
+    e.label = "E";
+    e.instructions = {makeBr("H")};
+    e.terminated = true;
+    core::BasicBlock h;
+    h.label = "H";
+    h.instructions = {makeCBr("B", "X")};
+    h.terminated = true;
+    core::BasicBlock body;
+    body.label = "B";
+    body.instructions = {makeBr("H")};
+    body.terminated = true;
+    core::BasicBlock exit;
+    exit.label = "X";
+    exit.instructions = {makeRet()};
+    exit.terminated = true;
+    lf.blocks = {e, h, body, exit};
+
+    analysis::CFG cfg2(lf);
+    analysis::DominatorTree dom2(cfg2);
+    const auto *E = &lf.blocks[0];
+    const auto *H = &lf.blocks[1];
+    const auto *B2 = &lf.blocks[2];
+    const auto *X = &lf.blocks[3];
+    assert(dom2.dominates(E, H));
+    assert(dom2.dominates(E, B2));
+    assert(dom2.dominates(E, X));
+    assert(dom2.dominates(H, B2));
+    assert(dom2.dominates(H, X));
+    assert(dom2.idom(H) == E);
+    assert(dom2.idom(B2) == H);
+    assert(dom2.idom(X) == H);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add CFG utility with predecessor/successor maps and postorder numbering
- compute dominator tree using simple Cooper algorithm
- add IL utility to check instruction membership in blocks
- document analysis APIs and add tests for diamond and loop CFGs

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b7ce40aff88324a57f75ce8b2d3711