### PR TITLE
refactor(fe/basic): factor expression analyzers into helpers

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -101,6 +101,19 @@ class SemanticAnalyzer
     /// @return Inferred type of the expression.
     Type visitExpr(const Expr &e);
 
+    /// @brief Analyze variable reference.
+    Type analyzeVar(VarExpr &v);
+    /// @brief Analyze unary expression.
+    Type analyzeUnary(const UnaryExpr &u);
+    /// @brief Analyze binary expression.
+    Type analyzeBinary(const BinaryExpr &b);
+    /// @brief Analyze built-in function call.
+    Type analyzeBuiltinCall(const BuiltinCallExpr &c);
+    /// @brief Analyze user-defined procedure call.
+    Type analyzeCall(const CallExpr &c);
+    /// @brief Analyze array access expression.
+    Type analyzeArray(ArrayExpr &a);
+
     /// @brief Determine if @p stmts guarantees a return value on all control paths.
     bool mustReturn(const std::vector<StmtPtr> &stmts) const;
     /// @brief Determine if single statement @p s guarantees a return value.


### PR DESCRIPTION
## Summary
- break SemanticAnalyzer expression handling into dedicated helpers
- dispatch visitExpr to helper methods by expression type
- centralize error emission logic per helper

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bbc03d8db88324b15301ec12cd7bfc