### PR TITLE
front/basic: table-driven constant folding with unified numeric promotion

### DIFF
--- a/docs/dev-frontend-basic.md
+++ b/docs/dev-frontend-basic.md
@@ -15,3 +15,12 @@ The BASIC parser is split into focused components:
 
 This separation keeps statement logic clear and isolates token mechanics and
 expression handling.
+
+## Constant Folding Rules
+
+The constant folder evaluates pure expressions composed only of literals. When
+both operands are numeric, they are promoted so that if either is a float, the
+other is converted to float before the operation. Integer arithmetic uses
+64-bit wrap-around semantics. String operands fold `+` as concatenation and
+support equality/inequality comparisons. Mixed string and numeric operations
+are left to the semantic analyzer for diagnostics.

--- a/src/frontends/basic/ConstFolder.hpp
+++ b/src/frontends/basic/ConstFolder.hpp
@@ -6,6 +6,8 @@
 #pragma once
 
 #include "frontends/basic/AST.hpp"
+#include "frontends/basic/Token.hpp"
+#include <optional>
 
 namespace il::frontends::basic
 {
@@ -13,5 +15,29 @@ namespace il::frontends::basic
 /// \brief Fold constant expressions within a BASIC program AST.
 /// \param prog Program to transform in place.
 void foldConstants(Program &prog);
+
+namespace detail
+{
+/// @brief Numeric literal wrapper used during folding.
+struct Numeric
+{
+    bool isFloat; ///< True if the value is floating point.
+    double f;     ///< Floating-point representation.
+    long long i;  ///< Integer representation.
+};
+
+/// @brief Interpret expression @p e as a numeric literal if possible.
+std::optional<Numeric> asNumeric(const Expr &e);
+
+/// @brief Promote @p a to match the type of @p b.
+Numeric promote(const Numeric &a, const Numeric &b);
+
+/// @brief Fold numeric binary operation using callback @p op.
+/// @return Folded expression or nullptr on mismatch.
+template <typename F> ExprPtr foldNumericBinary(const Expr &l, const Expr &r, F op);
+
+/// @brief Fold string binary operation (e.g., concatenation).
+ExprPtr foldStringBinary(const StringExpr &l, TokenKind op, const StringExpr &r);
+} // namespace detail
 
 } // namespace il::frontends::basic

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -247,6 +247,10 @@ add_executable(test_basic_diagnostic unit/test_basic_diagnostic.cpp)
 target_link_libraries(test_basic_diagnostic PRIVATE fe_basic support)
 add_test(NAME test_basic_diagnostic COMMAND test_basic_diagnostic)
 
+add_executable(test_basic_constfold unit/test_basic_constfold.cpp)
+target_link_libraries(test_basic_constfold PRIVATE fe_basic support)
+add_test(NAME test_basic_constfold COMMAND test_basic_constfold)
+
 add_executable(test_vm_trap_loc unit/test_vm_trap_loc.cpp)
 target_link_libraries(test_vm_trap_loc PRIVATE il_build il_vm support)
 add_test(NAME test_vm_trap_loc COMMAND test_vm_trap_loc)

--- a/tests/golden/basic_to_il/abs_mixed.il
+++ b/tests/golden/basic_to_il/abs_mixed.il
@@ -23,18 +23,14 @@ L10:
   .loc 1 1 4
   br L20
 L20:
-  .loc 1 2 15
-  %t2 = sitofp 1
-  .loc 1 2 15
-  %t3 = fsub %t2, 2.5
   .loc 1 2 10
-  %t4 = call @rt_abs_f64(%t3)
+  %t2 = call @rt_abs_f64(-1.5)
   .loc 1 2 4
-  call @rt_print_f64(%t4)
+  call @rt_print_f64(%t2)
   .loc 1 2 4
-  %t5 = const_str @.L0
+  %t3 = const_str @.L0
   .loc 1 2 4
-  call @rt_print_str(%t5)
+  call @rt_print_str(%t3)
   .loc 1 2 4
   br exit
 exit:

--- a/tests/golden/basic_to_il/conversions.il
+++ b/tests/golden/basic_to_il/conversions.il
@@ -78,35 +78,31 @@ L60:
   .loc 1 6 4
   br L70
 L70:
-  .loc 1 7 13
-  %t15 = sitofp 0
-  .loc 1 7 13
-  %t16 = fsub %t15, 1.9
   .loc 1 7 4
-  store f64, %t0, %t16
+  store f64, %t0, -1.9
   .loc 1 7 4
   br L80
 L80:
   .loc 1 8 14
-  %t17 = load f64, %t1
+  %t15 = load f64, %t1
   .loc 1 8 10
-  %t18 = fptosi %t17
+  %t16 = fptosi %t15
   .loc 1 8 4
-  call @rt_print_i64(%t18)
+  call @rt_print_i64(%t16)
   .loc 1 8 4
