### PR TITLE
feat(vm): normalize break-src paths

### DIFF
--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -13,7 +13,7 @@ Flags:
 | `--trace=il` | emit a line-per-instruction trace. |
 | `--trace=src` | show source file, line, and column for each step; falls back to `<unknown>` when locations are missing. |
 | `--break <Label>` | halt before executing the first instruction of block `Label`; may be repeated. |
-| `--break-src <file>:<line>` | halt before executing the instruction at source line; file path must match exactly; may be repeated. |
+| `--break-src <file>:<line>` | halt before executing the instruction at source line; paths are normalized and may match by basename; may be repeated. |
 | `--debug-cmds <file>` | read debugger actions from `file` when a breakpoint is hit. |
 | `--step` | enter debug mode, break at entry, and step one instruction. |
 | `--continue` | ignore breakpoints and run to completion. |
@@ -39,7 +39,9 @@ $ ilc -run foo.il --break-src foo.il:3
   [BREAK] src=foo.il:3 fn=@main blk=entry ip=#0
 ```
 
-The file path must match exactly as recorded in the IL.
+The file path is normalized ("\" -> "/", removing "./" and collapsing
+"dir/../" segments). If the provided path is a basename, it is matched against
+the recorded file's basename.
 
 ### Non-interactive debugging with --debug-cmds
 

--- a/lib/VM/Debug.cpp
+++ b/lib/VM/Debug.cpp
@@ -1,15 +1,50 @@
 // File: lib/VM/Debug.cpp
 // Purpose: Implement breakpoint control for the VM.
-// Key invariants: Interned labels and exact file paths uniquely identify breakpoints.
+// Key invariants: Interned labels and normalized file paths uniquely identify
+// breakpoints.
 // Ownership/Lifetime: DebugCtrl owns its interner, breakpoint set, and source line list.
 // Links: docs/dev/vm.md
 #include "VM/Debug.h"
 #include "il/core/Instr.hpp"
 #include "support/source_manager.hpp"
+#include <algorithm>
 #include <iostream>
+#include <vector>
 
 namespace il::vm
 {
+
+std::string DebugCtrl::normalizePath(std::string p)
+{
+    std::replace(p.begin(), p.end(), '\\', '/');
+    std::vector<std::string> stack;
+    size_t i = 0;
+    while (i < p.size())
+    {
+        size_t j = p.find('/', i);
+        if (j == std::string::npos)
+            j = p.size();
+        std::string part = p.substr(i, j - i);
+        if (part == "..")
+        {
+            if (!stack.empty())
+                stack.pop_back();
+        }
+        else if (!part.empty() && part != ".")
+        {
+            stack.push_back(std::move(part));
+        }
+        i = j + 1;
+    }
+    std::string out;
+    for (size_t k = 0; k < stack.size(); ++k)
+    {
+        if (k)
+            out += '/';
+        out += stack[k];
+    }
+    return out;
+}
 
 il::support::Symbol DebugCtrl::internLabel(std::string_view label)
 {
@@ -30,7 +65,10 @@ bool DebugCtrl::shouldBreak(const il::core::BasicBlock &blk) const
 
 void DebugCtrl::addBreakSrcLine(std::string file, int line)
 {
-    srcLineBPs_.push_back({std::move(file), line});
+    std::string norm = normalizePath(std::move(file));
+    size_t pos = norm.find_last_of('/');
+    std::string base = pos == std::string::npos ? norm : norm.substr(pos + 1);
+    srcLineBPs_.push_back({std::move(norm), std::move(base), line});
 }
 
 bool DebugCtrl::hasSrcLineBPs() const
@@ -53,8 +91,12 @@ bool DebugCtrl::shouldBreakOn(const il::core::Instr &I) const
     if (!sm_ || srcLineBPs_.empty() || !I.loc.isValid())
         return false;
     std::string path(sm_->getPath(I.loc.file_id));
+    std::string norm = normalizePath(std::move(path));
+    size_t pos = norm.find_last_of('/');
+    std::string base = pos == std::string::npos ? norm : norm.substr(pos + 1);
+    int line = static_cast<int>(I.loc.line);
     for (const auto &bp : srcLineBPs_)
-        if (path == bp.file && static_cast<int>(I.loc.line) == bp.line)
+        if (line == bp.line && (norm == bp.normFile || base == bp.base))
             return true;
     return false;
 }

--- a/lib/VM/Debug.h
+++ b/lib/VM/Debug.h
@@ -1,6 +1,7 @@
 // File: lib/VM/Debug.h
 // Purpose: Declare breakpoint control for the VM.
-// Key invariants: Breakpoints are keyed by interned block labels and source lines.
+// Key invariants: Breakpoints are keyed by interned block labels and normalized
+// source file paths.
 // Ownership/Lifetime: DebugCtrl owns its interner, breakpoint set, and source line list.
 // Links: docs/dev/vm.md
 #pragma once
@@ -9,9 +10,11 @@
 #include "il/core/Type.hpp"
 #include "support/string_interner.hpp"
 #include "support/symbol.hpp"
+#include <string>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 namespace il::core
 {
@@ -36,6 +39,9 @@ struct Breakpoint
 class DebugCtrl
 {
   public:
+    /// @brief Normalize path separators and dot segments.
+    static std::string normalizePath(std::string p);
+
     /// @brief Intern @p label and return its symbol.
     il::support::Symbol internLabel(std::string_view label);
 
@@ -78,8 +84,9 @@ class DebugCtrl
 
     struct SrcLineBP
     {
-        std::string file; ///< Source file path
-        int line;         ///< 1-based line number
+        std::string normFile; ///< Normalized source file path
+        std::string base;     ///< Basename of source file
+        int line;             ///< 1-based line number
     };
 
     const il::support::SourceManager *sm_ = nullptr; ///< Source manager for paths

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,10 @@ add_executable(test_support unit/test_support.cpp)
 target_link_libraries(test_support PRIVATE support)
 add_test(NAME test_support COMMAND test_support)
 
+add_executable(PathNormalizeTests unit/PathNormalizeTests.cpp)
+target_link_libraries(PathNormalizeTests PRIVATE VMTrace)
+add_test(NAME PathNormalizeTests COMMAND PathNormalizeTests)
+
 add_executable(test_il_serialize unit/test_il_serialize.cpp)
 target_link_libraries(test_il_serialize PRIVATE il_core il_build il_io support)
 target_compile_definitions(test_il_serialize PRIVATE TESTS_DIR="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/tests/e2e/test_break_src_exact.cmake
+++ b/tests/e2e/test_break_src_exact.cmake
@@ -26,3 +26,17 @@ file(READ ${GOLDEN} EXP)
 if(NOT OUT STREQUAL EXP)
   message(FATAL_ERROR "break output mismatch")
 endif()
+
+get_filename_component(BASENAME ${SRC_FILE} NAME)
+set(BREAK_FILE2 ${ROOT}/break_base.txt)
+execute_process(COMMAND ${ILC} -run ${SRC_FILE} --break-src ${BASENAME}:${LINE}
+                ERROR_FILE ${BREAK_FILE2}
+                RESULT_VARIABLE r
+                WORKING_DIRECTORY ${ROOT})
+if(NOT r EQUAL 10)
+  message(FATAL_ERROR "expected breakpoint")
+endif()
+file(READ ${BREAK_FILE2} OUT)
+if(NOT OUT STREQUAL EXP)
+  message(FATAL_ERROR "break output mismatch (basename)")
+endif()

--- a/tests/unit/PathNormalizeTests.cpp
+++ b/tests/unit/PathNormalizeTests.cpp
@@ -1,0 +1,19 @@
+// File: tests/unit/PathNormalizeTests.cpp
+// Purpose: Verify DebugCtrl path normalization and basename extraction.
+// Key invariants: normalization collapses dot segments and backslashes.
+// Ownership/Lifetime: N/A (standalone unit test).
+// Links: docs/dev/vm.md
+#include "VM/Debug.h"
+#include <cassert>
+#include <string>
+
+int main()
+{
+    std::string p = "a/b/../c\\file.bas";
+    std::string norm = il::vm::DebugCtrl::normalizePath(p);
+    assert(norm == "a/c/file.bas");
+    size_t pos = norm.find_last_of('/');
+    std::string base = pos == std::string::npos ? norm : norm.substr(pos + 1);
+    assert(base == "file.bas");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- normalize source paths and allow basename matching for `--break-src`
- test path normalization helper and basename breakpoint
- document `ilc` path normalization and basename fallback

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b9f2e85488832491026549b42fe87d