### PR TITLE
tools/ilc: split main into subcommand handlers; shared Basic→IL compile helper

### DIFF
--- a/docs/dev-cli.md
+++ b/docs/dev-cli.md
@@ -1,0 +1,13 @@
+# Developer CLI Structure
+
+The `ilc` tool delegates top-level commands to dedicated handlers:
+
+- `-run <file.il>` — executed by `cmdRunIL`.
+- `front basic` — handled by `cmdFrontBasic` for BASIC sources.
+- `il-opt` — optimized by `cmdILOpt`.
+
+`main.cpp` parses the initial tokens and forwards arguments to the
+appropriate handler, keeping the usage text in one place. BASIC
+compilation shares the `compileBasicToIL` helper used by both
+`-emit-il` and `-run` modes.
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,10 @@ target_link_libraries(il_vm PUBLIC il_core rt support)
 add_library(il_codegen_x86_64 STATIC codegen/x86_64/placeholder.cpp)
 set_target_properties(il_codegen_x86_64 PROPERTIES LINKER_LANGUAGE CXX)
 
-add_executable(ilc tools/ilc/main.cpp)
+add_executable(ilc tools/ilc/main.cpp
+  tools/ilc/cmd_run_il.cpp
+  tools/ilc/cmd_front_basic.cpp
+  tools/ilc/cmd_il_opt.cpp)
 set_target_properties(ilc PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/ilc)
 target_link_libraries(ilc PRIVATE il_core il_io il_vm il_verify il_transform fe_basic support Passes)
 

--- a/src/tools/ilc/cli.hpp
+++ b/src/tools/ilc/cli.hpp
@@ -1,0 +1,25 @@
+// File: src/tools/ilc/cli.hpp
+// Purpose: Declarations for ilc subcommand handlers.
+// Key invariants: None.
+// Ownership/Lifetime: Callers retain ownership of argv strings.
+// Links: docs/class-catalog.md
+
+#pragma once
+
+/// @brief Handle BASIC front-end commands after `ilc front basic`.
+/// @param argc Count of arguments following `ilc front basic`.
+/// @param argv Argument array starting after `ilc front basic`.
+/// @return Process exit code.
+int cmdFrontBasic(int argc, char **argv);
+
+/// @brief Run an IL module.
+/// @param argc Count of arguments following `ilc -run`.
+/// @param argv Argument array starting after `ilc -run`.
+/// @return Process exit code.
+int cmdRunIL(int argc, char **argv);
+
+/// @brief Optimize an IL module with transformation passes.
+/// @param argc Count of arguments following `ilc il-opt`.
+/// @param argv Argument array starting after `ilc il-opt`.
+/// @return Process exit code.
+int cmdILOpt(int argc, char **argv);

