### PR TITLE
Add unit test for IL parser leading comments

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,10 @@ add_executable(test_il_parse_comment unit/test_il_parse_comment.cpp)
 target_link_libraries(test_il_parse_comment PRIVATE il_core il_io support)
 add_test(NAME test_il_parse_comment COMMAND test_il_parse_comment)
 
+add_executable(test_il_comments unit/test_il_comments.cpp)
+target_link_libraries(test_il_comments PRIVATE il_core il_io support)
+add_test(NAME test_il_comments COMMAND test_il_comments)
+
 add_executable(test_il_utils il/UtilsTests.cpp)
 target_link_libraries(test_il_utils PRIVATE IL)
 add_test(NAME test_il_utils COMMAND test_il_utils)

--- a/tests/unit/test_il_comments.cpp
+++ b/tests/unit/test_il_comments.cpp
@@ -1,0 +1,29 @@
+// File: tests/unit/test_il_comments.cpp
+// Purpose: Ensure IL parser handles files starting with comment headers.
+// Key invariants: Leading lines beginning with '//' before the version line are ignored.
+// Ownership/Lifetime: Test owns module and buffers locally.
+// Links: docs/il-spec.md
+
+#include "il/io/Parser.hpp"
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    const char *src = R"(// header line 1
+// header line 2
+il 0.1.2
+func @main() -> i32 {
+entry:
+  ret 0
+}
+)";
+    std::istringstream in(src);
+    il::core::Module m;
+    std::ostringstream err;
+    bool ok = il::io::Parser::parse(in, m, err);
+    assert(ok);
+    assert(err.str().empty());
+    assert(m.functions.size() == 1);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add unit test ensuring IL parser accepts files with leading comment headers
- register the test in CMake

## Testing
- `cmake -S . -B build && cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bb01ffe36883248cc1b6e86bb7e759