### PR TITLE
refactor(basic): extract function parsing helpers

### DIFF
--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -445,7 +445,7 @@ std::vector<Param> Parser::parseParamList()
     return params;
 }
 
-StmtPtr Parser::parseFunction()
+std::unique_ptr<FunctionDecl> Parser::parseFunctionHeader()
 {
     auto loc = peek().loc;
     consume(); // FUNCTION
@@ -455,6 +455,11 @@ StmtPtr Parser::parseFunction()
     fn->name = nameTok.lexeme;
     fn->ret = typeFromSuffix(nameTok.lexeme);
     fn->params = parseParamList();
+    return fn;
+}
+
+void Parser::parseFunctionBody(FunctionDecl *fn)
+{
     if (at(TokenKind::EndOfLine))
         consume();
     else if (at(TokenKind::Colon))
@@ -485,6 +490,12 @@ StmtPtr Parser::parseFunction()
         else if (at(TokenKind::EndOfLine))
             consume();
     }
+}
+
+StmtPtr Parser::parseFunction()
+{
+    auto fn = parseFunctionHeader();
+    parseFunctionBody(fn.get());
     return fn;
 }
 

--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -45,6 +45,8 @@ class Parser
     StmtPtr parseDim();
     StmtPtr parseRandomize();
     StmtPtr parseFunction();
+    std::unique_ptr<FunctionDecl> parseFunctionHeader();
+    void parseFunctionBody(FunctionDecl *fn);
     StmtPtr parseSub();
     StmtPtr parseReturn();
     std::vector<Param> parseParamList();


### PR DESCRIPTION
## Summary
- split `parseFunction` into header and body helpers
- maintain original AST construction and token flow

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bc8549b7c08324b65935c5212be6f4