### PR TITLE
refactor(basic): extract expression parsing helpers

### DIFF
--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -52,6 +52,10 @@ class Parser
 
     ExprPtr parseExpression(int min_prec = 0);
     ExprPtr parsePrimary();
+    ExprPtr parseNumber();
+    ExprPtr parseString();
+    ExprPtr parseBuiltinCall(BuiltinCallExpr::Builtin builtin, il::support::SourceLoc loc);
+    ExprPtr parseArrayOrVar();
     int precedence(TokenKind k);
 };
 


### PR DESCRIPTION
## Summary
- factor numeric and string literal parsing into `parseNumber` and `parseString`
- centralize builtin handling via `parseBuiltinCall` and `parseArrayOrVar`
- simplify `parsePrimary` by delegating to helpers

## Testing
- `cmake -S . -B build && cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bbc696e3148324a8749a594c586f20