### PR TITLE
feat(runtime): add deterministic random generator

### DIFF
--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -14,3 +14,18 @@ This document describes the stable C ABI provided by the runtime library.
 | `@rt_pow` | `f64, f64 -> f64` | power |
 | `@rt_abs_i64` | `i64 -> i64` | absolute value (integer) |
 | `@rt_abs_f64` | `f64 -> f64` | absolute value (float) |
+
+## Random
+
+The runtime exposes a simple deterministic 64-bit linear congruential generator:
+
+```
+state = state * 6364136223846793005 + 1
+```
+
+`@rt_randomize_u64` and `@rt_randomize_i64` set the internal state exactly. The
+default state on startup is `0xDEADBEEFCAFEBABE`.
+
+`@rt_rnd` returns a `f64` uniformly distributed in `[0,1)` by taking the top
+53 bits of the state and scaling by `2^-53`. For a given seed the sequence of
+values is reproducible across platforms.

--- a/examples/il/random_three.il
+++ b/examples/il/random_three.il
@@ -1,0 +1,25 @@
+il 0.1
+extern @rt_randomize_i64(i64) -> void
+extern @rt_rnd() -> f64
+extern @rt_print_f64(f64) -> void
+extern @rt_print_str(str) -> void
+
+global const str @.L0 = "\n"
+
+func @main() -> i32 {
+entry:
+  call @rt_randomize_i64(42)
+  %r0 = call @rt_rnd()
+  call @rt_print_f64(%r0)
+  %nl0 = const_str @.L0
+  call @rt_print_str(%nl0)
+  %r1 = call @rt_rnd()
+  call @rt_print_f64(%r1)
+  %nl1 = const_str @.L0
+  call @rt_print_str(%nl1)
+  %r2 = call @rt_rnd()
+  call @rt_print_f64(%r2)
+  %nl2 = const_str @.L0
+  call @rt_print_str(%nl2)
+  ret 0
+}

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(rt STATIC rt.c rt_math.c)
+add_library(rt STATIC rt.c rt_math.c rt_random.c)
 target_include_directories(rt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(rt PUBLIC m)

--- a/runtime/rt_random.c
+++ b/runtime/rt_random.c
@@ -1,0 +1,26 @@
+// File: runtime/rt_random.c
+// Purpose: Implements deterministic random number generator.
+// Key invariants: Uses 64-bit LCG with fixed multiplier and increment; sequence is reproducible for
+// given seed. Ownership/Lifetime: Maintains a single internal state value; not thread-safe. Links:
+// docs/runtime-abi.md
+
+#include "rt_random.h"
+
+static uint64_t state = 0xDEADBEEFCAFEBABEULL; // default non-zero seed
+
+void rt_randomize_u64(uint64_t seed)
+{
+    state = seed;
+}
+
+void rt_randomize_i64(long long seed)
+{
+    state = (uint64_t)seed;
+}
+
+double rt_rnd(void)
+{
+    state = state * 6364136223846793005ULL + 1ULL;
+    uint64_t x = (state >> 11) & ((1ULL << 53) - 1);
+    return (double)x * (1.0 / 9007199254740992.0);
+}

--- a/runtime/rt_random.h
+++ b/runtime/rt_random.h
@@ -1,0 +1,21 @@
+// File: runtime/rt_random.h
+// Purpose: Declares deterministic random number helpers.
+// Key invariants: 64-bit linear congruential generator; reproducible across platforms.
+// Ownership/Lifetime: Uses internal global state; single-threaded.
+// Links: docs/runtime-abi.md
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    void rt_randomize_u64(uint64_t seed);
+    void rt_randomize_i64(long long seed);
+    double rt_rnd(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/vm/RuntimeBridge.cpp
+++ b/src/vm/RuntimeBridge.cpp
@@ -6,6 +6,7 @@
 
 #include "vm/RuntimeBridge.hpp"
 #include "rt_math.h"
+#include "rt_random.h"
 #include "vm/VM.hpp"
 #include <cassert>
 #include <sstream>
@@ -117,6 +118,14 @@ Slot RuntimeBridge::call(const std::string &name,
     else if (name == "rt_abs_f64")
     {
         res.f64 = rt_abs_f64(args[0].f64);
+    }
+    else if (name == "rt_randomize_i64")
+    {
+        rt_randomize_i64(args[0].i64);
+    }
+    else if (name == "rt_rnd")
+    {
+        res.f64 = rt_rnd();
     }
     else
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,6 +73,10 @@ add_executable(test_rt_math_core runtime/RTMathCoreTests.cpp)
 target_link_libraries(test_rt_math_core PRIVATE rt)
 add_test(NAME test_rt_math_core COMMAND test_rt_math_core)
 
+add_executable(test_rt_random runtime/RTRandomTests.cpp)
+target_link_libraries(test_rt_random PRIVATE rt)
+add_test(NAME test_rt_random COMMAND test_rt_random)
+
 add_test(NAME vm_strings_example COMMAND ${CMAKE_COMMAND}
   -DILC=$<TARGET_FILE:ilc>
   -DSRC_DIR=${CMAKE_SOURCE_DIR}

--- a/tests/runtime/RTRandomTests.cpp
+++ b/tests/runtime/RTRandomTests.cpp
@@ -1,0 +1,31 @@
+// File: tests/runtime/RTRandomTests.cpp
+// Purpose: Validate deterministic LCG random generator.
+// Key invariants: Sequence reproducible for given seed; outputs in [0,1).
+// Ownership: Uses runtime library.
+// Links: docs/runtime-abi.md
+#include "rt_random.h"
+#include <cassert>
+
+int main()
+{
+    const double expected[] = {0.3450005159944193, 0.7527091985813469, 0.795745269919544};
+    rt_randomize_i64(1);
+    for (int i = 0; i < 3; ++i)
+    {
+        double x = rt_rnd();
+        assert(x == expected[i]);
+    }
+
+    rt_randomize_u64(0xDEADBEEFCAFEBABEULL);
+    double first = rt_rnd();
+    assert(first == 0.5272554727616845);
+
+    rt_randomize_i64(1);
+    for (int i = 0; i < 100; ++i)
+    {
+        double x = rt_rnd();
+        assert(x >= 0.0);
+        assert(x < 1.0);
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add 64-bit LCG random generator with seeding and uniform double output
- expose rt_randomize_i64 and rt_rnd to the VM
- document runtime random ABI and provide example and tests

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b89a42c5448324a6318b68b52386b6