### PR TITLE
front/basic: standardize token skipping and diagnostic emission paths; no semantic changes

### DIFF
--- a/docs/dev-frontend-basic.md
+++ b/docs/dev-frontend-basic.md
@@ -10,11 +10,18 @@ The BASIC parser is split into focused components:
   - `bool at(TokenKind)`
   - `const Token &peek(int)`
   - `Token consume()`
-  - `Token expect(TokenKind, const char*)`
+  - `Token expect(TokenKind)`
   - `void syncToStmtBoundary()`
 
 This separation keeps statement logic clear and isolates token mechanics and
 expression handling.
+
+## Diagnostics
+
+`Parser::expect` now reports unexpected tokens via
+`DiagnosticEmitter::emitExpected`, producing a consistent "expected X, got Y"
+message. Each lexer invocation calls `skipWhitespaceExceptNewline` exactly once
+per token so newlines are preserved unless explicitly consumed.
 
 ## Constant Folding Rules
 

--- a/src/frontends/basic/DiagnosticEmitter.cpp
+++ b/src/frontends/basic/DiagnosticEmitter.cpp
@@ -32,6 +32,13 @@ void DiagnosticEmitter::emit(il::support::Severity sev,
     entries_.push_back({sev, std::move(code), std::move(message), loc, length});
 }
 
+void DiagnosticEmitter::emitExpected(TokenKind got, TokenKind expect, il::support::SourceLoc loc)
+{
+    std::string msg =
+        std::string("expected ") + tokenKindToString(expect) + ", got " + tokenKindToString(got);
+    emit(il::support::Severity::Error, "B0001", loc, 0, std::move(msg));
+}
+
 /// @brief Convert severity enum to human-readable string.
 /// @param s Severity to convert.
 /// @return Null-terminated severity name.

--- a/src/frontends/basic/DiagnosticEmitter.hpp
+++ b/src/frontends/basic/DiagnosticEmitter.hpp
@@ -5,6 +5,7 @@
 // Links: docs/class-catalog.md
 #pragma once
 
+#include "frontends/basic/Token.hpp"
 #include "support/diagnostics.hpp"
 #include "support/source_manager.hpp"
 #include <ostream>
@@ -42,6 +43,12 @@ class DiagnosticEmitter
               il::support::SourceLoc loc,
               uint32_t length,
               std::string message);
+
+    /// @brief Emit standardized "expected vs got" parse diagnostic.
+    /// @param got Actual token encountered.
+    /// @param expect Expected token kind.
+    /// @param loc Source location of the unexpected token.
+    void emitExpected(TokenKind got, TokenKind expect, il::support::SourceLoc loc);
 
     /// @brief Print all diagnostics to @p os with source snippets.
     /// @param os Output stream.

