### PR TITLE
feat(vm): add scalar watch support

### DIFF
--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -16,6 +16,7 @@ Flags:
 | `--debug-cmds <file>` | read debugger actions from `file` when a breakpoint is hit. |
 | `--step` | enter debug mode, break at entry, and step one instruction. |
 | `--continue` | ignore breakpoints and run to completion. |
+| `--watch <name>` | print when scalar `name` changes; may be repeated. |
 
 Example:
 
@@ -43,6 +44,16 @@ script:
 
 ```
 ilc -run examples/il/debug_script.il --break L3 --trace=il --debug-cmds examples/il/debug_script.txt
+```
+
+### Watching scalars
+
+Use `--watch` to monitor scalar IL variables by name:
+
+```
+ilc -run examples/il/watch_scalars.il --watch x
+  [WATCH] x=i64:1  (fn=@main blk=entry ip=#1)
+  [WATCH] x=i64:2  (fn=@main blk=entry ip=#3)
 ```
 
 ### Exit codes

--- a/examples/il/watch_scalars.il
+++ b/examples/il/watch_scalars.il
@@ -1,0 +1,10 @@
+il 0.1
+
+func @main() -> i64 {
+entry:
+  %x = alloca 8
+  store i64, %x, 1
+  store i64, %x, 1
+  store i64, %x, 2
+  ret 0
+}

--- a/lib/VM/Debug.cpp
+++ b/lib/VM/Debug.cpp
@@ -4,6 +4,7 @@
 // Ownership/Lifetime: DebugCtrl owns its interner and breakpoint set.
 // Links: docs/dev/vm.md
 #include "VM/Debug.h"
+#include <iostream>
 
 namespace il::vm
 {
@@ -23,6 +24,56 @@ bool DebugCtrl::shouldBreak(const il::core::BasicBlock &blk) const
 {
     il::support::Symbol sym = interner_.intern(blk.label);
     return breaks_.count(sym) != 0;
+}
+
+void DebugCtrl::addWatch(std::string_view name)
+{
+    il::support::Symbol sym = interner_.intern(name);
+    if (sym)
+        watches_[sym];
+}
+
+void DebugCtrl::onStore(std::string_view name,
+                        il::core::Type::Kind ty,
+                        int64_t i64,
+                        double f64,
+                        std::string_view fn,
+                        std::string_view blk,
+                        size_t ip)
+{
+    il::support::Symbol sym = interner_.intern(name);
+    auto it = watches_.find(sym);
+    if (it == watches_.end())
+        return;
+    WatchEntry &w = it->second;
+    if (ty != il::core::Type::Kind::I1 && ty != il::core::Type::Kind::I64 &&
+        ty != il::core::Type::Kind::F64)
+    {
+        std::cerr << "[WATCH] " << name << "=[unsupported]  (fn=@" << fn << " blk=" << blk
+                  << " ip=#" << ip << ")\n";
+        return;
+    }
+    bool changed = !w.hasValue;
+    if (ty == il::core::Type::Kind::F64)
+    {
+        if (w.hasValue && w.f64 != f64)
+            changed = true;
+        if (changed)
+            std::cerr << "[WATCH] " << name << "=" << il::core::kindToString(ty) << ":" << f64
+                      << "  (fn=@" << fn << " blk=" << blk << " ip=#" << ip << ")\n";
+        w.f64 = f64;
+    }
+    else
+    {
+        if (w.hasValue && w.i64 != i64)
+            changed = true;
+        if (changed)
+            std::cerr << "[WATCH] " << name << "=" << il::core::kindToString(ty) << ":" << i64
+                      << "  (fn=@" << fn << " blk=" << blk << " ip=#" << ip << ")\n";
+        w.i64 = i64;
+    }
+    w.type = ty;
+    w.hasValue = true;
 }
 
 } // namespace il::vm

--- a/lib/VM/Debug.h
+++ b/lib/VM/Debug.h
@@ -6,9 +6,11 @@
 #pragma once
 
 #include "il/core/BasicBlock.hpp"
