### PR TITLE
feat(analysis): add dominator tree construction

### DIFF
--- a/docs/dev/analysis.md
+++ b/docs/dev/analysis.md
@@ -19,3 +19,11 @@ Standard depth-first orders are available without materializing a graph.
 auto po = postOrder(fn);      // entry last
 auto rpo = reversePostOrder(fn); // entry first
 ```
+
+## Dominators
+
+Computes immediate dominators using the algorithm of Cooper, Harvey, and
+Kennedy ("A Simple, Fast Dominance Algorithm"). The function iterates to a
+fixed point over reverse post-order, yielding a tree of parent links and
+children for easy traversal. Complexity is linear in practice and worst-case
+\(O(V \times E)\).

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(Analysis CFG.cpp)
+add_library(Analysis CFG.cpp Dominators.cpp)
 target_link_libraries(Analysis PRIVATE il_core)
 target_include_directories(Analysis PUBLIC ${CMAKE_SOURCE_DIR}/lib)

--- a/lib/Analysis/Dominators.cpp
+++ b/lib/Analysis/Dominators.cpp
@@ -1,0 +1,109 @@
+// File: lib/Analysis/Dominators.cpp
+// Purpose: Implement dominator tree construction using the Cooper et al. algorithm.
+// Key invariants: Tree is built once per function; no incremental updates or caches.
+// Ownership/Lifetime: Relies on IL blocks owned by the caller.
+// Links: docs/dev/analysis.md
+
+#include "Analysis/Dominators.h"
+#include "Analysis/CFG.h"
+#include <cstddef>
+
+namespace viper::analysis
+{
+
+il::core::Block *DomTree::immediateDominator(il::core::Block *B) const
+{
+    auto it = idom.find(B);
+    return it == idom.end() ? nullptr : it->second;
+}
+
+bool DomTree::dominates(il::core::Block *A, il::core::Block *B) const
+{
+    if (!A || !B)
+        return false;
+    if (A == B)
+        return true;
+    while (B)
+    {
+        auto it = idom.find(B);
+        if (it == idom.end())
+            return false;
+        B = it->second;
+        if (B == A)
+            return true;
+    }
+    return false;
+}
+
+DomTree computeDominatorTree(il::core::Function &F)
+{
+    DomTree DT;
+    auto rpo = reversePostOrder(F);
+    if (rpo.empty())
+        return DT;
+
+    std::unordered_map<il::core::Block *, std::size_t> index;
+    for (std::size_t i = 0; i < rpo.size(); ++i)
+        index[rpo[i]] = i;
+
+    il::core::Block *entry = rpo.front();
+    DT.idom[entry] = nullptr;
+
+    bool changed = true;
+    while (changed)
+    {
+        changed = false;
+        for (std::size_t i = 1; i < rpo.size(); ++i)
+        {
+            il::core::Block *b = rpo[i];
+            auto preds = predecessors(F, *b);
+
+            il::core::Block *newIdom = nullptr;
+            for (auto *p : preds)
+            {
+                if (DT.idom.count(p))
+                {
+                    newIdom = p;
+                    break;
+                }
+            }
+            if (!newIdom)
+                continue;
+
+            auto intersect = [&](il::core::Block *b1, il::core::Block *b2)
+            {
+                while (b1 != b2)
+                {
+                    while (index[b1] > index[b2])
+                        b1 = DT.idom[b1];
+                    while (index[b2] > index[b1])
+                        b2 = DT.idom[b2];
+                }
+                return b1;
+            };
+
+            for (auto *p : preds)
+            {
+                if (p == newIdom || !DT.idom.count(p))
+                    continue;
+                newIdom = intersect(p, newIdom);
+            }
+
+            if (!DT.idom.count(b) || DT.idom[b] != newIdom)
+            {
+                DT.idom[b] = newIdom;
+                changed = true;
+            }
+        }
+    }
+
+    for (auto &[blk, id] : DT.idom)
+    {
+        if (id)
+            DT.children[id].push_back(blk);
+    }
+
+    return DT;
+}
+
+} // namespace viper::analysis

--- a/lib/Analysis/Dominators.h
+++ b/lib/Analysis/Dominators.h
@@ -1,0 +1,42 @@
+// File: lib/Analysis/Dominators.h
+// Purpose: Dominator tree computation and queries.
+// Key invariants: Dominator tree is computed eagerly and remains constant; no incremental updates.
+// Ownership/Lifetime: Operates on IL blocks owned by the caller.
+// Links: docs/dev/analysis.md
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+namespace il::core
+{
+struct Function;
+struct BasicBlock;
+using Block = BasicBlock;
+} // namespace il::core
+
+namespace viper::analysis
+{
+struct DomTree
+{
+    std::unordered_map<il::core::Block *, il::core::Block *> idom;
+    std::unordered_map<il::core::Block *, std::vector<il::core::Block *>> children;
+
+    /// @brief Return true if block @p A dominates block @p B.
+    /// @param A Potential dominator.
+    /// @param B Block being checked.
+    /// @return True if A dominates B.
+    bool dominates(il::core::Block *A, il::core::Block *B) const;
+
+    /// @brief Return the immediate dominator of block @p B.
+    /// @param B Block whose immediate dominator is requested.
+    /// @return Immediate dominator or nullptr for the entry block.
+    il::core::Block *immediateDominator(il::core::Block *B) const;
+};
+
+/// @brief Compute dominator tree for function @p F.
+/// @param F Function to analyze.
+/// @return Dominator tree with immediate dominators and child map.
+DomTree computeDominatorTree(il::core::Function &F);
+
+} // namespace viper::analysis

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,10 @@ add_executable(test_analysis_graph_order analysis/GraphOrderTests.cpp)
 target_link_libraries(test_analysis_graph_order PRIVATE Analysis il_build)
 add_test(NAME test_analysis_graph_order COMMAND test_analysis_graph_order)
 
+add_executable(test_analysis_dominators analysis/DominatorsTests.cpp)
+target_link_libraries(test_analysis_dominators PRIVATE Analysis il_build)
+add_test(NAME test_analysis_dominators COMMAND test_analysis_dominators)
+
 add_test(NAME il_verify_ex1 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex1_hello_cond.il)
 add_test(NAME il_verify_ex2 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex2_sum_1_to_10.il)
 add_test(NAME il_verify_ex3 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex3_table_5x5.il)

--- a/tests/analysis/DominatorsTests.cpp
+++ b/tests/analysis/DominatorsTests.cpp
@@ -1,0 +1,75 @@
+// File: tests/analysis/DominatorsTests.cpp
+// Purpose: Validate dominator tree construction and queries.
+// Key invariants: Immediate dominators and dominance checks reflect CFG structure.
+// Ownership/Lifetime: Builds local modules via IRBuilder.
+// Links: docs/dev/analysis.md
+
+#include "Analysis/CFG.h"
+#include "Analysis/Dominators.h"
+#include "il/build/IRBuilder.hpp"
+#include <cassert>
+
+int main()
+{
+    using namespace il::core;
+    using namespace viper::analysis;
+
+    Module m;
+    setModule(m);
+    il::build::IRBuilder b(m);
+
+    // Diamond graph: entry -> {t, f} -> join
+    Function &diamond = b.startFunction("diamond", Type(Type::Kind::Void), {});
+    b.createBlock(diamond, "entry");
+    b.createBlock(diamond, "t");
+    b.createBlock(diamond, "f");
+    b.createBlock(diamond, "join");
+    Block &dEntry = diamond.blocks[0];
+    Block &dT = diamond.blocks[1];
+    Block &dF = diamond.blocks[2];
+    Block &dJoin = diamond.blocks[3];
+
+    b.setInsertPoint(dEntry);
+    b.cbr(Value::constInt(1), dT, {}, dF, {});
+    b.setInsertPoint(dT);
+    b.br(dJoin, {});
+    b.setInsertPoint(dF);
+    b.br(dJoin, {});
+    b.setInsertPoint(dJoin);
+    b.emitRet(std::nullopt, {});
+
+    DomTree dtDiamond = computeDominatorTree(diamond);
+    assert(dtDiamond.immediateDominator(&dEntry) == nullptr);
+    assert(dtDiamond.immediateDominator(&dT) == &dEntry);
+    assert(dtDiamond.immediateDominator(&dF) == &dEntry);
+    assert(dtDiamond.immediateDominator(&dJoin) == &dEntry);
+    assert(dtDiamond.dominates(&dEntry, &dT));
+    assert(dtDiamond.dominates(&dEntry, &dF));
+    assert(dtDiamond.dominates(&dEntry, &dJoin));
+    assert(!dtDiamond.dominates(&dT, &dF));
+
+    // Linear chain: A -> B -> C
+    Function &chain = b.startFunction("chain", Type(Type::Kind::Void), {});
+    b.createBlock(chain, "A");
+    b.createBlock(chain, "B");
+    b.createBlock(chain, "C");
+    Block &A = chain.blocks[0];
+    Block &B = chain.blocks[1];
+    Block &C = chain.blocks[2];
+
+    b.setInsertPoint(A);
+    b.br(B, {});
+    b.setInsertPoint(B);
+    b.br(C, {});
+    b.setInsertPoint(C);
+    b.emitRet(std::nullopt, {});
+
+    DomTree dtChain = computeDominatorTree(chain);
+    assert(dtChain.immediateDominator(&A) == nullptr);
+    assert(dtChain.immediateDominator(&B) == &A);
+    assert(dtChain.immediateDominator(&C) == &B);
+    assert(dtChain.dominates(&A, &B));
+    assert(dtChain.dominates(&A, &C));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add Dominators analysis with Cooper et al. algorithm
- expose dominance and idom queries
- document algorithm and add basic tests

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 8`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b85718d844832499ac575acc2f4747