### PR TITLE
test(vm): verify break-src basename fallback

### DIFF
--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -13,7 +13,7 @@ Flags:
 | `--trace=il` | emit a line-per-instruction trace. |
 | `--trace=src` | show source file, line, and column for each step; falls back to `<unknown>` when locations are missing. |
 | `--break <Label>` | halt before executing the first instruction of block `Label`; may be repeated. |
-| `--break-src <file>:<line>` | halt before executing the instruction at source line; file path must match exactly; may be repeated. |
+| `--break-src <file>:<line>` | halt before executing the instruction at source line; paths are normalized (platform separators and `.`/`..` segments). If the normalized path does not match, `ilc` falls back to a basename match; may be repeated. |
 | `--debug-cmds <file>` | read debugger actions from `file` when a breakpoint is hit. |
 | `--step` | enter debug mode, break at entry, and step one instruction. |
 | `--continue` | ignore breakpoints and run to completion. |
@@ -39,7 +39,7 @@ $ ilc -run foo.il --break-src foo.il:3
   [BREAK] src=foo.il:3 fn=@main blk=entry ip=#0
 ```
 
-The file path must match exactly as recorded in the IL.
+Paths are normalized before comparison. If the normalized path still does not match the path recorded in the IL, `ilc` compares only the basename and triggers the breakpoint on a match.
 
 ### Non-interactive debugging with --debug-cmds
 

--- a/tests/e2e/test_break_src_exact.cmake
+++ b/tests/e2e/test_break_src_exact.cmake
@@ -13,7 +13,9 @@ endif()
 if(NOT DEFINED ROOT)
   message(FATAL_ERROR "ROOT not set")
 endif()
+get_filename_component(SRC_NAME ${SRC_FILE} NAME)
 set(BREAK_FILE ${ROOT}/break.txt)
+
 execute_process(COMMAND ${ILC} -run ${SRC_FILE} --break-src ${SRC_FILE}:${LINE}
                 ERROR_FILE ${BREAK_FILE}
                 RESULT_VARIABLE r
@@ -24,5 +26,18 @@ endif()
 file(READ ${BREAK_FILE} OUT)
 file(READ ${GOLDEN} EXP)
 if(NOT OUT STREQUAL EXP)
-  message(FATAL_ERROR "break output mismatch")
+  message(FATAL_ERROR "break output mismatch (full path)")
 endif()
+
+execute_process(COMMAND ${ILC} -run ${SRC_FILE} --break-src ${SRC_NAME}:${LINE}
+                ERROR_FILE ${BREAK_FILE}
+                RESULT_VARIABLE r
+                WORKING_DIRECTORY ${ROOT})
+if(NOT r EQUAL 10)
+  message(FATAL_ERROR "expected breakpoint")
+endif()
+file(READ ${BREAK_FILE} OUT)
+if(NOT OUT STREQUAL EXP)
+  message(FATAL_ERROR "break output mismatch (basename)")
+endif()
+


### PR DESCRIPTION
## Summary
- run ilc twice in vm_break_src_exact: full path and basename breakpoints
- document break-src path normalization and basename fallback

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure -R vm_break_src_exact`


------
https://chatgpt.com/codex/tasks/task_e_68ba46a163e4832489056b7041cefcfa