### PR TITLE
refactor(frontends): extract expr lowering helpers

### DIFF
--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -185,6 +185,22 @@ class Lowerer
     void materializeParams(const std::vector<Param> &params);
     void lowerStmt(const Stmt &stmt);
     RVal lowerExpr(const Expr &expr);
+    /// @brief Lower a variable reference expression.
+    /// @param expr Variable expression node.
+    /// @return Loaded value and its type.
+    RVal lowerVarExpr(const VarExpr &expr);
+    /// @brief Lower a unary expression (e.g. NOT).
+    /// @param expr Unary expression node.
+    /// @return Resulting value and type.
+    RVal lowerUnaryExpr(const UnaryExpr &expr);
+    /// @brief Lower a binary expression.
+    /// @param expr Binary expression node.
+    /// @return Resulting value and type.
+    RVal lowerBinaryExpr(const BinaryExpr &expr);
+    /// @brief Lower a built-in call expression.
+    /// @param expr Built-in call expression node.
+    /// @return Resulting value and type.
+    RVal lowerBuiltinCall(const BuiltinCallExpr &expr);
 
     void lowerLet(const LetStmt &stmt);
     void lowerPrint(const PrintStmt &stmt);


### PR DESCRIPTION
## Summary
- factor variable, unary, binary, and builtin call expressions into dedicated lowering helpers
- simplify `lowerExpr` by dispatching to helpers

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bbbfc8e248832488471f17169408ee