### PR TITLE
feat(passes): add block-param mem2reg

### DIFF
--- a/lib/Passes/Mem2Reg.h
+++ b/lib/Passes/Mem2Reg.h
@@ -1,7 +1,8 @@
 // File: lib/Passes/Mem2Reg.h
 // Purpose: Promote eligible stack slots to SSA registers.
-// Key invariants: Only handles allocas with a single dominating store and no address escaping.
-// Ownership/Lifetime: Mutates the module in place.
+// Key invariants: Operates on acyclic CFGs, promoting i64/f64/i1 allocas with
+// no escaped addresses by introducing block parameters. Ownership/Lifetime:
+// Mutates the module in place.
 // Links: docs/passes/mem2reg.md
 #pragma once
 

--- a/tests/golden/CMakeLists.txt
+++ b/tests/golden/CMakeLists.txt
@@ -129,3 +129,24 @@ add_test(NAME il_opt_mem2reg_simple COMMAND ${CMAKE_COMMAND}
   -DGOLDEN=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/mem2reg_simple.opt.il
   -DPASSES=mem2reg
   -P ${CMAKE_CURRENT_SOURCE_DIR}/il_opt/check_opt.cmake)
+
+add_test(NAME il_opt_mem2reg_diamond COMMAND ${CMAKE_COMMAND}
+  -DILC=${BASIC_ILC}
+  -DIL_FILE=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/mem2reg_diamond.in.il
+  -DGOLDEN=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/mem2reg_diamond.opt.il
+  -DPASSES=mem2reg
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/il_opt/check_opt.cmake)
+
+add_test(NAME il_opt_mem2reg_nested COMMAND ${CMAKE_COMMAND}
+  -DILC=${BASIC_ILC}
+  -DIL_FILE=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/mem2reg_nested.in.il
+  -DGOLDEN=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/mem2reg_nested.opt.il
+  -DPASSES=mem2reg
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/il_opt/check_opt.cmake)
+
+add_test(NAME il_opt_mem2reg_loop_skip COMMAND ${CMAKE_COMMAND}
+  -DILC=${BASIC_ILC}
+  -DIL_FILE=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/mem2reg_loop.in.il
+  -DGOLDEN=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/mem2reg_loop.opt.il
+  -DPASSES=mem2reg
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/il_opt/check_opt.cmake)

--- a/tests/golden/il_opt/mem2reg_diamond.in.il
+++ b/tests/golden/il_opt/mem2reg_diamond.in.il
@@ -1,0 +1,16 @@
+il 0.1.2
+func @main() -> i64 {
+entry:
+  %t0 = alloca 8
+  %t1 = icmp_eq 0, 0
+  cbr %t1, T, F
+T:
+  store i64 %t0, 2
+  br Join
+F:
+  store i64 %t0, 3
+  br Join
+Join:
+  %t2 = load i64 %t0
+  ret %t2
+}

--- a/tests/golden/il_opt/mem2reg_diamond.opt.il
+++ b/tests/golden/il_opt/mem2reg_diamond.opt.il
@@ -1,0 +1,12 @@
+il 0.1.2
+func @main() -> i64 {
+entry:
+  %t1 = icmp_eq 0, 0
+  cbr %t1, T, F
+T:
+  br Join(2)
+F:
+  br Join(3)
+Join(%a0:i64):
+  ret %t3
+}

--- a/tests/golden/il_opt/mem2reg_loop.in.il
+++ b/tests/golden/il_opt/mem2reg_loop.in.il
@@ -1,0 +1,16 @@
+il 0.1.2
+func @main() -> i64 {
+entry:
+  %t0 = alloca 8
+  store i64 %t0, 0
+  br L1
+L1:
+  %t1 = load i64 %t0
+  %t2 = add %t1, 1
+  store i64 %t0, %t2
+  %t3 = scmp_lt %t2, 10
+  cbr %t3, L1, Exit
+Exit:
+  %t4 = load i64 %t0
+  ret %t4
+}

--- a/tests/golden/il_opt/mem2reg_loop.opt.il
+++ b/tests/golden/il_opt/mem2reg_loop.opt.il
@@ -1,0 +1,16 @@
+il 0.1.2
+func @main() -> i64 {
+entry:
+  %t0 = alloca 8
+  store i64, %t0, 0
+  br L1
+L1:
+  %t1 = load i64, %t0
+  %t2 = add %t1, 1
+  store i64, %t0, %t2
+  %t3 = scmp_lt %t2, 10
+  cbr %t3, L1, Exit
+Exit:
+  %t4 = load i64, %t0
+  ret %t4
+}

--- a/tests/golden/il_opt/mem2reg_nested.in.il
+++ b/tests/golden/il_opt/mem2reg_nested.in.il
@@ -1,0 +1,22 @@
+il 0.1.2
+func @main() -> i64 {
+entry:
+  %t0 = alloca 8
+  %c1 = icmp_eq 0, 0
+  cbr %c1, T1, F1
+T1:
+  store i64 %t0, 2
+  br Join
+F1:
+  %c2 = icmp_eq 0, 0
+  cbr %c2, T2, F2
+T2:
+  store i64 %t0, 3
+  br Join
+F2:
+  store i64 %t0, 4
+  br Join
+Join:
+  %t1 = load i64 %t0
+  ret %t1
+}

--- a/tests/golden/il_opt/mem2reg_nested.opt.il
+++ b/tests/golden/il_opt/mem2reg_nested.opt.il
@@ -1,0 +1,17 @@
+il 0.1.2
+func @main() -> i64 {
+entry:
+  %t1 = icmp_eq 0, 0
+  cbr %t1, T1, F1
+T1:
+  br Join(2)
+F1:
+  %t2 = icmp_eq 0, 0
+  cbr %t2, T2, F2
+T2:
+  br Join(3)
+F2:
+  br Join(4)
+Join(%a0:i64):
+  ret %t4
+}


### PR DESCRIPTION
## Summary
- expand mem2reg to promote allocas through acyclic CFGs using block params and branch args
- skip functions with loops and add diamond, nested, and loop tests
- document mem2reg v2 algorithm and examples

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b86753ece48324ac59b435cdc28687