### PR TITLE
docs(ilc): document source-line breakpoints

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Added source-line breakpoints with normalization and coalescing (C9).

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,24 @@
+# Debugging
+
+## Breaking on source lines
+
+Use `--break <file:line>` to stop before executing the instruction that maps to a
+specific source location. `--break` accepts either a block label or a
+`file:line` pair; the `--break-src` flag is an explicit alias for source-line
+breakpoints.
+
+Paths are normalized before matching: platform separators are converted to `/`,
+and `.` and `..` segments are resolved. If the normalized path still does not
+match the path recorded in the IL, `ilc` falls back to comparing only the
+basename. When multiple instructions map to the same source line, `ilc` reports a
+break only once per line until execution reaches a different line.
+
+Example:
+
+```
+$ ilc -run examples/il/break_src.il --break examples/il/break_src.il:3
+  [BREAK] src=examples/il/break_src.il:3 fn=@main blk=entry ip=#0
+
+$ ilc -run examples/il/break_src.il --break-src examples/il/break_src.il:3
+  [BREAK] src=examples/il/break_src.il:3 fn=@main blk=entry ip=#0
+```

--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -10,14 +10,13 @@ Flags:
 
 | Flag | Description |
 | ---- | ----------- |
-| `--trace=il` | emit a line-per-instruction trace. |
-| `--trace=src` | show source file, line, and column for each step; falls back to `<unknown>` when locations are missing. |
-| `--break <Label\|file:line>` | halt before executing the first instruction of block `Label` or the instruction at `file:line`; may be repeated. |
-| `--break-src <file>:<line>` | explicit form of the source-line breakpoint; paths are normalized (platform separators and `.`/`..` segments). If the normalized path does not match, `ilc` falls back to a basename match; may be repeated. |
+| `--trace=<il|src>` | emit an IL instruction trace or show source file, line, and column for each step. |
+| `--break <label|file:line>` | halt before executing the first instruction of block `label` or the instruction at `file:line`; may be repeated. |
+| `--break-src <file:line>` | explicit form of the source-line breakpoint; paths are normalized (platform separators and `.`/`..` segments). If the normalized path does not match, `ilc` falls back to a basename match; may be repeated. |
 | `--debug-cmds <file>` | read debugger actions from `file` when a breakpoint is hit. |
-| `--step` | enter debug mode, break at entry, and step one instruction. |
-| `--continue` | ignore breakpoints and run to completion. |
 | `--watch <name>` | print when scalar `name` changes; may be repeated. |
+| `--continue` | ignore breakpoints and run to completion. |
+| `--step` | enter debug mode, break at entry, and step one instruction. |
 | `--count` | print executed instruction count at exit. |
 | `--time` | print wall-clock execution time in milliseconds. |
 
@@ -37,16 +36,25 @@ $ ilc -run examples/il/trace_min.il --trace=il
   [IL] fn=@main blk=entry ip=#2 op=ret 0
 ```
 
+Example using a label breakpoint:
+
+```
+$ ilc -run examples/il/break_label.il --break L3
+  [BREAK] fn=@main blk=L3 reason=label
+```
+
 Example using a source-line breakpoint:
 
 ```
-$ ilc -run foo.il --break foo.il:3
-  [BREAK] src=foo.il:3 fn=@main blk=entry ip=#0
+$ ilc -run examples/il/break_src.il --break examples/il/break_src.il:3
+  [BREAK] src=examples/il/break_src.il:3 fn=@main blk=entry ip=#0
 ```
 
-Paths are normalized before comparison. If the normalized path still does not match the path recorded in the IL, `ilc` compares only the basename and triggers the breakpoint on a match.
+Paths are normalized before comparison. If the normalized path still does not match the path recorded in the IL, `ilc` compares
+only the basename and triggers the breakpoint on a match.
 
-When multiple IL instructions map to the same source line, `ilc` reports a breakpoint only once per line until control transfers to a different basic block.
+When multiple IL instructions map to the same source line, `ilc` reports a breakpoint only once per line until control transfers
+ to a different basic block.
 
 ### Non-interactive debugging with --debug-cmds
 
@@ -107,4 +115,3 @@ Example:
 ```
 ilc il-opt foo.il -o foo.opt.il --mem2reg-stats
 ```
-

--- a/examples/il/break_src.il
+++ b/examples/il/break_src.il
@@ -1,0 +1,8 @@
+il 0.1
+
+func @main() -> i64 {
+entry:
+  .loc 1 3 0
+  %t0 = add 1, 2
+  ret 0
+}

--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -18,7 +18,10 @@ void usage()
         << "       ilc front basic -emit-il <file.bas> [--bounds-checks]\n"
         << "       ilc front basic -run <file.bas> [--trace=il|src] [--stdin-from <file>] "
            "[--max-steps N] [--break label|file:line]* [--break-src file:line]* [--bounds-checks]\n"
-        << "       ilc il-opt <in.il> -o <out.il> --passes p1,p2\n";
+        << "       ilc il-opt <in.il> -o <out.il> --passes p1,p2\n"
+        << "\n"
+        << "       --break <label|file:line>  break at a block label or source line\n"
+        << "       --break-src <file:line>    alias for --break file:line\n";
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
## Summary
- document source-line breakpoints, normalization, and coalescing
- expand ilc flags and help to cover label vs source-line breaks
- add example IL demonstrating source-line break

## Testing
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `build/src/tools/ilc/ilc -run examples/il/break_label.il --break L3`
- `build/src/tools/ilc/ilc -run examples/il/break_src.il --break examples/il/break_src.il:3`
- `build/src/tools/ilc/ilc -run examples/il/break_src.il --break-src examples/il/break_src.il:3`


------
https://chatgpt.com/codex/tasks/task_e_68ba5a1ef5988324be64a99b4749d3b9