### PR TITLE
fix(il/io): skip comment-only lines in parser

### DIFF
--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -142,7 +142,7 @@ bool Parser::parse(std::istream &is, Module &m, std::ostream &err)
     {
         ++lineNo;
         line = trim(line);
-        if (line.empty())
+        if (line.empty() || line.rfind("//", 0) == 0)
             continue;
         if (!curFn)
         {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,10 @@ target_link_libraries(test_il_parse_negative PRIVATE il_core il_io support)
 target_compile_definitions(test_il_parse_negative PRIVATE BAD_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse")
 add_test(NAME test_il_parse_negative COMMAND test_il_parse_negative)
 
+add_executable(test_il_parse_comment unit/test_il_parse_comment.cpp)
+target_link_libraries(test_il_parse_comment PRIVATE il_core il_io support)
+add_test(NAME test_il_parse_comment COMMAND test_il_parse_comment)
+
 add_executable(test_il_utils il/UtilsTests.cpp)
 target_link_libraries(test_il_utils PRIVATE IL)
 add_test(NAME test_il_utils COMMAND test_il_utils)

--- a/tests/unit/test_il_parse_comment.cpp
+++ b/tests/unit/test_il_parse_comment.cpp
@@ -1,0 +1,28 @@
+// File: tests/unit/test_il_parse_comment.cpp
+// Purpose: Ensure IL parser ignores comment lines.
+// Key invariants: Parser treats lines starting with '//' as comments.
+// Ownership/Lifetime: Test owns modules and buffers locally.
+// Links: docs/il-spec.md
+
+#include "il/io/Parser.hpp"
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    const char *src = R"(il 0.1.2
+// comment before function
+func @main() -> i32 {
+entry:
+  ret 0
+}
+)";
+    std::istringstream in(src);
+    il::core::Module m;
+    std::ostringstream err;
+    bool ok = il::io::Parser::parse(in, m, err);
+    assert(ok);
+    assert(err.str().empty());
+    assert(m.functions.size() == 1);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ignore lines starting with `//` before parsing
- test parser handling of comment-only lines

## Testing
- `cmake -S . -B build && cmake --build build`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bafa7af2248324b357666f9935861d