### PR TITLE
docs: add BASIC recursion debugging guide

### DIFF
--- a/docs/dev/debug-recursion.md
+++ b/docs/dev/debug-recursion.md
@@ -1,0 +1,24 @@
+<!--
+File: docs/dev/debug-recursion.md
+Purpose: Guide for debugging BASIC recursion failures using source tracing and breakpoints.
+-->
+
+# Debugging BASIC Recursion Failures
+
+Use the factorial example to inspect recursive calls.
+
+```sh
+ilc -run tests/e2e/factorial.bas --trace=src \
+    --break-src tests/e2e/factorial.bas:5 \
+    --debug-cmds examples/il/debug_script.txt
+```
+
+The `--trace=src` flag prints each executed instruction with the originating
+file and line. The `--break-src` flag pauses before the recursive call. The
+debug script steps twice and then continues so you can watch the call enter
+and return.
+
+Check the trace for a `RETURN` at the end of `FACT`; missing returns suggest
+the recursion never reaches the base case. At startup the trace should show
+`fn=@main` followed by a call to `@fact`. If `@main` is absent or never calls
+the function, the program may have been lowered incorrectly.

--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -11,7 +11,7 @@ Flags:
 | Flag | Description |
 | ---- | ----------- |
 | `--trace=il` | emit a line-per-instruction trace. |
-| `--trace=src` | show source file, line, and column for each step; falls back to `<unknown>` when locations are missing. |
+| `--trace=src` | show source file, line, and column for each step; falls back to `<unknown>` when locations are missing. See [debug-recursion guide](../dev/debug-recursion.md). |
 | `--break <Label\|file:line>` | halt before executing the first instruction of block `Label` or the instruction at `file:line`; may be repeated. |
 | `--break-src <file>:<line>` | explicit form of the source-line breakpoint; paths are normalized (platform separators and `.`/`..` segments). If the normalized path does not match, `ilc` falls back to a basename match; may be repeated. |
 | `--debug-cmds <file>` | read debugger actions from `file` when a breakpoint is hit. |


### PR DESCRIPTION
## Summary
- document how to debug BASIC recursion using `ilc --trace=src` and breakpoints
- link recursion debugging guide from `--trace=src` option in `ilc` docs

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bbae2f1e88832487c66841e892fbd5