### PR TITLE
feat(tools): allow --break for labels and source lines

### DIFF
--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -12,8 +12,8 @@ Flags:
 | ---- | ----------- |
 | `--trace=il` | emit a line-per-instruction trace. |
 | `--trace=src` | show source file, line, and column for each step; falls back to `<unknown>` when locations are missing. |
-| `--break <Label>` | halt before executing the first instruction of block `Label`; may be repeated. |
-| `--break-src <file>:<line>` | halt before executing the instruction at source line; paths are normalized (platform separators and `.`/`..` segments). If the normalized path does not match, `ilc` falls back to a basename match; may be repeated. |
+| `--break <label\|file:line>` | halt before executing the first instruction of block `label` or the instruction at `file:line`. A token is treated as `file:line` if it matches `^.+:[0-9]+$` and the left side contains `/`, `\\`, or `.`; may be repeated. |
+| `--break-src <file>:<line>` | explicit source-line breakpoint, equivalent to `--break file:line`; paths are normalized (platform separators and `.`/`..` segments). If the normalized path does not match, `ilc` falls back to a basename match; may be repeated. |
 | `--debug-cmds <file>` | read debugger actions from `file` when a breakpoint is hit. |
 | `--step` | enter debug mode, break at entry, and step one instruction. |
 | `--continue` | ignore breakpoints and run to completion. |
@@ -35,7 +35,7 @@ $ ilc -run examples/il/trace_min.il --trace=il
 Example using a source-line breakpoint:
 
 ```
-$ ilc -run foo.il --break-src foo.il:3
+$ ilc -run foo.il --break foo.il:3
   [BREAK] src=foo.il:3 fn=@main blk=entry ip=#0
 ```
 

--- a/src/tools/ilc/break_parse.hpp
+++ b/src/tools/ilc/break_parse.hpp
@@ -1,0 +1,27 @@
+// File: src/tools/ilc/break_parse.hpp
+// Purpose: Define helper for interpreting --break tokens.
+// Key invariants: None.
+// Ownership/Lifetime: N/A.
+// Links: docs/class-catalog.md
+#pragma once
+#include <cctype>
+#include <string_view>
+
+namespace ilc
+{
+/// @brief Determine if @p spec denotes a source line breakpoint.
+inline bool isBreakSrcSpec(std::string_view spec)
+{
+    auto pos = spec.rfind(':');
+    if (pos == std::string_view::npos || pos + 1 >= spec.size())
+        return false;
+    for (size_t i = pos + 1; i < spec.size(); ++i)
+    {
+        if (!std::isdigit(static_cast<unsigned char>(spec[i])))
+            return false;
+    }
+    std::string_view left = spec.substr(0, pos);
+    return left.find('/') != std::string_view::npos || left.find('\\') != std::string_view::npos ||
+           left.find('.') != std::string_view::npos;
+}
+} // namespace ilc

--- a/src/tools/ilc/cmd_run_il.cpp
+++ b/src/tools/ilc/cmd_run_il.cpp
@@ -7,6 +7,7 @@
 #include "VM/Debug.h"
 #include "VM/DebugScript.h"
 #include "VM/Trace.h"
+#include "break_parse.hpp"
 #include "cli.hpp"
 #include "il/io/Parser.hpp"
 #include "il/verify/Verifier.hpp"
