### PR TITLE
feat(analysis): add CFG utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,4 +96,5 @@ enable_testing()
 
 add_subdirectory(runtime)
 add_subdirectory(src)
+add_subdirectory(lib/Analysis)
 add_subdirectory(tests)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing
+
+The project includes an `Analysis` library (`lib/Analysis`) that provides on-demand control-flow graph utilities. Link against `Analysis` when writing analyses or tests requiring CFG queries.
+

--- a/docs/dev/analysis.md
+++ b/docs/dev/analysis.md
@@ -1,0 +1,12 @@
+# Analysis Library
+
+## Control Flow Graph (CFG)
+
+On-demand helpers to inspect successors and predecessors of IL basic blocks.
+
+```cpp
+using namespace viper::analysis;
+auto succ = successors(fn, block);
+auto pred = predecessors(fn, block);
+```
+

--- a/lib/Analysis/CFG.cpp
+++ b/lib/Analysis/CFG.cpp
@@ -1,0 +1,59 @@
+// File: lib/Analysis/CFG.cpp
+// Purpose: Implements control-flow graph utilities for IL blocks.
+// Key invariants: Uses no caching; recomputes on each call.
+// Ownership/Lifetime: Borrowed IL structures remain owned by callers.
+// Links: docs/dev/analysis.md
+
+#include "Analysis/CFG.h"
+
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+
+#include <algorithm>
+
+namespace viper::analysis
+{
+
+std::vector<il::core::BasicBlock *> successors(const il::core::Function &F,
+                                               const il::core::BasicBlock &B)
+{
+    std::vector<il::core::BasicBlock *> succs;
+    if (B.instructions.empty())
+        return succs;
+
+    const il::core::Instr &term = B.instructions.back();
+    using il::core::Opcode;
+    if (term.op == Opcode::Br || term.op == Opcode::CBr)
+    {
+        for (const auto &label : term.labels)
+        {
+            auto it =
+                std::find_if(F.blocks.begin(),
+                             F.blocks.end(),
+                             [&](const il::core::BasicBlock &blk) { return blk.label == label; });
+            if (it != F.blocks.end())
+                succs.push_back(const_cast<il::core::BasicBlock *>(&*it));
+        }
+    }
+    return succs;
+}
+
+std::vector<il::core::BasicBlock *> predecessors(const il::core::Function &F,
+                                                 const il::core::BasicBlock &B)
+{
+    std::vector<il::core::BasicBlock *> preds;
+    for (const auto &blk : F.blocks)
+    {
+        if (blk.instructions.empty())
+            continue;
+        const il::core::Instr &term = blk.instructions.back();
+        using il::core::Opcode;
+        if (term.op != Opcode::Br && term.op != Opcode::CBr)
+            continue;
+        if (std::find(term.labels.begin(), term.labels.end(), B.label) != term.labels.end())
+            preds.push_back(const_cast<il::core::BasicBlock *>(&blk));
+    }
+    return preds;
+}
+
+} // namespace viper::analysis