--- a/src/tools/ilc/cmd_front_basic.cpp
+++ b/src/tools/ilc/cmd_front_basic.cpp
@@ -1,0 +1,139 @@
+// File: src/tools/ilc/cmd_front_basic.cpp
+// Purpose: Handle `ilc front basic` commands.
+// Key invariants: BASIC source must compile to valid IL before optional execution.
+// Ownership/Lifetime: Tool owns loaded modules and diagnostics.
+// Links: docs/class-catalog.md
+
+#include "tools/ilc/cli.hpp"
+
+#include "frontends/basic/ConstFolder.hpp"
+#include "frontends/basic/DiagnosticEmitter.hpp"
+#include "frontends/basic/Lowerer.hpp"
+#include "frontends/basic/Parser.hpp"
+#include "frontends/basic/SemanticAnalyzer.hpp"
+#include "il/io/Serializer.hpp"
+#include "il/verify/Verifier.hpp"
+#include "support/source_manager.hpp"
+#include "vm/VM.hpp"
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+using namespace il;
+using namespace il::frontends::basic;
+using namespace il::support;
+
+extern void usage();
+
+/// @brief Compile BASIC source file at @p path to IL.
+/// @param path Path to the BASIC source file.
+/// @param boundsChecks Enable bounds checks during lowering.
+/// @param hadErrors Set to true if compilation produced errors.
+/// @return Resulting IL module; empty if @p hadErrors is true.
+static core::Module compileBasicToIL(const std::string &path, bool boundsChecks, bool &hadErrors)
+{
+    std::ifstream in(path);
+    if (!in)
+    {
+        std::cerr << "unable to open " << path << "\n";
+        hadErrors = true;
+        return {};
+    }
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    std::string src = ss.str();
+    SourceManager sm;
+    uint32_t fid = sm.addFile(path);
+    Parser p(src, fid);
+    auto prog = p.parseProgram();
+    foldConstants(*prog);
+    support::DiagnosticEngine de;
+    DiagnosticEmitter em(de, sm);
+    em.addSource(fid, src);
+    SemanticAnalyzer sema(em);
+    sema.analyze(*prog);
+    if (em.errorCount() > 0)
+    {
+        em.printAll(std::cerr);
+        hadErrors = true;
+        return {};
+    }
+    Lowerer lower(boundsChecks);
+    hadErrors = false;
+    return lower.lower(*prog);
+}
+
+/// @brief Handle BASIC front-end compilation and execution.
+int cmdFrontBasic(int argc, char **argv)
+{
+    bool emitIl = false;
+    bool run = false;
+    std::string file;
+    std::string stdinPath;
+    uint64_t maxSteps = 0;
+    bool boundsChecks = false;
+    bool trace = false;
+    for (int i = 0; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+        if (arg == "-emit-il" && i + 1 < argc)
+        {
+            emitIl = true;
+            file = argv[++i];
+        }
+        else if (arg == "-run" && i + 1 < argc)
+        {
+            run = true;
+            file = argv[++i];
+        }
+        else if (arg == "--trace")
+        {
+            trace = true;
+        }
+        else if (arg == "--stdin-from" && i + 1 < argc)
+        {
+            stdinPath = argv[++i];
+        }
+        else if (arg == "--max-steps" && i + 1 < argc)
+        {
+            maxSteps = std::stoull(argv[++i]);
+        }
+        else if (arg == "--bounds-checks")
+        {
+            boundsChecks = true;
+        }
+        else
+        {
+            usage();
+            return 1;
+        }
+    }
+    if ((emitIl == run) || file.empty())
+    {
+        usage();
+        return 1;
+    }
+    bool hadErrors = false;
+    core::Module m = compileBasicToIL(file, boundsChecks, hadErrors);
+    if (hadErrors)
+        return 1;
+    if (emitIl)
+    {
+        io::Serializer::write(m, std::cout);
+        return 0;
+    }
+    if (!verify::Verifier::verify(m, std::cerr))
+        return 1;
+    if (!stdinPath.empty())
+    {
+        if (!freopen(stdinPath.c_str(), "r", stdin))
+        {
+            std::cerr << "unable to open stdin file\n";
+            return 1;
+        }
+    }
+    vm::VM vm(m, trace, maxSteps);
+    return static_cast<int>(vm.run());
+}

--- a/src/tools/ilc/cmd_il_opt.cpp
+++ b/src/tools/ilc/cmd_il_opt.cpp
@@ -1,0 +1,122 @@
+// File: src/tools/ilc/cmd_il_opt.cpp
+// Purpose: Handle `ilc il-opt` optimization invocation.
+// Key invariants: Input IL must parse successfully before optimization.
+// Ownership/Lifetime: Tool owns loaded modules.
+// Links: docs/class-catalog.md
+
+#include "tools/ilc/cli.hpp"
+
+#include "Passes/Mem2Reg.h"
+#include "il/io/Parser.hpp"
+#include "il/io/Serializer.hpp"
+#include "il/transform/ConstFold.hpp"
+#include "il/transform/DCE.hpp"
+#include "il/transform/PassManager.hpp"
+#include "il/transform/Peephole.hpp"
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace il;
+
+extern void usage();
+
+/// @brief Optimize an IL module with selected transformation passes.
+int cmdILOpt(int argc, char **argv)
+{
+    if (argc < 3)
+    {
+        usage();
+        return 1;
+    }
+    std::string inFile = argv[0];
+    std::string outFile;
+    std::vector<std::string> passList;
+    bool passesExplicit = false;
+    bool noMem2Reg = false;
+    bool mem2regStats = false;
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+        if (arg == "-o" && i + 1 < argc)
+        {
+            outFile = argv[++i];
+        }
+        else if (arg == "--passes" && i + 1 < argc)
+        {
+            std::string passes = argv[++i];
+            size_t pos = 0;
+            passesExplicit = true;
+            while (pos != std::string::npos)
+            {
+                size_t comma = passes.find(',', pos);
+                passList.push_back(passes.substr(pos, comma - pos));
+                if (comma == std::string::npos)
+                    break;
+                pos = comma + 1;
+            }
+        }
+        else if (arg == "--no-mem2reg")
+        {
+            noMem2Reg = true;
+        }
+        else if (arg == "--mem2reg-stats")
+        {
+            mem2regStats = true;
+        }
+        else
+        {
+            usage();
+            return 1;
+        }
+    }
+    if (!passesExplicit)
+    {
+        passList = {"mem2reg", "constfold", "peephole", "dce"};
+    }
+    if (noMem2Reg)
+    {
+        passList.erase(std::remove(passList.begin(), passList.end(), "mem2reg"), passList.end());
+    }
+    if (outFile.empty())
+    {
+        usage();
+        return 1;
+    }
+    std::ifstream ifs(inFile);
+    if (!ifs)
+    {
+        std::cerr << "unable to open " << inFile << "\n";
+        return 1;
+    }
+    core::Module m;
+    if (!io::Parser::parse(ifs, m, std::cerr))
+        return 1;
+    transform::PassManager pm;
+    pm.addPass("constfold", transform::constFold);
+    pm.addPass("peephole", transform::peephole);
+    pm.addPass("dce", transform::dce);
+    pm.addPass("mem2reg",
+               [mem2regStats](core::Module &mod)
+               {
+                   viper::passes::Mem2RegStats st;
+                   viper::passes::mem2reg(mod, mem2regStats ? &st : nullptr);
+                   if (mem2regStats)
+                   {
+                       std::cout << "mem2reg: promoted " << st.promotedVars << ", removed loads "
+                                 << st.removedLoads << ", removed stores " << st.removedStores
+                                 << "\n";
+                   }
+               });
+    pm.run(m, passList);
+    std::ofstream ofs(outFile);
+    if (!ofs)
+    {
+        std::cerr << "unable to open " << outFile << "\n";
+        return 1;
+    }
+    io::Serializer::write(m, ofs, io::Serializer::Mode::Canonical);
+    return 0;
+}

