### PR TITLE
refactor(fe/basic): factor binary checks into helpers

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -133,6 +133,14 @@ class SemanticAnalyzer
     Type analyzeUnary(const UnaryExpr &u);
     /// @brief Analyze binary expression.
     Type analyzeBinary(const BinaryExpr &b);
+    /// @brief Analyze arithmetic operators (+, -, *).
+    Type analyzeArithmetic(const BinaryExpr &b, Type lt, Type rt);
+    /// @brief Analyze division and modulus operators.
+    Type analyzeDivMod(const BinaryExpr &b, Type lt, Type rt);
+    /// @brief Analyze comparison operators (==, <>, <, <=, >, >=).
+    Type analyzeComparison(const BinaryExpr &b, Type lt, Type rt);
+    /// @brief Analyze logical operators (AND, OR).
+    Type analyzeLogical(const BinaryExpr &b, Type lt, Type rt);
     /// @brief Analyze built-in function call.
     Type analyzeBuiltinCall(const BuiltinCallExpr &c);
     /// @brief Analyze RND builtin.


### PR DESCRIPTION
## Summary
- split BinaryExpr analysis into dedicated helpers for arithmetic, division/modulus, comparison and logical operators
- each helper validates operand types and emits the same diagnostics as before

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bc866048c88324a8614036abd95bf6