### PR TITLE
tools/ilc: split main into subcommand handlers; shared Basic→IL compile helper

### DIFF
--- a/docs/dev-cli.md
+++ b/docs/dev-cli.md
@@ -1,0 +1,12 @@
+# CLI Architecture
+
+`ilc` dispatches to focused handlers based on the initial tokens:
+
+- `-run <file.il> [--trace] [--stdin-from <file>] [--max-steps N] [--bounds-checks]`
+- `front basic -emit-il <file.bas> [--bounds-checks]`
+- `front basic -run <file.bas> [--trace] [--stdin-from <file>] [--max-steps N] [--bounds-checks]`
+- `il-opt <in.il> -o <out.il> --passes p1,p2`
+
+Handlers live in `src/tools/ilc/cmd_run_il.cpp`, `cmd_front_basic.cpp`, and `cmd_il_opt.cpp`.
+`src/tools/ilc/main.cpp` merely dispatches to these subcommands.
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ target_link_libraries(il_vm PUBLIC il_core rt support)
 add_library(il_codegen_x86_64 STATIC codegen/x86_64/placeholder.cpp)
 set_target_properties(il_codegen_x86_64 PROPERTIES LINKER_LANGUAGE CXX)
 
-add_executable(ilc tools/ilc/main.cpp)
+add_executable(ilc tools/ilc/main.cpp tools/ilc/cmd_run_il.cpp tools/ilc/cmd_front_basic.cpp tools/ilc/cmd_il_opt.cpp)
 set_target_properties(ilc PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/ilc)
 target_link_libraries(ilc PRIVATE il_core il_io il_vm il_verify il_transform fe_basic support Passes)
 

--- a/src/tools/ilc/cli.hpp
+++ b/src/tools/ilc/cli.hpp
@@ -1,0 +1,19 @@
+// File: src/tools/ilc/cli.hpp
+// Purpose: Declarations for ilc subcommand handlers and usage helper.
+// Key invariants: None.
+// Ownership/Lifetime: N/A.
+// Links: docs/class-catalog.md
+
+#pragma once
+
+/// @brief Handle `ilc front basic` subcommands.
+int cmdFrontBasic(int argc, char **argv);
+
+/// @brief Handle `ilc -run`.
+int cmdRunIL(int argc, char **argv);
+
+/// @brief Handle `ilc il-opt`.
+int cmdILOpt(int argc, char **argv);
+
+/// @brief Print usage information for ilc.
+void usage();