--- a/src/tools/ilc/cmd_run_il.cpp
+++ b/src/tools/ilc/cmd_run_il.cpp
@@ -1,0 +1,78 @@
+// File: src/tools/ilc/cmd_run_il.cpp
+// Purpose: Handle `ilc -run <file.il>` invocation.
+// Key invariants: IL file must parse and verify before execution.
+// Ownership/Lifetime: Tool owns loaded modules.
+// Links: docs/class-catalog.md
+
+#include "tools/ilc/cli.hpp"
+
+#include "il/io/Parser.hpp"
+#include "il/verify/Verifier.hpp"
+#include "vm/VM.hpp"
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+using namespace il;
+
+extern void usage();
+
+/// @brief Run an IL module through the VM.
+int cmdRunIL(int argc, char **argv)
+{
+    if (argc < 1)
+    {
+        usage();
+        return 1;
+    }
+    bool trace = false;
+    std::string ilFile = argv[0];
+    std::string stdinPath;
+    uint64_t maxSteps = 0;
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+        if (arg == "--trace")
+        {
+            trace = true;
+        }
+        else if (arg == "--stdin-from" && i + 1 < argc)
+        {
+            stdinPath = argv[++i];
+        }
+        else if (arg == "--max-steps" && i + 1 < argc)
+        {
+            maxSteps = std::stoull(argv[++i]);
+        }
+        else if (arg == "--bounds-checks")
+        {
+        }
+        else
+        {
+            usage();
+            return 1;
+        }
+    }
+    std::ifstream ifs(ilFile);
+    if (!ifs)
+    {
+        std::cerr << "unable to open " << ilFile << "\n";
+        return 1;
+    }
+    core::Module m;
+    if (!io::Parser::parse(ifs, m, std::cerr))
+        return 1;
+    if (!verify::Verifier::verify(m, std::cerr))
+        return 1;
+    if (!stdinPath.empty())
+    {
+        if (!freopen(stdinPath.c_str(), "r", stdin))
+        {
+            std::cerr << "unable to open stdin file\n";
+            return 1;
+        }
+    }
+    vm::VM vm(m, trace, maxSteps);
+    return static_cast<int>(vm.run());
+}

--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -1,38 +1,16 @@
 // File: src/tools/ilc/main.cpp
-// Purpose: Main driver for IL compiler and runner.
+// Purpose: Dispatch to ilc subcommand handlers.
 // Key invariants: None.
 // Ownership/Lifetime: Tool owns loaded modules.
 // Links: docs/class-catalog.md
 
-#include "Passes/Mem2Reg.h"
-#include "frontends/basic/ConstFolder.hpp"
-#include "frontends/basic/DiagnosticEmitter.hpp"
-#include "frontends/basic/Lowerer.hpp"
-#include "frontends/basic/Parser.hpp"
-#include "frontends/basic/SemanticAnalyzer.hpp"
-#include "il/io/Parser.hpp"
-#include "il/io/Serializer.hpp"
-#include "il/transform/ConstFold.hpp"
-#include "il/transform/DCE.hpp"
-#include "il/transform/PassManager.hpp"
-#include "il/transform/Peephole.hpp"
-#include "il/verify/Verifier.hpp"
-#include "support/source_manager.hpp"
-#include "vm/VM.hpp"
-#include <algorithm>
-#include <cstdint>
-#include <cstdio>
-#include <fstream>
+#include "tools/ilc/cli.hpp"
+
 #include <iostream>
