### PR TITLE
feat(vm): add source-line breakpoints

### DIFF
--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -13,6 +13,7 @@ Flags:
 | `--trace=il` | emit a line-per-instruction trace. |
 | `--trace=src` | show source file, line, and column for each step; falls back to `<unknown>` when locations are missing. |
 | `--break <Label>` | halt before executing the first instruction of block `Label`; may be repeated. |
+| `--break-src <file>:<line>` | halt before executing the first instruction at the given source file and line; path must match exactly; may be repeated. |
 | `--debug-cmds <file>` | read debugger actions from `file` when a breakpoint is hit. |
 | `--step` | enter debug mode, break at entry, and step one instruction. |
 | `--continue` | ignore breakpoints and run to completion. |
@@ -48,6 +49,12 @@ script:
 
 ```
 ilc -run examples/il/debug_script.il --break L3 --trace=il --debug-cmds examples/il/debug_script.txt
+```
+
+Example source-line breakpoint:
+
+```
+ilc front basic -run tests/e2e/BreakSrcExact.bas --break-src tests/e2e/BreakSrcExact.bas:4
 ```
 
 ### Watching scalars

--- a/lib/VM/Debug.cpp
+++ b/lib/VM/Debug.cpp
@@ -5,6 +5,7 @@
 // Links: docs/dev/vm.md
 #include "VM/Debug.h"
 #include <iostream>
+#include <utility>
 
 namespace il::vm
 {
@@ -74,6 +75,29 @@ void DebugCtrl::onStore(std::string_view name,
     }
     w.type = ty;
     w.hasValue = true;
+}
+
+void DebugCtrl::addBreakSrcLine(std::string file, int line)
+{
+    srcLineBPs_.push_back({std::move(file), line});
+}
+
+bool DebugCtrl::hasSrcLineBPs() const
+{
+    return !srcLineBPs_.empty();
+}
+
+bool DebugCtrl::shouldBreakOn(const il::core::Instr &I) const
+{
+    if (!sm_ || !I.loc.isValid())
+        return false;
+    std::string_view path = sm_->getPath(I.loc.file_id);
+    for (const auto &bp : srcLineBPs_)
+    {
+        if (bp.file == path && static_cast<int>(I.loc.line) == bp.line)
+            return true;
+    }
+    return false;
 }
 
 } // namespace il::vm

--- a/src/tools/ilc/cmd_front_basic.cpp
+++ b/src/tools/ilc/cmd_front_basic.cpp
@@ -85,6 +85,7 @@ int cmdFrontBasic(int argc, char **argv)
     bool boundsChecks = false;
     vm::TraceConfig traceCfg{};
     SourceManager sm;
+    vm::DebugCtrl dbg(&sm);
     for (int i = 0; i < argc; ++i)
     {
         std::string arg = argv[i];
@@ -113,6 +114,17 @@ int cmdFrontBasic(int argc, char **argv)
         else if (arg == "--max-steps" && i + 1 < argc)
         {
             maxSteps = std::stoull(argv[++i]);
+        }
+        else if (arg == "--break-src" && i + 1 < argc)
+        {
+            std::string spec = argv[++i];
+            size_t pos = spec.find_last_of(':');
+            if (pos != std::string::npos)
+            {
+                std::string file2 = spec.substr(0, pos);
+                int line = std::stoi(spec.substr(pos + 1));
+                dbg.addBreakSrcLine(file2, line);
+            }
         }
         else if (arg == "--bounds-checks")
         {
@@ -149,6 +161,6 @@ int cmdFrontBasic(int argc, char **argv)
         }
     }
     traceCfg.sm = &sm;
-    vm::VM vm(m, traceCfg, maxSteps);
+    vm::VM vm(m, traceCfg, maxSteps, std::move(dbg));
     return static_cast<int>(vm.run());
 }

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -116,6 +116,15 @@ int64_t VM::execFunction(const Function &fn)
         }
         skipBreakOnce = false;
         const Instr &in = bb->instructions[ip];
