### PR TITLE
chore(build): add POSIX clean script

### DIFF
--- a/docs/build/cleaning.md
+++ b/docs/build/cleaning.md
@@ -36,5 +36,19 @@ Remove the entire build directory to start fresh:
 rm -rf build
 ```
 
-Future prompts will add `scripts/clean.*` helpers and a `distclean` target.
+### Full purge (POSIX)
+
+Use the helper script to remove build directories. It prompts before deleting
+unless `YES=1` is set:
+
+```sh
+# auto-detect build* dirs at repo root
+scripts/clean.sh
+
+# explicit directories
+scripts/clean.sh build build-rel
+
+# non-interactive
+YES=1 scripts/clean.sh
+```
 

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# scripts/clean.sh -- remove CMake build directories safely.
+#
+# This script removes build directories located at the repository root.
+# It prompts for confirmation unless YES=1 is set.
+#
+# Usage:
+#   scripts/clean.sh                 # auto-detect build* dirs at repo root
+#   scripts/clean.sh build build-rel # explicit dirs
+#   YES=1 scripts/clean.sh           # non-interactive
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+mapfile -t DIRS < <(
+  if [[ $# -gt 0 ]]; then printf '%s\n' "$@"; else find "$ROOT" -maxdepth 1 -type d -name 'build*' -printf '%f\n'; fi
+)
+if [[ ${#DIRS[@]} -eq 0 ]]; then echo "[clean] no build* directories found at repo root"; exit 0; fi
+echo "[clean] will remove:"; for d in "${DIRS[@]}"; do echo "  - $d"; done
+if [[ "${YES:-}" != "1" ]]; then read -r -p "[clean] proceed? [y/N] " ans; [[ "$ans" =~ ^[yY]$ ]] || { echo "[clean] aborted"; exit 1; }; fi
+for d in "${DIRS[@]}"; do rm -rf "$ROOT/$d"; echo "[clean] removed $d"; done
+echo "[clean] done."


### PR DESCRIPTION
## Summary
- add scripts/clean.sh to safely remove CMake build directories
- document full purge helper in docs/build/cleaning.md

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bb0fcc59388324ae7deaddb60814ec