### PR TITLE
docs: document source-line breakpoints

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+- Added source-line breakpoints with normalization and coalescing (C9).
+

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,26 @@
+# Debugging
+
+## Breaking on source lines
+
+Use `--break <file:line>` to stop execution before the instruction mapped to a
+source line. `--break-src <file:line>` is an explicit alias.
+
+Paths are normalized (platform separators and `.`/`..` segments). If the
+normalized path still does not match the path recorded in the IL, `ilc` falls
+back to comparing only the basename.
+
+When multiple instructions map to the same source line, `ilc` reports a
+breakpoint once per line until control transfers to a different line.
+
+Example using `--break`:
+
+```bash
+ilc -run examples/il/break_src.il --break examples/il/break_src.il:1
+```
+
+Example using `--break-src`:
+
+```bash
+ilc -run examples/il/break_src.il --break-src examples/il/break_src.il:1
+```
+

--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -10,14 +10,13 @@ Flags:
 
 | Flag | Description |
 | ---- | ----------- |
-| `--trace=il` | emit a line-per-instruction trace. |
-| `--trace=src` | show source file, line, and column for each step; falls back to `<unknown>` when locations are missing. |
-| `--break <Label\|file:line>` | halt before executing the first instruction of block `Label` or the instruction at `file:line`; may be repeated. |
-| `--break-src <file>:<line>` | explicit form of the source-line breakpoint; paths are normalized (platform separators and `.`/`..` segments). If the normalized path does not match, `ilc` falls back to a basename match; may be repeated. |
+| `--break <label\|file:line>` | halt before executing the first instruction of block `label` or the instruction at `file:line`; may be repeated. |
+| `--break-src <file:line>` | explicit form of the source-line breakpoint; paths are normalized (platform separators and `.`/`..` segments). If the normalized path does not match, `ilc` falls back to a basename match; may be repeated. |
+| `--trace (il\|src)` | `il` emits a line-per-instruction trace; `src` shows source file, line, and column for each step and falls back to `<unknown>` when locations are missing. |
 | `--debug-cmds <file>` | read debugger actions from `file` when a breakpoint is hit. |
-| `--step` | enter debug mode, break at entry, and step one instruction. |
-| `--continue` | ignore breakpoints and run to completion. |
 | `--watch <name>` | print when scalar `name` changes; may be repeated. |
+| `--continue` | ignore breakpoints and run to completion. |
+| `--step` | enter debug mode, break at entry, and step one instruction. |
 | `--count` | print executed instruction count at exit. |
 | `--time` | print wall-clock execution time in milliseconds. |
 
@@ -37,11 +36,18 @@ $ ilc -run examples/il/trace_min.il --trace=il
   [IL] fn=@main blk=entry ip=#2 op=ret 0
 ```
 
+Example using a label breakpoint:
+
+```
+$ ilc -run examples/il/break_label.il --break L3
+  [BREAK] fn=@main blk=L3 reason=label
+```
+
 Example using a source-line breakpoint:
 
 ```
-$ ilc -run foo.il --break foo.il:3
-  [BREAK] src=foo.il:3 fn=@main blk=entry ip=#0
+$ ilc -run examples/il/break_src.il --break examples/il/break_src.il:1
+  [BREAK] src=examples/il/break_src.il:1 fn=@main blk=entry ip=#0
 ```
 
 Paths are normalized before comparison. If the normalized path still does not match the path recorded in the IL, `ilc` compares only the basename and triggers the breakpoint on a match.

--- a/examples/il/break_src.il
+++ b/examples/il/break_src.il
@@ -1,0 +1,11 @@
+il 0.1.2
+
+func @main() -> i64 {
+entry:
+  .loc 1 1 1
+  %t0 = add 1, 2
+  .loc 1 1 1
+  %t1 = add %t0, 3
+  .loc 1 1 1
+  ret 0
+}

--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -18,7 +18,9 @@ void usage()
         << "       ilc front basic -emit-il <file.bas> [--bounds-checks]\n"
         << "       ilc front basic -run <file.bas> [--trace=il|src] [--stdin-from <file>] "
            "[--max-steps N] [--break label|file:line]* [--break-src file:line]* [--bounds-checks]\n"
-        << "       ilc il-opt <in.il> -o <out.il> --passes p1,p2\n";
+        << "       ilc il-opt <in.il> -o <out.il> --passes p1,p2\n"
+        << "\n--break accepts either a block label or file:line; --break-src is an explicit alias "
+           "for the source form.\n";
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
## Summary
- explain source-line breakpoints, path normalization, and coalescing in new debugging guide
- expand ilc docs and help text for `--break`/`--break-src` with label and source examples
- record source-line breakpoint feature in the changelog and add a sample IL file

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`
- `./build/src/tools/ilc/ilc -run examples/il/break_label.il --break L3`
- `./build/src/tools/ilc/ilc -run examples/il/break_src.il --break examples/il/break_src.il:1`
- `./build/src/tools/ilc/ilc -run examples/il/break_src.il --break-src examples/il/break_src.il:1`


------
https://chatgpt.com/codex/tasks/task_e_68ba5a1ef5988324be64a99b4749d3b9