### PR TITLE
test(vm): add path normalization basename test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -292,6 +292,10 @@ add_executable(test_vm_normalize_path unit/test_vm_normalize_path.cpp)
 target_link_libraries(test_vm_normalize_path PRIVATE VMTrace)
 add_test(NAME test_vm_normalize_path COMMAND test_vm_normalize_path)
 
+add_executable(test_path_normalize unit/PathNormalizeTests.cpp)
+target_link_libraries(test_path_normalize PRIVATE VMTrace)
+add_test(NAME test_path_normalize COMMAND test_path_normalize)
+
 
 set(BASIC_AST_DUMP $<TARGET_FILE:basic-ast-dump>)
 add_test(NAME basic_ast_ex1 COMMAND ${CMAKE_COMMAND}

--- a/tests/unit/PathNormalizeTests.cpp
+++ b/tests/unit/PathNormalizeTests.cpp
@@ -1,0 +1,19 @@
+// File: tests/unit/PathNormalizeTests.cpp
+// Purpose: Verify normalized paths yield correct basename.
+// Key invariants: Backslashes become slashes; '..' segments collapsed;
+// basename extracted from normalized path.
+// Ownership: Standalone executable.
+// Links: docs/class-catalog.md
+#include "VM/Debug.h"
+#include <cassert>
+
+int main()
+{
+    using il::vm::DebugCtrl;
+    std::string norm = DebugCtrl::normalizePath("a/b/../c\\file.bas");
+    assert(norm == "a/c/file.bas");
+    size_t pos = norm.find_last_of('/');
+    std::string base = (pos == std::string::npos) ? norm : norm.substr(pos + 1);
+    assert(base == "file.bas");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add unit test covering DebugCtrl::normalizePath and basename extraction
- register path normalization test with VMTrace

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure -R path_normalize`


------
https://chatgpt.com/codex/tasks/task_e_68ba3e11eb40832497804af5b22c56b5