--- a/src/tools/ilc/cmd_front_basic.cpp
+++ b/src/tools/ilc/cmd_front_basic.cpp
@@ -1,0 +1,145 @@
+// File: src/tools/ilc/cmd_front_basic.cpp
+// Purpose: BASIC front-end driver for ilc.
+// Key invariants: None.
+// Ownership/Lifetime: Tool owns loaded modules.
+// Links: docs/class-catalog.md
+
+#include "cli.hpp"
+#include "frontends/basic/ConstFolder.hpp"
+#include "frontends/basic/DiagnosticEmitter.hpp"
+#include "frontends/basic/Lowerer.hpp"
+#include "frontends/basic/Parser.hpp"
+#include "frontends/basic/SemanticAnalyzer.hpp"
+#include "il/io/Serializer.hpp"
+#include "il/verify/Verifier.hpp"
+#include "support/source_manager.hpp"
+#include "vm/VM.hpp"
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+using namespace il;
+using namespace il::frontends::basic;
+using namespace il::support;
+
+/**
+ * @brief Compile a BASIC source file to IL.
+ *
+ * @param path Path to the BASIC source.
+ * @param boundsChecks Enable bounds checks during lowering.
+ * @param hadErrors Set to true if compilation fails.
+ * @return Compiled IL module or empty module on error.
+ */
+static core::Module compileBasicToIL(const std::string &path, bool boundsChecks, bool &hadErrors)
+{
+    hadErrors = true;
+    std::ifstream in(path);
+    if (!in)
+    {
+        std::cerr << "unable to open " << path << "\n";
+        return {};
+    }
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    std::string src = ss.str();
+    SourceManager sm;
+    uint32_t fid = sm.addFile(path);
+    Parser p(src, fid);
+    auto prog = p.parseProgram();
+    foldConstants(*prog);
+    support::DiagnosticEngine de;
+    DiagnosticEmitter em(de, sm);
+    em.addSource(fid, src);
+    SemanticAnalyzer sema(em);
+    sema.analyze(*prog);
+    if (em.errorCount() > 0)
+    {
+        em.printAll(std::cerr);
+        return {};
+    }
+    Lowerer lower(boundsChecks);
+    hadErrors = false;
+    return lower.lower(*prog);
+}
+
+/**
+ * @brief Handle BASIC front-end subcommands.
+ *
+ * @param argc Number of subcommand arguments (excluding `front basic`).
+ * @param argv Argument list.
+ * @return Exit status code.
+ */
+int cmdFrontBasic(int argc, char **argv)
+{
+    bool emitIl = false;
+    bool run = false;
+    std::string file;
+    std::string stdinPath;
+    uint64_t maxSteps = 0;
+    bool boundsChecks = false;
+    bool trace = false;
+    for (int i = 0; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+        if (arg == "-emit-il" && i + 1 < argc)
+        {
+            emitIl = true;
+            file = argv[++i];
+        }
+        else if (arg == "-run" && i + 1 < argc)
+        {
+            run = true;
+            file = argv[++i];
+        }
+        else if (arg == "--trace")
+        {
+            trace = true;
+        }
+        else if (arg == "--stdin-from" && i + 1 < argc)
+        {
+            stdinPath = argv[++i];
+        }
+        else if (arg == "--max-steps" && i + 1 < argc)
+        {
+            maxSteps = std::stoull(argv[++i]);
+        }
+        else if (arg == "--bounds-checks")
+        {
+            boundsChecks = true;
+        }
+        else
+        {
+            usage();
+            return 1;
+        }
+    }
+    if ((emitIl == run) || file.empty())
+    {
+        usage();
+        return 1;
+    }
+    bool hadErrors = false;
+    core::Module m = compileBasicToIL(file, boundsChecks, hadErrors);
+    if (hadErrors)
+        return 1;
+    if (emitIl)
+    {
+        io::Serializer::write(m, std::cout);
+        return 0;
+    }
+    if (!verify::Verifier::verify(m, std::cerr))
+        return 1;
+    if (!stdinPath.empty())
+    {
+        if (!freopen(stdinPath.c_str(), "r", stdin))
+        {
+            std::cerr << "unable to open stdin file\n";
+            return 1;
+        }
+    }
+    vm::VM vm(m, trace, maxSteps);
+    return static_cast<int>(vm.run());
+}

--- a/src/tools/ilc/cmd_il_opt.cpp
+++ b/src/tools/ilc/cmd_il_opt.cpp
@@ -1,0 +1,125 @@
+// File: src/tools/ilc/cmd_il_opt.cpp
+// Purpose: Implements IL optimization subcommand.
+// Key invariants: None.
+// Ownership/Lifetime: Tool owns loaded modules.
+// Links: docs/class-catalog.md
+
+#include "Passes/Mem2Reg.h"
+#include "cli.hpp"
+#include "il/io/Parser.hpp"
+#include "il/io/Serializer.hpp"
+#include "il/transform/ConstFold.hpp"
+#include "il/transform/DCE.hpp"
+#include "il/transform/PassManager.hpp"
+#include "il/transform/Peephole.hpp"
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace il;
+
+/**
+ * @brief Optimize an IL module using selected passes.
+ *
+ * @param argc Number of subcommand arguments (excluding `il-opt`).
+ * @param argv Argument list starting with the input IL file.
+ * @return Exit status code.
+ */
+int cmdILOpt(int argc, char **argv)
+{
+    if (argc < 3)
+    {
+        usage();
+        return 1;
+    }
+    std::string inFile = argv[0];
+    std::string outFile;
+    std::vector<std::string> passList;
+    bool passesExplicit = false;
+    bool noMem2Reg = false;
+    bool mem2regStats = false;
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+        if (arg == "-o" && i + 1 < argc)
+        {
+            outFile = argv[++i];
+        }
+        else if (arg == "--passes" && i + 1 < argc)
+        {
+            std::string passes = argv[++i];
+            size_t pos = 0;
+            passesExplicit = true;
+            while (pos != std::string::npos)
+            {
+                size_t comma = passes.find(',', pos);
+                passList.push_back(passes.substr(pos, comma - pos));
+                if (comma == std::string::npos)
+                    break;
+                pos = comma + 1;
+            }
+        }
+        else if (arg == "--no-mem2reg")
+        {
+            noMem2Reg = true;
+        }
+        else if (arg == "--mem2reg-stats")
+        {
+            mem2regStats = true;
+        }
+        else
+        {
+            usage();
+            return 1;
+        }
+    }
+    if (!passesExplicit)
+    {
+        passList = {"mem2reg", "constfold", "peephole", "dce"};
+    }
+    if (noMem2Reg)
+    {
+        passList.erase(std::remove(passList.begin(), passList.end(), "mem2reg"), passList.end());
+    }
+    if (outFile.empty())
+    {
+        usage();
+        return 1;
+    }
+    std::ifstream ifs(inFile);
+    if (!ifs)
+    {
+        std::cerr << "unable to open " << inFile << "\n";
+        return 1;
+    }
+    core::Module m;
+    if (!io::Parser::parse(ifs, m, std::cerr))
+        return 1;
+    transform::PassManager pm;
+    pm.addPass("constfold", transform::constFold);
+    pm.addPass("peephole", transform::peephole);
+    pm.addPass("dce", transform::dce);
+    pm.addPass("mem2reg",
+               [mem2regStats](core::Module &mod)
+               {
+                   viper::passes::Mem2RegStats st;
+                   viper::passes::mem2reg(mod, mem2regStats ? &st : nullptr);
+                   if (mem2regStats)
+                   {
+                       std::cout << "mem2reg: promoted " << st.promotedVars << ", removed loads "
+                                 << st.removedLoads << ", removed stores " << st.removedStores
+                                 << "\n";
+                   }
+               });
+    pm.run(m, passList);
+    std::ofstream ofs(outFile);
+    if (!ofs)
+    {
+        std::cerr << "unable to open " << outFile << "\n";
+        return 1;
+    }
+    io::Serializer::write(m, ofs, io::Serializer::Mode::Canonical);
+    return 0;
+}

