### PR TITLE
build(cmake): add distclean target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,3 +101,8 @@ add_subdirectory(lib/IL)
 add_subdirectory(lib/Passes)
 add_subdirectory(lib/VM)
 add_subdirectory(tests)
+
+add_custom_target(distclean
+  COMMAND "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/cmake/DistClean.cmake"
+  COMMENT "Scrub CMake-generated files in this build tree"
+)

--- a/cmake/DistClean.cmake
+++ b/cmake/DistClean.cmake
@@ -1,0 +1,28 @@
+# File: cmake/DistClean.cmake
+# Purpose: Scrub CMake-generated files in this build tree.
+# Key invariants: Removes common CMake cache and generator files while
+# preserving the build directory itself.
+# Ownership/Lifetime: Invoked via the 'distclean' custom target or directly
+# with `cmake -P` from inside a build tree.
+# Links: docs/build/cleaning.md
+
+# DistClean.cmake — scrub CMake-generated files in this build tree.
+message(STATUS "DistClean in: ${CMAKE_BINARY_DIR}")
+set(_paths
+  "${CMAKE_BINARY_DIR}/CMakeCache.txt"
+  "${CMAKE_BINARY_DIR}/CMakeFiles"
+  "${CMAKE_BINARY_DIR}/cmake_install.cmake"
+  "${CMAKE_BINARY_DIR}/install_manifest.txt"
+  "${CMAKE_BINARY_DIR}/Testing"
+  "${CMAKE_BINARY_DIR}/Makefile"
+  "${CMAKE_BINARY_DIR}/build.ninja"
+  "${CMAKE_BINARY_DIR}/rules.ninja"
+  "${CMAKE_BINARY_DIR}/.ninja_deps"
+  "${CMAKE_BINARY_DIR}/.ninja_log"
+)
+foreach(p IN LISTS _paths)
+  if (EXISTS "${p}" OR IS_SYMLINK "${p}")
+    file(REMOVE_RECURSE "${p}")
+  endif()
+endforeach()
+message(STATUS "DistClean done.")

--- a/docs/build/cleaning.md
+++ b/docs/build/cleaning.md
@@ -28,6 +28,19 @@ Multi-config:
 cmake --build build --target clean --config Debug
 ```
 
+## CMake distclean (from a build dir)
+
+Scrub CMake-generated files in the current build tree:
+
+```sh
+cmake --build . --target distclean
+# or
+cmake -P cmake/DistClean.cmake
+```
+
+On Windows, files that are still in use may require running the command again
+after closing the program holding the lock.
+
 ## Full purge
 
 Remove the entire build directory to start fresh:


### PR DESCRIPTION
## Summary
- add portable DistClean.cmake script to scrub CMake-generated files in build tree
- expose new `distclean` custom target in root CMakeLists
- document the `distclean` usage and behavior

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bb139b7cb083248845597bb9627dba