@@ -70,8 +71,19 @@ int cmdRunIL(int argc, char **argv)
         }
         else if (arg == "--break" && i + 1 < argc)
         {
-            auto sym = dbg.internLabel(argv[++i]);
-            dbg.addBreak(sym);
+            std::string spec = argv[++i];
+            if (ilc::isBreakSrcSpec(spec))
+            {
+                auto pos = spec.rfind(':');
+                std::string file = spec.substr(0, pos);
+                int line = std::stoi(spec.substr(pos + 1));
+                dbg.addBreakSrcLine(file, line);
+            }
+            else
+            {
+                auto sym = dbg.internLabel(spec);
+                dbg.addBreak(sym);
+            }
         }
         else if (arg == "--break-src" && i + 1 < argc)
         {

--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -10,14 +10,15 @@
 
 void usage()
 {
-    std::cerr << "ilc v0.1.0\n"
-              << "Usage: ilc -run <file.il> [--trace=il|src] [--stdin-from <file>] [--max-steps N]"
-                 " [--break label]* [--break-src file:line]* [--watch name]* [--bounds-checks] "
-                 "[--count] [--time]\n"
-              << "       ilc front basic -emit-il <file.bas> [--bounds-checks]\n"
-              << "       ilc front basic -run <file.bas> [--trace=il|src] [--stdin-from <file>] "
-                 "[--max-steps N] [--break label]* [--break-src file:line]* [--bounds-checks]\n"
-              << "       ilc il-opt <in.il> -o <out.il> --passes p1,p2\n";
+    std::cerr
+        << "ilc v0.1.0\n"
+        << "Usage: ilc -run <file.il> [--trace=il|src] [--stdin-from <file>] [--max-steps N]"
+           " [--break label|file:line]* [--break-src file:line]* [--watch name]* [--bounds-checks] "
+           "[--count] [--time]\n"
+        << "       ilc front basic -emit-il <file.bas> [--bounds-checks]\n"
+        << "       ilc front basic -run <file.bas> [--trace=il|src] [--stdin-from <file>] "
+           "[--max-steps N] [--break label|file:line]* [--break-src file:line]* [--bounds-checks]\n"
+        << "       ilc il-opt <in.il> -o <out.il> --passes p1,p2\n";
 }
 
 int main(int argc, char **argv)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,10 @@ add_executable(test_il_utils il/UtilsTests.cpp)
 target_link_libraries(test_il_utils PRIVATE IL)
 add_test(NAME test_il_utils COMMAND test_il_utils)
 
+add_executable(test_break_parsing tools/BreakParsingTests.cpp)
+target_include_directories(test_break_parsing PRIVATE ${CMAKE_SOURCE_DIR}/src)
+add_test(NAME test_break_parsing COMMAND test_break_parsing)
+
 add_executable(test_vm_trace_il vm/TraceILTests.cpp)
 add_test(NAME test_vm_trace_il COMMAND test_vm_trace_il $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/trace_min.il ${CMAKE_SOURCE_DIR}/tests/vm/trace_min.trace)
 add_executable(test_vm_break_label vm/BreakLabelTests.cpp)

--- a/tests/e2e/test_break_src_exact.cmake
+++ b/tests/e2e/test_break_src_exact.cmake
@@ -16,7 +16,7 @@ endif()
 get_filename_component(SRC_NAME ${SRC_FILE} NAME)
 set(BREAK_FILE ${ROOT}/break.txt)
 
-execute_process(COMMAND ${ILC} -run ${SRC_FILE} --break-src ${SRC_FILE}:${LINE}
+execute_process(COMMAND ${ILC} -run ${SRC_FILE} --break ${SRC_FILE}:${LINE}
                 ERROR_FILE ${BREAK_FILE}
                 RESULT_VARIABLE r
                 WORKING_DIRECTORY ${ROOT})
@@ -29,7 +29,7 @@ if(NOT OUT STREQUAL EXP)
   message(FATAL_ERROR "break output mismatch (full path)")
 endif()
 
-execute_process(COMMAND ${ILC} -run ${SRC_FILE} --break-src ${SRC_NAME}:${LINE}
+execute_process(COMMAND ${ILC} -run ${SRC_FILE} --break ${SRC_NAME}:${LINE}
                 ERROR_FILE ${BREAK_FILE}
                 RESULT_VARIABLE r
                 WORKING_DIRECTORY ${ROOT})

--- a/tests/tools/BreakParsingTests.cpp
+++ b/tests/tools/BreakParsingTests.cpp
@@ -1,0 +1,33 @@
+// File: tests/tools/BreakParsingTests.cpp
+// Purpose: Verify heuristic classification of --break tokens.
+// Key invariants: None.
+// Ownership/Lifetime: N/A.
+// Links: docs/testing.md
+#include "tools/ilc/break_parse.hpp"
+#include <iostream>
+
+int main()
+{
+    using ilc::isBreakSrcSpec;
+    if (isBreakSrcSpec("L1"))
+    {
+        std::cerr << "L1 misclassified as src line\n";
+        return 1;
+    }
+    if (!isBreakSrcSpec("tests/e2e/BreakSrcExact.bas:5"))
+    {
+        std::cerr << "path with slash not detected\n";
+        return 1;
+    }
+    if (!isBreakSrcSpec("file.with.dots.bas:7"))
+    {
+        std::cerr << "path with dots not detected\n";
+        return 1;
+    }
+    if (isBreakSrcSpec("L1:2"))
+    {
+        std::cerr << "label-like token misclassified\n";
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- allow `--break` to accept either a label or `file:line` using a heuristic
- add tests for break parsing and update e2e breakpoint test
- document unified `--break` flag and retain `--break-src` alias

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68ba5061f1ac8324b8ee40804afe1906