### PR TITLE
build: add root Makefile for cleaning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# File: Makefile
+# Purpose: Provide root-level convenience targets for cleaning CMake builds.
+# Links: scripts/clean.sh scripts/clean.ps1
+
+.PHONY: help clean distclean nuke
+BUILD ?= build
+help:
+@echo "Targets:"
+@echo "  clean     - cmake --build $(BUILD) --target clean [use CONFIG=Debug|Release]"
+@echo "  distclean - scrub CMake files inside $(BUILD)"
+@echo "  nuke      - delete build* dirs via scripts/clean.sh or scripts/clean.ps1"
+clean:
+# Single-config:
+@if [ -d "$(BUILD)" ]; then cmake --build $(BUILD) --target clean; else echo "No $(BUILD)/ dir"; fi
+# Multi-config (use CONFIG var):
+@if [ -n "$$CONFIG" ]; then cmake --build $(BUILD) --config $$CONFIG --target clean; fi
+distclean:
+@if [ -d "$(BUILD)" ]; then (cd $(BUILD) && cmake --build . --target distclean || cmake -P ../cmake/DistClean.cmake); else echo "No $(BUILD)/ dir"; fi
+nuke:
+@./scripts/clean.sh

--- a/README.md
+++ b/README.md
@@ -21,17 +21,22 @@ cmake --build build
 
 Out-of-source builds (for example, using a dedicated `build/` directory) are recommended.
 
-- **Buildsystem clean** (portable):
+- **Buildsystem clean**:
   ```sh
-  cmake --build build --target clean
+  make clean
   ```
-  For multi-config generators such as MSVC or Xcode, add `--config Debug` or `--config Release`.
+  For multi-config generators such as MSVC or Xcode, pass `CONFIG=Debug` or `CONFIG=Release`.
 
-- **Full purge**: remove the entire build directory for a fresh start.
+- **Distclean**: scrub CMake files inside `build/`:
   ```sh
-  rm -rf build
+  make distclean
   ```
-  Convenience scripts will be added in later prompts.
+
+- **Full purge**: delete `build*` directories via the cleanup script:
+  ```sh
+  make nuke
+  ```
+  The Makefile is a convenience for POSIX shells. Windows users should run `scripts/clean.ps1` or invoke the `cmake --build` commands directly.
 
 ## Directory layout
 


### PR DESCRIPTION
## Summary
- add root Makefile with clean, distclean, and nuke convenience targets
- document Makefile usage in README cleaning section

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bb1598ca148324aee6e5823759b635