### PR TITLE
refactor(fe/basic): split binary expression lowering helpers

### DIFF
--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -197,6 +197,26 @@ class Lowerer
     /// @param expr Binary expression node.
     /// @return Resulting value and type.
     RVal lowerBinaryExpr(const BinaryExpr &expr);
+    /// @brief Lower logical (`AND`/`OR`) expressions with short-circuiting.
+    /// @param expr Binary expression node.
+    /// @return Resulting value and type.
+    RVal lowerLogicalBinary(const BinaryExpr &expr);
+    /// @brief Lower integer division and modulo with divide-by-zero check.
+    /// @param expr Binary expression node.
+    /// @return Resulting value and type.
+    RVal lowerDivOrMod(const BinaryExpr &expr);
+    /// @brief Lower string concatenation and equality/inequality comparisons.
+    /// @param expr Binary expression node.
+    /// @param lhs Pre-lowered left-hand side.
+    /// @param rhs Pre-lowered right-hand side.
+    /// @return Resulting value and type.
+    RVal lowerStringBinary(const BinaryExpr &expr, RVal lhs, RVal rhs);
+    /// @brief Lower numeric arithmetic and comparisons.
+    /// @param expr Binary expression node.
+    /// @param lhs Pre-lowered left-hand side.
+    /// @param rhs Pre-lowered right-hand side.
+    /// @return Resulting value and type.
+    RVal lowerNumericBinary(const BinaryExpr &expr, RVal lhs, RVal rhs);
     /// @brief Lower a built-in call expression.
     /// @param expr Built-in call expression node.
     /// @return Resulting value and type.


### PR DESCRIPTION
## Summary
- refactor `Lowerer::lowerBinaryExpr` to delegate to dedicated helpers for logical, division/modulo, string, and numeric operations
- add helper functions for short-circuit logic, zero-checked div/mod, string ops, and numeric ops

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bc85e3caac8324a81cc304f1fdfd71