+        if (debug.hasSrcLineBPs() && debug.shouldBreakOn(in))
+        {
+            std::string file = "<unknown>";
+            if (auto sm = debug.sourceManager())
+                file = std::string(sm->getPath(in.loc.file_id));
+            std::cerr << "[BREAK] src=" << file << ':' << in.loc.line << " fn=@" << fr.func->name
+                      << " blk=" << bb->label << " ip=#" << ip << "\n";
+            return 10;
+        }
         tracer.onStep(in, fr);
         ++instrCount;
         bool jumped = false;

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -53,7 +53,7 @@ class VM
     VM(const il::core::Module &m,
        TraceConfig tc = {},
        uint64_t maxSteps = 0,
-       DebugCtrl dbg = {},
+       DebugCtrl dbg = DebugCtrl(),
        DebugScript *script = nullptr);
 
     /// @brief Execute the module's entry function.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,6 +110,12 @@ add_test(NAME vm_block_params COMMAND ${CMAKE_COMMAND}
   -P ${CMAKE_CURRENT_SOURCE_DIR}/e2e/test_vm_block_params.cmake)
 set_tests_properties(vm_block_params PROPERTIES LABELS VM)
 
+add_test(NAME vm_break_src_exact COMMAND ${CMAKE_COMMAND}
+  -DILC=$<TARGET_FILE:ilc>
+  -DSRC_DIR=${CMAKE_SOURCE_DIR}
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/e2e/test_break_src_exact.cmake)
+set_tests_properties(vm_break_src_exact PROPERTIES LABELS VM)
+
 add_test(NAME vm_math_core COMMAND ${CMAKE_COMMAND}
   -DILC=$<TARGET_FILE:ilc>
   -DSRC_DIR=${CMAKE_SOURCE_DIR}

--- a/tests/e2e/BreakSrcExact.bas
+++ b/tests/e2e/BreakSrcExact.bas
@@ -1,0 +1,6 @@
+il 0.1
+func @main() -> i64 {
+entry:
+  .loc 1 2 1
+  ret 0
+}

--- a/tests/e2e/test_break_src_exact.cmake
+++ b/tests/e2e/test_break_src_exact.cmake
@@ -1,0 +1,19 @@
+if(NOT DEFINED ILC)
+  message(FATAL_ERROR "ILC not set")
+endif()
+if(NOT DEFINED SRC_DIR)
+  message(FATAL_ERROR "SRC_DIR not set")
+endif()
+set(GOLDEN "${SRC_DIR}/tests/goldens/break_src_exact.out")
+execute_process(COMMAND ${ILC} -run tests/e2e/BreakSrcExact.bas --break-src tests/e2e/BreakSrcExact.bas:2
+                WORKING_DIRECTORY ${SRC_DIR}
+                ERROR_FILE ${CMAKE_CURRENT_BINARY_DIR}/out.txt
+                RESULT_VARIABLE r)
+if(NOT r EQUAL 10)
+  message(FATAL_ERROR "execution did not break")
+endif()
+file(READ ${CMAKE_CURRENT_BINARY_DIR}/out.txt OUT)
+file(READ ${GOLDEN} EXP)
+if(NOT OUT STREQUAL EXP)
+  message(FATAL_ERROR "break output mismatch")
+endif()

--- a/tests/goldens/break_src_exact.out
+++ b/tests/goldens/break_src_exact.out
@@ -1,0 +1,1 @@
+[BREAK] src=tests/e2e/BreakSrcExact.bas:2 fn=@main blk=entry ip=#0


### PR DESCRIPTION
## Summary
- add `--break-src` flag to ilc to halt on an exact file:line
- support source-line breakpoints in `DebugCtrl` and VM interpreter
- cover with e2e test for exact path matching

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b9c76070a08324a4feb31ea5b2c0d3