-  %t19 = const_str @.L0
+  %t17 = const_str @.L0
   .loc 1 8 4
-  call @rt_print_str(%t19)
+  call @rt_print_str(%t17)
   .loc 1 8 23
-  %t20 = load f64, %t0
+  %t18 = load f64, %t0
   .loc 1 8 19
-  %t21 = fptosi %t20
+  %t19 = fptosi %t18
   .loc 1 8 4
-  call @rt_print_i64(%t21)
+  call @rt_print_i64(%t19)
   .loc 1 8 4
-  %t22 = const_str @.L1
+  %t20 = const_str @.L1
   .loc 1 8 4
-  call @rt_print_str(%t22)
+  call @rt_print_str(%t20)
   .loc 1 8 4
   br L90
 L90:

--- a/tests/golden/basic_to_il/float_ops.il
+++ b/tests/golden/basic_to_il/float_ops.il
@@ -11,38 +11,28 @@ entry:
   %t0 = alloca 8
   br L10
 L10:
-  .loc 1 1 15
-  %t1 = sitofp 1
-  .loc 1 1 15
-  %t2 = fadd %t1, 2.5
   .loc 1 1 4
-  store f64, %t0, %t2
+  store f64, %t0, 3.5
   .loc 1 1 4
   br L20
 L20:
-  .loc 1 2 12
-  %t3 = sitofp 1
-  .loc 1 2 12
-  %t4 = fcmp_lt %t3, 2.5
   .loc 1 2 4
-  %t5 = zext1 %t4
+  call @rt_print_i64(1)
   .loc 1 2 4
-  call @rt_print_i64(%t5)
+  %t1 = const_str @.L0
   .loc 1 2 4
-  %t6 = const_str @.L0
-  .loc 1 2 4
-  call @rt_print_str(%t6)
+  call @rt_print_str(%t1)
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 10
-  %t7 = load f64, %t0
+  %t2 = load f64, %t0
   .loc 1 3 4
-  call @rt_print_f64(%t7)
+  call @rt_print_f64(%t2)
   .loc 1 3 4
-  %t8 = const_str @.L0
+  %t3 = const_str @.L0
   .loc 1 3 4
-  call @rt_print_str(%t8)
+  call @rt_print_str(%t3)
   .loc 1 3 4
   br exit
 exit:

--- a/tests/golden/basic_to_il/math_phase1.il
+++ b/tests/golden/basic_to_il/math_phase1.il
@@ -26,51 +26,47 @@ L10:
   .loc 1 1 4
   br L20
 L20:
-  .loc 1 2 14
-  %t2 = sitofp 0
-  .loc 1 2 14
-  %t3 = fsub %t2, 1.5
   .loc 1 2 10
-  %t4 = call @rt_abs_f64(%t3)
+  %t2 = call @rt_abs_f64(-1.5)
   .loc 1 2 4
-  call @rt_print_f64(%t4)
+  call @rt_print_f64(%t2)
   .loc 1 2 4
-  %t5 = const_str @.L0
+  %t3 = const_str @.L0
   .loc 1 2 4
-  call @rt_print_str(%t5)
+  call @rt_print_str(%t3)
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 10
-  %t6 = call @rt_floor(1.9)
+  %t4 = call @rt_floor(1.9)
   .loc 1 3 4
-  call @rt_print_f64(%t6)
+  call @rt_print_f64(%t4)
   .loc 1 3 4
-  %t7 = const_str @.L0
+  %t5 = const_str @.L0
   .loc 1 3 4
-  call @rt_print_str(%t7)
+  call @rt_print_str(%t5)
   .loc 1 3 4
   br L40
 L40:
   .loc 1 4 10
-  %t8 = call @rt_ceil(1.1)
+  %t6 = call @rt_ceil(1.1)
   .loc 1 4 4
-  call @rt_print_f64(%t8)
+  call @rt_print_f64(%t6)
   .loc 1 4 4
-  %t9 = const_str @.L0
+  %t7 = const_str @.L0
   .loc 1 4 4
-  call @rt_print_str(%t9)
+  call @rt_print_str(%t7)
   .loc 1 4 4
   br L50
 L50:
   .loc 1 5 10
-  %t10 = call @rt_sqrt(9)
+  %t8 = call @rt_sqrt(9)
   .loc 1 5 4
-  call @rt_print_f64(%t10)
+  call @rt_print_f64(%t8)
   .loc 1 5 4
-  %t11 = const_str @.L0
+  %t9 = const_str @.L0
   .loc 1 5 4
-  call @rt_print_str(%t11)
+  call @rt_print_str(%t9)
   .loc 1 5 4
   br exit
 exit:


### PR DESCRIPTION
## Summary
- refactor BASIC const folder with table-driven numeric and string dispatch
- add numeric promotion helpers and float-aware folding
- update docs and golden IL outputs; add const-fold unit tests

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b8f6ec06ac83249395662c462deb44