### PR TITLE
feat(analysis): add on-demand CFG utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,4 +96,5 @@ enable_testing()
 
 add_subdirectory(runtime)
 add_subdirectory(src)
+add_subdirectory(lib/Analysis)
 add_subdirectory(tests)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing
+
+- The repository includes a lightweight `Analysis` library in `lib/Analysis`.
+  Run the tests under `tests/analysis` when modifying these utilities.

--- a/docs/dev/analysis.md
+++ b/docs/dev/analysis.md
@@ -1,0 +1,12 @@
+# Analysis
+
+## CFG
+
+On-demand helpers to query basic block successors and predecessors without
+constructing an explicit graph.
+
+```cpp
+using namespace viper::analysis;
+auto succ = successors(block);
+auto pred = predecessors(func, block);
+```

--- a/lib/Analysis/CFG.cpp
+++ b/lib/Analysis/CFG.cpp
@@ -1,0 +1,90 @@
+// File: lib/Analysis/CFG.cpp
+// Purpose: Implements minimal CFG utilities for IL blocks and functions.
+// Key invariants: Results are computed on demand; no caches or global graphs.
+// Ownership/Lifetime: Uses IL objects owned by the caller.
+// Links: docs/dev/analysis.md
+
+#include "Analysis/CFG.h"
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Module.hpp"
+#include "il/core/Opcode.hpp"
+
+namespace
+{
+const il::core::Module *gModule = nullptr;
+}
+
+namespace viper::analysis
+{
+
+void setModule(const il::core::Module &M)
+{
+    gModule = &M;
+}
+
+std::vector<il::core::Block *> successors(const il::core::Block &B)
+{
+    std::vector<il::core::Block *> out;
+    if (!gModule || B.instructions.empty())
+        return out;
+
+    const il::core::Instr &term = B.instructions.back();
+    if (term.op != il::core::Opcode::Br && term.op != il::core::Opcode::CBr)
+        return out;
+
+    const il::core::Function *parent = nullptr;
+    for (const auto &fn : gModule->functions)
+    {
+        for (const auto &blk : fn.blocks)
+        {
+            if (&blk == &B)
+            {
+                parent = &fn;
+                break;
+            }
+        }
+        if (parent)
+            break;
+    }
+    if (!parent)
+        return out;
+
+    for (const auto &lbl : term.labels)
+    {
+        for (auto &blk : parent->blocks)
+        {
+            if (blk.label == lbl)
+            {
+                out.push_back(const_cast<il::core::Block *>(&blk));
+                break;
+            }
+        }
+    }
+    return out;
+}
+
+std::vector<il::core::Block *> predecessors(const il::core::Function &F, const il::core::Block &B)
+{
+    std::vector<il::core::Block *> out;
+    for (auto &blk : F.blocks)
+    {
+        if (blk.instructions.empty())
+            continue;
+        const il::core::Instr &term = blk.instructions.back();
+        if (term.op != il::core::Opcode::Br && term.op != il::core::Opcode::CBr)
+            continue;
+        for (const auto &lbl : term.labels)
+        {
+            if (lbl == B.label)
+            {
+                out.push_back(const_cast<il::core::Block *>(&blk));
+                break;
+            }
+        }
+    }
+    return out;
+}
+
+} // namespace viper::analysis

