### PR TITLE
docs: consolidate deterministic naming documentation

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -1,0 +1,10 @@
+<!--
+File: docs/dev/architecture.md
+Purpose: Overview note on deterministic naming and its rationale.
+-->
+
+# Architecture Notes
+
+Deterministic label naming ensures that recompiling the same source yields identical IL.
+Stable labels keep golden tests from drifting and make builds reproducible.
+

--- a/docs/lowering.md
+++ b/docs/lowering.md
@@ -49,43 +49,66 @@ directly without copying.
 ### Deterministic label naming (procedures)
 
 Blocks created while lowering a procedure use predictable labels so goldens
-stay stable. Within a procedure `proc`, a per-procedure counter assigns
-monotonic IDs `k` used by common control-flow shapes:
+stay stable. Within a procedure `proc`, block names follow these patterns:
 
 * `entry_proc` and `ret_proc` for the entry and synthetic return blocks.
 * `if_then_k_proc`, `if_else_k_proc`, `if_end_k_proc` for `IF` constructs.
+* `while_head_k_proc`, `while_body_k_proc`, `while_end_k_proc` for `WHILE`.
+* `for_head_k_proc`, `for_body_k_proc`, `for_inc_k_proc`, `for_end_k_proc` for `FOR`.
+* `call_cont_k_proc` for call continuations.
 
-Loop and call-continuation labels share a single counter so their `k` reflects
-lexical ordering:
+The counter `k` is monotonic **per procedure**; labels never depend on container
+iteration order. Rebuilding the same source therefore yields identical label
+names across runs.
 
-| Construct           | Label pattern      |
-|---------------------|--------------------|
-| `WHILE` head        | `while_head_k_proc`|
-| `WHILE` body        | `while_body_k_proc`|
-| `WHILE` end         | `while_end_k_proc` |
-| `FOR` head          | `for_head_k_proc`  |
-| `FOR` body          | `for_body_k_proc`  |
-| `FOR` increment     | `for_inc_k_proc`   |
-| `FOR` end           | `for_end_k_proc`   |
-| Call continuation   | `call_cont_k_proc` |
-
-Example:
+Example BASIC and corresponding IL excerpt:
 
 ```
-FUNCTION F(X)
-IF X THEN F = 1 ELSE F = 2 END IF RETURN F END FUNCTION
+10 FUNCTION F(X)
+20 FOR I = 0 TO 1
+30   WHILE X < 10
+40     IF X THEN CALL P
+50     X = X + 1
+60   WEND
+70 NEXT I
+80 F = X
+90 RETURN
+100 END FUNCTION
 ```
 
-                         Lowers
-                         to(abridged)
-    :
-
-``` func @F()->i64{
-          entry_F : br if_test_0_F if_test_0_F : ... cbr % t0,
-          if_then_0_F,
-          if_else_0_F if_then_0_F : ... br if_end_0_F if_else_0_F : ... br if_end_0_F
-          if_end_0_F : ... br ret_F ret_F : ret 0
-      }
+```
+func @F(i64 %X) -> i64 {
+  entry_F:
+    br for_head_0_F
+  for_head_0_F:
+    ...
+    cbr %t0 for_body_0_F for_end_0_F
+  for_body_0_F:
+    br while_head_0_F
+  while_head_0_F:
+    ...
+    cbr %t1 while_body_0_F while_end_0_F
+  while_body_0_F:
+    cbr %t2 if_then_0_F if_end_0_F
+  if_then_0_F:
+    call @P()
+    br call_cont_0_F
+  call_cont_0_F:
+    ...
+    br while_head_0_F
+  if_end_0_F:
+    ...
+    br while_head_0_F
+  while_end_0_F:
+    br for_inc_0_F
+  for_inc_0_F:
+    ...
+    br for_head_0_F
+  for_end_0_F:
+    br ret_F
+  ret_F:
+    ret %X
+}
 ```
 
 ## Return statements


### PR DESCRIPTION
## Summary
- detail deterministic label naming patterns in lowering guide with BASIC and IL examples
- add architecture notes explaining deterministic naming for stable goldens and reproducible builds

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bbb704898483248f09d3c2bb164524