--- a/src/tools/ilc/cmd_run_il.cpp
+++ b/src/tools/ilc/cmd_run_il.cpp
@@ -1,0 +1,83 @@
+// File: src/tools/ilc/cmd_run_il.cpp
+// Purpose: Implements execution of IL programs.
+// Key invariants: None.
+// Ownership/Lifetime: Tool owns loaded modules.
+// Links: docs/class-catalog.md
+
+#include "cli.hpp"
+#include "il/io/Parser.hpp"
+#include "il/verify/Verifier.hpp"
+#include "vm/VM.hpp"
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+using namespace il;
+
+/**
+ * @brief Run an IL program from file.
+ *
+ * @param argc Number of subcommand arguments (excluding `-run`).
+ * @param argv Argument list starting with the IL file path.
+ * @return Exit status code.
+ */
+int cmdRunIL(int argc, char **argv)
+{
+    if (argc < 1)
+    {
+        usage();
+        return 1;
+    }
+    std::string ilFile = argv[0];
+    bool trace = false;
+    std::string stdinPath;
+    uint64_t maxSteps = 0;
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+        if (arg == "--trace")
+        {
+            trace = true;
+        }
+        else if (arg == "--stdin-from" && i + 1 < argc)
+        {
+            stdinPath = argv[++i];
+        }
+        else if (arg == "--max-steps" && i + 1 < argc)
+        {
+            maxSteps = std::stoull(argv[++i]);
+        }
+        else if (arg == "--bounds-checks")
+        {
+            // Flag accepted for parity with front-end run mode.
+        }
+        else
+        {
+            usage();
+            return 1;
+        }
+    }
+    std::ifstream ifs(ilFile);
+    if (!ifs)
+    {
+        std::cerr << "unable to open " << ilFile << "\n";
+        return 1;
+    }
+    core::Module m;
+    if (!io::Parser::parse(ifs, m, std::cerr))
+        return 1;
+    if (!verify::Verifier::verify(m, std::cerr))
+        return 1;
+    if (!stdinPath.empty())
+    {
+        if (!freopen(stdinPath.c_str(), "r", stdin))
+        {
+            std::cerr << "unable to open stdin file\n";
+            return 1;
+        }
+    }
+    vm::VM vm(m, trace, maxSteps);
+    return static_cast<int>(vm.run());
+}

--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -1,38 +1,14 @@
 // File: src/tools/ilc/main.cpp
-// Purpose: Main driver for IL compiler and runner.
+// Purpose: Dispatcher for ilc subcommands.
 // Key invariants: None.
 // Ownership/Lifetime: Tool owns loaded modules.
 // Links: docs/class-catalog.md
 
-#include "Passes/Mem2Reg.h"
-#include "frontends/basic/ConstFolder.hpp"
-#include "frontends/basic/DiagnosticEmitter.hpp"
-#include "frontends/basic/Lowerer.hpp"
-#include "frontends/basic/Parser.hpp"
-#include "frontends/basic/SemanticAnalyzer.hpp"
-#include "il/io/Parser.hpp"
-#include "il/io/Serializer.hpp"
-#include "il/transform/ConstFold.hpp"
-#include "il/transform/DCE.hpp"
-#include "il/transform/PassManager.hpp"
-#include "il/transform/Peephole.hpp"
-#include "il/verify/Verifier.hpp"
-#include "support/source_manager.hpp"
-#include "vm/VM.hpp"
-#include <algorithm>
-#include <cstdint>
-#include <cstdio>
-#include <fstream>
+#include "cli.hpp"
 #include <iostream>