-#include <sstream>
 #include <string>
-#include <vector>
 
-using namespace il;
-using namespace il::frontends::basic;
-using namespace il::support;
-
-static void usage()
+/// @brief Print usage information for ilc.
+void usage()
 {
     std::cerr << "ilc v0.1.0\n"
               << "Usage: ilc -run <file.il> [--trace] [--stdin-from <file>] [--max-steps N]"
@@ -50,265 +28,28 @@ int main(int argc, char **argv)
         usage();
         return 1;
     }
-
     std::string cmd = argv[1];
-    bool trace = false;
-
     if (cmd == "-run")
     {
-        if (argc < 3)
-        {
-            usage();
-            return 1;
-        }
-        std::string ilFile = argv[2];
-        std::string stdinPath;
-        uint64_t maxSteps = 0;
-        for (int i = 3; i < argc; ++i)
-        {
-            std::string arg = argv[i];
-            if (arg == "--trace")
-            {
-                trace = true;
-            }
-            else if (arg == "--stdin-from" && i + 1 < argc)
-            {
-                stdinPath = argv[++i];
-            }
-            else if (arg == "--max-steps" && i + 1 < argc)
-            {
-                maxSteps = std::stoull(argv[++i]);
-            }
-            else if (arg == "--bounds-checks")
-            {
-            }
-            else
-            {
-                usage();
-                return 1;
-            }
-        }
-        std::ifstream ifs(ilFile);
-        if (!ifs)
-        {
-            std::cerr << "unable to open " << ilFile << "\n";
-            return 1;
-        }
-        core::Module m;
-        if (!io::Parser::parse(ifs, m, std::cerr))
-            return 1;
-        if (!verify::Verifier::verify(m, std::cerr))
-            return 1;
-        if (!stdinPath.empty())
-        {
-            if (!freopen(stdinPath.c_str(), "r", stdin))
-            {
-                std::cerr << "unable to open stdin file\n";
-                return 1;
-            }
-        }
-        vm::VM vm(m, trace, maxSteps);
-        return static_cast<int>(vm.run());
+        return cmdRunIL(argc - 2, argv + 2);
     }
-
     if (cmd == "il-opt")
     {
-        if (argc < 5)
-        {
-            usage();
-            return 1;
-        }
-        std::string inFile = argv[2];
-        std::string outFile;
-        std::vector<std::string> passList;
-        bool passesExplicit = false;
-        bool noMem2Reg = false;
-        bool mem2regStats = false;
-        for (int i = 3; i < argc; ++i)
-        {
-            std::string arg = argv[i];
-            if (arg == "-o" && i + 1 < argc)
-            {
-                outFile = argv[++i];
-            }
-            else if (arg == "--passes" && i + 1 < argc)
-            {
-                std::string passes = argv[++i];
-                size_t pos = 0;
-                passesExplicit = true;
-                while (pos != std::string::npos)
-                {
-                    size_t comma = passes.find(',', pos);
-                    passList.push_back(passes.substr(pos, comma - pos));
-                    if (comma == std::string::npos)
-                        break;
-                    pos = comma + 1;
-                }
-            }
-            else if (arg == "--no-mem2reg")
-            {
-                noMem2Reg = true;
-            }
-            else if (arg == "--mem2reg-stats")
-            {
-                mem2regStats = true;
-            }
-            else
-            {
-                usage();
-                return 1;
-            }
-        }
-        if (!passesExplicit)
-        {
-            passList = {"mem2reg", "constfold", "peephole", "dce"};
-        }
-        if (noMem2Reg)
-        {
-            passList.erase(std::remove(passList.begin(), passList.end(), "mem2reg"),
-                           passList.end());
-        }
-        if (outFile.empty())
-        {
-            usage();
-            return 1;
-        }
-        std::ifstream ifs(inFile);
-        if (!ifs)
-        {
-            std::cerr << "unable to open " << inFile << "\n";
-            return 1;
-        }
-        core::Module m;
-        if (!io::Parser::parse(ifs, m, std::cerr))
-            return 1;
-        transform::PassManager pm;
-        pm.addPass("constfold", transform::constFold);
-        pm.addPass("peephole", transform::peephole);
-        pm.addPass("dce", transform::dce);
-        pm.addPass("mem2reg",
-                   [mem2regStats](core::Module &mod)
-                   {
-                       viper::passes::Mem2RegStats st;
-                       viper::passes::mem2reg(mod, mem2regStats ? &st : nullptr);
-                       if (mem2regStats)
-                       {
-                           std::cout << "mem2reg: promoted " << st.promotedVars
-                                     << ", removed loads " << st.removedLoads << ", removed stores "
-                                     << st.removedStores << "\n";
-                       }
-                   });
-        pm.run(m, passList);
-        std::ofstream ofs(outFile);
-        if (!ofs)
-        {
-            std::cerr << "unable to open " << outFile << "\n";
-            return 1;
-        }
-        io::Serializer::write(m, ofs, io::Serializer::Mode::Canonical);
-        return 0;
+        return cmdILOpt(argc - 2, argv + 2);
     }
