### PR TITLE
docs: document procedure lowering rules

### DIFF
--- a/docs/basic-ref.md
+++ b/docs/basic-ref.md
@@ -25,6 +25,28 @@ declarations followed by top-level statements that form the main program. The
 procedure section and the main section are both optional, and procedures may be
 invoked before or after their textual definitions.
 
+## FUNCTION
+
+Defines a procedure that returns a value. The return type is determined by the
+name suffix: `#` → `f64`, `$` → `str`, no suffix → `i64`. Parameters are passed
+by value unless an argument is an array, in which case a bare array variable
+must be supplied and is passed by reference. See the lowering tables for
+[procedure definitions](lowering.md#procedure-definitions) and
+[procedure calls](lowering.md#procedure-calls).
+
+## SUB
+
+Declares a procedure with no return value. Parameter rules match those of
+`FUNCTION`, including ByRef array parameters. Lowering details are listed under
+[procedure definitions](lowering.md#procedure-definitions) and
+[procedure calls](lowering.md#procedure-calls).
+
+## RETURN
+
+Transfers control out of the current `FUNCTION` or `SUB`. In a `FUNCTION`,
+assign the result to the function name before `RETURN`. This lowers directly to
+an IL `ret`; see [Return statements](lowering.md#return-statements).
+
 ## Array Parameters ByRef
 
 Array parameters in `FUNCTION` and `SUB` declarations are passed by reference. The caller must supply an array variable declared with `DIM`; expressions or indexed elements are rejected.

--- a/docs/lowering.md
+++ b/docs/lowering.md
@@ -12,17 +12,22 @@
 
 Integer arguments to `SQR`, `FLOOR`, and `CEIL` are first widened to `f64`.
 
+## Procedure calls
+
 User-defined `FUNCTION` and `SUB` calls lower to direct `call` instructions.
 Arguments are evaluated left-to-right and converted to the callee's expected
 types:
 
-- When a parameter expects `f64` but receives `i64`, a `sitofp` widening is
-  inserted.
-- `str` parameters receive their handles directly.
-- Array parameters (`i64[]` or `str[]`) pass the pointer/handle without any
-  load.
+| BASIC                              | IL                                                  | Notes                                               |
+|------------------------------------|------------------------------------------------------|-----------------------------------------------------|
+| `F(1)` where `F` expects `f64`     | `%t0 = sitofp i64 1 to f64`<br>`%r = call f64 @F(%t0)` | Scalar `i64` widened to `f64` via `sitofp`.          |
+| `CALL P(T$)`                       | `call void @P(str %T)`                                | String parameters pass handles directly.            |
+| `CALL P(A())`                      | `call void @P(ptr %A)`                                | Array parameters are ByRef; pointer/handle passed.  |
+| `CALL S()`                         | `call void @S()`                                      | `SUB` call used as a statement.                     |
+| `X = F()`                          | `%x = call i64 @F()`                                  | `FUNCTION` call used as an expression.              |
 
-Recursive calls lower the same way; see [factorial.bas](examples.md#factorial) for a recursion sanity check.
+Recursive calls lower the same way; see [factorial.bas](examples.md#factorial)
+for a recursion sanity check.
 
 ## Compilation unit lowering
 
@@ -39,12 +44,38 @@ This ordering guarantees functions are listed before `@main`.
 
 ## Procedure Definitions
 
+| BASIC                                | IL                                                      |
+|--------------------------------------|----------------------------------------------------------|
+| `FUNCTION f(...) ... END FUNCTION`   | `func @f(<params>) -> <retTy>`<br>`entry_f`/`ret_f` blocks |
+| `SUB s(...) ... END SUB`             | `func @s(<params>)`<br>`entry_s`/`ret_s` blocks            |
+
+Return type is derived from the name suffix (`$` → `str`, `#` → `f64`, none →
+`i64`). Parameters lower by scalar type or as array handles.
+
 Each BASIC `FUNCTION` or `SUB` becomes an IL function named `@<name>`. The
 entry block label is deterministically `entry_<name>` and a closing block
-`ret_<name>` carries the fallthrough `ret`. Scalar parameters are
-materialized by allocating stack slots and storing the incoming values. Array
-parameters (`i64[]` or `str[]`) are passed as pointers/handles and stored
-directly without copying.
+`ret_<name>` carries the fallthrough `ret`. Scalar parameters are materialized
+by allocating stack slots and storing the incoming values. Array parameters
+(`i64[]` or `str[]`) are passed as pointers/handles and stored directly without
+copying.
+
+```il
+func @F(i64 %X) -> i64 {
+  entry_F:
+    br ret_F
+  ret_F:
+    ret %X
+}
+```
+
+```il
+func @S(i64 %X) {
+  entry_S:
+    br ret_S
+  ret_S:
+    ret void
+}
+```
 
 ### Deterministic label naming (procedures)
 


### PR DESCRIPTION
## Summary
- expand lowering reference with tables for procedure definitions and calls
- note function/sub/return semantics in BASIC reference

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bbb88c98508324bf323c34938200cf