### PR TITLE
feat(analysis): add CFG post-order traversal utilities

### DIFF
--- a/docs/dev/analysis.md
+++ b/docs/dev/analysis.md
@@ -10,3 +10,12 @@ using namespace viper::analysis;
 auto succ = successors(block);
 auto pred = predecessors(func, block);
 ```
+
+## Orders
+
+Standard depth-first orders are available without materializing a graph.
+
+```cpp
+auto po = postOrder(fn);      // entry last
+auto rpo = reversePostOrder(fn); // entry first
+```

--- a/lib/Analysis/CFG.h
+++ b/lib/Analysis/CFG.h
@@ -33,4 +33,14 @@ std::vector<il::core::Block *> successors(const il::core::Block &B);
 /// @return List of predecessor blocks (may be empty).
 std::vector<il::core::Block *> predecessors(const il::core::Function &F, const il::core::Block &B);
 
+/// @brief Compute DFS post-order of blocks in @p F starting from the entry block.
+/// @param F Function whose blocks are traversed.
+/// @return Blocks in post-order; the entry block is last.
+std::vector<il::core::Block *> postOrder(il::core::Function &F);
+
+/// @brief Compute reverse post-order (RPO) of blocks in @p F.
+/// @param F Function whose blocks are traversed.
+/// @return Blocks in RPO; the entry block is first.
+std::vector<il::core::Block *> reversePostOrder(il::core::Function &F);
+
 } // namespace viper::analysis

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,10 @@ add_executable(test_analysis_cfg analysis/CFGTests.cpp)
 target_link_libraries(test_analysis_cfg PRIVATE Analysis il_build)
 add_test(NAME test_analysis_cfg COMMAND test_analysis_cfg)
 
+add_executable(test_analysis_graph_order analysis/GraphOrderTests.cpp)
+target_link_libraries(test_analysis_graph_order PRIVATE Analysis il_build)
+add_test(NAME test_analysis_graph_order COMMAND test_analysis_graph_order)
+
 add_test(NAME il_verify_ex1 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex1_hello_cond.il)
 add_test(NAME il_verify_ex2 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex2_sum_1_to_10.il)
 add_test(NAME il_verify_ex3 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex3_table_5x5.il)

--- a/tests/analysis/GraphOrderTests.cpp
+++ b/tests/analysis/GraphOrderTests.cpp
@@ -1,0 +1,80 @@
+// File: tests/analysis/GraphOrderTests.cpp
+// Purpose: Verify post-order and reverse-post-order traversals.
+// Key invariants: Entry is last in post-order and first in RPO; each block appears once.
+// Ownership/Lifetime: Builds local modules via IRBuilder.
+// Links: docs/dev/analysis.md
+
+#include "Analysis/CFG.h"
+#include "il/build/IRBuilder.hpp"
+#include <algorithm>
+#include <cassert>
+#include <unordered_set>
+
+using namespace il::core;
+using namespace viper::analysis;
+
+static void checkOrders(Function &fn)
+{
+    auto po = postOrder(fn);
+    auto rpo = reversePostOrder(fn);
+
+    assert(po.size() == fn.blocks.size());
+    assert(rpo.size() == fn.blocks.size());
+
+    std::unordered_set<Block *> s1(po.begin(), po.end());
+    std::unordered_set<Block *> s2(rpo.begin(), rpo.end());
+    assert(s1.size() == po.size());
+    assert(s2.size() == rpo.size());
+
+    assert(po.back() == &fn.blocks.front());
+    assert(rpo.front() == &fn.blocks.front());
+}
+
+int main()
+{
+    Module m;
+    setModule(m);
+    il::build::IRBuilder b(m);
+
+    // Diamond: entry -> {t,f} -> join
+    Function &diamond = b.startFunction("diamond", Type(Type::Kind::Void), {});
+    b.createBlock(diamond, "entry");
+    b.createBlock(diamond, "t");
+    b.createBlock(diamond, "f");
+    b.createBlock(diamond, "join");
+    Block &dEntry = diamond.blocks[0];
+    Block &dT = diamond.blocks[1];
+    Block &dF = diamond.blocks[2];
+    Block &dJoin = diamond.blocks[3];
+
+    b.setInsertPoint(dEntry);
+    b.cbr(Value::constInt(1), dT, {}, dF, {});
+    b.setInsertPoint(dT);
+    b.br(dJoin, {});
+    b.setInsertPoint(dF);
+    b.br(dJoin, {});
+    b.setInsertPoint(dJoin);
+    b.emitRet(std::nullopt, {});
+
+    checkOrders(diamond);
+
+    // Linear chain: A -> B -> C
+    Function &chain = b.startFunction("chain", Type(Type::Kind::Void), {});
+    b.createBlock(chain, "A");
+    b.createBlock(chain, "B");
+    b.createBlock(chain, "C");
+    Block &A = chain.blocks[0];
+    Block &B = chain.blocks[1];
+    Block &C = chain.blocks[2];
+
+    b.setInsertPoint(A);
+    b.br(B, {});
+    b.setInsertPoint(B);
+    b.br(C, {});
+    b.setInsertPoint(C);
+    b.emitRet(std::nullopt, {});
+
+    checkOrders(chain);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extend CFG analysis helpers with postOrder and reversePostOrder
- cover diamond and linear CFG shapes in tests
- document new traversal APIs in analysis notes

## Testing
- `cmake -S . -B build && cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b8559d0c1483249abf8b72aa226690