### PR TITLE
feat(vm): add label breakpoints

### DIFF
--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -11,6 +11,7 @@ Flags:
 - `--trace=il` — emit a line-per-instruction trace.
 - `--trace=src` — show source file, line, and column for each step; falls back to
   `<unknown>` when locations are missing.
+- `--break <Label>` — halt before executing the first instruction of block `<Label>`; may be repeated.
 
 Example:
 

--- a/examples/il/break_label.il
+++ b/examples/il/break_label.il
@@ -1,0 +1,9 @@
+il 0.1
+
+func @main() -> i64 {
+entry:
+  br L3
+L3:
+  trap
+  ret 0
+}

--- a/lib/VM/CMakeLists.txt
+++ b/lib/VM/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(VMTrace Trace.cpp)
+add_library(VMTrace Trace.cpp Debug.cpp)
 target_link_libraries(VMTrace PUBLIC il_core rt support)
 target_include_directories(VMTrace PUBLIC ${CMAKE_SOURCE_DIR}/lib ${CMAKE_SOURCE_DIR}/src)

--- a/lib/VM/Debug.cpp
+++ b/lib/VM/Debug.cpp
@@ -1,0 +1,28 @@
+// File: lib/VM/Debug.cpp
+// Purpose: Implement breakpoint control for the VM.
+// Key invariants: Interned labels uniquely identify breakpoints.
+// Ownership/Lifetime: DebugCtrl owns its interner and breakpoint set.
+// Links: docs/dev/vm.md
+#include "VM/Debug.h"
+
+namespace il::vm
+{
+
+il::support::Symbol DebugCtrl::internLabel(std::string_view label)
+{
+    return interner_.intern(label);
+}
+
+void DebugCtrl::addBreak(il::support::Symbol sym)
+{
+    if (sym)
+        breaks_.insert(sym);
+}
+
+bool DebugCtrl::shouldBreak(const il::core::BasicBlock &blk) const
+{
+    il::support::Symbol sym = interner_.intern(blk.label);
+    return breaks_.count(sym) != 0;
+}
+
+} // namespace il::vm

--- a/lib/VM/Debug.h
+++ b/lib/VM/Debug.h
@@ -1,0 +1,41 @@
+// File: lib/VM/Debug.h
+// Purpose: Declare breakpoint control for the VM.
+// Key invariants: Breakpoints are keyed by interned block labels.
+// Ownership/Lifetime: DebugCtrl owns its interner and breakpoint set.
+// Links: docs/dev/vm.md
+#pragma once
+
+#include "il/core/BasicBlock.hpp"
+#include "support/string_interner.hpp"
+#include "support/symbol.hpp"
+#include <string_view>
+#include <unordered_set>
+
+namespace il::vm
+{
+
+/// @brief Breakpoint identified by a block label symbol.
+struct Breakpoint
+{
+    il::support::Symbol label; ///< Target block label
+};
+
+/// @brief Controller for debug breakpoints.
+class DebugCtrl
+{
+  public:
+    /// @brief Intern @p label and return its symbol.
+    il::support::Symbol internLabel(std::string_view label);
+
+    /// @brief Add breakpoint for block label @p sym.
+    void addBreak(il::support::Symbol sym);
+
+    /// @brief Check whether entering @p blk triggers a breakpoint.
+    bool shouldBreak(const il::core::BasicBlock &blk) const;
+
+  private:
+    mutable il::support::StringInterner interner_;   ///< Label interner
+    std::unordered_set<il::support::Symbol> breaks_; ///< Registered breakpoints
+};
+
+} // namespace il::vm

--- a/src/tools/ilc/cmd_run_il.cpp
+++ b/src/tools/ilc/cmd_run_il.cpp
@@ -4,6 +4,7 @@
 // Ownership/Lifetime: Tool owns loaded modules.
 // Links: docs/class-catalog.md
 
+#include "VM/Debug.h"
 #include "VM/Trace.h"
 #include "cli.hpp"
 #include "il/io/Parser.hpp"
@@ -14,6 +15,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <utility>
 
 using namespace il;
 
@@ -35,6 +37,7 @@ int cmdRunIL(int argc, char **argv)
     vm::TraceConfig traceCfg{};
     std::string stdinPath;
     uint64_t maxSteps = 0;
+    vm::DebugCtrl dbg;
     for (int i = 1; i < argc; ++i)
     {
         std::string arg = argv[i];
@@ -53,6 +56,11 @@ int cmdRunIL(int argc, char **argv)
         else if (arg == "--max-steps" && i + 1 < argc)
         {
             maxSteps = std::stoull(argv[++i]);
+        }
+        else if (arg == "--break" && i + 1 < argc)
+        {
+            auto sym = dbg.internLabel(argv[++i]);
+            dbg.addBreak(sym);
         }
         else if (arg == "--bounds-checks")
         {
@@ -83,6 +91,6 @@ int cmdRunIL(int argc, char **argv)
             return 1;
         }
     }
