### PR TITLE
Normalize break-src paths with basename fallback

### DIFF
--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -13,7 +13,7 @@ Flags:
 | `--trace=il` | emit a line-per-instruction trace. |
 | `--trace=src` | show source file, line, and column for each step; falls back to `<unknown>` when locations are missing. |
 | `--break <Label>` | halt before executing the first instruction of block `Label`; may be repeated. |
-| `--break-src <file>:<line>` | halt before executing the instruction at source line; file path must match exactly; may be repeated. |
+| `--break-src <file>:<line>` | halt before executing the instruction at source line; paths are normalized and basename-only matches are accepted; may be repeated. |
 | `--debug-cmds <file>` | read debugger actions from `file` when a breakpoint is hit. |
 | `--step` | enter debug mode, break at entry, and step one instruction. |
 | `--continue` | ignore breakpoints and run to completion. |
@@ -39,7 +39,7 @@ $ ilc -run foo.il --break-src foo.il:3
   [BREAK] src=foo.il:3 fn=@main blk=entry ip=#0
 ```
 
-The file path must match exactly as recorded in the IL.
+Paths are normalized (slashes, `.` and `..` segments collapsed) and a breakpoint will match even if only the basename aligns with the recorded path.
 
 ### Non-interactive debugging with --debug-cmds
 

--- a/lib/VM/Debug.h
+++ b/lib/VM/Debug.h
@@ -9,9 +9,11 @@
 #include "il/core/Type.hpp"
 #include "support/string_interner.hpp"
 #include "support/symbol.hpp"
+#include <string>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 namespace il::core
 {
@@ -54,6 +56,9 @@ class DebugCtrl
     /// @brief Check whether instruction @p I matches a source line breakpoint.
     bool shouldBreakOn(const il::core::Instr &I) const;
 
+    /// @brief Lexically normalize @p p for breakpoint matching.
+    static std::string normalizePath(std::string p);
+
     /// @brief Set source manager used to resolve file paths.
     void setSourceManager(const il::support::SourceManager *sm);
 
@@ -78,8 +83,9 @@ class DebugCtrl
 
     struct SrcLineBP
     {
-        std::string file; ///< Source file path
-        int line;         ///< 1-based line number
+        std::string normFile; ///< Normalized source file path
+        std::string base;     ///< Basename of source file
+        int line;             ///< 1-based line number
     };
 
     const il::support::SourceManager *sm_ = nullptr; ///< Source manager for paths

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,10 @@ add_test(NAME test_vm_watch COMMAND test_vm_watch $<TARGET_FILE:ilc> ${CMAKE_SOU
 add_executable(test_vm_summary vm/SummaryTests.cpp)
 add_test(NAME test_vm_summary COMMAND test_vm_summary $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/summary.il)
 
+add_executable(test_path_normalize unit/PathNormalizeTests.cpp)
+target_link_libraries(test_path_normalize PRIVATE VMTrace)
+add_test(NAME test_path_normalize COMMAND test_path_normalize)
+
 
 add_executable(test_analysis_cfg analysis/CFGTests.cpp)
 target_link_libraries(test_analysis_cfg PRIVATE Analysis il_build)

--- a/tests/e2e/test_break_src_exact.cmake
+++ b/tests/e2e/test_break_src_exact.cmake
@@ -26,3 +26,15 @@ file(READ ${GOLDEN} EXP)
 if(NOT OUT STREQUAL EXP)
   message(FATAL_ERROR "break output mismatch")
 endif()
+
+execute_process(COMMAND ${ILC} -run ${SRC_FILE} --break-src BreakSrcExact.bas:${LINE}
+                ERROR_FILE ${BREAK_FILE}
+                RESULT_VARIABLE r2
+                WORKING_DIRECTORY ${ROOT})
+if(NOT r2 EQUAL 10)
+  message(FATAL_ERROR "expected breakpoint (basename)")
+endif()
+file(READ ${BREAK_FILE} OUT2)
+if(NOT OUT2 STREQUAL EXP)
+  message(FATAL_ERROR "break output mismatch (basename)")
+endif()

--- a/tests/unit/PathNormalizeTests.cpp
+++ b/tests/unit/PathNormalizeTests.cpp
@@ -1,0 +1,18 @@
+// File: tests/unit/PathNormalizeTests.cpp
+// Purpose: Verify path normalization for debug source breakpoints.
+// Key invariants: Normalization is purely lexical and extracts basename.
+// Ownership/Lifetime: Test owns no resources.
+// Links: docs/dev/vm.md
+#include "VM/Debug.h"
+#include <cassert>
+#include <string>
+
+int main()
+{
+    std::string in = "a/b/../c\\file.bas";
+    std::string norm = il::vm::DebugCtrl::normalizePath(in);
+    assert(norm == "a/c/file.bas");
+    std::string base = norm.substr(norm.find_last_of('/') + 1);
+    assert(base == "file.bas");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- normalize source paths for VM breakpoints and match on basename
- test path normalization and break-src basename handling
- document break-src normalization behavior in ilc

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b9ff1471b08324b97bc4b06a069e8f