### PR TITLE
feat(vm): normalize --break-src paths and match basename

### DIFF
--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -13,7 +13,7 @@ Flags:
 | `--trace=il` | emit a line-per-instruction trace. |
 | `--trace=src` | show source file, line, and column for each step; falls back to `<unknown>` when locations are missing. |
 | `--break <Label>` | halt before executing the first instruction of block `Label`; may be repeated. |
-| `--break-src <file>:<line>` | halt before executing the instruction at source line; file path must match exactly; may be repeated. |
+| `--break-src <file>:<line>` | halt before executing the instruction at source line; paths are normalized and may match by basename; may be repeated. |
 | `--debug-cmds <file>` | read debugger actions from `file` when a breakpoint is hit. |
 | `--step` | enter debug mode, break at entry, and step one instruction. |
 | `--continue` | ignore breakpoints and run to completion. |
@@ -39,7 +39,8 @@ $ ilc -run foo.il --break-src foo.il:3
   [BREAK] src=foo.il:3 fn=@main blk=entry ip=#0
 ```
 
-The file path must match exactly as recorded in the IL.
+Paths are normalized ("\\" becomes "/", redundant "./" and "dir/../" removed).
+If no full-path match is found, the basename alone can trigger the breakpoint.
 
 ### Non-interactive debugging with --debug-cmds
 

--- a/lib/VM/Debug.h
+++ b/lib/VM/Debug.h
@@ -1,6 +1,6 @@
 // File: lib/VM/Debug.h
 // Purpose: Declare breakpoint control for the VM.
-// Key invariants: Breakpoints are keyed by interned block labels and source lines.
+// Key invariants: Breakpoints are keyed by interned block labels and normalized source lines.
 // Ownership/Lifetime: DebugCtrl owns its interner, breakpoint set, and source line list.
 // Links: docs/dev/vm.md
 #pragma once
@@ -60,6 +60,9 @@ class DebugCtrl
     /// @brief Retrieve associated source manager.
     const il::support::SourceManager *getSourceManager() const;
 
+    /// @brief Normalize path by replacing '\\' with '/' and collapsing '.' and '..' segments.
+    static std::string normalizePath(std::string p);
+
     /// @brief Register a watch on variable @p name.
     void addWatch(std::string_view name);
 
@@ -78,8 +81,9 @@ class DebugCtrl
 
     struct SrcLineBP
     {
-        std::string file; ///< Source file path
-        int line;         ///< 1-based line number
+        std::string normFile; ///< Normalized source file path
+        std::string base;     ///< Basename of source file
+        int line;             ///< 1-based line number
     };
 
     const il::support::SourceManager *sm_ = nullptr; ///< Source manager for paths

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,10 @@ add_executable(test_vm_summary vm/SummaryTests.cpp)
 add_test(NAME test_vm_summary COMMAND test_vm_summary $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/summary.il)
 
 
+add_executable(test_path_normalize unit/PathNormalizeTests.cpp)
+target_link_libraries(test_path_normalize PRIVATE VMTrace)
+add_test(NAME test_path_normalize COMMAND test_path_normalize)
+
 add_executable(test_analysis_cfg analysis/CFGTests.cpp)
 target_link_libraries(test_analysis_cfg PRIVATE Analysis il_build)
 add_test(NAME test_analysis_cfg COMMAND test_analysis_cfg)

--- a/tests/e2e/test_break_src_exact.cmake
+++ b/tests/e2e/test_break_src_exact.cmake
@@ -26,3 +26,16 @@ file(READ ${GOLDEN} EXP)
 if(NOT OUT STREQUAL EXP)
   message(FATAL_ERROR "break output mismatch")
 endif()
+
+get_filename_component(BASE ${SRC_FILE} NAME)
+execute_process(COMMAND ${ILC} -run ${SRC_FILE} --break-src ${BASE}:${LINE}
+                ERROR_FILE ${BREAK_FILE}
+                RESULT_VARIABLE r
+                WORKING_DIRECTORY ${ROOT})
+if(NOT r EQUAL 10)
+  message(FATAL_ERROR "expected breakpoint")
+endif()
+file(READ ${BREAK_FILE} OUT2)
+if(NOT OUT2 STREQUAL EXP)
+  message(FATAL_ERROR "break basename output mismatch")
+endif()

--- a/tests/unit/PathNormalizeTests.cpp
+++ b/tests/unit/PathNormalizeTests.cpp
@@ -1,0 +1,19 @@
+// File: tests/unit/PathNormalizeTests.cpp
+// Purpose: Verify path normalization helper handles separators and parent segments.
+// Key invariants: Normalization replaces backslashes, removes './', and collapses 'dir/../'.
+// Ownership: Test directly exercises il::vm::DebugCtrl utility.
+// Links: docs/class-catalog.md
+
+#include "VM/Debug.h"
+#include <cassert>
+
+int main()
+{
+    std::string p = "a/b/../c\\file.bas";
+    std::string norm = il::vm::DebugCtrl::normalizePath(p);
+    assert(norm == "a/c/file.bas");
+    size_t pos = norm.find_last_of('/');
+    std::string base = pos == std::string::npos ? norm : norm.substr(pos + 1);
+    assert(base == "file.bas");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- normalize source paths for --break-src and fall back to basename matching
- add unit test for path normalization and extend e2e breakpoint test
- document path normalization and basename fallback in ilc manual

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b9f2e85488832491026549b42fe87d