### PR TITLE
feat(vm): normalize break-src paths with basename fallback

### DIFF
--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -13,7 +13,7 @@ Flags:
 | `--trace=il` | emit a line-per-instruction trace. |
 | `--trace=src` | show source file, line, and column for each step; falls back to `<unknown>` when locations are missing. |
 | `--break <Label>` | halt before executing the first instruction of block `Label`; may be repeated. |
-| `--break-src <file>:<line>` | halt before executing the instruction at source line; file path must match exactly; may be repeated. |
+| `--break-src <file>:<line>` | halt before executing the instruction at source line; paths are normalized ("\\"→"/", "./" removed, "dir/../" collapsed) and basename matches are accepted; may be repeated. |
 | `--debug-cmds <file>` | read debugger actions from `file` when a breakpoint is hit. |
 | `--step` | enter debug mode, break at entry, and step one instruction. |
 | `--continue` | ignore breakpoints and run to completion. |
@@ -39,7 +39,7 @@ $ ilc -run foo.il --break-src foo.il:3
   [BREAK] src=foo.il:3 fn=@main blk=entry ip=#0
 ```
 
-The file path must match exactly as recorded in the IL.
+Paths are compared after normalization and fall back to matching on the basename if full paths differ.
 
 ### Non-interactive debugging with --debug-cmds
 

--- a/lib/VM/Debug.h
+++ b/lib/VM/Debug.h
@@ -1,6 +1,6 @@
 // File: lib/VM/Debug.h
 // Purpose: Declare breakpoint control for the VM.
-// Key invariants: Breakpoints are keyed by interned block labels and source lines.
+// Key invariants: Breakpoints are keyed by interned block labels and normalized source lines.
 // Ownership/Lifetime: DebugCtrl owns its interner, breakpoint set, and source line list.
 // Links: docs/dev/vm.md
 #pragma once
@@ -54,6 +54,9 @@ class DebugCtrl
     /// @brief Check whether instruction @p I matches a source line breakpoint.
     bool shouldBreakOn(const il::core::Instr &I) const;
 
+    /// @brief Normalize a filesystem path for breakpoint matching.
+    static std::string normalizePath(std::string p);
+
     /// @brief Set source manager used to resolve file paths.
     void setSourceManager(const il::support::SourceManager *sm);
 
@@ -78,8 +81,9 @@ class DebugCtrl
 
     struct SrcLineBP
     {
-        std::string file; ///< Source file path
-        int line;         ///< 1-based line number
+        std::string normFile; ///< Normalized source file path
+        std::string base;     ///< Basename of source file
+        int line;             ///< 1-based line number
     };
 
     const il::support::SourceManager *sm_ = nullptr; ///< Source manager for paths

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,10 @@ add_executable(test_vm_summary vm/SummaryTests.cpp)
 add_test(NAME test_vm_summary COMMAND test_vm_summary $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/summary.il)
 
 
+add_executable(test_vm_path_normalize unit/PathNormalizeTests.cpp)
+target_link_libraries(test_vm_path_normalize PRIVATE VMTrace)
+add_test(NAME test_vm_path_normalize COMMAND test_vm_path_normalize)
+
 add_executable(test_analysis_cfg analysis/CFGTests.cpp)
 target_link_libraries(test_analysis_cfg PRIVATE Analysis il_build)
 add_test(NAME test_analysis_cfg COMMAND test_analysis_cfg)

--- a/tests/e2e/test_break_src_exact.cmake
+++ b/tests/e2e/test_break_src_exact.cmake
@@ -26,3 +26,16 @@ file(READ ${GOLDEN} EXP)
 if(NOT OUT STREQUAL EXP)
   message(FATAL_ERROR "break output mismatch")
 endif()
+
+set(BREAK_FILE2 ${ROOT}/break_base.txt)
+execute_process(COMMAND ${ILC} -run ${SRC_FILE} --break-src BreakSrcExact.bas:${LINE}
+                ERROR_FILE ${BREAK_FILE2}
+                RESULT_VARIABLE r2
+                WORKING_DIRECTORY ${ROOT})
+if(NOT r2 EQUAL 10)
+  message(FATAL_ERROR "expected basename breakpoint")
+endif()
+file(READ ${BREAK_FILE2} OUT2)
+if(NOT OUT2 STREQUAL EXP)
+  message(FATAL_ERROR "basename break output mismatch")
+endif()

--- a/tests/unit/PathNormalizeTests.cpp
+++ b/tests/unit/PathNormalizeTests.cpp
@@ -1,0 +1,20 @@
+// File: tests/unit/PathNormalizeTests.cpp
+// Purpose: Verify path normalization used for --break-src.
+// Key invariants: normalizePath collapses segments and basename extraction is correct.
+// Ownership: Standalone unit test with no external dependencies.
+// Links: docs/dev/vm.md
+
+#include "VM/Debug.h"
+#include <cassert>
+#include <string>
+
+int main()
+{
+    std::string raw = "a/b/../c\\file.bas";
+    std::string norm = il::vm::DebugCtrl::normalizePath(raw);
+    assert(norm == "a/c/file.bas");
+    size_t pos = norm.find_last_of('/');
+    std::string base = pos == std::string::npos ? norm : norm.substr(pos + 1);
+    assert(base == "file.bas");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- normalize breakpoint source paths and store basenames
- allow `--break-src` to match on basename when full path differs
- test path normalization and document behavior

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68b9ff1471b08324b97bc4b06a069e8f