### PR TITLE
Add VM execution summary flags

### DIFF
--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -17,6 +17,8 @@ Flags:
 | `--step` | enter debug mode, break at entry, and step one instruction. |
 | `--continue` | ignore breakpoints and run to completion. |
 | `--watch <name>` | print when scalar `name` changes; may be repeated. |
+| `--count` | print total instructions executed. |
+| `--time` | print wall-clock execution time in milliseconds (may vary between runs). |
 
 Example:
 
@@ -25,6 +27,13 @@ $ ilc -run examples/il/trace_min.il --trace=il
   [IL] fn=@main blk=entry ip=#0 op=add 1, 2 -> %t0
   [IL] fn=@main blk=entry ip=#1 op=mul %t0, 3 -> %t1
   [IL] fn=@main blk=entry ip=#2 op=ret 0
+```
+
+Using `--count` and `--time` prints a summary line at program exit:
+
+```
+$ ilc -run examples/il/summary.il --count --time
+[SUMMARY] instr=3 time_ms=0.01
 ```
 
 ### Non-interactive debugging with --debug-cmds

--- a/examples/il/summary.il
+++ b/examples/il/summary.il
@@ -1,0 +1,8 @@
+il 0.1
+
+func @main() -> i64 {
+entry:
+  %t0 = add 1, 2
+  %t1 = mul %t0, 3
+  ret 0
+}

--- a/src/tools/ilc/cmd_run_il.cpp
+++ b/src/tools/ilc/cmd_run_il.cpp
@@ -12,6 +12,7 @@
 #include "il/verify/Verifier.hpp"
 #include "vm/VM.hpp"
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <fstream>
@@ -44,6 +45,8 @@ int cmdRunIL(int argc, char **argv)
     std::unique_ptr<vm::DebugScript> script;
     bool stepFlag = false;
     bool continueFlag = false;
+    bool timeFlag = false;
+    bool countFlag = false;
     for (int i = 1; i < argc; ++i)
     {
         std::string arg = argv[i];
@@ -79,6 +82,14 @@ int cmdRunIL(int argc, char **argv)
         else if (arg == "--continue")
         {
             continueFlag = true;
+        }
+        else if (arg == "--time")
+        {
+            timeFlag = true;
+        }
+        else if (arg == "--count")
+        {
+            countFlag = true;
         }
         else if (arg == "--bounds-checks")
         {
@@ -136,5 +147,22 @@ int cmdRunIL(int argc, char **argv)
         script->addStep(1);
     }
     vm::VM vm(m, traceCfg, maxSteps, std::move(dbg), script.get());
-    return static_cast<int>(vm.run());
+    auto start = std::chrono::steady_clock::now();
+    int rc = static_cast<int>(vm.run());
+    auto end = std::chrono::steady_clock::now();
+    if (countFlag || timeFlag)
+    {
+        std::cerr << "[SUMMARY]";
+        if (countFlag)
+            std::cerr << " instr=" << vm.getInstrCount();
+        if (timeFlag)
+        {
+            double ms = std::chrono::duration<double, std::milli>(end - start).count();
+            if (countFlag)
+                std::cerr << ' ';
+            std::cerr << "time_ms=" << ms;
+        }
+        std::cerr << "\n";
+    }
+    return rc;
 }

--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -12,10 +12,10 @@ void usage()
 {
     std::cerr << "ilc v0.1.0\n"
               << "Usage: ilc -run <file.il> [--trace=il|src] [--stdin-from <file>] [--max-steps N]"
-                 " [--watch name]* [--bounds-checks]\n"
+                 " [--count] [--time] [--watch name]* [--bounds-checks]\n"
               << "       ilc front basic -emit-il <file.bas> [--bounds-checks]\n"
               << "       ilc front basic -run <file.bas> [--trace=il|src] [--stdin-from <file>] "
-                 "[--max-steps N] [--bounds-checks]\n"
+                 "[--max-steps N] [--count] [--time] [--bounds-checks]\n"
               << "       ilc il-opt <in.il> -o <out.il> --passes p1,p2\n";
 }
 

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -76,7 +76,7 @@ int64_t VM::execFunction(const Function &fn)
     bool skipBreakOnce = false;
     while (bb && ip < bb->instructions.size())
     {
-        if (maxSteps && steps >= maxSteps)
+        if (maxSteps && instrCount >= maxSteps)
         {
             std::cerr << "VM: step limit exceeded (" << maxSteps << "); aborting.\n";
             return 1;
@@ -117,7 +117,7 @@ int64_t VM::execFunction(const Function &fn)
         skipBreakOnce = false;
         const Instr &in = bb->instructions[ip];
         tracer.onStep(in, fr);
-        ++steps;
+        ++instrCount;
         bool jumped = false;
         switch (in.op)
         {

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -60,13 +60,20 @@ class VM
     /// @return Exit code from main function.
     int64_t run();
 
+    /// @brief Total executed instruction count.
+    /// @return Number of instructions executed by the VM.
+    uint64_t getInstrCount() const
+    {
+        return instrCount;
+    }
+
   private:
     const il::core::Module &mod; ///< Module to execute
     TraceSink tracer;            ///< Trace output sink
     DebugCtrl debug;             ///< Breakpoint controller
     DebugScript *script;         ///< Optional debug command script
     uint64_t maxSteps;           ///< Step limit; 0 means unlimited
-    uint64_t steps = 0;          ///< Executed instruction count
+    uint64_t instrCount = 0;     ///< Executed instruction count
     uint64_t stepBudget = 0;     ///< Remaining instructions to step before pausing
     std::unordered_map<std::string, const il::core::Function *> fnMap; ///< Name lookup
     std::unordered_map<std::string, rt_str> strMap;                    ///< String pool

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,9 @@ add_test(NAME test_vm_debug_script COMMAND test_vm_debug_script $<TARGET_FILE:il
 add_executable(test_vm_watch vm/WatchTests.cpp)
 add_test(NAME test_vm_watch COMMAND test_vm_watch $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/tests/vm/WatchTests.il)
 
+add_executable(test_vm_summary vm/SummaryTests.cpp)
+add_test(NAME test_vm_summary COMMAND test_vm_summary $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/summary.il)
+
 
 add_executable(test_analysis_cfg analysis/CFGTests.cpp)
 target_link_libraries(test_analysis_cfg PRIVATE Analysis il_build)

--- a/tests/vm/SummaryTests.cpp
+++ b/tests/vm/SummaryTests.cpp
@@ -1,0 +1,41 @@
+// File: tests/vm/SummaryTests.cpp
+// Purpose: Ensure VM reports instruction count and time summary.
+// Key invariants: Instruction count matches expected value.
+// Ownership/Lifetime: Test manages temporary files and cleans them up.
+// Links: docs/testing.md
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+int main(int argc, char **argv)
+{
+    if (argc != 3)
+    {
+        std::cerr << "usage: SummaryTests <ilc> <il file>\n";
+        return 1;
+    }
+    std::string ilc = argv[1];
+    std::string ilFile = argv[2];
+    std::string outFile = "summary.out";
+    std::string cmd = ilc + " -run " + ilFile + " --count --time 2>" + outFile;
+    if (std::system(cmd.c_str()) != 0)
+        return 1;
+    std::ifstream out(outFile);
+    std::string line;
+    bool found = false;
+    while (std::getline(out, line))
+    {
+        if (line.rfind("[SUMMARY]", 0) == 0)
+        {
+            if (line.find("instr=3") == std::string::npos)
+                return 1;
+            if (line.find("time_ms=") == std::string::npos)
+                return 1;
+            found = true;
+        }
+    }
+    std::remove(outFile.c_str());
+    return found ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- add `--count` and `--time` flags to `ilc` run modes
- track instruction count in VM and report optional wall-clock timing
- document and test execution summary behavior

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b9b1f121f48324a27d9d65782ba22f