+#include "il/core/Type.hpp"
 #include "support/string_interner.hpp"
 #include "support/symbol.hpp"
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace il::vm
@@ -33,9 +35,31 @@ class DebugCtrl
     /// @brief Check whether entering @p blk triggers a breakpoint.
     bool shouldBreak(const il::core::BasicBlock &blk) const;
 
+    /// @brief Register a watch on variable @p name.
+    void addWatch(std::string_view name);
+
+    /// @brief Record store to watched variable.
+    void onStore(std::string_view name,
+                 il::core::Type::Kind ty,
+                 int64_t i64,
+                 double f64,
+                 std::string_view fn,
+                 std::string_view blk,
+                 size_t ip);
+
   private:
     mutable il::support::StringInterner interner_;   ///< Label interner
     std::unordered_set<il::support::Symbol> breaks_; ///< Registered breakpoints
+
+    struct WatchEntry
+    {
+        il::core::Type::Kind type = il::core::Type::Kind::Void;
+        int64_t i64 = 0;
+        double f64 = 0.0;
+        bool hasValue = false;
+    };
+
+    std::unordered_map<il::support::Symbol, WatchEntry> watches_; ///< Watched variables
 };
 
 } // namespace il::vm

--- a/src/il/build/IRBuilder.cpp
+++ b/src/il/build/IRBuilder.cpp
@@ -28,7 +28,7 @@ Function &IRBuilder::startFunction(const std::string &name,
                                    Type ret,
                                    const std::vector<Param> &params)
 {
-    mod.functions.push_back({name, ret, {}, {}});
+    mod.functions.push_back({name, ret, {}, {}, {}});
     curFunc = &mod.functions.back();
     curBlock = nullptr;
     nextTemp = 0;
@@ -38,6 +38,9 @@ Function &IRBuilder::startFunction(const std::string &name,
         np.id = nextTemp++;
         curFunc->params.push_back(np);
     }
+    curFunc->valueNames.resize(nextTemp);
+    for (const auto &p : curFunc->params)
+        curFunc->valueNames[p.id] = p.name;
     return *curFunc;
 }
 
@@ -52,6 +55,9 @@ BasicBlock &IRBuilder::createBlock(Function &fn,
         Param np = p;
         np.id = nextTemp++;
         bb.params.push_back(np);
+        if (fn.valueNames.size() <= np.id)
+            fn.valueNames.resize(np.id + 1);
+        fn.valueNames[np.id] = np.name;
     }
     return bb;
 }

--- a/src/il/core/Function.hpp
+++ b/src/il/core/Function.hpp
@@ -21,6 +21,7 @@ struct Function
     Type retType;
     std::vector<Param> params;
     std::vector<BasicBlock> blocks;
+    std::vector<std::string> valueNames; ///< Temp id to original name mapping
 };
 
 } // namespace il::core

--- a/src/tools/ilc/cmd_run_il.cpp
+++ b/src/tools/ilc/cmd_run_il.cpp
@@ -84,6 +84,10 @@ int cmdRunIL(int argc, char **argv)
         {
             // Flag accepted for parity with front-end run mode.
         }
+        else if (arg == "--watch" && i + 1 < argc)
+        {
+            dbg.addWatch(argv[++i]);
+        }
         else
         {
             usage();

--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -12,7 +12,7 @@ void usage()
 {
     std::cerr << "ilc v0.1.0\n"
               << "Usage: ilc -run <file.il> [--trace=il|src] [--stdin-from <file>] [--max-steps N]"
-                 " [--bounds-checks]\n"
+                 " [--watch name]* [--bounds-checks]\n"
               << "       ilc front basic -emit-il <file.bas> [--bounds-checks]\n"
               << "       ilc front basic -run <file.bas> [--trace=il|src] [--stdin-from <file>] "
                  "[--max-steps N] [--bounds-checks]\n"

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -103,6 +103,13 @@ int64_t VM::execFunction(const Function &fn)
                     if (fr.regs.size() <= p.id)
                         fr.regs.resize(p.id + 1);
                     fr.regs[p.id] = it->second;
+                    debug.onStore(p.name,
+                                  p.type.kind,
+                                  fr.regs[p.id].i64,
+                                  fr.regs[p.id].f64,
+                                  fr.func->name,
+                                  bb->label,
+                                  0);
                 }
             }
             fr.params.clear();