--- a/src/frontends/basic/Lexer.cpp
+++ b/src/frontends/basic/Lexer.cpp
@@ -180,22 +180,30 @@ Token Lexer::lexString()
 
 Token Lexer::next()
 {
+    // Skip leading spaces and tabs but preserve newlines for tokenization.
     skipWhitespaceExceptNewline();
-    il::support::SourceLoc loc{file_id_, line_, column_};
+
     if (eof())
-        return {TokenKind::EndOfFile, "", loc};
+        return {TokenKind::EndOfFile, "", {file_id_, line_, column_}};
+
     char c = peek();
+
+    // Handle newline explicitly so skipWhitespaceExceptNewline is called only once.
     if (c == '\n')
     {
+        il::support::SourceLoc loc{file_id_, line_, column_};
         get();
         return {TokenKind::EndOfLine, "\n", loc};
     }
+
     if (std::isdigit(c) || (c == '.' && pos_ + 1 < src_.size() && std::isdigit(src_[pos_ + 1])))
         return lexNumber();
     if (std::isalpha(c))
         return lexIdentifierOrKeyword();
     if (c == '"')
         return lexString();
+
+    il::support::SourceLoc loc{file_id_, line_, column_};
     get();
     switch (c)
     {

--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "frontends/basic/AST.hpp"
+#include "frontends/basic/DiagnosticEmitter.hpp"
 #include "frontends/basic/Lexer.hpp"
 #include <memory>
 #include <string_view>
@@ -17,12 +18,13 @@ namespace il::frontends::basic
 class Parser
 {
   public:
-    Parser(std::string_view src, uint32_t file_id);
+    Parser(std::string_view src, uint32_t file_id, DiagnosticEmitter *emitter = nullptr);
     std::unique_ptr<Program> parseProgram();
 
   private:
     mutable Lexer lexer_;
     mutable std::vector<Token> tokens_;
+    DiagnosticEmitter *emitter_ = nullptr;
 
 #include "frontends/basic/Parser_Token.hpp"
 

--- a/src/frontends/basic/Parser_Expr.cpp
+++ b/src/frontends/basic/Parser_Expr.cpp
@@ -159,15 +159,15 @@ ExprPtr Parser::parsePrimary()
         TokenKind tk = peek().kind;
         auto loc = peek().loc;
         consume();
-        expect(TokenKind::LParen, "(");
+        expect(TokenKind::LParen);
         auto arg = parseExpression();
         ExprPtr arg2;
         if (tk == TokenKind::KeywordPow)
         {
-            expect(TokenKind::Comma, ",");
+            expect(TokenKind::Comma);
             arg2 = parseExpression();
         }
-        expect(TokenKind::RParen, ")");
+        expect(TokenKind::RParen);
         auto call = std::make_unique<CallExpr>();
         call->loc = loc;
         if (tk == TokenKind::KeywordSqr)
@@ -193,8 +193,8 @@ ExprPtr Parser::parsePrimary()
     {
         auto loc = peek().loc;
         consume();
-        expect(TokenKind::LParen, "(");
-        expect(TokenKind::RParen, ")");
+        expect(TokenKind::LParen);
+        expect(TokenKind::RParen);
         auto call = std::make_unique<CallExpr>();
         call->loc = loc;
         call->builtin = CallExpr::Builtin::Rnd;
@@ -225,7 +225,7 @@ ExprPtr Parser::parsePrimary()
                         break;
                     }
                 }
-                expect(TokenKind::RParen, ")");
+                expect(TokenKind::RParen);
                 auto call = std::make_unique<CallExpr>();
                 call->loc = loc;
                 if (name == "LEN")
@@ -248,7 +248,7 @@ ExprPtr Parser::parsePrimary()
             else
             {
                 auto idx = parseExpression();
-                expect(TokenKind::RParen, ")");
+                expect(TokenKind::RParen);
                 auto arr = std::make_unique<ArrayExpr>();
                 arr->loc = loc;
                 arr->name = name;
@@ -265,7 +265,7 @@ ExprPtr Parser::parsePrimary()
     {
         consume();
         auto e = parseExpression();
-        expect(TokenKind::RParen, ")");
+        expect(TokenKind::RParen);
         return e;
     }
     auto e = std::make_unique<IntExpr>();

--- a/src/frontends/basic/Parser_Token.cpp
+++ b/src/frontends/basic/Parser_Token.cpp
@@ -4,6 +4,7 @@
 // Ownership/Lifetime: Parser owns lexer and token buffer.
 // Links: docs/class-catalog.md
 
+#include "frontends/basic/DiagnosticEmitter.hpp"
 #include "frontends/basic/Parser.hpp"
 #include <cstdio>
 
@@ -31,12 +32,20 @@ Token Parser::consume()
     return t;
 }
 
-Token Parser::expect(TokenKind k, const char *what)
+Token Parser::expect(TokenKind k)
 {
     if (!at(k))
     {
         Token t = peek();
-        std::fprintf(stderr, "expected %s, got %s\n", what, tokenKindToString(t.kind));
+        if (emitter_)
+        {
+            emitter_->emitExpected(t.kind, k, t.loc);
+        }
+        else
+        {
+            std::fprintf(
+                stderr, "expected %s, got %s\n", tokenKindToString(k), tokenKindToString(t.kind));
+        }
         syncToStmtBoundary();
         return t;
     }

--- a/src/frontends/basic/Parser_Token.hpp
+++ b/src/frontends/basic/Parser_Token.hpp
@@ -12,6 +12,6 @@ const Token &peek(int n = 0) const;
 /// @brief Consume and return the current token.
 Token consume();
 /// @brief Consume a token of kind @p k or report a mismatch.
-Token expect(TokenKind k, const char *what);
+Token expect(TokenKind k);
 /// @brief Advance to the next statement boundary token.
 void syncToStmtBoundary();


### PR DESCRIPTION
## Summary
- ensure lexer skips whitespace once per token while preserving newlines
- centralize "expected vs got" diagnostics via `DiagnosticEmitter::emitExpected`
- document standardized diagnostics in frontend notes

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b90367493c8324b6374a0c8ae18c2f