### PR TITLE
front/basic: table-driven constant folding with unified numeric promotion

### DIFF
--- a/docs/dev-frontend-basic.md
+++ b/docs/dev-frontend-basic.md
@@ -15,3 +15,14 @@ The BASIC parser is split into focused components:
 
 This separation keeps statement logic clear and isolates token mechanics and
 expression handling.
+
+## Constant Folding Rules
+
+The BASIC constant folder reduces pure literal expressions before semantic
+analysis. Binary folding uses a dispatch table with these rules:
+
+- Numeric operands promote to float if either side is a float.
+- Integer arithmetic wraps on 64-bit overflow.
+- `/` always yields a float; `\` and `MOD` require integers.
+- String `+` concatenates literals; `=` and `<>` compare strings.
+- Mixed string/number operations are rejected with diagnostic `B2001`.

--- a/src/frontends/basic/ConstFolder.cpp
+++ b/src/frontends/basic/ConstFolder.cpp
@@ -1,5 +1,5 @@
 // File: src/frontends/basic/ConstFolder.cpp
-// Purpose: Implements constant folding for BASIC AST nodes.
+// Purpose: Implements table-driven constant folding for BASIC AST nodes.
 // Key invariants: Folding preserves 64-bit wrap-around semantics.
 // Ownership/Lifetime: AST nodes are mutated in place.
 // Links: docs/class-catalog.md
@@ -10,9 +10,73 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
+#include <type_traits>
+#include <unordered_map>
 
 namespace il::frontends::basic
 {
+
+std::optional<Numeric> asNumeric(const Expr &e)
+{
+    if (auto *i = dynamic_cast<const IntExpr *>(&e))
+        return Numeric{false, 0.0, i->value};
+    if (auto *f = dynamic_cast<const FloatExpr *>(&e))
+        return Numeric{true, f->value, 0};
+    return std::nullopt;
+}
+
+Numeric promote(const Numeric &a, const Numeric &b)
+{
+    if (a.isFloat || b.isFloat)
+        return Numeric{true, a.isFloat ? a.f : static_cast<double>(a.i), 0};
+    return a;
+}
+
+ExprPtr foldStringBinary(const StringExpr &L, TokenKind op, const StringExpr &R)
+{
+    if (op == TokenKind::Plus)
+    {
+        auto s = std::make_unique<StringExpr>();
+        s->value = L.value + R.value;
+        return s;
+    }
+    if (op == TokenKind::Equal)
+    {
+        auto i = std::make_unique<IntExpr>();
+        i->value = (L.value == R.value);
+        return i;
+    }
+    if (op == TokenKind::NotEqual)
+    {
+        auto i = std::make_unique<IntExpr>();
+        i->value = (L.value != R.value);
+        return i;
+    }
+    return nullptr;
+}
+
+template <typename F> ExprPtr foldNumericBinary(const Expr &L, const Expr &R, F op)
+{
+    auto ln = asNumeric(L);
+    auto rn = asNumeric(R);
+    if (!ln || !rn)
+        return nullptr;
+    Numeric pl = promote(*ln, *rn);
+    Numeric pr = promote(*rn, *ln);
+    std::optional<Numeric> res = pl.isFloat ? op(pl.f, pr.f) : op(pl.i, pr.i);
+    if (!res)
+        return nullptr;
+    if (res->isFloat)
+    {
+        auto fe = std::make_unique<FloatExpr>();
+        fe->value = res->f;
+        return fe;
+    }
+    auto ie = std::make_unique<IntExpr>();
+    ie->value = res->i;
+    return ie;
+}
 
 namespace
 {
@@ -31,6 +95,170 @@ static long long wrapMul(long long a, long long b)
 {
     return static_cast<long long>(static_cast<uint64_t>(a) * static_cast<uint64_t>(b));
 }
+
+using FoldFn = std::function<ExprPtr(const Expr &, const Expr &)>;
+
+static const std::unordered_map<TokenKind, FoldFn> kNumericFold = {
+    {TokenKind::Plus,
+     [](const Expr &L, const Expr &R)
+     {
+         return foldNumericBinary(L,
+                                  R,
+                                  [](auto a, auto b) -> std::optional<Numeric>
+                                  {
+                                      using T = decltype(a);
+                                      if constexpr (std::is_floating_point_v<T>)
+                                          return Numeric{true, a + b, 0};
+                                      else
+                                          return Numeric{false, 0.0, wrapAdd(a, b)};
+                                  });
+     }},
+    {TokenKind::Minus,
+     [](const Expr &L, const Expr &R)
+     {
+         return foldNumericBinary(L,
+                                  R,
+                                  [](auto a, auto b) -> std::optional<Numeric>
+                                  {
+                                      using T = decltype(a);
+                                      if constexpr (std::is_floating_point_v<T>)
+                                          return Numeric{true, a - b, 0};
+                                      else
+                                          return Numeric{false, 0.0, wrapSub(a, b)};
+                                  });
+     }},
+    {TokenKind::Star,
+     [](const Expr &L, const Expr &R)
+     {
+         return foldNumericBinary(L,
+                                  R,
+                                  [](auto a, auto b) -> std::optional<Numeric>
+                                  {
+                                      using T = decltype(a);
+                                      if constexpr (std::is_floating_point_v<T>)
+                                          return Numeric{true, a * b, 0};
+                                      else
+                                          return Numeric{false, 0.0, wrapMul(a, b)};
+                                  });
+     }},
+    {TokenKind::Slash,
+     [](const Expr &L, const Expr &R)
+     {
+         return foldNumericBinary(L,
+                                  R,
+                                  [](auto a, auto b) -> std::optional<Numeric>
+                                  {
+                                      if (b == 0)
+                                          return std::nullopt;
+                                      return Numeric{
+                                          true, static_cast<double>(a) / static_cast<double>(b), 0};
+                                  });
+     }},
+    {TokenKind::Backslash,
+     [](const Expr &L, const Expr &R)
+     {
+         return foldNumericBinary(L,
+                                  R,
+                                  [](auto a, auto b) -> std::optional<Numeric>
+                                  {
+                                      using T = decltype(a);
+                                      if constexpr (std::is_floating_point_v<T>)
+                                      {
+                                          return std::nullopt;
+                                      }
+                                      else
+                                      {
+                                          if (b == 0)
+                                              return std::nullopt;
+                                          return Numeric{false, 0.0, a / b};
+                                      }
+                                  });
+     }},
+    {TokenKind::KeywordMod,
+     [](const Expr &L, const Expr &R)
+     {
+         return foldNumericBinary(L,
+                                  R,
+                                  [](auto a, auto b) -> std::optional<Numeric>
+                                  {
+                                      using T = decltype(a);
+                                      if constexpr (std::is_floating_point_v<T>)
+                                      {
+                                          return std::nullopt;
+                                      }
+                                      else
+                                      {
+                                          if (b == 0)
+                                              return std::nullopt;
+                                          return Numeric{false, 0.0, a % b};
+                                      }
+                                  });
+     }},
+    {TokenKind::Equal,
+     [](const Expr &L, const Expr &R)
+     {
+         return foldNumericBinary(L,
+                                  R,
+                                  [](auto a, auto b) -> std::optional<Numeric>
+                                  { return Numeric{false, 0.0, a == b}; });
+     }},
+    {TokenKind::NotEqual,
+     [](const Expr &L, const Expr &R)
+     {
+         return foldNumericBinary(L,
+                                  R,
+                                  [](auto a, auto b) -> std::optional<Numeric>
+                                  { return Numeric{false, 0.0, a != b}; });
+     }},
+    {TokenKind::Less,
+     [](const Expr &L, const Expr &R)
+     {
+         return foldNumericBinary(L,
+                                  R,
+                                  [](auto a, auto b) -> std::optional<Numeric>
+                                  { return Numeric{false, 0.0, a < b}; });
+     }},
+    {TokenKind::LessEqual,
+     [](const Expr &L, const Expr &R)
+     {
+         return foldNumericBinary(L,
+                                  R,
+                                  [](auto a, auto b) -> std::optional<Numeric>
+                                  { return Numeric{false, 0.0, a <= b}; });
+     }},
+    {TokenKind::Greater,
+     [](const Expr &L, const Expr &R)
+     {
+         return foldNumericBinary(L,
+                                  R,
+                                  [](auto a, auto b) -> std::optional<Numeric>
+                                  { return Numeric{false, 0.0, a > b}; });
+     }},
+    {TokenKind::GreaterEqual,
+     [](const Expr &L, const Expr &R)
+     {
+         return foldNumericBinary(L,
+                                  R,
+                                  [](auto a, auto b) -> std::optional<Numeric>
+                                  { return Numeric{false, 0.0, a >= b}; });
+     }},
+    {TokenKind::KeywordAnd,
+     [](const Expr &L, const Expr &R)
+     {
+         return foldNumericBinary(L,
+                                  R,
+                                  [](auto a, auto b) -> std::optional<Numeric>
+                                  { return Numeric{false, 0.0, (a != 0 && b != 0) ? 1 : 0}; });
+     }},
+    {TokenKind::KeywordOr,
+     [](const Expr &L, const Expr &R)
+     {
+         return foldNumericBinary(L,
+                                  R,
+                                  [](auto a, auto b) -> std::optional<Numeric>
+                                  { return Numeric{false, 0.0, (a != 0 || b != 0) ? 1 : 0}; });
+     }},
+};
 
 static bool isInt(const Expr *e, long long &v)
 {
@@ -166,61 +394,63 @@ static void foldBinary(ExprPtr &e, BinaryExpr *b)
 {
     foldExpr(b->lhs);
     foldExpr(b->rhs);
-    long long l, r;
-    std::string ls, rs;
-    if (isInt(b->lhs.get(), l) && isInt(b->rhs.get(), r))
+    auto toToken = [](BinaryExpr::Op op)
     {
-        switch (b->op)
+        switch (op)
         {
             case BinaryExpr::Op::Add:
-                replaceWithInt(e, wrapAdd(l, r), b->loc);
-                return;
+                return TokenKind::Plus;
             case BinaryExpr::Op::Sub:
-                replaceWithInt(e, wrapSub(l, r), b->loc);
-                return;
+                return TokenKind::Minus;
             case BinaryExpr::Op::Mul:
-                replaceWithInt(e, wrapMul(l, r), b->loc);
-                return;
+                return TokenKind::Star;
+            case BinaryExpr::Op::Div:
+                return TokenKind::Slash;
             case BinaryExpr::Op::IDiv:
-                if (r != 0)
-                    replaceWithInt(e, l / r, b->loc);
-                return;
+                return TokenKind::Backslash;
             case BinaryExpr::Op::Mod:
-                if (r != 0)
-                    replaceWithInt(e, l % r, b->loc);
-                return;
+                return TokenKind::KeywordMod;
             case BinaryExpr::Op::Eq:
-                replaceWithInt(e, l == r, b->loc);
-                return;
+                return TokenKind::Equal;
             case BinaryExpr::Op::Ne:
-                replaceWithInt(e, l != r, b->loc);
-                return;
+                return TokenKind::NotEqual;
             case BinaryExpr::Op::Lt:
-                replaceWithInt(e, l < r, b->loc);
-                return;
+                return TokenKind::Less;
             case BinaryExpr::Op::Le:
-                replaceWithInt(e, l <= r, b->loc);
-                return;
+                return TokenKind::LessEqual;
             case BinaryExpr::Op::Gt:
-                replaceWithInt(e, l > r, b->loc);
-                return;
+                return TokenKind::Greater;
             case BinaryExpr::Op::Ge:
-                replaceWithInt(e, l >= r, b->loc);
-                return;
+                return TokenKind::GreaterEqual;
             case BinaryExpr::Op::And:
-                replaceWithInt(e, (l != 0 && r != 0) ? 1 : 0, b->loc);
-                return;
+                return TokenKind::KeywordAnd;
             case BinaryExpr::Op::Or:
-                replaceWithInt(e, (l != 0 || r != 0) ? 1 : 0, b->loc);
+                return TokenKind::KeywordOr;
+        }
+        return TokenKind::Plus;
+    };
+
+    TokenKind tk = toToken(b->op);
+    if (auto *ls = dynamic_cast<StringExpr *>(b->lhs.get()))
+    {
+        if (auto *rs = dynamic_cast<StringExpr *>(b->rhs.get()))
+        {
+            if (auto se = foldStringBinary(*ls, tk, *rs))
+            {
+                se->loc = b->loc;
+                e = std::move(se);
                 return;
-            default:
-                break;
+            }
         }
     }
-    else if (b->op == BinaryExpr::Op::Add && isStr(b->lhs.get(), ls) && isStr(b->rhs.get(), rs))
+    auto it = kNumericFold.find(tk);
+    if (it != kNumericFold.end())
     {
-        replaceWithStr(e, ls + rs, b->loc);
-        return;
+        if (auto ne = it->second(*b->lhs, *b->rhs))
+        {
+            ne->loc = b->loc;
+            e = std::move(ne);
+        }
     }
 }
 

--- a/src/frontends/basic/ConstFolder.hpp
+++ b/src/frontends/basic/ConstFolder.hpp
@@ -6,9 +6,33 @@
 #pragma once
 
 #include "frontends/basic/AST.hpp"
+#include "frontends/basic/Token.hpp"
+#include <optional>
 
 namespace il::frontends::basic
 {
+
+/// @brief Numeric value that may be an int or float.
+struct Numeric
+{
+    bool isFloat; ///< True if @c f is valid.
+    double f;     ///< Floating point value.
+    long long i;  ///< Integer value.
+};
+
+/// @brief Attempt to view @p e as a numeric literal.
+/// @param e Expression to inspect.
+/// @return Numeric value if @p e is IntExpr or FloatExpr.
+std::optional<Numeric> asNumeric(const Expr &e);
+
+/// @brief Promote @p a to match type of @p b (float if either is float).
+Numeric promote(const Numeric &a, const Numeric &b);
+
+/// @brief Fold numeric binary expression @p L op @p R with operation @p op.
+template <typename F> ExprPtr foldNumericBinary(const Expr &L, const Expr &R, F op);
+
+/// @brief Fold string binary operation if supported.
+ExprPtr foldStringBinary(const StringExpr &L, TokenKind op, const StringExpr &R);
 
 /// \brief Fold constant expressions within a BASIC program AST.
 /// \param prog Program to transform in place.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -247,6 +247,10 @@ add_executable(test_basic_diagnostic unit/test_basic_diagnostic.cpp)
 target_link_libraries(test_basic_diagnostic PRIVATE fe_basic support)
 add_test(NAME test_basic_diagnostic COMMAND test_basic_diagnostic)
 
+add_executable(test_basic_constfolder unit/test_basic_constfolder.cpp)
+target_link_libraries(test_basic_constfolder PRIVATE fe_basic support)
+add_test(NAME test_basic_constfolder COMMAND test_basic_constfolder)
+
 add_executable(test_vm_trap_loc unit/test_vm_trap_loc.cpp)
 target_link_libraries(test_vm_trap_loc PRIVATE il_build il_vm support)
 add_test(NAME test_vm_trap_loc COMMAND test_vm_trap_loc)

--- a/tests/golden/basic_to_il/abs_mixed.il
+++ b/tests/golden/basic_to_il/abs_mixed.il
@@ -23,18 +23,14 @@ L10:
   .loc 1 1 4
   br L20
 L20:
-  .loc 1 2 15
-  %t2 = sitofp 1
-  .loc 1 2 15
-  %t3 = fsub %t2, 2.5
   .loc 1 2 10
-  %t4 = call @rt_abs_f64(%t3)
+  %t2 = call @rt_abs_f64(-1.5)
   .loc 1 2 4
-  call @rt_print_f64(%t4)
+  call @rt_print_f64(%t2)
   .loc 1 2 4
-  %t5 = const_str @.L0
+  %t3 = const_str @.L0
   .loc 1 2 4
-  call @rt_print_str(%t5)
+  call @rt_print_str(%t3)
   .loc 1 2 4
   br exit
 exit:

--- a/tests/golden/basic_to_il/conversions.il
+++ b/tests/golden/basic_to_il/conversions.il
@@ -78,35 +78,31 @@ L60:
   .loc 1 6 4
   br L70
 L70:
-  .loc 1 7 13
-  %t15 = sitofp 0
-  .loc 1 7 13
-  %t16 = fsub %t15, 1.9
   .loc 1 7 4
-  store f64, %t0, %t16
+  store f64, %t0, -1.9
   .loc 1 7 4
   br L80
 L80:
   .loc 1 8 14
-  %t17 = load f64, %t1
+  %t15 = load f64, %t1
   .loc 1 8 10
-  %t18 = fptosi %t17
+  %t16 = fptosi %t15
   .loc 1 8 4
-  call @rt_print_i64(%t18)
+  call @rt_print_i64(%t16)
   .loc 1 8 4
-  %t19 = const_str @.L0
+  %t17 = const_str @.L0
   .loc 1 8 4
-  call @rt_print_str(%t19)
+  call @rt_print_str(%t17)
   .loc 1 8 23
-  %t20 = load f64, %t0
+  %t18 = load f64, %t0
   .loc 1 8 19
-  %t21 = fptosi %t20
+  %t19 = fptosi %t18
   .loc 1 8 4
-  call @rt_print_i64(%t21)
+  call @rt_print_i64(%t19)
   .loc 1 8 4
-  %t22 = const_str @.L1
+  %t20 = const_str @.L1
   .loc 1 8 4
-  call @rt_print_str(%t22)
+  call @rt_print_str(%t20)
   .loc 1 8 4
   br L90
 L90:

--- a/tests/golden/basic_to_il/float_ops.il
+++ b/tests/golden/basic_to_il/float_ops.il
@@ -11,38 +11,28 @@ entry:
   %t0 = alloca 8
   br L10
 L10:
-  .loc 1 1 15
-  %t1 = sitofp 1
-  .loc 1 1 15
-  %t2 = fadd %t1, 2.5
   .loc 1 1 4
-  store f64, %t0, %t2
+  store f64, %t0, 3.5
   .loc 1 1 4
   br L20
 L20:
-  .loc 1 2 12
-  %t3 = sitofp 1
-  .loc 1 2 12
-  %t4 = fcmp_lt %t3, 2.5
   .loc 1 2 4
-  %t5 = zext1 %t4
+  call @rt_print_i64(1)
   .loc 1 2 4
-  call @rt_print_i64(%t5)
+  %t1 = const_str @.L0
   .loc 1 2 4
-  %t6 = const_str @.L0
-  .loc 1 2 4
-  call @rt_print_str(%t6)
+  call @rt_print_str(%t1)
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 10
-  %t7 = load f64, %t0
+  %t2 = load f64, %t0
   .loc 1 3 4
-  call @rt_print_f64(%t7)
+  call @rt_print_f64(%t2)
   .loc 1 3 4
-  %t8 = const_str @.L0
+  %t3 = const_str @.L0
   .loc 1 3 4
-  call @rt_print_str(%t8)
+  call @rt_print_str(%t3)
   .loc 1 3 4
   br exit
 exit:

--- a/tests/golden/basic_to_il/math_phase1.il
+++ b/tests/golden/basic_to_il/math_phase1.il
@@ -26,51 +26,47 @@ L10:
   .loc 1 1 4
   br L20
 L20:
-  .loc 1 2 14
-  %t2 = sitofp 0
-  .loc 1 2 14
-  %t3 = fsub %t2, 1.5
   .loc 1 2 10
-  %t4 = call @rt_abs_f64(%t3)
+  %t2 = call @rt_abs_f64(-1.5)
   .loc 1 2 4
-  call @rt_print_f64(%t4)
+  call @rt_print_f64(%t2)
   .loc 1 2 4
-  %t5 = const_str @.L0
+  %t3 = const_str @.L0
   .loc 1 2 4
-  call @rt_print_str(%t5)
+  call @rt_print_str(%t3)
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 10
-  %t6 = call @rt_floor(1.9)
+  %t4 = call @rt_floor(1.9)
   .loc 1 3 4
-  call @rt_print_f64(%t6)
+  call @rt_print_f64(%t4)
   .loc 1 3 4
-  %t7 = const_str @.L0
+  %t5 = const_str @.L0
   .loc 1 3 4
-  call @rt_print_str(%t7)
+  call @rt_print_str(%t5)
   .loc 1 3 4
   br L40
 L40:
   .loc 1 4 10
-  %t8 = call @rt_ceil(1.1)
+  %t6 = call @rt_ceil(1.1)
   .loc 1 4 4
-  call @rt_print_f64(%t8)
+  call @rt_print_f64(%t6)
   .loc 1 4 4
-  %t9 = const_str @.L0
+  %t7 = const_str @.L0
   .loc 1 4 4
-  call @rt_print_str(%t9)
+  call @rt_print_str(%t7)
   .loc 1 4 4
   br L50
 L50:
   .loc 1 5 10
-  %t10 = call @rt_sqrt(9)
+  %t8 = call @rt_sqrt(9)
   .loc 1 5 4
-  call @rt_print_f64(%t10)
+  call @rt_print_f64(%t8)
   .loc 1 5 4
-  %t11 = const_str @.L0
+  %t9 = const_str @.L0
   .loc 1 5 4
-  call @rt_print_str(%t11)
+  call @rt_print_str(%t9)
   .loc 1 5 4
   br exit
 exit:

--- a/tests/unit/test_basic_constfolder.cpp
+++ b/tests/unit/test_basic_constfolder.cpp
@@ -1,0 +1,69 @@
+// File: tests/unit/test_basic_constfolder.cpp
+// Purpose: Unit tests for BASIC constant folder numeric promotion and string rules.
+// Key invariants: Folding respects type promotion and emits existing diagnostics.
+// Ownership/Lifetime: Test owns all created objects.
+// Links: docs/class-catalog.md
+
+#include "frontends/basic/ConstFolder.hpp"
+#include "frontends/basic/DiagnosticEmitter.hpp"
+#include "frontends/basic/Parser.hpp"
+#include "frontends/basic/SemanticAnalyzer.hpp"
+#include "support/source_manager.hpp"
+#include <cassert>
+#include <sstream>
+#include <string>
+
+using namespace il::frontends::basic;
+using namespace il::support;
+
+static std::unique_ptr<Program> parse(const std::string &src, SourceManager &sm, uint32_t &fid)
+{
+    fid = sm.addFile("test.bas");
+    Parser p(src, fid);
+    return p.parseProgram();
+}
+
+int main()
+{
+    // int + float promotes to float
+    {
+        SourceManager sm;
+        uint32_t fid;
+        auto prog = parse("10 LET X = 1 + 2.5\n", sm, fid);
+        foldConstants(*prog);
+        auto *let = dynamic_cast<LetStmt *>(prog->statements[0].get());
+        auto *f = dynamic_cast<FloatExpr *>(let->expr.get());
+        assert(f && f->value == 3.5);
+    }
+
+    // string concatenation
+    {
+        SourceManager sm;
+        uint32_t fid;
+        auto prog = parse("10 PRINT \"A\" + \"B\"\n", sm, fid);
+        foldConstants(*prog);
+        auto *pr = dynamic_cast<PrintStmt *>(prog->statements[0].get());
+        auto *s = dynamic_cast<StringExpr *>(pr->items[0].expr.get());
+        assert(s && s->value == "AB");
+    }
+
+    // rejected string arithmetic keeps diagnostic code
+    {
+        std::string src = "10 PRINT \"A\" * 2\n";
+        SourceManager sm;
+        uint32_t fid;
+        auto prog = parse(src, sm, fid);
+        foldConstants(*prog);
+        DiagnosticEngine de;
+        DiagnosticEmitter em(de, sm);
+        em.addSource(fid, src);
+        SemanticAnalyzer sema(em);
+        sema.analyze(*prog);
+        std::ostringstream oss;
+        em.printAll(oss);
+        std::string out = oss.str();
+        assert(out.find("error[B2001]") != std::string::npos);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- refactor constant folder to use Numeric helpers and dispatch tables
- document constant folding rules and add tests for numeric promotion, string concat, and diagnostics

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b8f6ec06ac83249395662c462deb44