### PR TITLE
front/basic: standardize token skipping and diagnostic emission paths

### DIFF
--- a/docs/dev-frontend-basic.md
+++ b/docs/dev-frontend-basic.md
@@ -39,3 +39,10 @@ creates or looks up blocks through the lowering context, sets the builder's
 insert point, emits the condition and body, and finally branches to a merge
 block. Runtime externs required by a program are declared once up front via
 `declareRequiredRuntime`, keeping control-flow lowering focused on IL structure.
+
+## Diagnostics
+
+Token mismatches are reported using `DiagnosticEmitter::emitExpected`, which
+standardizes messages in the form `expected <token>, got <token>`. The parser's
+`expect` helper funnels all such errors through this single routine to keep
+wording and formatting consistent.

--- a/src/frontends/basic/DiagnosticEmitter.cpp
+++ b/src/frontends/basic/DiagnosticEmitter.cpp
@@ -32,6 +32,13 @@ void DiagnosticEmitter::emit(il::support::Severity sev,
     entries_.push_back({sev, std::move(code), std::move(message), loc, length});
 }
 
+void DiagnosticEmitter::emitExpected(TokenKind got, TokenKind expect, il::support::SourceLoc loc)
+{
+    std::string msg =
+        std::string("expected ") + tokenKindToString(expect) + ", got " + tokenKindToString(got);
+    emit(il::support::Severity::Error, "B0001", loc, 0, std::move(msg));
+}
+
 /// @brief Convert severity enum to human-readable string.
 /// @param s Severity to convert.
 /// @return Null-terminated severity name.

--- a/src/frontends/basic/DiagnosticEmitter.hpp
+++ b/src/frontends/basic/DiagnosticEmitter.hpp
@@ -5,6 +5,7 @@
 // Links: docs/class-catalog.md
 #pragma once
 
+#include "frontends/basic/Token.hpp"
 #include "support/diagnostics.hpp"
 #include "support/source_manager.hpp"
 #include <ostream>
@@ -42,6 +43,12 @@ class DiagnosticEmitter
               il::support::SourceLoc loc,
               uint32_t length,
               std::string message);
+
+    /// @brief Emit standardized "expected/ got" error.
+    /// @param got Actual token encountered.
+    /// @param expect Expected token kind.
+    /// @param loc Location of the unexpected token.
+    void emitExpected(TokenKind got, TokenKind expect, il::support::SourceLoc loc);
 
     /// @brief Print all diagnostics to @p os with source snippets.
     /// @param os Output stream.

--- a/src/frontends/basic/Lexer.cpp
+++ b/src/frontends/basic/Lexer.cpp
@@ -45,7 +45,7 @@ void Lexer::skipWhitespaceExceptNewline()
     while (!eof())
     {
         char c = peek();
-        if (c == ' ' || c == '\t' || c == '\r')
+        if (c != '\n' && std::isspace(static_cast<unsigned char>(c)))
         {
             get();
         }

--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -10,7 +10,8 @@
 namespace il::frontends::basic
 {
 
-Parser::Parser(std::string_view src, uint32_t file_id) : lexer_(src, file_id)
+Parser::Parser(std::string_view src, uint32_t file_id, DiagnosticEmitter *de)
+    : lexer_(src, file_id), de_(de)
 {
     tokens_.push_back(lexer_.next());
 }

--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -14,15 +14,18 @@
 namespace il::frontends::basic
 {
 
+class DiagnosticEmitter;
+
 class Parser
 {
   public:
-    Parser(std::string_view src, uint32_t file_id);
+    Parser(std::string_view src, uint32_t file_id, DiagnosticEmitter *de = nullptr);
     std::unique_ptr<Program> parseProgram();
 
   private:
     mutable Lexer lexer_;
     mutable std::vector<Token> tokens_;
+    DiagnosticEmitter *de_;
 
 #include "frontends/basic/Parser_Token.hpp"
 

--- a/src/frontends/basic/Parser_Token.cpp
+++ b/src/frontends/basic/Parser_Token.cpp
@@ -4,6 +4,7 @@
 // Ownership/Lifetime: Parser owns lexer and token buffer.
 // Links: docs/class-catalog.md
 
+#include "frontends/basic/DiagnosticEmitter.hpp"
 #include "frontends/basic/Parser.hpp"
 #include <cstdio>
 
@@ -36,7 +37,10 @@ Token Parser::expect(TokenKind k, const char *what)
     if (!at(k))
     {
         Token t = peek();
-        std::fprintf(stderr, "expected %s, got %s\n", what, tokenKindToString(t.kind));
+        if (de_)
+            de_->emitExpected(t.kind, k, t.loc);
+        else
+            std::fprintf(stderr, "expected %s, got %s\n", what, tokenKindToString(t.kind));
         syncToStmtBoundary();
         return t;
     }

--- a/src/frontends/basic/Parser_Token.hpp
+++ b/src/frontends/basic/Parser_Token.hpp
@@ -12,6 +12,7 @@ const Token &peek(int n = 0) const;
 /// @brief Consume and return the current token.
 Token consume();
 /// @brief Consume a token of kind @p k or report a mismatch.
+///        Mismatches are reported via DiagnosticEmitter when available.
 Token expect(TokenKind k, const char *what);
 /// @brief Advance to the next statement boundary token.
 void syncToStmtBoundary();


### PR DESCRIPTION
## Summary
- ensure lexer whitespace skipping excludes newlines
- funnel parser `expect` errors through new DiagnosticEmitter helper
- document diagnostic standardization

## Testing
- `cmake -S . -B build && cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b90367493c8324b6374a0c8ae18c2f