### PR TITLE
feat(runtime): add deterministic RNG

### DIFF
--- a/docs/dev/vm-externs.md
+++ b/docs/dev/vm-externs.md
@@ -22,3 +22,5 @@ The VM runtime bridge recognizes these symbols:
 - rt_pow
 - rt_abs_i64
 - rt_abs_f64
+- rt_randomize_i64
+- rt_rnd

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -14,3 +14,25 @@ This document describes the stable C ABI provided by the runtime library.
 | `@rt_pow` | `f64, f64 -> f64` | power |
 | `@rt_abs_i64` | `i64 -> i64` | absolute value (integer) |
 | `@rt_abs_f64` | `f64 -> f64` | absolute value (float) |
+
+## Random
+
+The runtime exposes a reproducible pseudo‑random number generator based on a
+64‑bit linear congruential generator:
+
+```
+state = state * 6364136223846793005 + 1
+```
+
+`rt_rnd` returns the top 53 bits of `state` scaled by `2^-53`, yielding a
+double in \[0,1). The generator is seeded via `rt_randomize_u64` or
+`rt_randomize_i64`, which set the internal `state` exactly (the signed variant
+casts to `uint64_t`). The initial state defaults to `0x0123456789ABCDEF` and is
+non‑zero so that calling `rt_rnd` without seeding is deterministic. Seeding with
+the same value guarantees the same sequence across platforms.
+
+| Symbol | Signature | Semantics |
+|--------|-----------|-----------|
+| `@rt_randomize_u64` | `i64 -> void` | set RNG state exactly |
+| `@rt_randomize_i64` | `i64 -> void` | set RNG state from signed value |
+| `@rt_rnd` | ` -> f64` | next uniform double in \[0,1) |

--- a/examples/il/random_three.il
+++ b/examples/il/random_three.il
@@ -1,0 +1,17 @@
+il 0.1.2
+
+extern @rt_randomize_i64(i64) -> void
+extern @rt_rnd() -> f64
+extern @rt_print_f64(f64) -> void
+
+func @main() -> i64 {
+entry:
+  call @rt_randomize_i64(1)
+  %r1 = call @rt_rnd()
+  %r2 = call @rt_rnd()
+  %r3 = call @rt_rnd()
+  call @rt_print_f64(%r1)
+  call @rt_print_f64(%r2)
+  call @rt_print_f64(%r3)
+  ret 0
+}

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(rt STATIC rt.c rt_math.c)
+add_library(rt STATIC rt.c rt_math.c rt_random.c)
 target_include_directories(rt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(rt PUBLIC m)

--- a/runtime/rt_random.c
+++ b/runtime/rt_random.c
@@ -1,0 +1,35 @@
+// File: runtime/rt_random.c
+// Purpose: Implement deterministic random number utilities.
+// Key invariants: 64-bit linear congruential generator; top 53 bits scaled to [0,1).
+// Ownership/Lifetime: Global state with default non-zero seed; single-threaded.
+// Links: docs/runtime-abi.md
+
+#include "rt_random.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    static uint64_t state = 0x0123456789abcdefULL; // Default non-zero seed
+
+    void rt_randomize_u64(uint64_t seed)
+    {
+        state = seed;
+    }
+
+    void rt_randomize_i64(long long seed)
+    {
+        state = (uint64_t)seed;
+    }
+
+    double rt_rnd(void)
+    {
+        state = state * 6364136223846793005ULL + 1ULL;
+        double x = (double)((state >> 11) & ((1ULL << 53) - 1));
+        return x * (1.0 / 9007199254740992.0);
+    }
+
+#ifdef __cplusplus
+}
+#endif

--- a/runtime/rt_random.h
+++ b/runtime/rt_random.h
@@ -1,0 +1,26 @@
+// File: runtime/rt_random.h
+// Purpose: Declare deterministic random number utilities for the runtime.
+// Key invariants: 64-bit LCG with reproducible output; 53-bit double precision.
+// Ownership/Lifetime: Global state local to runtime; single-threaded use.
+// Links: docs/runtime-abi.md
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /// @brief Seed the RNG with an exact 64-bit value.
+    void rt_randomize_u64(uint64_t seed);
+
+    /// @brief Seed the RNG with a signed 64-bit value (cast to unsigned).
+    void rt_randomize_i64(long long seed);
+
+    /// @brief Generate a uniform double in [0,1) with 53 bits of precision.
+    double rt_rnd(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/vm/RuntimeBridge.cpp
+++ b/src/vm/RuntimeBridge.cpp
@@ -6,6 +6,7 @@
 
 #include "vm/RuntimeBridge.hpp"
 #include "rt_math.h"
+#include "rt_random.h"
 #include "vm/VM.hpp"
 #include <cassert>
 #include <sstream>
@@ -117,6 +118,14 @@ Slot RuntimeBridge::call(const std::string &name,
     else if (name == "rt_abs_f64")
     {
         res.f64 = rt_abs_f64(args[0].f64);
+    }
+    else if (name == "rt_randomize_i64")
+    {
+        rt_randomize_i64(args[0].i64);
+    }
+    else if (name == "rt_rnd")
+    {
+        res.f64 = rt_rnd();
     }
     else
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,6 +73,10 @@ add_executable(test_rt_math_core runtime/RTMathCoreTests.cpp)
 target_link_libraries(test_rt_math_core PRIVATE rt)
 add_test(NAME test_rt_math_core COMMAND test_rt_math_core)
 
+add_executable(test_rt_random runtime/RTRandomTests.cpp)
+target_link_libraries(test_rt_random PRIVATE rt)
+add_test(NAME test_rt_random COMMAND test_rt_random)
+
 add_test(NAME vm_strings_example COMMAND ${CMAKE_COMMAND}
   -DILC=$<TARGET_FILE:ilc>
   -DSRC_DIR=${CMAKE_SOURCE_DIR}

--- a/tests/runtime/RTRandomTests.cpp
+++ b/tests/runtime/RTRandomTests.cpp
@@ -1,0 +1,31 @@
+// File: tests/runtime/RTRandomTests.cpp
+// Purpose: Validate deterministic RNG core.
+// Key invariants: Sequence depends solely on seed; outputs are in [0,1).
+// Ownership: Uses runtime library.
+// Links: docs/runtime-abi.md
+#include "rt_random.h"
+#include <cassert>
+#include <cmath>
+
+int main()
+{
+    const double expect[] = {
+        0.34500051599441928,
+        0.75270919858134688,
+        0.79574526991954397,
+        0.77739245673250346,
+    };
+    const double eps = 1e-12;
+    rt_randomize_i64(1);
+    for (int i = 0; i < 4; ++i)
+    {
+        double x = rt_rnd();
+        assert(std::fabs(x - expect[i]) < eps);
+        assert(x >= 0.0 && x < 1.0);
+    }
+    rt_randomize_i64(0);
+    double z = rt_rnd();
+    assert(std::fabs(z - 0.0) < eps);
+    assert(z >= 0.0 && z < 1.0);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement 64-bit LCG-based RNG with seeding and [0,1) double output
- expose RNG to VM and document runtime ABI
- cover new RNG with unit tests and example program

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b89a42c5448324a6318b68b52386b6