### PR TITLE
refactor(basic): split for lowering helpers

### DIFF
--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -175,6 +175,16 @@ class Lowerer
         }
     };
 
+    struct ForBlocks
+    {
+        size_t headIdx{0};
+        size_t headPosIdx{0};
+        size_t headNegIdx{0};
+        size_t bodyIdx{0};
+        size_t incIdx{0};
+        size_t doneIdx{0};
+    };
+
     std::unique_ptr<BlockNamer> blockNamer;
 
     void collectVars(const Program &prog);
@@ -249,6 +259,10 @@ class Lowerer
     void lowerIf(const IfStmt &stmt);
     void lowerWhile(const WhileStmt &stmt);
     void lowerFor(const ForStmt &stmt);
+    void lowerForConstStep(const ForStmt &stmt, Value slot, RVal end, RVal step, long stepConst);
+    void lowerForVarStep(const ForStmt &stmt, Value slot, RVal end, RVal step);
+    ForBlocks setupForBlocks(bool varStep);
+    void emitForStep(Value slot, Value step);
     void lowerNext(const NextStmt &stmt);
     void lowerGoto(const GotoStmt &stmt);
     void lowerEnd(const EndStmt &stmt);


### PR DESCRIPTION
## Summary
- extract shared for-loop block setup and step increment helpers
- separate constant and variable step for lowering paths
- simplify `lowerFor` to delegate to new helpers

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bc87aae4f88324a039d80a195f87c7