### PR TITLE
feat(cli): add step/continue flags and breakpoint exit code

### DIFF
--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -13,6 +13,16 @@ Flags:
   `<unknown>` when locations are missing.
 - `--break <Label>` — halt before executing the first instruction of block `<Label>`; may be repeated.
 - `--debug-cmds <file>` — read debugger actions from `<file>` when a breakpoint is hit.
+- `--step` — start in debug mode with an implicit breakpoint at `entry`.
+- `--continue` — ignore all breakpoints.
+
+Exit codes:
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | Program completed successfully |
+| 10 | Halted at a breakpoint with no debug script |
+| >0 | Runtime trap or error |
 
 Example:
 

--- a/src/tools/ilc/cmd_run_il.cpp
+++ b/src/tools/ilc/cmd_run_il.cpp
@@ -41,6 +41,8 @@ int cmdRunIL(int argc, char **argv)
     uint64_t maxSteps = 0;
     vm::DebugCtrl dbg;
     std::unique_ptr<vm::DebugScript> script;
+    bool step = false;
+    bool cont = false;
     for (int i = 1; i < argc; ++i)
     {
         std::string arg = argv[i];
@@ -69,6 +71,14 @@ int cmdRunIL(int argc, char **argv)
         {
             script = std::make_unique<vm::DebugScript>(argv[++i]);
         }
+        else if (arg == "--step")
+        {
+            step = true;
+        }
+        else if (arg == "--continue")
+        {
+            cont = true;
+        }
         else if (arg == "--bounds-checks")
         {
             // Flag accepted for parity with front-end run mode.
@@ -78,6 +88,16 @@ int cmdRunIL(int argc, char **argv)
             usage();
             return 1;
         }
+    }
+    if (cont)
+    {
+        dbg = vm::DebugCtrl{};
+        script.reset();
+    }
+    else if (step)
+    {
+        auto sym = dbg.internLabel("entry");
+        dbg.addBreak(sym);
     }
     std::ifstream ifs(ilFile);
     if (!ifs)

--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -12,6 +12,7 @@ void usage()
 {
     std::cerr << "ilc v0.1.0\n"
               << "Usage: ilc -run <file.il> [--trace=il|src] [--stdin-from <file>] [--max-steps N]"
+                 " [--break <Label>] [--debug-cmds <file>] [--step] [--continue]"
                  " [--bounds-checks]\n"
               << "       ilc front basic -emit-il <file.bas> [--bounds-checks]\n"
               << "       ilc front basic -run <file.bas> [--trace=il|src] [--stdin-from <file>] "

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -88,7 +88,7 @@ int64_t VM::execFunction(const Function &fn)
                 std::cerr << "[BREAK] fn=@" << fr.func->name << " blk=" << bb->label
                           << " reason=label\n";
                 if (!script)
-                    return 0;
+                    return 10;
                 auto act = script->nextAction();
                 if (act.kind == DebugActionKind::Step)
                     stepBudget = act.count;
@@ -609,7 +609,7 @@ int64_t VM::execFunction(const Function &fn)
                 std::cerr << "[BREAK] fn=@" << fr.func->name << " blk=" << bb->label
                           << " reason=step\n";
                 if (!script)
-                    return 0;
+                    return 10;
                 auto act = script->nextAction();
                 if (act.kind == DebugActionKind::Step)
                     stepBudget = act.count;

--- a/tests/vm/BreakLabelTests.cpp
+++ b/tests/vm/BreakLabelTests.cpp
@@ -20,7 +20,8 @@ int main(int argc, char **argv)
     std::string ilFile = argv[2];
     std::string outFile = "break.out";
     std::string cmd = ilc + " -run " + ilFile + " --break L3 2>" + outFile;
-    if (std::system(cmd.c_str()) != 0)
+    int rc = std::system(cmd.c_str());
+    if ((rc >> 8) != 10)
         return 1;
     std::ifstream out(outFile);
     std::string line;


### PR DESCRIPTION
## Summary
- support `--step` to break at entry and `--continue` to bypass breakpoints
- standardize breakpoint halt exit code to 10
- document new flags and exit codes

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b9a9f3e3c0832497e956da221f6e99