### PR TITLE
feat(io): document source-line breakpoints and allow IL comments

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,30 @@
+# Debugging
+
+## Breaking on source lines
+
+`ilc` can halt execution when it reaches a specific file and line. There are
+ two options:
+
+- `--break <file:line>`: break on the given IL file.
+- `--break-src <file:line>`: break on the original source file when debug info is present.
+
+Before matching, the debugger normalizes paths (resolving relative segments and
+symlinks). If no file matches the normalized path, it falls back to comparing
+just the basename. This allows commands like `--break break_label.il:5` even
+when the compiled program was referenced via a different directory.
+
+Breakpoints are coalesced: if multiple instructions map to the same line, `ilc`
+will stop only once per line until the line number changes.
+
+### Examples
+
+```sh
+# Break on line 5 of the IL file
+ilc -run examples/il/break_label.il --break examples/il/break_label.il:5
+
+# Break using only the basename; path resolution falls back to the filename
+ilc -run examples/il/break_label.il --break break_label.il:5
+
+# Break on the original source line when debug info is available
+ilc -run examples/il/break_label.il --break-src break_label.il:5
+```

--- a/examples/il/break_label.il
+++ b/examples/il/break_label.il
@@ -1,3 +1,6 @@
+// File: examples/il/break_label.il
+// Purpose: Demonstrates a simple program for debugger breakpoints.
+// Links: docs/debugging.md
 il 0.1
 
 func @main() -> i64 {

--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -144,6 +144,8 @@ bool Parser::parse(std::istream &is, Module &m, std::ostream &err)
         line = trim(line);
         if (line.empty())
             continue;
+        if (line.rfind("//", 0) == 0)
+            continue;
         if (!curFn)
         {
             if (line.rfind("il", 0) == 0)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,10 @@ add_executable(test_il_utils il/UtilsTests.cpp)
 target_link_libraries(test_il_utils PRIVATE IL)
 add_test(NAME test_il_utils COMMAND test_il_utils)
 
+add_executable(test_il_comments unit/test_il_comments.cpp)
+target_link_libraries(test_il_comments PRIVATE il_core il_io support)
+add_test(NAME test_il_comments COMMAND test_il_comments)
+
 add_executable(test_tools_break_parsing tools/BreakParsingTests.cpp)
 target_include_directories(test_tools_break_parsing PRIVATE ${CMAKE_SOURCE_DIR}/src)
 add_test(NAME test_tools_break_parsing COMMAND test_tools_break_parsing)

--- a/tests/unit/test_il_comments.cpp
+++ b/tests/unit/test_il_comments.cpp
@@ -1,0 +1,28 @@
+// File: tests/unit/test_il_comments.cpp
+// Purpose: Ensure IL parser skips comment-only lines.
+// Key invariants: Parser succeeds when file begins with comments.
+// Ownership/Lifetime: Test uses in-memory strings only.
+// Links: docs/il-spec.md
+
+#include "il/io/Parser.hpp"
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    const char *src =
+        "// File: dummy.il\n"
+        "// Purpose: test comment handling\n"
+        "il 0.1\n"
+        "\n"
+        "func @main() -> i64 {\n"
+        "entry:\n"
+        "  ret 0\n"
+        "}\n";
+    il::core::Module m;
+    std::stringstream buf(src);
+    std::ostringstream err;
+    bool ok = il::io::Parser::parse(buf, m, err);
+    assert(ok);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- document `--break` and `--break-src` usage and breakpoint behavior
- support `//` comment lines so IL examples can carry headers
- cover comment handling with a unit test

## Testing
- `cmake -S . -B build && cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68ba63ca62308324b7af55f821b8364a