@@ -165,6 +172,17 @@ int64_t VM::execFunction(const Function &fn)
                     *reinterpret_cast<rt_str *>(ptr) = val.str;
                 else if (in.type.kind == Type::Kind::Ptr)
                     *reinterpret_cast<void **>(ptr) = val.ptr;
+                if (in.operands[0].kind == Value::Kind::Temp)
+                {
+                    unsigned id = in.operands[0].id;
+                    if (id < fr.func->valueNames.size())
+                    {
+                        const std::string &nm = fr.func->valueNames[id];
+                        if (!nm.empty())
+                            debug.onStore(
+                                nm, in.type.kind, val.i64, val.f64, fr.func->name, bb->label, ip);
+                    }
+                }
                 break;
             }
             case Opcode::Add:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,8 @@ add_executable(test_vm_break_label vm/BreakLabelTests.cpp)
 add_test(NAME test_vm_break_label COMMAND test_vm_break_label $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/break_label.il)
 add_executable(test_vm_debug_script vm/DebugScriptTests.cpp)
 add_test(NAME test_vm_debug_script COMMAND test_vm_debug_script $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/debug_script.il ${CMAKE_SOURCE_DIR}/examples/il/debug_script.txt)
+add_executable(test_vm_watch vm/WatchTests.cpp)
+add_test(NAME test_vm_watch COMMAND test_vm_watch $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/tests/vm/WatchTests.il)
 
 
 add_executable(test_analysis_cfg analysis/CFGTests.cpp)

--- a/tests/vm/WatchTests.cpp
+++ b/tests/vm/WatchTests.cpp
@@ -1,0 +1,44 @@
+// File: tests/vm/WatchTests.cpp
+// Purpose: Verify watched scalars print only on value changes.
+// Key invariants: Output lines appear only when the value differs.
+// Ownership/Lifetime: Test creates and removes a temporary file.
+// Links: docs/testing.md
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main(int argc, char **argv)
+{
+    if (argc != 3)
+    {
+        std::cerr << "usage: WatchTests <ilc> <il file>\n";
+        return 1;
+    }
+    std::string ilc = argv[1];
+    std::string ilFile = argv[2];
+    std::string outFile = "watch.out";
+    std::string cmd = ilc + " -run " + ilFile + " --watch x 2>" + outFile;
+    if (std::system(cmd.c_str()) != 0)
+        return 1;
+    std::ifstream out(outFile);
+    std::vector<std::string> lines;
+    std::string line;
+    while (std::getline(out, line))
+        lines.push_back(line);
+    if (lines.size() != 2)
+    {
+        std::cerr << "unexpected line count\n";
+        return 1;
+    }
+    if (lines[0] != "[WATCH] x=i64:1  (fn=@main blk=entry ip=#1)" ||
+        lines[1] != "[WATCH] x=i64:2  (fn=@main blk=entry ip=#3)")
+    {
+        std::cerr << "unexpected watch output\n";
+        return 1;
+    }
+    std::remove(outFile.c_str());
+    return 0;
+}

--- a/tests/vm/WatchTests.il
+++ b/tests/vm/WatchTests.il
@@ -1,0 +1,11 @@
+il 0.1
+
+func @main() -> i64 {
+entry:
+  %x = alloca 8
+  store i64, %x, 1
+  store i64, %x, 1
+  store i64, %x, 2
+  store i64, %x, 2
+  ret 0
+}


### PR DESCRIPTION
## Summary
- allow `--watch` flag to track scalar variable changes
- capture and report watched stores in the VM
- document and test new watch functionality

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b9af3cec188324b06aae614474e5c0