-    vm::VM vm(m, traceCfg, maxSteps);
+    vm::VM vm(m, traceCfg, maxSteps, std::move(dbg));
     return static_cast<int>(vm.run());
 }

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -11,13 +11,15 @@
 #include <cassert>
 #include <cstring>
 #include <iostream>
+#include <utility>
 
 using namespace il::core;
 
 namespace il::vm
 {
 
-VM::VM(const Module &m, TraceConfig tc, uint64_t ms) : mod(m), tracer(tc), maxSteps(ms)
+VM::VM(const Module &m, TraceConfig tc, uint64_t ms, DebugCtrl dbg)
+    : mod(m), tracer(tc), debug(std::move(dbg)), maxSteps(ms)
 {
     for (const auto &f : m.functions)
         fnMap[f.name] = &f;
@@ -79,6 +81,13 @@ int64_t VM::execFunction(const Function &fn)
         }
         if (ip == 0)
         {
+            if (debug.shouldBreak(*bb))
+            {
+                std::cerr << "[BREAK] fn=@" << fr.func->name << " blk=" << bb->label
+                          << " reason=label\n";
+                return 0;
+            }
+
             for (const auto &p : bb->params)
             {
                 auto it = fr.params.find(p.id);

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -5,6 +5,7 @@
 // Links: docs/il-spec.md
 #pragma once
 
+#include "VM/Debug.h"
 #include "VM/Trace.h"
 #include "il/core/Module.hpp"
 #include "rt.hpp"
@@ -46,7 +47,7 @@ class VM
     /// @param m IL module to execute.
     /// @param tc Trace configuration.
     /// @param maxSteps Abort after executing @p maxSteps instructions (0 = unlimited).
-    VM(const il::core::Module &m, TraceConfig tc = {}, uint64_t maxSteps = 0);
+    VM(const il::core::Module &m, TraceConfig tc = {}, uint64_t maxSteps = 0, DebugCtrl dbg = {});
 
     /// @brief Execute the module's entry function.
     /// @return Exit code from main function.
@@ -55,6 +56,7 @@ class VM
   private:
     const il::core::Module &mod; ///< Module to execute
     TraceSink tracer;            ///< Trace output sink
+    DebugCtrl debug;             ///< Breakpoint controller
     uint64_t maxSteps;           ///< Step limit; 0 means unlimited
     uint64_t steps = 0;          ///< Executed instruction count
     std::unordered_map<std::string, const il::core::Function *> fnMap; ///< Name lookup

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,9 @@ add_test(NAME test_il_utils COMMAND test_il_utils)
 
 add_executable(test_vm_trace_il vm/TraceILTests.cpp)
 add_test(NAME test_vm_trace_il COMMAND test_vm_trace_il $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/trace_min.il ${CMAKE_SOURCE_DIR}/tests/vm/trace_min.trace)
+add_executable(test_vm_break_label vm/BreakLabelTests.cpp)
+add_test(NAME test_vm_break_label COMMAND test_vm_break_label $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/break_label.il)
+
 
 add_executable(test_analysis_cfg analysis/CFGTests.cpp)
 target_link_libraries(test_analysis_cfg PRIVATE Analysis il_build)

--- a/tests/vm/BreakLabelTests.cpp
+++ b/tests/vm/BreakLabelTests.cpp
@@ -1,0 +1,44 @@
+// File: tests/vm/BreakLabelTests.cpp
+// Purpose: Verify that label breakpoints halt execution before block entry.
+// Key invariants: VM prints a single BREAK line and executes no block instructions.
+// Ownership/Lifetime: Test creates temporary output file.
+// Links: docs/testing.md
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+int main(int argc, char **argv)
+{
+    if (argc != 3)
+    {
+        std::cerr << "usage: BreakLabelTests <ilc> <il file>\n";
+        return 1;
+    }
+    std::string ilc = argv[1];
+    std::string ilFile = argv[2];
+    std::string outFile = "break.out";
+    std::string cmd = ilc + " -run " + ilFile + " --break L3 2>" + outFile;
+    if (std::system(cmd.c_str()) != 0)
+        return 1;
+    std::ifstream out(outFile);
+    std::string line;
+    if (!std::getline(out, line))
+    {
+        std::cerr << "no break output\n";
+        return 1;
+    }
+    if (line != "[BREAK] fn=@main blk=L3 reason=label")
+    {
+        std::cerr << "unexpected break line: " << line << "\n";
+        return 1;
+    }
+    if (std::getline(out, line))
+    {
+        std::cerr << "extra output\n";
+        return 1;
+    }
+    std::remove(outFile.c_str());
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add DebugCtrl for label breakpoints
- allow multiple `--break` labels in `ilc -run`
- stop VM before executing break block and emit a `[BREAK]` line

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b9a05ba54c83248b38d0902f0f5750