-
     if (cmd == "front" && argc >= 3)
     {
         std::string lang = argv[2];
         if (lang == "basic")
         {
-            bool emitIl = false;
-            bool run = false;
-            std::string file;
-            std::string stdinPath;
-            uint64_t maxSteps = 0;
-            bool boundsChecks = false;
-            for (int i = 3; i < argc; ++i)
-            {
-                std::string arg = argv[i];
-                if (arg == "-emit-il" && i + 1 < argc)
-                {
-                    emitIl = true;
-                    file = argv[++i];
-                }
-                else if (arg == "-run" && i + 1 < argc)
-                {
-                    run = true;
-                    file = argv[++i];
-                }
-                else if (arg == "--trace")
-                {
-                    trace = true;
-                }
-                else if (arg == "--stdin-from" && i + 1 < argc)
-                {
-                    stdinPath = argv[++i];
-                }
-                else if (arg == "--max-steps" && i + 1 < argc)
-                {
-                    maxSteps = std::stoull(argv[++i]);
-                }
-                else if (arg == "--bounds-checks")
-                {
-                    boundsChecks = true;
-                }
-                else
-                {
-                    usage();
-                    return 1;
-                }
-            }
-            if ((emitIl == run) || file.empty())
-            {
-                usage();
-                return 1;
-            }
-
-            std::ifstream in(file);
-            if (!in)
-            {
-                std::cerr << "unable to open " << file << "\n";
-                return 1;
-            }
-            std::ostringstream ss;
-            ss << in.rdbuf();
-            std::string src = ss.str();
-            SourceManager sm;
-            uint32_t fid = sm.addFile(file);
-            Parser p(src, fid);
-            auto prog = p.parseProgram();
-            foldConstants(*prog);
-            support::DiagnosticEngine de;
-            DiagnosticEmitter em(de, sm);
-            em.addSource(fid, src);
-            SemanticAnalyzer sema(em);
-            sema.analyze(*prog);
-            if (em.errorCount() > 0)
-            {
-                em.printAll(std::cerr);
-                return 1;
-            }
-            Lowerer lower(boundsChecks);
-            core::Module m = lower.lower(*prog);
-
-            if (emitIl)
-            {
-                io::Serializer::write(m, std::cout);
-                return 0;
-            }
-
-            if (!verify::Verifier::verify(m, std::cerr))
-                return 1;
-            if (!stdinPath.empty())
-            {
-                if (!freopen(stdinPath.c_str(), "r", stdin))
-                {
-                    std::cerr << "unable to open stdin file\n";
-                    return 1;
-                }
-            }
-            vm::VM vm(m, trace, maxSteps);
-            return static_cast<int>(vm.run());
+            return cmdFrontBasic(argc - 3, argv + 3);
         }
     }
-
+    if (cmd == "--help")
+    {
+        usage();
+        return 0;
+    }
     usage();
     return 1;
 }


### PR DESCRIPTION
## Summary
- factor ilc main into `cmd_run_il`, `cmd_front_basic`, and `cmd_il_opt`
- add `compileBasicToIL` helper and CLI header
- document subcommand structure for developers

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`
- `build/src/tools/ilc/ilc --help`
- `build/src/tools/ilc/ilc -run /tmp/min.il && echo OK`
- `build/src/tools/ilc/ilc front basic -emit-il tests/golden/basic_to_il/loc_add.bas`
- `build/src/tools/ilc/ilc front basic -run tests/golden/basic_to_il/loc_add.bas`
- `build/src/tools/ilc/ilc il-opt tests/golden/il_opt/arith_id.in.il -o /tmp/opt.il --passes dce`


------
https://chatgpt.com/codex/tasks/task_e_68b8fd6e96e48324b5a9ac3044354f7e