### PR TITLE
front/basic: introduce Printer helper in AstPrinter; keep output stable

### DIFF
--- a/docs/dev-frontend-basic.md
+++ b/docs/dev-frontend-basic.md
@@ -24,3 +24,9 @@ other is converted to float before the operation. Integer arithmetic uses
 64-bit wrap-around semantics. String operands fold `+` as concatenation and
 support equality/inequality comparisons. Mixed string and numeric operations
 are left to the semantic analyzer for diagnostics.
+
+## AST printing conventions
+
+`AstPrinter` renders a compact, Lisp-style representation of the AST for
+debugging. An internal `Printer` helper centralizes indentation so nested
+blocks are indented uniformly.

--- a/src/frontends/basic/AstPrinter.hpp
+++ b/src/frontends/basic/AstPrinter.hpp
@@ -2,11 +2,14 @@
 // Purpose: Declares utilities to print BASIC AST nodes.
 // Key invariants: None.
 // Ownership/Lifetime: Functions do not take ownership of nodes.
+// Notes: Uses internal Printer helper for formatting.
 // Links: docs/class-catalog.md
 #pragma once
 
 #include "frontends/basic/AST.hpp"
+#include <ostream>
 #include <string>
+#include <string_view>
 
 namespace il::frontends::basic
 {
@@ -17,8 +20,27 @@ class AstPrinter
     std::string dump(const Program &prog);
 
   private:
-    std::string dump(const Stmt &stmt);
-    std::string dump(const Expr &expr);
+    struct Printer
+    {
+        std::ostream &os;
+        int indent = 0;
+        void line(std::string_view text);
+
+        struct Indent
+        {
+            Printer &p;
+
+            ~Indent()
+            {
+                --p.indent;
+            }
+        };
+
+        Indent push();
+    };
+
+    void dump(const Stmt &stmt, Printer &p);
+    void dump(const Expr &expr, Printer &p);
 };
 
 } // namespace il::frontends::basic


### PR DESCRIPTION
## Summary
- refactor AstPrinter to use a small Printer helper for indentation
- streamline printing logic for common statements and expressions
- document AST printing conventions

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`
- `build/src/tools/basic-ast-dump/basic-ast-dump docs/examples/basic/ex1_hello_cond.bas > /tmp/ex1.ast && diff -u tests/golden/basic_ast/ex1_hello_cond.ast /tmp/ex1.ast`


------
https://chatgpt.com/codex/tasks/task_e_68b8fae42230832494c87aff03821e41