### PR TITLE
docs: document CMake cleaning strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ cmake --build build
 ./build/src/tools/ilc/ilc front basic -run docs/examples/basic/ex1_hello_cond.bas
 ```
 
+## Cleaning
+
+Out-of-source builds (for example, using a dedicated `build/` directory) are recommended.
+
+- **Buildsystem clean** (portable):
+  ```sh
+  cmake --build build --target clean
+  ```
+  For multi-config generators such as MSVC or Xcode, add `--config Debug` or `--config Release`.
+
+- **Full purge**: remove the entire build directory for a fresh start.
+  ```sh
+  rm -rf build
+  ```
+  Convenience scripts will be added in later prompts.
+
 ## Directory layout
 
 ```text

--- a/docs/build/cleaning.md
+++ b/docs/build/cleaning.md
@@ -1,0 +1,40 @@
+<!--
+File: docs/build/cleaning.md
+Purpose: Explain how to clean CMake build artifacts.
+-->
+
+# Cleaning CMake builds
+
+CMake build trees accumulate intermediate files. This guide covers removing
+those artifacts.
+
+## Single vs multi-config generators
+
+Single-config generators (Ninja, Makefiles) produce one build tree per build
+type. Multi-config generators (MSVC, Xcode) keep multiple configurations in one
+tree and require selecting a configuration at build time.
+
+## Buildsystem clean
+
+Single-config:
+
+```sh
+cmake --build build --target clean
+```
+
+Multi-config:
+
+```sh
+cmake --build build --target clean --config Debug
+```
+
+## Full purge
+
+Remove the entire build directory to start fresh:
+
+```sh
+rm -rf build
+```
+
+Future prompts will add `scripts/clean.*` helpers and a `distclean` target.
+


### PR DESCRIPTION
## Summary
- document portable buildsystem clean and full purge in README
- add detailed cleaning guide with single vs multi-config commands

## Testing
- `cmake -S . -B build && cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bb0b1e2e3c83248148c643fe514abe