--- a/lib/Analysis/CFG.h
+++ b/lib/Analysis/CFG.h
@@ -1,0 +1,33 @@
+// File: lib/Analysis/CFG.h
+// Purpose: Declares control-flow graph utilities for IL blocks.
+// Key invariants: No global state; queries are on-demand.
+// Ownership/Lifetime: Operates on externally owned IL structures.
+// Links: docs/dev/analysis.md
+#pragma once
+
+#include <vector>
+
+namespace il::core
+{
+struct Function;
+struct BasicBlock;
+} // namespace il::core
+
+namespace viper::analysis
+{
+
+/// @brief Return successor blocks for @p B by examining its terminator.
+/// @param F Function containing @p B.
+/// @param B Block to inspect.
+/// @return Successor blocks in the order encoded by the terminator.
+std::vector<il::core::BasicBlock *> successors(const il::core::Function &F,
+                                               const il::core::BasicBlock &B);
+
+/// @brief Return predecessors of block @p B by scanning @p F's terminators.
+/// @param F Function to scan.
+/// @param B Block whose predecessors are queried.
+/// @return Blocks that branch to @p B.
+std::vector<il::core::BasicBlock *> predecessors(const il::core::Function &F,
+                                                 const il::core::BasicBlock &B);
+
+} // namespace viper::analysis

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(Analysis STATIC CFG.cpp)
+target_include_directories(Analysis PUBLIC ${CMAKE_SOURCE_DIR}/lib)
+target_link_libraries(Analysis PRIVATE il_core)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,10 @@ target_link_libraries(test_il_parse_negative PRIVATE il_core il_io support)
 target_compile_definitions(test_il_parse_negative PRIVATE BAD_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse")
 add_test(NAME test_il_parse_negative COMMAND test_il_parse_negative)
 
+add_executable(test_analysis_cfg analysis/CFGTests.cpp)
+target_link_libraries(test_analysis_cfg PRIVATE Analysis il_build)
+add_test(NAME test_analysis_cfg COMMAND test_analysis_cfg)
+
 add_test(NAME il_verify_ex1 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex1_hello_cond.il)
 add_test(NAME il_verify_ex2 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex2_sum_1_to_10.il)
 add_test(NAME il_verify_ex3 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex3_table_5x5.il)

--- a/tests/analysis/CFGTests.cpp
+++ b/tests/analysis/CFGTests.cpp
@@ -1,0 +1,59 @@
+// File: tests/analysis/CFGTests.cpp
+// Purpose: Tests for Analysis CFG utilities.
+// Key invariants: Builds a diamond-shaped function to check successors and predecessors.
+// Ownership/Lifetime: IR objects owned by a local module.
+// Links: docs/dev/analysis.md
+
+#include "Analysis/CFG.h"
+#include "il/build/IRBuilder.hpp"
+#include <algorithm>
+#include <cassert>
+
+int main()
+{
+    il::core::Module m;
+    il::build::IRBuilder builder(m);
+    auto &fn = builder.startFunction("cfg", il::core::Type(il::core::Type::Kind::Void), {});
+    builder.addBlock(fn, "entry");
+    builder.addBlock(fn, "t");
+    builder.addBlock(fn, "f");
+    builder.addBlock(fn, "join");
+
+    auto &entry = fn.blocks[0];
+    auto &t = fn.blocks[1];
+    auto &f = fn.blocks[2];
+    auto &join = fn.blocks[3];
+
+    builder.setInsertPoint(entry);
+    builder.cbr(il::core::Value::temp(0), t, {}, f, {});
+
+    builder.setInsertPoint(t);
+    builder.br(join, {});
+
+    builder.setInsertPoint(f);
+    builder.br(join, {});
+
+    builder.setInsertPoint(join);
+    builder.emitRet(std::nullopt, {});
+
+    auto succ_entry = viper::analysis::successors(fn, entry);
+    bool entry_has_t = std::find(succ_entry.begin(), succ_entry.end(), &t) != succ_entry.end();
+    bool entry_has_f = std::find(succ_entry.begin(), succ_entry.end(), &f) != succ_entry.end();
+    assert(entry_has_t && entry_has_f);
+
+    auto succ_t = viper::analysis::successors(fn, t);
+    assert(succ_t.size() == 1 && succ_t[0] == &join);
+
+    auto succ_f = viper::analysis::successors(fn, f);
+    assert(succ_f.size() == 1 && succ_f[0] == &join);
+
+    auto succ_join = viper::analysis::successors(fn, join);
+    assert(succ_join.empty());
+
+    auto preds_join = viper::analysis::predecessors(fn, join);
+    bool has_t = std::find(preds_join.begin(), preds_join.end(), &t) != preds_join.end();
+    bool has_f = std::find(preds_join.begin(), preds_join.end(), &f) != preds_join.end();
+    assert(has_t && has_f);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add minimal Analysis library providing CFG successor and predecessor queries
- document Analysis library and mention it in contributing guide
- test CFG utilities on a diamond control-flow function

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b851d457488324828824a73e7bcc0f