### PR TITLE
fix(build): restore tabs in Makefile recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,16 @@
 .PHONY: help clean distclean nuke
 BUILD ?= build
 help:
-@echo "Targets:"
-@echo "  clean     - cmake --build $(BUILD) --target clean [use CONFIG=Debug|Release]"
-@echo "  distclean - scrub CMake files inside $(BUILD)"
-@echo "  nuke      - delete build* dirs via scripts/clean.sh or scripts/clean.ps1"
+	@echo "Targets:"
+	@echo "  clean     - cmake --build $(BUILD) --target clean [use CONFIG=Debug|Release]"
+	@echo "  distclean - scrub CMake files inside $(BUILD)"
+	@echo "  nuke      - delete build* dirs via scripts/clean.sh or scripts/clean.ps1"
 clean:
-# Single-config:
-@if [ -d "$(BUILD)" ]; then cmake --build $(BUILD) --target clean; else echo "No $(BUILD)/ dir"; fi
-# Multi-config (use CONFIG var):
-@if [ -n "$$CONFIG" ]; then cmake --build $(BUILD) --config $$CONFIG --target clean; fi
+	# Single-config:
+	@if [ -d "$(BUILD)" ]; then cmake --build $(BUILD) --target clean; else echo "No $(BUILD)/ dir"; fi
+	# Multi-config (use CONFIG var):
+	@if [ -n "$$CONFIG" ]; then cmake --build $(BUILD) --config $$CONFIG --target clean; fi
 distclean:
-@if [ -d "$(BUILD)" ]; then (cd $(BUILD) && cmake --build . --target distclean || cmake -P ../cmake/DistClean.cmake); else echo "No $(BUILD)/ dir"; fi
+	@if [ -d "$(BUILD)" ]; then (cd $(BUILD) && cmake --build . --target distclean || cmake -P ../cmake/DistClean.cmake); else echo "No $(BUILD)/ dir"; fi
 nuke:
-@./scripts/clean.sh
+	@./scripts/clean.sh


### PR DESCRIPTION
## Summary
- add missing tab characters before recipe commands in root Makefile to resolve "missing separator" errors

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68bb182836008324bdcbb321aa8f8ec4