--- a/lib/Analysis/CFG.h
+++ b/lib/Analysis/CFG.h
@@ -1,0 +1,36 @@
+// File: lib/Analysis/CFG.h
+// Purpose: Minimal control-flow graph utilities for IL blocks and functions.
+// Key invariants: Computes edges on demand without caching.
+// Ownership/Lifetime: Operates on IL structures owned by caller.
+// Links: docs/dev/analysis.md
+#pragma once
+
+#include <vector>
+
+namespace il::core
+{
+struct Module;
+struct Function;
+struct BasicBlock;
+using Block = BasicBlock;
+} // namespace il::core
+
+namespace viper::analysis
+{
+
+/// @brief Set the current module for CFG queries.
+/// @param M IL module providing function/block context.
+void setModule(const il::core::Module &M);
+
+/// @brief Return successors of block @p B by inspecting its terminator.
+/// @param B Block whose outgoing edges are requested.
+/// @return List of successor blocks (may be empty).
+std::vector<il::core::Block *> successors(const il::core::Block &B);
+
+/// @brief Return predecessors of block @p B within function @p F.
+/// @param F Function containing blocks to scan.
+/// @param B Target block whose incoming edges are requested.
+/// @return List of predecessor blocks (may be empty).
+std::vector<il::core::Block *> predecessors(const il::core::Function &F, const il::core::Block &B);
+
+} // namespace viper::analysis

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(Analysis CFG.cpp)
+target_link_libraries(Analysis PRIVATE il_core)
+target_include_directories(Analysis PUBLIC ${CMAKE_SOURCE_DIR}/lib)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,10 @@ target_link_libraries(test_il_parse_negative PRIVATE il_core il_io support)
 target_compile_definitions(test_il_parse_negative PRIVATE BAD_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse")
 add_test(NAME test_il_parse_negative COMMAND test_il_parse_negative)
 
+add_executable(test_analysis_cfg analysis/CFGTests.cpp)
+target_link_libraries(test_analysis_cfg PRIVATE Analysis il_build)
+add_test(NAME test_analysis_cfg COMMAND test_analysis_cfg)
+
 add_test(NAME il_verify_ex1 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex1_hello_cond.il)
 add_test(NAME il_verify_ex2 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex2_sum_1_to_10.il)
 add_test(NAME il_verify_ex3 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex3_table_5x5.il)

--- a/tests/analysis/CFGTests.cpp
+++ b/tests/analysis/CFGTests.cpp
@@ -1,0 +1,60 @@
+// File: tests/analysis/CFGTests.cpp
+// Purpose: Verify CFG successor and predecessor utilities.
+// Key invariants: Successor and predecessor sets reflect branch targets.
+// Ownership/Lifetime: Builds a local module via IRBuilder.
+// Links: docs/dev/analysis.md
+
+#include "Analysis/CFG.h"
+#include "il/build/IRBuilder.hpp"
+#include <algorithm>
+#include <cassert>
+
+int main()
+{
+    using namespace il::core;
+    using viper::analysis::predecessors;
+    using viper::analysis::setModule;
+    using viper::analysis::successors;
+
+    Module m;
+    setModule(m);
+    il::build::IRBuilder b(m);
+    Function &fn = b.startFunction("f", Type(Type::Kind::Void), {});
+    b.createBlock(fn, "entry");
+    b.createBlock(fn, "t");
+    b.createBlock(fn, "f");
+    b.createBlock(fn, "join");
+    Block &entry = fn.blocks[0];
+    Block &t = fn.blocks[1];
+    Block &f = fn.blocks[2];
+    Block &join = fn.blocks[3];
+
+    b.setInsertPoint(entry);
+    b.cbr(Value::constInt(1), t, {}, f, {});
+
+    b.setInsertPoint(t);
+    b.br(join, {});
+
+    b.setInsertPoint(f);
+    b.br(join, {});
+
+    b.setInsertPoint(join);
+    b.emitRet(std::nullopt, {});
+
+    auto sEntry = successors(entry);
+    assert(sEntry.size() == 2);
+    assert((sEntry[0] == &t && sEntry[1] == &f) || (sEntry[0] == &f && sEntry[1] == &t));
+
+    auto sT = successors(t);
+    assert(sT.size() == 1 && sT[0] == &join);
+    auto sF = successors(f);
+    assert(sF.size() == 1 && sF[0] == &join);
+    auto sJoin = successors(join);
+    assert(sJoin.empty());
+
+    auto pJoin = predecessors(fn, join);
+    assert(pJoin.size() == 2);
+    assert((pJoin[0] == &t && pJoin[1] == &f) || (pJoin[0] == &f && pJoin[1] == &t));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add minimal Analysis library with CFG successor and predecessor helpers
- document and test CFG analysis utilities

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b851d457488324828824a73e7bcc0f