-#include <sstream>
 #include <string>
-#include <vector>
 
-using namespace il;
-using namespace il::frontends::basic;
-using namespace il::support;
-
-static void usage()
+void usage()
 {
     std::cerr << "ilc v0.1.0\n"
               << "Usage: ilc -run <file.il> [--trace] [--stdin-from <file>] [--max-steps N]"
@@ -50,265 +26,19 @@ int main(int argc, char **argv)
         usage();
         return 1;
     }
-
     std::string cmd = argv[1];
-    bool trace = false;
-
     if (cmd == "-run")
     {
-        if (argc < 3)
-        {
-            usage();
-            return 1;
-        }
-        std::string ilFile = argv[2];
-        std::string stdinPath;
-        uint64_t maxSteps = 0;
-        for (int i = 3; i < argc; ++i)
-        {
-            std::string arg = argv[i];
-            if (arg == "--trace")
-            {
-                trace = true;
-            }
-            else if (arg == "--stdin-from" && i + 1 < argc)
-            {
-                stdinPath = argv[++i];
-            }
-            else if (arg == "--max-steps" && i + 1 < argc)
-            {
-                maxSteps = std::stoull(argv[++i]);
-            }
-            else if (arg == "--bounds-checks")
-            {
-            }
-            else
-            {
-                usage();
-                return 1;
-            }
-        }
-        std::ifstream ifs(ilFile);
-        if (!ifs)
-        {
-            std::cerr << "unable to open " << ilFile << "\n";
-            return 1;
-        }
-        core::Module m;
-        if (!io::Parser::parse(ifs, m, std::cerr))
-            return 1;
-        if (!verify::Verifier::verify(m, std::cerr))
-            return 1;
-        if (!stdinPath.empty())
-        {
-            if (!freopen(stdinPath.c_str(), "r", stdin))
-            {
-                std::cerr << "unable to open stdin file\n";
-                return 1;
-            }
-        }
-        vm::VM vm(m, trace, maxSteps);
-        return static_cast<int>(vm.run());
+        return cmdRunIL(argc - 2, argv + 2);
     }
-
     if (cmd == "il-opt")
     {
-        if (argc < 5)
-        {
-            usage();
-            return 1;
-        }
-        std::string inFile = argv[2];
-        std::string outFile;
-        std::vector<std::string> passList;
-        bool passesExplicit = false;
-        bool noMem2Reg = false;
-        bool mem2regStats = false;
-        for (int i = 3; i < argc; ++i)
-        {
-            std::string arg = argv[i];
-            if (arg == "-o" && i + 1 < argc)
-            {
-                outFile = argv[++i];
-            }
-            else if (arg == "--passes" && i + 1 < argc)
-            {
-                std::string passes = argv[++i];
-                size_t pos = 0;
-                passesExplicit = true;
-                while (pos != std::string::npos)
-                {
-                    size_t comma = passes.find(',', pos);
-                    passList.push_back(passes.substr(pos, comma - pos));
-                    if (comma == std::string::npos)
-                        break;
-                    pos = comma + 1;
-                }
-            }
-            else if (arg == "--no-mem2reg")
-            {
-                noMem2Reg = true;
-            }
-            else if (arg == "--mem2reg-stats")
-            {
-                mem2regStats = true;
-            }
-            else
-            {
-                usage();
-                return 1;
-            }
-        }
-        if (!passesExplicit)
-        {
-            passList = {"mem2reg", "constfold", "peephole", "dce"};
-        }
-        if (noMem2Reg)
-        {
-            passList.erase(std::remove(passList.begin(), passList.end(), "mem2reg"),
-                           passList.end());
-        }
-        if (outFile.empty())
-        {
-            usage();
-            return 1;
-        }
-        std::ifstream ifs(inFile);
-        if (!ifs)
-        {
-            std::cerr << "unable to open " << inFile << "\n";
-            return 1;
-        }
-        core::Module m;
-        if (!io::Parser::parse(ifs, m, std::cerr))
-            return 1;
-        transform::PassManager pm;
-        pm.addPass("constfold", transform::constFold);
-        pm.addPass("peephole", transform::peephole);
-        pm.addPass("dce", transform::dce);
-        pm.addPass("mem2reg",
-                   [mem2regStats](core::Module &mod)
-                   {
-                       viper::passes::Mem2RegStats st;
-                       viper::passes::mem2reg(mod, mem2regStats ? &st : nullptr);
-                       if (mem2regStats)
-                       {
-                           std::cout << "mem2reg: promoted " << st.promotedVars
-                                     << ", removed loads " << st.removedLoads << ", removed stores "
-                                     << st.removedStores << "\n";
-                       }
-                   });
-        pm.run(m, passList);
-        std::ofstream ofs(outFile);
-        if (!ofs)
-        {
-            std::cerr << "unable to open " << outFile << "\n";
-            return 1;
-        }
-        io::Serializer::write(m, ofs, io::Serializer::Mode::Canonical);
-        return 0;
+        return cmdILOpt(argc - 2, argv + 2);
     }
