### PR TITLE
feat(vm): add label breakpoints

### DIFF
--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -11,6 +11,7 @@ Flags:
 - `--trace=il` — emit a line-per-instruction trace.
 - `--trace=src` — show source file, line, and column for each step; falls back to
   `<unknown>` when locations are missing.
+- `--break <Label>` — halt before executing block `<Label>`; may be used multiple times.
 
 Example:
 
@@ -19,6 +20,11 @@ $ ilc -run examples/il/trace_min.il --trace=il
   [IL] fn=@main blk=entry ip=#0 op=add 1, 2 -> %t0
   [IL] fn=@main blk=entry ip=#1 op=mul %t0, 3 -> %t1
   [IL] fn=@main blk=entry ip=#2 op=ret 0
+```
+
+```
+$ ilc -run examples/il/break_label.il --break L3
+  [BREAK] fn=@main blk=L3 reason=label
 ```
 
 ```

--- a/examples/il/break_label.il
+++ b/examples/il/break_label.il
@@ -1,0 +1,9 @@
+il 0.1
+
+func @main() -> i64 {
+entry:
+  br L3
+L3:
+  trap
+  ret 0
+}

--- a/lib/VM/CMakeLists.txt
+++ b/lib/VM/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(VMTrace Trace.cpp)
+add_library(VMTrace Trace.cpp Debug.cpp)
 target_link_libraries(VMTrace PUBLIC il_core rt support)
 target_include_directories(VMTrace PUBLIC ${CMAKE_SOURCE_DIR}/lib ${CMAKE_SOURCE_DIR}/src)

--- a/lib/VM/Debug.cpp
+++ b/lib/VM/Debug.cpp
@@ -1,0 +1,32 @@
+// File: lib/VM/Debug.cpp
+// Purpose: Implement breakpoint management for the VM.
+// Key invariants: Breakpoints are matched by exact label string.
+// Ownership/Lifetime: DebugCtrl owns all interned labels and breakpoints.
+// Links: docs/dev/vm.md
+
+#include "VM/Debug.h"
+
+namespace il::vm
+{
+
+il::support::Symbol DebugCtrl::internLabel(const std::string &lbl)
+{
+    return interner.intern(lbl);
+}
+
+void DebugCtrl::addBreak(il::support::Symbol lbl)
+{
+    bps.push_back({lbl});
+}
+
+bool DebugCtrl::shouldBreak(const il::core::BasicBlock &blk) const
+{
+    for (const auto &bp : bps)
+    {
+        if (interner.lookup(bp.label) == blk.label)
+            return true;
+    }
+    return false;
+}
+
+} // namespace il::vm

--- a/lib/VM/Debug.h
+++ b/lib/VM/Debug.h
@@ -1,0 +1,41 @@
+// File: lib/VM/Debug.h
+// Purpose: Manage VM breakpoints keyed by block labels.
+// Key invariants: Breakpoints compare exact block label strings.
+// Ownership/Lifetime: DebugCtrl owns interned label strings and breakpoint list.
+// Links: docs/dev/vm.md
+#pragma once
+
+#include "il/core/BasicBlock.hpp"
+#include "support/string_interner.hpp"
+#include "support/symbol.hpp"
+#include <string>
+#include <vector>
+
+namespace il::vm
+{
+
+/// @brief Label-based breakpoint.
+struct Breakpoint
+{
+    il::support::Symbol label; ///< Target block label.
+};
+
+/// @brief Collects breakpoints and evaluates block matches.
+class DebugCtrl
+{
+  public:
+    /// @brief Intern @p lbl and return its Symbol.
+    il::support::Symbol internLabel(const std::string &lbl);
+
+    /// @brief Add breakpoint for block label @p lbl.
+    void addBreak(il::support::Symbol lbl);
+
+    /// @brief Check if execution should break before entering @p blk.
+    bool shouldBreak(const il::core::BasicBlock &blk) const;
+
+  private:
+    il::support::StringInterner interner; ///< Interns breakpoint labels.
+    std::vector<Breakpoint> bps;          ///< Active breakpoints.
+};
+
+} // namespace il::vm

--- a/src/tools/ilc/cmd_run_il.cpp
+++ b/src/tools/ilc/cmd_run_il.cpp
@@ -4,6 +4,7 @@
 // Ownership/Lifetime: Tool owns loaded modules.
 // Links: docs/class-catalog.md
 
+#include "VM/Debug.h"
 #include "VM/Trace.h"
 #include "cli.hpp"
 #include "il/io/Parser.hpp"
@@ -33,6 +34,7 @@ int cmdRunIL(int argc, char **argv)
     }
     std::string ilFile = argv[0];
     vm::TraceConfig traceCfg{};
+    vm::DebugCtrl debugCtrl{};
     std::string stdinPath;
     uint64_t maxSteps = 0;
     for (int i = 1; i < argc; ++i)
