### PR TITLE
docs: document CMake cleaning strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ cmake --build build
 ./build/src/tools/ilc/ilc front basic -run docs/examples/basic/ex1_hello_cond.bas
 ```
 
+## Cleaning
+
+Out-of-source builds place artifacts under a separate `build/` directory.
+To remove compiler outputs but keep the directory structure intact, run:
+
+```sh
+cmake --build build --target clean
+# Multi-config generators like MSVC or Xcode require a configuration:
+cmake --build build --target clean --config Debug
+```
+
+For a full purge, delete the entire build directory (or use the upcoming
+`scripts/clean.*` helpers):
+
+```sh
+rm -rf build
+```
+
 ## Directory layout
 
 ```text

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ IL-based compiler stack. For an overview of the project, see the [root README](.
 - [class-catalog.md](class-catalog.md) — C++ class catalog.
 - [roadmap.md](roadmap.md) — milestones and current status.
 - [style-guide.md](style-guide.md) — doc & comment conventions.
+- [build/cleaning.md](build/cleaning.md) — cleaning build directories.
 - [examples/](examples/) — sample BASIC + IL programs.
 
 ## Contributing to docs

--- a/docs/build/cleaning.md
+++ b/docs/build/cleaning.md
@@ -1,0 +1,39 @@
+<!--
+File: docs/build/cleaning.md
+Purpose: Guide on cleaning CMake build artifacts.
+-->
+
+# Cleaning CMake build trees
+
+CMake generates build artifacts in a separate directory. Cleaning removes these
+artifacts without reconfiguring the project.
+
+## Generator types
+
+Single-config generators (Ninja, Make) produce one configuration per build
+tree. Multi-config generators (MSVC, Xcode) hold multiple configurations side by
+side and require a specific build type when invoking targets.
+
+### Single-config (Ninja/Make)
+
+```sh
+cmake --build build --target clean
+```
+
+### Multi-config (MSVC/Xcode)
+
+```sh
+cmake --build build --target clean --config Debug
+cmake --build build --target clean --config Release
+```
+
+## Purging
+
+Removing the build directory nukes all generated files and caches:
+
+```sh
+rm -rf build
+```
+
+Upcoming `scripts/clean.*` helpers and a `distclean` target will offer a
+portable way to purge build trees.


### PR DESCRIPTION
## Summary
- document portable build-system clean and full purge steps
- add dedicated guide for cleaning single- vs. multi-config CMake builds
- cross-link cleaning guide from docs index

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`
- `scripts/check_docs_exist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0b1e2e3c83248148c643fe514abe