### PR TITLE
feat(vm): normalize debug file paths

### DIFF
--- a/lib/VM/Debug.h
+++ b/lib/VM/Debug.h
@@ -1,5 +1,5 @@
 // File: lib/VM/Debug.h
-// Purpose: Declare breakpoint control for the VM.
+// Purpose: Declare breakpoint control and path normalization utilities for the VM.
 // Key invariants: Breakpoints are keyed by interned block labels and source lines.
 // Ownership/Lifetime: DebugCtrl owns its interner, breakpoint set, and source line list.
 // Links: docs/dev/vm.md
@@ -9,9 +9,11 @@
 #include "il/core/Type.hpp"
 #include "support/string_interner.hpp"
 #include "support/symbol.hpp"
+#include <string>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 namespace il::core
 {
@@ -59,6 +61,11 @@ class DebugCtrl
 
     /// @brief Retrieve associated source manager.
     const il::support::SourceManager *getSourceManager() const;
+
+    /// @brief Normalize @p p by canonicalizing separators and dot segments.
+    /// Replaces backslashes with forward slashes, removes redundant "./", and
+    /// collapses "dir/../" without resolving symlinks.
+    static std::string normalizePath(std::string p);
 
     /// @brief Register a watch on variable @p name.
     void addWatch(std::string_view name);


### PR DESCRIPTION
## Summary
- add DebugCtrl::normalizePath to canonicalize path separators and dot segments
- normalize paths when registering and matching source line breakpoints
- document path normalization support in Debug headers

## Testing
- `cmake --build build`
- `ctest --test-dir build --output-on-failure -R Debug`


------
https://chatgpt.com/codex/tasks/task_e_68ba1075e1a88324b7a504c227d36cdb