### PR TITLE
refactor(fe/basic): factor builtin lowering helpers

### DIFF
--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -202,6 +202,28 @@ class Lowerer
     /// @return Resulting value and type.
     RVal lowerBuiltinCall(const BuiltinCallExpr &expr);
 
+    // Built-in helpers
+    RVal lowerLen(const BuiltinCallExpr &expr);
+    RVal lowerMid(const BuiltinCallExpr &expr);
+    RVal lowerLeft(const BuiltinCallExpr &expr);
+    RVal lowerRight(const BuiltinCallExpr &expr);
+    RVal lowerStr(const BuiltinCallExpr &expr);
+    RVal lowerVal(const BuiltinCallExpr &expr);
+    RVal lowerInt(const BuiltinCallExpr &expr);
+    RVal lowerSqr(const BuiltinCallExpr &expr);
+    RVal lowerAbs(const BuiltinCallExpr &expr);
+    RVal lowerFloor(const BuiltinCallExpr &expr);
+    RVal lowerCeil(const BuiltinCallExpr &expr);
+    RVal lowerSin(const BuiltinCallExpr &expr);
+    RVal lowerCos(const BuiltinCallExpr &expr);
+    RVal lowerPow(const BuiltinCallExpr &expr);
+    RVal lowerRnd(const BuiltinCallExpr &expr);
+
+    // Shared argument helpers
+    RVal lowerArg(const BuiltinCallExpr &c, size_t idx);
+    RVal ensureI64(RVal v, il::support::SourceLoc loc);
+    RVal ensureF64(RVal v, il::support::SourceLoc loc);
+
     void lowerLet(const LetStmt &stmt);
     void lowerPrint(const PrintStmt &stmt);
     void lowerIf(const IfStmt &stmt);


### PR DESCRIPTION
## Summary
- factor out individual builtin lowering helpers and shared arg conversion utilities
- dispatch builtin calls via a compact switch

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bc838ff5ec832492f35dc340d8c6d3