### PR TITLE
feat(opt): fold math intrinsics with literals

### DIFF
--- a/docs/passes/constfold.md
+++ b/docs/passes/constfold.md
@@ -1,0 +1,25 @@
+# constfold (v1)
+
+Folds literal computations at the IL level.
+
+## Supported folds
+
+| Pattern | Result |
+|--------|--------|
+| `ABS(i64 lit)` | absolute value as i64 |
+| `ABS(f64 lit)` | absolute value as f64 |
+| `FLOOR(f64 lit)` | `floor` result |
+| `CEIL(f64 lit)` | `ceil` result |
+| `SQR(f64 lit ≥ 0)` | `sqrt` result |
+| `POW(f64 lit, i64 lit)` *(\|exp\| ≤ 16)* | `pow` result |
+| `SIN(0)` | `0` |
+| `COS(0)` | `1` |
+
+All floating-point folds use C math semantics and emit exact `f64` literals in the
+optimized IL.
+
+## Caveats
+
+* Only the patterns above are folded.
+* No general trigonometric folding beyond `SIN(0)` and `COS(0)`.
+* `POW` folds only for small integer exponents and `SQR` requires non‑negative inputs.

--- a/examples/basic/math_constfold.bas
+++ b/examples/basic/math_constfold.bas
@@ -1,0 +1,11 @@
+' File: examples/basic/math_constfold.bas
+' Purpose: Demonstrates compile-time constant folding of math intrinsics.
+
+PRINT ABS(-5)
+PRINT ABS(-1.5#)
+PRINT FLOOR(1.9#)
+PRINT CEIL(1.1#)
+PRINT SQR(9#)
+PRINT POW(2#,10)
+PRINT SIN(0#)
+PRINT COS(0#)

--- a/src/il/transform/ConstFold.cpp
+++ b/src/il/transform/ConstFold.cpp
@@ -1,12 +1,15 @@
 // File: src/il/transform/ConstFold.cpp
-// Purpose: Implements constant folding for simple IL integer operations.
-// Key invariants: Uses wraparound semantics for 64-bit integer arithmetic.
+// Purpose: Implements constant folding for integer ops and math intrinsics.
+// Key invariants: Uses wraparound semantics for integers and C math for f64.
 // Ownership/Lifetime: Operates in place on the module.
 // Links: docs/class-catalog.md
 
 #include "il/transform/ConstFold.hpp"
 #include "il/core/Instr.hpp"
+#include <cmath>
 #include <cstdint>
+#include <cstdlib>
+#include <limits>
 
 using namespace il::core;
 
@@ -21,6 +24,21 @@ static bool isConstInt(const Value &v, long long &out)
     if (v.kind == Value::Kind::ConstInt)
     {
         out = v.i64;
+        return true;
+    }
+    return false;
+}
+
+static bool getConstFloat(const Value &v, double &out)
+{
+    if (v.kind == Value::Kind::ConstFloat)
+    {
+        out = v.f64;
+        return true;
+    }
+    if (v.kind == Value::Kind::ConstInt)
+    {
+        out = static_cast<double>(v.i64);
         return true;
     }
     return false;
@@ -50,6 +68,97 @@ static void replaceAll(Function &f, unsigned id, const Value &v)
                     op = v;
 }
 
+static bool foldCall(const Instr &in, Value &out)
+{
+    if (in.op != Opcode::Call)
+        return false;
+    const std::string &c = in.callee;
+    if (c == "rt_abs_i64" && in.operands.size() == 1)
+    {
+        long long v;
+        if (isConstInt(in.operands[0], v) && v != std::numeric_limits<long long>::min())
+        {
+            out = Value::constInt(v < 0 ? -v : v);
+            return true;
+        }
+        return false;
+    }
+    double a;
+    if (c == "rt_abs_f64" && in.operands.size() == 1)
+    {
+        if (getConstFloat(in.operands[0], a))
+        {
+            out = Value::constFloat(std::fabs(a));
+            return true;
+        }
+        return false;
+    }
+    if (c == "rt_floor" && in.operands.size() == 1)
+    {
+        if (getConstFloat(in.operands[0], a))
+        {
+            out = Value::constFloat(std::floor(a));
+            return true;
+        }
+        return false;
+    }
+    if (c == "rt_ceil" && in.operands.size() == 1)
+    {
+        if (getConstFloat(in.operands[0], a))
+        {
+            out = Value::constFloat(std::ceil(a));
+            return true;
+        }
+        return false;
+    }
+    if (c == "rt_sqrt" && in.operands.size() == 1)
+    {
+        if (getConstFloat(in.operands[0], a) && a >= 0.0)
+        {
+            out = Value::constFloat(std::sqrt(a));
+            return true;
+        }
+        return false;
+    }
+    if (c == "rt_pow" && in.operands.size() == 2)
+    {
+        double base, expd;
+        if (getConstFloat(in.operands[0], base) && getConstFloat(in.operands[1], expd))
+        {
+            double t = std::trunc(expd);
+            if (expd == t)
+            {
+                long long exp = static_cast<long long>(t);
+                if (std::llabs(exp) <= 16)
+                {
+                    out = Value::constFloat(std::pow(base, static_cast<double>(exp)));
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    if (c == "rt_sin" && in.operands.size() == 1)
+    {
+        if (getConstFloat(in.operands[0], a) && a == 0.0)
+        {
+            out = Value::constFloat(0.0);
+            return true;
+        }
+        return false;
+    }
+    if (c == "rt_cos" && in.operands.size() == 1)
+    {
+        if (getConstFloat(in.operands[0], a) && a == 0.0)
+        {
+            out = Value::constFloat(1.0);
+            return true;
+        }
+        return false;
+    }
+    return false;
+}
+
 } // namespace
 
 void constFold(Module &m)
@@ -61,40 +170,51 @@ void constFold(Module &m)
             for (size_t i = 0; i < b.instructions.size(); ++i)
             {
                 Instr &in = b.instructions[i];
-                if (!in.result || in.operands.size() != 2)
+                if (!in.result)
                     continue;
-                long long lhs, rhs;
-                if (!isConstInt(in.operands[0], lhs) || !isConstInt(in.operands[1], rhs))
-                    continue;
-                long long res = 0;
-                bool folded = true;
-                switch (in.op)
+                Value repl;
+                bool folded = false;
+                if (in.op == Opcode::Call)
                 {
-                    case Opcode::Add:
-                        res = wrapAdd(lhs, rhs);
-                        break;
-                    case Opcode::Sub:
-                        res = wrapSub(lhs, rhs);
-                        break;
-                    case Opcode::Mul:
-                        res = wrapMul(lhs, rhs);
-                        break;
-                    case Opcode::And:
-                        res = lhs & rhs;
-                        break;
-                    case Opcode::Or:
-                        res = lhs | rhs;
-                        break;
-                    case Opcode::Xor:
-                        res = lhs ^ rhs;
-                        break;
-                    default:
-                        folded = false;
-                        break;
+                    folded = foldCall(in, repl);
+                }
+                else if (in.operands.size() == 2)
+                {
+                    long long lhs, rhs, res = 0;
+                    if (isConstInt(in.operands[0], lhs) && isConstInt(in.operands[1], rhs))
+                    {
+                        folded = true;
+                        switch (in.op)
+                        {
+                            case Opcode::Add:
+                                res = wrapAdd(lhs, rhs);
+                                break;
+                            case Opcode::Sub:
+                                res = wrapSub(lhs, rhs);
+                                break;
+                            case Opcode::Mul:
+                                res = wrapMul(lhs, rhs);
+                                break;
+                            case Opcode::And:
+                                res = lhs & rhs;
+                                break;
+                            case Opcode::Or:
+                                res = lhs | rhs;
+                                break;
+                            case Opcode::Xor:
+                                res = lhs ^ rhs;
+                                break;
+                            default:
+                                folded = false;
+                                break;
+                        }
+                        if (folded)
+                            repl = Value::constInt(res);
+                    }
                 }
                 if (folded)
                 {
-                    replaceAll(f, *in.result, Value::constInt(res));
+                    replaceAll(f, *in.result, repl);
                     b.instructions.erase(b.instructions.begin() + i);
                     --i;
                 }

--- a/src/il/transform/ConstFold.hpp
+++ b/src/il/transform/ConstFold.hpp
@@ -1,6 +1,7 @@
 // File: src/il/transform/ConstFold.hpp
 // Purpose: Declares IL constant folding transformations.
 // Key invariants: Only folds operations with literal operands.
+// Updates integer ops and selected math intrinsics.
 // Ownership/Lifetime: Mutates the module in place.
 // Links: docs/class-catalog.md
 #pragma once

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -139,6 +139,10 @@ add_test(NAME il_opt_equiv COMMAND ${CMAKE_COMMAND}
   -DILC=$<TARGET_FILE:ilc>
   -DIL_FILE=${CMAKE_SOURCE_DIR}/tests/golden/il_opt/e2e.in.il
   -P ${CMAKE_CURRENT_SOURCE_DIR}/e2e/test_il_opt_equiv.cmake)
+add_test(NAME constfold_equiv COMMAND ${CMAKE_COMMAND}
+  -DILC=$<TARGET_FILE:ilc>
+  -DIL_FILE=${CMAKE_SOURCE_DIR}/tests/il/e2e/math_constfold.il
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/e2e/test_constfold_equiv.cmake)
 
 add_test(NAME mem2reg_basic COMMAND ${CMAKE_COMMAND}
   -DILC=$<TARGET_FILE:ilc>

--- a/tests/e2e/test_constfold_equiv.cmake
+++ b/tests/e2e/test_constfold_equiv.cmake
@@ -1,0 +1,28 @@
+# File: tests/e2e/test_constfold_equiv.cmake
+# Purpose: Ensure constfold preserves program behavior.
+# Key invariants: Optimized IL runs produce identical stdout.
+# Ownership/Lifetime: Invoked by CTest.
+# Links: docs/class-catalog.md
+
+if(NOT DEFINED ILC)
+  message(FATAL_ERROR "ILC not set")
+endif()
+if(NOT DEFINED IL_FILE)
+  message(FATAL_ERROR "IL_FILE not set")
+endif()
+set(OPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/opt.il")
+execute_process(COMMAND ${ILC} -run ${IL_FILE} OUTPUT_VARIABLE before RESULT_VARIABLE r1)
+if(NOT r1 EQUAL 0)
+  message(FATAL_ERROR "run before failed")
+endif()
+execute_process(COMMAND ${ILC} il-opt ${IL_FILE} -o ${OPT_FILE} --passes constfold RESULT_VARIABLE r2)
+if(NOT r2 EQUAL 0)
+  message(FATAL_ERROR "il-opt failed")
+endif()
+execute_process(COMMAND ${ILC} -run ${OPT_FILE} OUTPUT_VARIABLE after RESULT_VARIABLE r3)
+if(NOT r3 EQUAL 0)
+  message(FATAL_ERROR "run after failed")
+endif()
+if(NOT before STREQUAL after)
+  message(FATAL_ERROR "stdout mismatch")
+endif()

--- a/tests/golden/CMakeLists.txt
+++ b/tests/golden/CMakeLists.txt
@@ -123,6 +123,12 @@ add_test(NAME il_opt_arith_id COMMAND ${CMAKE_COMMAND}
   -DIL_FILE=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/arith_id.in.il
   -DGOLDEN=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/arith_id.opt.il
   -P ${CMAKE_CURRENT_SOURCE_DIR}/il_opt/check_opt.cmake)
+add_test(NAME il_opt_math_constfold COMMAND ${CMAKE_COMMAND}
+  -DILC=${BASIC_ILC}
+  -DIL_FILE=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/math_constfold.in.il
+  -DGOLDEN=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/math_constfold.opt.il
+  -DPASSES=constfold
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/il_opt/check_opt.cmake)
 add_test(NAME il_opt_cbr_same_target COMMAND ${CMAKE_COMMAND}
   -DILC=${BASIC_ILC}
   -DIL_FILE=${CMAKE_CURRENT_SOURCE_DIR}/il_opt/cbr_same_target.in.il

--- a/tests/golden/il_opt/math_constfold.in.il
+++ b/tests/golden/il_opt/math_constfold.in.il
@@ -1,0 +1,31 @@
+il 0.1.2
+extern @rt_print_i64(i64) -> void
+extern @rt_print_f64(f64) -> void
+extern @rt_abs_i64(i64) -> i64
+extern @rt_abs_f64(f64) -> f64
+extern @rt_floor(f64) -> f64
+extern @rt_ceil(f64) -> f64
+extern @rt_sqrt(f64) -> f64
+extern @rt_pow(f64, f64) -> f64
+extern @rt_sin(f64) -> f64
+extern @rt_cos(f64) -> f64
+func @main() -> i64 {
+entry:
+  %t0 = call @rt_abs_i64(-5)
+  %t1 = call @rt_abs_f64(-1.5)
+  %t2 = call @rt_floor(1.9)
+  %t3 = call @rt_ceil(1.1)
+  %t4 = call @rt_sqrt(9.0)
+  %t5 = call @rt_pow(2.0, 10.0)
+  %t6 = call @rt_sin(0.0)
+  %t7 = call @rt_cos(0.0)
+  call @rt_print_i64(%t0)
+  call @rt_print_f64(%t1)
+  call @rt_print_f64(%t2)
+  call @rt_print_f64(%t3)
+  call @rt_print_f64(%t4)
+  call @rt_print_f64(%t5)
+  call @rt_print_f64(%t6)
+  call @rt_print_f64(%t7)
+  ret 0
+}

--- a/tests/golden/il_opt/math_constfold.opt.il
+++ b/tests/golden/il_opt/math_constfold.opt.il
@@ -1,0 +1,23 @@
+il 0.1.2
+extern @rt_abs_f64(f64) -> f64
+extern @rt_abs_i64(i64) -> i64
+extern @rt_ceil(f64) -> f64
+extern @rt_cos(f64) -> f64
+extern @rt_floor(f64) -> f64
+extern @rt_pow(f64, f64) -> f64
+extern @rt_print_f64(f64) -> void
+extern @rt_print_i64(i64) -> void
+extern @rt_sin(f64) -> f64
+extern @rt_sqrt(f64) -> f64
+func @main() -> i64 {
+entry:
+  call @rt_print_i64(5)
+  call @rt_print_f64(1.5)
+  call @rt_print_f64(1)
+  call @rt_print_f64(2)
+  call @rt_print_f64(3)
+  call @rt_print_f64(1024)
+  call @rt_print_f64(0.0)
+  call @rt_print_f64(1)
+  ret 0
+}

--- a/tests/il/e2e/math_constfold.il
+++ b/tests/il/e2e/math_constfold.il
@@ -1,0 +1,22 @@
+il 0.1.2
+extern @rt_print_i64(i64) -> void
+extern @rt_print_f64(f64) -> void
+extern @rt_abs_i64(i64) -> i64
+extern @rt_abs_f64(f64) -> f64
+extern @rt_sqrt(f64) -> f64
+extern @rt_pow(f64, f64) -> f64
+extern @rt_sin(f64) -> f64
+func @main() -> i64 {
+entry:
+  %t0 = call @rt_abs_i64(-5)
+  %t1 = call @rt_abs_f64(-1.5)
+  %t2 = call @rt_sqrt(2.0)
+  %t3 = call @rt_pow(2.0, -1.0)
+  %t4 = call @rt_sin(0.0)
+  call @rt_print_i64(%t0)
+  call @rt_print_f64(%t1)
+  call @rt_print_f64(%t2)
+  call @rt_print_f64(%t3)
+  call @rt_print_f64(%t4)
+  ret 0
+}


### PR DESCRIPTION
## Summary
- extend constfold pass to evaluate ABS/FLOOR/CEIL/SQR/POW/SIN/COS with literal inputs
- document math folding rules and add BASIC example
- add golden and e2e tests for math constant folding

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68b8a6e49b5483248300d397e1148495