-
-    if (cmd == "front" && argc >= 3)
+    if (cmd == "front" && argc >= 3 && std::string(argv[2]) == "basic")
     {
-        std::string lang = argv[2];
-        if (lang == "basic")
-        {
-            bool emitIl = false;
-            bool run = false;
-            std::string file;
-            std::string stdinPath;
-            uint64_t maxSteps = 0;
-            bool boundsChecks = false;
-            for (int i = 3; i < argc; ++i)
-            {
-                std::string arg = argv[i];
-                if (arg == "-emit-il" && i + 1 < argc)
-                {
-                    emitIl = true;
-                    file = argv[++i];
-                }
-                else if (arg == "-run" && i + 1 < argc)
-                {
-                    run = true;
-                    file = argv[++i];
-                }
-                else if (arg == "--trace")
-                {
-                    trace = true;
-                }
-                else if (arg == "--stdin-from" && i + 1 < argc)
-                {
-                    stdinPath = argv[++i];
-                }
-                else if (arg == "--max-steps" && i + 1 < argc)
-                {
-                    maxSteps = std::stoull(argv[++i]);
-                }
-                else if (arg == "--bounds-checks")
-                {
-                    boundsChecks = true;
-                }
-                else
-                {
-                    usage();
-                    return 1;
-                }
-            }
-            if ((emitIl == run) || file.empty())
-            {
-                usage();
-                return 1;
-            }
-
-            std::ifstream in(file);
-            if (!in)
-            {
-                std::cerr << "unable to open " << file << "\n";
-                return 1;
-            }
-            std::ostringstream ss;
-            ss << in.rdbuf();
-            std::string src = ss.str();
-            SourceManager sm;
-            uint32_t fid = sm.addFile(file);
-            Parser p(src, fid);
-            auto prog = p.parseProgram();
-            foldConstants(*prog);
-            support::DiagnosticEngine de;
-            DiagnosticEmitter em(de, sm);
-            em.addSource(fid, src);
-            SemanticAnalyzer sema(em);
-            sema.analyze(*prog);
-            if (em.errorCount() > 0)
-            {
-                em.printAll(std::cerr);
-                return 1;
-            }
-            Lowerer lower(boundsChecks);
-            core::Module m = lower.lower(*prog);
-
-            if (emitIl)
-            {
-                io::Serializer::write(m, std::cout);
-                return 0;
-            }
-
-            if (!verify::Verifier::verify(m, std::cerr))
-                return 1;
-            if (!stdinPath.empty())
-            {
-                if (!freopen(stdinPath.c_str(), "r", stdin))
-                {
-                    std::cerr << "unable to open stdin file\n";
-                    return 1;
-                }
-            }
-            vm::VM vm(m, trace, maxSteps);
-            return static_cast<int>(vm.run());
-        }
+        return cmdFrontBasic(argc - 3, argv + 3);
     }
-
     usage();
     return 1;
 }


### PR DESCRIPTION
## Summary
- split ilc main into tiny dispatcher and dedicated subcommand handlers
- add reusable BASIC→IL compilation helper
- document ilc's subcommand structure

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`
- `./build/src/tools/ilc/ilc --help`
- `./build/src/tools/ilc/ilc front basic -emit-il examples/basic/math_basics.bas`
- `./build/src/tools/ilc/ilc front basic -run examples/basic/math_basics.bas`
- `./build/src/tools/ilc/ilc -run examples/il/random_three.il`
- `./build/src/tools/ilc/ilc il-opt examples/il/random_three.il -o /tmp/out.il --passes dce`


------
https://chatgpt.com/codex/tasks/task_e_68b8fd6e96e48324b5a9ac3044354f7e