### PR TITLE
feat(vm): normalize breakpoint paths

### DIFF
--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -13,7 +13,7 @@ Flags:
 | `--trace=il` | emit a line-per-instruction trace. |
 | `--trace=src` | show source file, line, and column for each step; falls back to `<unknown>` when locations are missing. |
 | `--break <Label>` | halt before executing the first instruction of block `Label`; may be repeated. |
-| `--break-src <file>:<line>` | halt before executing the instruction at source line; file path must match exactly; may be repeated. |
+| `--break-src <file>:<line>` | halt before executing the instruction at source line; paths are normalized and may match either the full path or just the basename; may be repeated. |
 | `--debug-cmds <file>` | read debugger actions from `file` when a breakpoint is hit. |
 | `--step` | enter debug mode, break at entry, and step one instruction. |
 | `--continue` | ignore breakpoints and run to completion. |
@@ -39,7 +39,9 @@ $ ilc -run foo.il --break-src foo.il:3
   [BREAK] src=foo.il:3 fn=@main blk=entry ip=#0
 ```
 
-The file path must match exactly as recorded in the IL.
+Paths are normalized (e.g., `\` becomes `/`, `a/./b` → `a/b`, `a/x/../b` → `a/b`).
+If the normalized path doesn't match, the basename is also checked, so `--break-src foo.il:3`
+will also match a file recorded as `path/to/foo.il`.
 
 ### Non-interactive debugging with --debug-cmds
 

--- a/lib/VM/Debug.cpp
+++ b/lib/VM/Debug.cpp
@@ -1,15 +1,56 @@
 // File: lib/VM/Debug.cpp
 // Purpose: Implement breakpoint control for the VM.
-// Key invariants: Interned labels and exact file paths uniquely identify breakpoints.
+// Key invariants: Interned labels and normalized file paths (with basename fallback)
+// uniquely identify breakpoints.
 // Ownership/Lifetime: DebugCtrl owns its interner, breakpoint set, and source line list.
 // Links: docs/dev/vm.md
 #include "VM/Debug.h"
 #include "il/core/Instr.hpp"
 #include "support/source_manager.hpp"
 #include <iostream>
+#include <vector>
 
 namespace il::vm
 {
+
+std::string DebugCtrl::normalizePath(std::string p)
+{
+    for (char &ch : p)
+        if (ch == '\\')
+            ch = '/';
+
+    std::vector<std::string> parts;
+    size_t i = 0;
+    bool absolute = !p.empty() && p[0] == '/';
+    while (i < p.size())
+    {
+        size_t j = i;
+        while (j < p.size() && p[j] != '/')
+            ++j;
+        std::string_view part(p.data() + i, j - i);
+        if (part == "..")
+        {
+            if (!parts.empty())
+                parts.pop_back();
+        }
+        else if (!part.empty() && part != ".")
+        {
+            parts.emplace_back(part);
+        }
+        i = j + 1;
+    }
+
+    std::string out;
+    if (absolute)
+        out.push_back('/');
+    for (size_t k = 0; k < parts.size(); ++k)
+    {
+        if (k)
+            out.push_back('/');
+        out += parts[k];
+    }
+    return out;
+}
 
 il::support::Symbol DebugCtrl::internLabel(std::string_view label)
 {
@@ -30,7 +71,10 @@ bool DebugCtrl::shouldBreak(const il::core::BasicBlock &blk) const
 
 void DebugCtrl::addBreakSrcLine(std::string file, int line)
 {
-    srcLineBPs_.push_back({std::move(file), line});
+    std::string norm = normalizePath(std::move(file));
+    size_t pos = norm.rfind('/');
+    std::string base = (pos == std::string::npos) ? norm : norm.substr(pos + 1);
+    srcLineBPs_.push_back({std::move(norm), std::move(base), line});
 }
 
 bool DebugCtrl::hasSrcLineBPs() const
@@ -53,8 +97,11 @@ bool DebugCtrl::shouldBreakOn(const il::core::Instr &I) const
     if (!sm_ || srcLineBPs_.empty() || !I.loc.isValid())
         return false;
     std::string path(sm_->getPath(I.loc.file_id));
+    std::string norm = normalizePath(std::move(path));
+    size_t pos = norm.rfind('/');
+    std::string base = (pos == std::string::npos) ? norm : norm.substr(pos + 1);
     for (const auto &bp : srcLineBPs_)
-        if (path == bp.file && static_cast<int>(I.loc.line) == bp.line)
+        if (static_cast<int>(I.loc.line) == bp.line && (norm == bp.normFile || base == bp.base))
             return true;
     return false;
 }

--- a/lib/VM/Debug.h
+++ b/lib/VM/Debug.h
@@ -1,6 +1,7 @@
 // File: lib/VM/Debug.h
 // Purpose: Declare breakpoint control for the VM.
-// Key invariants: Breakpoints are keyed by interned block labels and source lines.
+// Key invariants: Breakpoints are keyed by interned block labels and normalized source
+// line file paths (with basename fallback).
 // Ownership/Lifetime: DebugCtrl owns its interner, breakpoint set, and source line list.
 // Links: docs/dev/vm.md
 #pragma once
@@ -12,6 +13,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 namespace il::core
 {
@@ -36,6 +38,10 @@ struct Breakpoint
 class DebugCtrl
 {
   public:
+    /// @brief Normalize a file path for breakpoint matching.
+    /// @notes Replaces '\\' with '/', removes './', and collapses 'dir/..'.
+    static std::string normalizePath(std::string p);
+
     /// @brief Intern @p label and return its symbol.
     il::support::Symbol internLabel(std::string_view label);
 
@@ -78,8 +84,9 @@ class DebugCtrl
 
     struct SrcLineBP
     {
-        std::string file; ///< Source file path
-        int line;         ///< 1-based line number
+        std::string normFile; ///< Normalized source file path
+        std::string base;     ///< Basename of source file
+        int line;             ///< 1-based line number
     };
 
     const il::support::SourceManager *sm_ = nullptr; ///< Source manager for paths

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,10 @@ add_executable(test_il_utils il/UtilsTests.cpp)
 target_link_libraries(test_il_utils PRIVATE IL)
 add_test(NAME test_il_utils COMMAND test_il_utils)
 
+add_executable(test_path_normalize unit/PathNormalizeTests.cpp)
+target_link_libraries(test_path_normalize PRIVATE VMTrace)
+add_test(NAME test_path_normalize COMMAND test_path_normalize)
+
 add_executable(test_vm_trace_il vm/TraceILTests.cpp)
 add_test(NAME test_vm_trace_il COMMAND test_vm_trace_il $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/trace_min.il ${CMAKE_SOURCE_DIR}/tests/vm/trace_min.trace)
 add_executable(test_vm_break_label vm/BreakLabelTests.cpp)

--- a/tests/e2e/test_break_src_exact.cmake
+++ b/tests/e2e/test_break_src_exact.cmake
@@ -26,3 +26,16 @@ file(READ ${GOLDEN} EXP)
 if(NOT OUT STREQUAL EXP)
   message(FATAL_ERROR "break output mismatch")
 endif()
+
+get_filename_component(SRC_BASE ${SRC_FILE} NAME)
+execute_process(COMMAND ${ILC} -run ${SRC_FILE} --break-src ${SRC_BASE}:${LINE}
+                ERROR_FILE ${BREAK_FILE}
+                RESULT_VARIABLE r
+                WORKING_DIRECTORY ${ROOT})
+if(NOT r EQUAL 10)
+  message(FATAL_ERROR "expected breakpoint")
+endif()
+file(READ ${BREAK_FILE} OUT)
+if(NOT OUT STREQUAL EXP)
+  message(FATAL_ERROR "break output mismatch")
+endif()

--- a/tests/unit/PathNormalizeTests.cpp
+++ b/tests/unit/PathNormalizeTests.cpp
@@ -1,0 +1,19 @@
+// File: tests/unit/PathNormalizeTests.cpp
+// Purpose: Validate path normalization helper.
+// Key invariants: Normalizes separators and resolves '.' and '..' segments lexically.
+// Ownership/Lifetime: Test owns no resources.
+// Links: docs/tools/ilc.md
+#include "VM/Debug.h"
+#include <cassert>
+#include <string>
+
+int main()
+{
+    std::string path = "a/b/../c\\file.bas";
+    std::string norm = il::vm::DebugCtrl::normalizePath(path);
+    assert(norm == "a/c/file.bas");
+    size_t pos = norm.rfind('/');
+    std::string base = (pos == std::string::npos) ? norm : norm.substr(pos + 1);
+    assert(base == "file.bas");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- normalize `--break-src` file paths and store basenames
- allow breakpoints to match by normalized path or basename
- document path normalization and basename fallback

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b9f2e85488832491026549b42fe87d