@@ -57,6 +59,11 @@ int cmdRunIL(int argc, char **argv)
         else if (arg == "--bounds-checks")
         {
             // Flag accepted for parity with front-end run mode.
+        }
+        else if (arg == "--break" && i + 1 < argc)
+        {
+            auto sym = debugCtrl.internLabel(argv[++i]);
+            debugCtrl.addBreak(sym);
         }
         else
         {
@@ -83,6 +90,6 @@ int cmdRunIL(int argc, char **argv)
             return 1;
         }
     }
-    vm::VM vm(m, traceCfg, maxSteps);
+    vm::VM vm(m, traceCfg, maxSteps, &debugCtrl);
     return static_cast<int>(vm.run());
 }

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -17,7 +17,8 @@ using namespace il::core;
 namespace il::vm
 {
 
-VM::VM(const Module &m, TraceConfig tc, uint64_t ms) : mod(m), tracer(tc), maxSteps(ms)
+VM::VM(const Module &m, TraceConfig tc, uint64_t ms, const DebugCtrl *dbg)
+    : mod(m), tracer(tc), maxSteps(ms), debug(dbg)
 {
     for (const auto &f : m.functions)
         fnMap[f.name] = &f;
@@ -90,6 +91,11 @@ int64_t VM::execFunction(const Function &fn)
                 }
             }
             fr.params.clear();
+            if (debug && debug->shouldBreak(*bb))
+            {
+                std::cerr << "[BREAK] fn=@" << fn.name << " blk=" << bb->label << " reason=label\n";
+                return 0;
+            }
         }
         const Instr &in = bb->instructions[ip];
         tracer.onStep(in, fr);

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -5,6 +5,7 @@
 // Links: docs/il-spec.md
 #pragma once
 
+#include "VM/Debug.h"
 #include "VM/Trace.h"
 #include "il/core/Module.hpp"
 #include "rt.hpp"
@@ -46,7 +47,11 @@ class VM
     /// @param m IL module to execute.
     /// @param tc Trace configuration.
     /// @param maxSteps Abort after executing @p maxSteps instructions (0 = unlimited).
-    VM(const il::core::Module &m, TraceConfig tc = {}, uint64_t maxSteps = 0);
+    /// @param dbg Optional debug controller for breakpoints.
+    VM(const il::core::Module &m,
+       TraceConfig tc = {},
+       uint64_t maxSteps = 0,
+       const DebugCtrl *dbg = nullptr);
 
     /// @brief Execute the module's entry function.
     /// @return Exit code from main function.
@@ -59,6 +64,7 @@ class VM
     uint64_t steps = 0;          ///< Executed instruction count
     std::unordered_map<std::string, const il::core::Function *> fnMap; ///< Name lookup
     std::unordered_map<std::string, rt_str> strMap;                    ///< String pool
+    const DebugCtrl *debug;                                            ///< Breakpoint controller
 
     /// @brief Execute function @p fn.
     /// @param fn Function to execute.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,8 @@ add_test(NAME test_il_utils COMMAND test_il_utils)
 
 add_executable(test_vm_trace_il vm/TraceILTests.cpp)
 add_test(NAME test_vm_trace_il COMMAND test_vm_trace_il $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/trace_min.il ${CMAKE_SOURCE_DIR}/tests/vm/trace_min.trace)
+add_executable(test_vm_break_label vm/BreakLabelTests.cpp)
+add_test(NAME test_vm_break_label COMMAND test_vm_break_label $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/break_label.il)
 
 add_executable(test_analysis_cfg analysis/CFGTests.cpp)
 target_link_libraries(test_analysis_cfg PRIVATE Analysis il_build)

--- a/tests/vm/BreakLabelTests.cpp
+++ b/tests/vm/BreakLabelTests.cpp
@@ -1,0 +1,35 @@
+// File: tests/vm/BreakLabelTests.cpp
+// Purpose: Verify VM halts on label breakpoints before executing block code.
+// Key invariants: Breakpoint message matches expected format and block body not run.
+// Ownership/Lifetime: Test manages temporary output files.
+// Links: docs/testing.md
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+int main(int argc, char **argv)
+{
+    if (argc != 3)
+    {
+        std::cerr << "usage: BreakLabelTests <ilc> <il file>\n";
+        return 1;
+    }
+    std::string ilc = argv[1];
+    std::string ilFile = argv[2];
+    std::string outFile = "break.out";
+    std::string cmd = ilc + " -run " + ilFile + " --break L3 2>" + outFile;
+    if (std::system(cmd.c_str()) != 0)
+        return 1;
+    std::ifstream out(outFile);
+    std::string line;
+    if (!std::getline(out, line))
+        return 1;
+    if (line != "[BREAK] fn=@main blk=L3 reason=label")
+        return 1;
+    if (out.peek() != EOF)
+        return 1;
+    std::remove(outFile.c_str());
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add DebugCtrl to manage block label breakpoints
- support multiple `--break <Label>` flags in ilc
- halt VM on matching block entry and emit `[BREAK]`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68b9a05ba54c83248b38d0902f0f5750