### PR TITLE
refactor(fe/basic): factor program scanning from emission

### DIFF
--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -283,6 +283,21 @@ class Lowerer
     std::vector<RuntimeFn> runtimeOrder;
     std::unordered_set<RuntimeFn, RuntimeFnHash> runtimeSet;
 
+    void trackRuntime(RuntimeFn fn);
+
+    enum class ExprType
+    {
+        I64,
+        F64,
+        Str,
+        Bool,
+    };
+    ExprType scanExpr(const Expr &e);
+    void scanStmt(const Stmt &s);
+    /// @brief Analyze @p prog for runtime usage prior to emission.
+    void scanProgram(const Program &prog);
+    /// @brief Emit IR for @p prog after scanning.
+    void emitProgram(const Program &prog);
     void declareRequiredRuntime(build::IRBuilder &b);
 };
 


### PR DESCRIPTION
## Summary
- separate BASIC lowering into scan and emit phases
- add helpers for runtime tracking and expression scanning
- document scanning helpers

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bbc6738e388324a49c8a3d3428cdaf