### PR TITLE
feat(analysis): add DAG cycle check and topological order

### DIFF
--- a/docs/dev/analysis.md
+++ b/docs/dev/analysis.md
@@ -20,6 +20,19 @@ auto po = postOrder(fn);      // entry last
 auto rpo = reversePostOrder(fn); // entry first
 ```
 
+## Acyclicity & Topological Order
+
+Cycle detection and topological sorting are available for DAG-restricted
+analyses.
+
+```cpp
+bool ok = isAcyclic(fn);      // false if any cycle exists
+auto topo = topoOrder(fn);    // empty if cyclic
+```
+
+These helpers gate passes like the mem2reg v2 prototype, which operates only
+on acyclic control-flow graphs.
+
 ## Dominators
 
 Computes immediate dominators using the algorithm of Cooper, Harvey, and

--- a/lib/Analysis/CFG.h
+++ b/lib/Analysis/CFG.h
@@ -43,4 +43,14 @@ std::vector<il::core::Block *> postOrder(il::core::Function &F);
 /// @return Blocks in RPO; the entry block is first.
 std::vector<il::core::Block *> reversePostOrder(il::core::Function &F);
 
+/// @brief Check whether the control-flow graph of @p F has no cycles.
+/// @param F Function whose CFG is inspected.
+/// @return True if the CFG is acyclic; false otherwise.
+bool isAcyclic(il::core::Function &F);
+
+/// @brief Compute a topological order of blocks in @p F.
+/// @param F Function whose blocks are ordered.
+/// @return Blocks in topological order; empty if @p F contains cycles.
+std::vector<il::core::Block *> topoOrder(il::core::Function &F);
+
 } // namespace viper::analysis

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,10 @@ add_executable(test_analysis_dominators analysis/DominatorsTests.cpp)
 target_link_libraries(test_analysis_dominators PRIVATE Analysis il_build)
 add_test(NAME test_analysis_dominators COMMAND test_analysis_dominators)
 
+add_executable(test_analysis_acyclic analysis/AcyclicTests.cpp)
+target_link_libraries(test_analysis_acyclic PRIVATE Analysis il_build)
+add_test(NAME test_analysis_acyclic COMMAND test_analysis_acyclic)
+
 add_test(NAME il_verify_ex1 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex1_hello_cond.il)
 add_test(NAME il_verify_ex2 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex2_sum_1_to_10.il)
 add_test(NAME il_verify_ex3 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/docs/examples/il/ex3_table_5x5.il)

--- a/tests/analysis/AcyclicTests.cpp
+++ b/tests/analysis/AcyclicTests.cpp
@@ -1,0 +1,78 @@
+// File: tests/analysis/AcyclicTests.cpp
+// Purpose: Verify cycle detection and topological ordering for CFGs.
+// Key invariants: topoOrder returns empty on cycles; order respects DAG edges.
+// Ownership/Lifetime: Builds local modules via IRBuilder.
+// Links: docs/dev/analysis.md
+
+#include "Analysis/CFG.h"
+#include "il/build/IRBuilder.hpp"
+#include <cassert>
+
+using namespace il::core;
+using namespace viper::analysis;
+
+int main()
+{
+    Module m;
+    setModule(m);
+    il::build::IRBuilder b(m);
+
+    // Linear chain: A -> B -> C
+    Function &chain = b.startFunction("chain", Type(Type::Kind::Void), {});
+    b.createBlock(chain, "A");
+    b.createBlock(chain, "B");
+    b.createBlock(chain, "C");
+    Block &A = chain.blocks[0];
+    Block &B = chain.blocks[1];
+    Block &C = chain.blocks[2];
+    b.setInsertPoint(A);
+    b.br(B, {});
+    b.setInsertPoint(B);
+    b.br(C, {});
+    b.setInsertPoint(C);
+    b.emitRet(std::nullopt, {});
+    assert(isAcyclic(chain));
+    auto chainOrder = topoOrder(chain);
+    assert(chainOrder.size() == 3);
+    assert(chainOrder[0] == &A && chainOrder[1] == &B && chainOrder[2] == &C);
+
+    // Diamond: entry -> {t, f} -> join
+    Function &diamond = b.startFunction("diamond", Type(Type::Kind::Void), {});
+    b.createBlock(diamond, "entry");
+    b.createBlock(diamond, "t");
+    b.createBlock(diamond, "f");
+    b.createBlock(diamond, "join");
+    Block &dEntry = diamond.blocks[0];
+    Block &dT = diamond.blocks[1];
+    Block &dF = diamond.blocks[2];
+    Block &dJoin = diamond.blocks[3];
+    b.setInsertPoint(dEntry);
+    b.cbr(Value::constInt(1), dT, {}, dF, {});
+    b.setInsertPoint(dT);
+    b.br(dJoin, {});
+    b.setInsertPoint(dF);
+    b.br(dJoin, {});
+    b.setInsertPoint(dJoin);
+    b.emitRet(std::nullopt, {});
+    assert(isAcyclic(diamond));
+    auto diamondOrder = topoOrder(diamond);
+    assert(diamondOrder.size() == 4);
+    assert(diamondOrder.front() == &dEntry);
+    assert(diamondOrder.back() == &dJoin);
+
+    // Loop: entry -> loop -> loop (cycle)
+    Function &loopFn = b.startFunction("loop", Type(Type::Kind::Void), {});
+    b.createBlock(loopFn, "entry");
+    b.createBlock(loopFn, "loop");
+    Block &lEntry = loopFn.blocks[0];
+    Block &lLoop = loopFn.blocks[1];
+    b.setInsertPoint(lEntry);
+    b.br(lLoop, {});
+    b.setInsertPoint(lLoop);
+    b.br(lLoop, {});
+    assert(!isAcyclic(loopFn));
+    auto loopOrder = topoOrder(loopFn);
+    assert(loopOrder.empty());
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- detect cycles in function CFGs using Kahn's algorithm
- produce topological block ordering for DAGs
- document and test acyclicity utilities

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b85adadec08324b35e5e5bc3f8b9c7