### PR TITLE
feat(vm): normalize breakpoint paths with basename fallback

### DIFF
--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -13,7 +13,7 @@ Flags:
 | `--trace=il` | emit a line-per-instruction trace. |
 | `--trace=src` | show source file, line, and column for each step; falls back to `<unknown>` when locations are missing. |
 | `--break <Label>` | halt before executing the first instruction of block `Label`; may be repeated. |
-| `--break-src <file>:<line>` | halt before executing the instruction at source line; file path must match exactly; may be repeated. |
+| `--break-src <file>:<line>` | halt before executing the instruction at source line; paths are normalized and may match by basename; may be repeated. |
 | `--debug-cmds <file>` | read debugger actions from `file` when a breakpoint is hit. |
 | `--step` | enter debug mode, break at entry, and step one instruction. |
 | `--continue` | ignore breakpoints and run to completion. |
@@ -39,7 +39,9 @@ $ ilc -run foo.il --break-src foo.il:3
   [BREAK] src=foo.il:3 fn=@main blk=entry ip=#0
 ```
 
-The file path must match exactly as recorded in the IL.
+Paths are normalized ("./" removed, "dir/../" collapsed, and backslashes
+converted) before matching. If an exact path match fails, the basename is used
+as a fallback.
 
 ### Non-interactive debugging with --debug-cmds
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,10 @@ add_executable(test_vm_summary vm/SummaryTests.cpp)
 add_test(NAME test_vm_summary COMMAND test_vm_summary $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/summary.il)
 
 
+add_executable(test_vm_path_normalize unit/PathNormalizeTests.cpp)
+target_link_libraries(test_vm_path_normalize PRIVATE VMTrace)
+add_test(NAME test_vm_path_normalize COMMAND test_vm_path_normalize)
+
 add_executable(test_analysis_cfg analysis/CFGTests.cpp)
 target_link_libraries(test_analysis_cfg PRIVATE Analysis il_build)
 add_test(NAME test_analysis_cfg COMMAND test_analysis_cfg)

--- a/tests/e2e/test_break_src_exact.cmake
+++ b/tests/e2e/test_break_src_exact.cmake
@@ -26,3 +26,16 @@ file(READ ${GOLDEN} EXP)
 if(NOT OUT STREQUAL EXP)
   message(FATAL_ERROR "break output mismatch")
 endif()
+
+get_filename_component(SRC_BASENAME ${SRC_FILE} NAME)
+execute_process(COMMAND ${ILC} -run ${SRC_FILE} --break-src ${SRC_BASENAME}:${LINE}
+                ERROR_FILE ${BREAK_FILE}
+                RESULT_VARIABLE r
+                WORKING_DIRECTORY ${ROOT})
+if(NOT r EQUAL 10)
+  message(FATAL_ERROR "expected breakpoint")
+endif()
+file(READ ${BREAK_FILE} OUT)
+if(NOT OUT STREQUAL EXP)
+  message(FATAL_ERROR "break output mismatch basename")
+endif()

--- a/tests/unit/PathNormalizeTests.cpp
+++ b/tests/unit/PathNormalizeTests.cpp
@@ -1,0 +1,18 @@
+// File: tests/unit/PathNormalizeTests.cpp
+// Purpose: Unit tests for DebugCtrl path normalization.
+// Key invariants: Paths are normalized lexically and basenames extracted correctly.
+// Ownership/Lifetime: Test owns all objects locally.
+// Links: docs/dev/vm.md
+
+#include "VM/Debug.h"
+#include <cassert>
+#include <string>
+
+int main()
+{
+    std::string norm = il::vm::DebugCtrl::normalizePath("a/b/../c\\file.bas");
+    assert(norm == "a/c/file.bas");
+    auto pos = norm.find_last_of('/');
+    std::string base = pos == std::string::npos ? norm : norm.substr(pos + 1);
+    assert(base == "file.bas");
+}


### PR DESCRIPTION
## Summary
- normalize breakpoint file paths and keep basenames for fallback matching
- test path normalization utility and basename-only breakpoint
- document breakpoint path normalization and basename matching

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b9ff1471b08324b97bc4b06a069e8f