### PR TITLE
refactor(il/io): modularize instruction parsing

### DIFF
--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -9,6 +9,7 @@
 #include "il/core/Value.hpp"
 #include "support/source_manager.hpp"
 #include <cctype>
+#include <functional>
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
@@ -140,6 +141,363 @@ struct ParserState
     explicit ParserState(Module &mod) : m(mod) {}
 };
 
+using InstrHandler =
+    std::function<bool(const std::string &, Instr &, ParserState &, std::ostream &)>;
+
+InstrHandler makeBinaryHandler(Opcode op, Type ty)
+{
+    return [op, ty](const std::string &rest, Instr &in, ParserState &st, std::ostream &)
+    {
+        std::istringstream ss(rest);
+        std::string a = readToken(ss);
+        std::string b = readToken(ss);
+        in.op = op;
+        if (!a.empty())
+            in.operands.push_back(parseValue(a, st.tempIds));
+        if (!b.empty())
+            in.operands.push_back(parseValue(b, st.tempIds));
+        in.type = ty;
+        return true;
+    };
+}
+
+InstrHandler makeUnaryHandler(Opcode op, Type ty)
+{
+    return [op, ty](const std::string &rest, Instr &in, ParserState &st, std::ostream &)
+    {
+        std::istringstream ss(rest);
+        std::string a = readToken(ss);
+        in.op = op;
+        if (!a.empty())
+            in.operands.push_back(parseValue(a, st.tempIds));
+        in.type = ty;
+        return true;
+    };
+}
+
+InstrHandler makeCmpHandler(Opcode op)
+{
+    return makeBinaryHandler(op, Type(Type::Kind::I1));
+}
+
+bool parseAllocaInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
+bool parseGEPInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
+bool parseLoadInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
+bool parseStoreInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
+bool parseAddrOfInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
+bool parseConstStrInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
+bool parseConstNullInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
+bool parseCallInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err);
+bool parseBrInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err);
+bool parseCBrInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err);
+bool parseRetInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
+bool parseTrapInstr(const std::string &rest, Instr &in, ParserState &, std::ostream &);
+
+static const std::unordered_map<std::string, InstrHandler> kInstrHandlers = {
+    {"add", makeBinaryHandler(Opcode::Add, Type(Type::Kind::I64))},
+    {"sub", makeBinaryHandler(Opcode::Sub, Type(Type::Kind::I64))},
+    {"mul", makeBinaryHandler(Opcode::Mul, Type(Type::Kind::I64))},
+    {"sdiv", makeBinaryHandler(Opcode::SDiv, Type(Type::Kind::I64))},
+    {"udiv", makeBinaryHandler(Opcode::UDiv, Type(Type::Kind::I64))},
+    {"srem", makeBinaryHandler(Opcode::SRem, Type(Type::Kind::I64))},
+    {"urem", makeBinaryHandler(Opcode::URem, Type(Type::Kind::I64))},
+    {"and", makeBinaryHandler(Opcode::And, Type(Type::Kind::I64))},
+    {"or", makeBinaryHandler(Opcode::Or, Type(Type::Kind::I64))},
+    {"xor", makeBinaryHandler(Opcode::Xor, Type(Type::Kind::I64))},
+    {"shl", makeBinaryHandler(Opcode::Shl, Type(Type::Kind::I64))},
+    {"lshr", makeBinaryHandler(Opcode::LShr, Type(Type::Kind::I64))},
+    {"ashr", makeBinaryHandler(Opcode::AShr, Type(Type::Kind::I64))},
+    {"fadd", makeBinaryHandler(Opcode::FAdd, Type(Type::Kind::F64))},
+    {"fsub", makeBinaryHandler(Opcode::FSub, Type(Type::Kind::F64))},
+    {"fmul", makeBinaryHandler(Opcode::FMul, Type(Type::Kind::F64))},
+    {"fdiv", makeBinaryHandler(Opcode::FDiv, Type(Type::Kind::F64))},
+    {"icmp_eq", makeCmpHandler(Opcode::ICmpEq)},
+    {"icmp_ne", makeCmpHandler(Opcode::ICmpNe)},
+    {"scmp_lt", makeCmpHandler(Opcode::SCmpLT)},
+    {"scmp_le", makeCmpHandler(Opcode::SCmpLE)},
+    {"scmp_gt", makeCmpHandler(Opcode::SCmpGT)},
+    {"scmp_ge", makeCmpHandler(Opcode::SCmpGE)},
+    {"ucmp_lt", makeCmpHandler(Opcode::UCmpLT)},
+    {"ucmp_le", makeCmpHandler(Opcode::UCmpLE)},
+    {"ucmp_gt", makeCmpHandler(Opcode::UCmpGT)},
+    {"ucmp_ge", makeCmpHandler(Opcode::UCmpGE)},
+    {"fcmp_lt", makeCmpHandler(Opcode::FCmpLT)},
+    {"fcmp_le", makeCmpHandler(Opcode::FCmpLE)},
+    {"fcmp_gt", makeCmpHandler(Opcode::FCmpGT)},
+    {"fcmp_ge", makeCmpHandler(Opcode::FCmpGE)},
+    {"fcmp_eq", makeCmpHandler(Opcode::FCmpEQ)},
+    {"fcmp_ne", makeCmpHandler(Opcode::FCmpNE)},
+    {"sitofp", makeUnaryHandler(Opcode::Sitofp, Type(Type::Kind::F64))},
+    {"fptosi", makeUnaryHandler(Opcode::Fptosi, Type(Type::Kind::I64))},
+    {"zext1", makeUnaryHandler(Opcode::Zext1, Type(Type::Kind::I64))},
+    {"trunc1", makeUnaryHandler(Opcode::Trunc1, Type(Type::Kind::I1))},
+    {"alloca", parseAllocaInstr},
+    {"gep", parseGEPInstr},
+    {"load", parseLoadInstr},
+    {"store", parseStoreInstr},
+    {"addr_of", parseAddrOfInstr},
+    {"const_str", parseConstStrInstr},
+    {"const_null", parseConstNullInstr},
+    {"call", parseCallInstr},
+    {"br", parseBrInstr},
+    {"cbr", parseCBrInstr},
+    {"ret", parseRetInstr},
+    {"trap", parseTrapInstr}};
+
+bool parseAllocaInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &)
+{
+    std::istringstream ss(rest);
+    std::string sz = readToken(ss);
+    in.op = Opcode::Alloca;
+    if (!sz.empty())
+        in.operands.push_back(parseValue(sz, st.tempIds));
+    in.type = Type(Type::Kind::Ptr);
+    return true;
+}
+
+bool parseGEPInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &)
+{
+    std::istringstream ss(rest);
+    std::string base = readToken(ss);
+    std::string off = readToken(ss);
+    in.op = Opcode::GEP;
+    in.operands.push_back(parseValue(base, st.tempIds));
+    in.operands.push_back(parseValue(off, st.tempIds));
+    in.type = Type(Type::Kind::Ptr);
+    return true;
+}
+
+bool parseLoadInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &)
+{
+    std::istringstream ss(rest);
+    std::string ty = readToken(ss);
+    std::string ptr = readToken(ss);
+    in.op = Opcode::Load;
+    in.type = parseType(ty);
+    in.operands.push_back(parseValue(ptr, st.tempIds));
+    return true;
+}
+
+bool parseStoreInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &)
+{
+    std::istringstream ss(rest);
+    std::string ty = readToken(ss);
+    std::string ptr = readToken(ss);
+    std::string val = readToken(ss);
+    in.op = Opcode::Store;
+    in.type = parseType(ty);
+    in.operands.push_back(parseValue(ptr, st.tempIds));
+    in.operands.push_back(parseValue(val, st.tempIds));
+    return true;
+}
+
+bool parseAddrOfInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &)
+{
+    std::istringstream ss(rest);
+    std::string g = readToken(ss);
+    in.op = Opcode::AddrOf;
+    if (!g.empty())
+        in.operands.push_back(parseValue(g, st.tempIds));
+    in.type = Type(Type::Kind::Ptr);
+    return true;
+}
+
+bool parseConstStrInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &)
+{
+    std::istringstream ss(rest);
+    std::string g = readToken(ss);
+    in.op = Opcode::ConstStr;
+    if (!g.empty())
+        in.operands.push_back(parseValue(g, st.tempIds));
+    in.type = Type(Type::Kind::Str);
+    return true;
+}
+
+bool parseConstNullInstr(const std::string &rest, Instr &in, ParserState &, std::ostream &)
+{
+    (void)rest;
+    in.op = Opcode::ConstNull;
+    in.type = Type(Type::Kind::Ptr);
+    return true;
+}
+
+bool parseCallInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err)
+{
+    in.op = Opcode::Call;
+    size_t at = rest.find('@');
+    size_t lp = rest.find('(', at);
+    size_t rp = rest.find(')', lp);
+    if (at == std::string::npos || lp == std::string::npos || rp == std::string::npos)
+    {
+        err << "line " << st.lineNo << ": malformed call\n";
+        return false;
+    }
+    in.callee = rest.substr(at + 1, lp - at - 1);
+    std::string args = rest.substr(lp + 1, rp - lp - 1);
+    std::stringstream as(args);
+    std::string a;
+    while (std::getline(as, a, ','))
+    {
+        a = trim(a);
+        if (!a.empty())
+            in.operands.push_back(parseValue(a, st.tempIds));
+    }
+    in.type = Type(Type::Kind::Void);
+    return true;
+}
+
+bool parseBrInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err)
+{
+    in.op = Opcode::Br;
+    std::string t = rest;
+    if (t.rfind("label ", 0) == 0)
+        t = trim(t.substr(6));
+    size_t lp = t.find('(');
+    std::vector<Value> args;
+    std::string lbl;
+    if (lp == std::string::npos)
+    {
+        lbl = t;
+    }
+    else
+    {
+        size_t rp = t.find(')', lp);
+        if (rp == std::string::npos)
+        {
+            err << "line " << st.lineNo << ": mismatched ')\n";
+            return false;
+        }
+        lbl = trim(t.substr(0, lp));
+        std::string argsStr = t.substr(lp + 1, rp - lp - 1);
+        std::stringstream as(argsStr);
+        std::string a;
+        while (std::getline(as, a, ','))
+        {
+            a = trim(a);
+            if (!a.empty())
+                args.push_back(parseValue(a, st.tempIds));
+        }
+    }
+    in.labels.push_back(lbl);
+    in.brArgs.push_back(args);
+    size_t argCount = args.size();
+    auto it = st.blockParamCount.find(lbl);
+    if (it != st.blockParamCount.end())
+    {
+        if (it->second != argCount)
+        {
+            err << "line " << st.lineNo << ": bad arg count\n";
+            return false;
+        }
+    }
+    else
+        st.pendingBrs.push_back({lbl, argCount, st.lineNo});
+    in.type = Type(Type::Kind::Void);
+    return true;
+}
+
+bool parseCBrInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err)
+{
+    in.op = Opcode::CBr;
+    std::istringstream ss(rest);
+    std::string c = readToken(ss);
+    std::string rem;
+    std::getline(ss, rem);
+    rem = trim(rem);
+    size_t comma = rem.find(',');
+    if (comma == std::string::npos)
+    {
+        err << "line " << st.lineNo << ": malformed cbr\n";
+        return false;
+    }
+    std::string first = trim(rem.substr(0, comma));
+    std::string second = trim(rem.substr(comma + 1));
+    auto parseTarget =
+        [&](const std::string &part, std::string &lbl, std::vector<Value> &args) -> bool
+    {
+        std::string t = part;
+        if (t.rfind("label ", 0) == 0)
+            t = trim(t.substr(6));
+        size_t lp = t.find('(');
+        if (lp == std::string::npos)
+        {
+            lbl = trim(t);
+        }
+        else
+        {
+            size_t rp = t.find(')', lp);
+            if (rp == std::string::npos)
+                return false;
+            lbl = trim(t.substr(0, lp));
+            std::string argsStr = t.substr(lp + 1, rp - lp - 1);
+            std::stringstream as(argsStr);
+            std::string a;
+            while (std::getline(as, a, ','))
+            {
+                a = trim(a);
+                if (!a.empty())
+                    args.push_back(parseValue(a, st.tempIds));
+            }
+        }
+        return true;
+    };
+    std::vector<Value> a1, a2;
+    std::string l1, l2;
+    if (!parseTarget(first, l1, a1) || !parseTarget(second, l2, a2))
+    {
+        err << "line " << st.lineNo << ": mismatched ')\n";
+        return false;
+    }
+    in.operands.push_back(parseValue(c, st.tempIds));
+    in.labels.push_back(l1);
+    in.labels.push_back(l2);
+    in.brArgs.push_back(a1);
+    in.brArgs.push_back(a2);
+    size_t n1 = a1.size();
+    auto it1 = st.blockParamCount.find(l1);
+    if (it1 != st.blockParamCount.end())
+    {
+        if (it1->second != n1)
+        {
+            err << "line " << st.lineNo << ": bad arg count\n";
+            return false;
+        }
+    }
+    else
+        st.pendingBrs.push_back({l1, n1, st.lineNo});
+    size_t n2 = a2.size();
+    auto it2 = st.blockParamCount.find(l2);
+    if (it2 != st.blockParamCount.end())
+    {
+        if (it2->second != n2)
+        {
+            err << "line " << st.lineNo << ": bad arg count\n";
+            return false;
+        }
+    }
+    else
+        st.pendingBrs.push_back({l2, n2, st.lineNo});
+    in.type = Type(Type::Kind::Void);
+    return true;
+}
+
+bool parseRetInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &)
+{
+    in.op = Opcode::Ret;
+    std::string v = trim(rest);
+    if (!v.empty())
+        in.operands.push_back(parseValue(v, st.tempIds));
+    in.type = Type(Type::Kind::Void);
+    return true;
+}
+
+bool parseTrapInstr(const std::string &, Instr &in, ParserState &, std::ostream &)
+{
+    in.op = Opcode::Trap;
+    in.type = Type(Type::Kind::Void);
+    return true;
+}
+
 bool parseInstruction(const std::string &line, ParserState &st, std::ostream &err)
 {
     Instr in;
@@ -160,306 +518,20 @@ bool parseInstruction(const std::string &line, ParserState &st, std::ostream &er
         in.result = it->second;
         work = trim(work.substr(eq + 1));
     }
-    std::string op;
     std::istringstream ss(work);
+    std::string op;
     ss >> op;
-    static const std::unordered_map<std::string, Opcode> opMap = {{"add", Opcode::Add},
-                                                                  {"sub", Opcode::Sub},
-                                                                  {"mul", Opcode::Mul},
-                                                                  {"sdiv", Opcode::SDiv},
-                                                                  {"udiv", Opcode::UDiv},
-                                                                  {"srem", Opcode::SRem},
-                                                                  {"urem", Opcode::URem},
-                                                                  {"and", Opcode::And},
-                                                                  {"or", Opcode::Or},
-                                                                  {"xor", Opcode::Xor},
-                                                                  {"shl", Opcode::Shl},
-                                                                  {"lshr", Opcode::LShr},
-                                                                  {"ashr", Opcode::AShr},
-                                                                  {"fadd", Opcode::FAdd},
-                                                                  {"fsub", Opcode::FSub},
-                                                                  {"fmul", Opcode::FMul},
-                                                                  {"fdiv", Opcode::FDiv},
-                                                                  {"icmp_eq", Opcode::ICmpEq},
-                                                                  {"icmp_ne", Opcode::ICmpNe},
-                                                                  {"scmp_lt", Opcode::SCmpLT},
-                                                                  {"scmp_le", Opcode::SCmpLE},
-                                                                  {"scmp_gt", Opcode::SCmpGT},
-                                                                  {"scmp_ge", Opcode::SCmpGE},
-                                                                  {"ucmp_lt", Opcode::UCmpLT},
-                                                                  {"ucmp_le", Opcode::UCmpLE},
-                                                                  {"ucmp_gt", Opcode::UCmpGT},
-                                                                  {"ucmp_ge", Opcode::UCmpGE},
-                                                                  {"fcmp_lt", Opcode::FCmpLT},
-                                                                  {"fcmp_le", Opcode::FCmpLE},
-                                                                  {"fcmp_gt", Opcode::FCmpGT},
-                                                                  {"fcmp_ge", Opcode::FCmpGE},
-                                                                  {"fcmp_eq", Opcode::FCmpEQ},
-                                                                  {"fcmp_ne", Opcode::FCmpNE},
-                                                                  {"sitofp", Opcode::Sitofp},
-                                                                  {"fptosi", Opcode::Fptosi},
-                                                                  {"zext1", Opcode::Zext1},
-                                                                  {"trunc1", Opcode::Trunc1},
-                                                                  {"alloca", Opcode::Alloca},
-                                                                  {"gep", Opcode::GEP},
-                                                                  {"load", Opcode::Load},
-                                                                  {"store", Opcode::Store},
-                                                                  {"addr_of", Opcode::AddrOf},
-                                                                  {"const_str", Opcode::ConstStr},
-                                                                  {"const_null", Opcode::ConstNull},
-                                                                  {"call", Opcode::Call},
-                                                                  {"br", Opcode::Br},
-                                                                  {"cbr", Opcode::CBr},
-                                                                  {"ret", Opcode::Ret},
-                                                                  {"trap", Opcode::Trap}};
-    auto itOp = opMap.find(op);
-    if (itOp == opMap.end())
+    std::string rest;
+    std::getline(ss, rest);
+    rest = trim(rest);
+    auto it = kInstrHandlers.find(op);
+    if (it == kInstrHandlers.end())
     {
         err << "line " << st.lineNo << ": unknown opcode " << op << "\n";
         return false;
     }
-    in.op = itOp->second;
-    switch (in.op)
-    {
-        case Opcode::Alloca:
-        {
-            std::string sz = readToken(ss);
-            in.operands.push_back(parseValue(sz, st.tempIds));
-            in.type = Type(Type::Kind::Ptr);
-            break;
-        }
-        case Opcode::GEP:
-        {
-            std::string base = readToken(ss);
-            std::string off = readToken(ss);
-            in.operands.push_back(parseValue(base, st.tempIds));
-            in.operands.push_back(parseValue(off, st.tempIds));
-            in.type = Type(Type::Kind::Ptr);
-            break;
-        }
-        case Opcode::Load:
-        {
-            std::string ty = readToken(ss);
-            std::string ptr = readToken(ss);
-            in.type = parseType(ty);
-            in.operands.push_back(parseValue(ptr, st.tempIds));
-            break;
-        }
-        case Opcode::Store:
-        {
-            std::string ty = readToken(ss);
-            std::string ptr = readToken(ss);
-            std::string val = readToken(ss);
-            in.type = parseType(ty);
-            in.operands.push_back(parseValue(ptr, st.tempIds));
-            in.operands.push_back(parseValue(val, st.tempIds));
-            break;
-        }
-        case Opcode::AddrOf:
-        {
-            std::string g = readToken(ss);
-            in.operands.push_back(parseValue(g, st.tempIds));
-            in.type = Type(Type::Kind::Ptr);
-            break;
-        }
-        case Opcode::ConstStr:
-        {
-            std::string g = readToken(ss);
-            if (!g.empty())
-                in.operands.push_back(parseValue(g, st.tempIds));
-            in.type = Type(Type::Kind::Str);
-            break;
-        }
-        case Opcode::ConstNull:
-        {
-            in.type = Type(Type::Kind::Ptr);
-            break;
-        }
-        case Opcode::Call:
-        {
-            size_t at = work.find('@');
-            size_t lp = work.find('(', at);
-            size_t rp = work.find(')', lp);
-            in.callee = work.substr(at + 1, lp - at - 1);
-            std::string args = work.substr(lp + 1, rp - lp - 1);
-            std::stringstream as(args);
-            std::string a;
-            while (std::getline(as, a, ','))
-            {
-                a = trim(a);
-                if (!a.empty())
-                    in.operands.push_back(parseValue(a, st.tempIds));
-            }
-            in.type = Type(Type::Kind::Void);
-            break;
-        }
-        case Opcode::Br:
-        {
-            std::string rest;
-            std::getline(ss, rest);
-            rest = trim(rest);
-            if (rest.rfind("label ", 0) == 0)
-                rest = trim(rest.substr(6));
-            size_t lp = rest.find('(');
-            std::vector<Value> args;
-            std::string lbl;
-            if (lp == std::string::npos)
-            {
-                lbl = rest;
-            }
-            else
-            {
-                size_t rp = rest.find(')', lp);
-                if (rp == std::string::npos)
-                {
-                    err << "line " << st.lineNo << ": mismatched ')\n";
-                    return false;
-                }
-                lbl = trim(rest.substr(0, lp));
-                std::string argsStr = rest.substr(lp + 1, rp - lp - 1);
-                std::stringstream as(argsStr);
-                std::string a;
-                while (std::getline(as, a, ','))
-                {
-                    a = trim(a);
-                    if (!a.empty())
-                        args.push_back(parseValue(a, st.tempIds));
-                }
-            }
-            in.labels.push_back(lbl);
-            in.brArgs.push_back(args);
-            size_t argCount = args.size();
-            auto it = st.blockParamCount.find(lbl);
-            if (it != st.blockParamCount.end())
-            {
-                if (it->second != argCount)
-                {
-                    err << "line " << st.lineNo << ": bad arg count\n";
-                    return false;
-                }
-            }
-            else
-                st.pendingBrs.push_back({lbl, argCount, st.lineNo});
-            in.type = Type(Type::Kind::Void);
-            break;
-        }
-        case Opcode::CBr:
-        {
-            std::string c = readToken(ss);
-            std::string rest;
-            std::getline(ss, rest);
-            rest = trim(rest);
-            size_t comma = rest.find(',');
-            if (comma == std::string::npos)
-            {
-                err << "line " << st.lineNo << ": malformed cbr\n";
-                return false;
-            }
-            std::string first = trim(rest.substr(0, comma));
-            std::string second = trim(rest.substr(comma + 1));
-            auto parseTarget =
-                [&](const std::string &part, std::string &lbl, std::vector<Value> &args) -> bool
-            {
-                std::string t = part;
-                if (t.rfind("label ", 0) == 0)
-                    t = trim(t.substr(6));
-                size_t lp = t.find('(');
-                if (lp == std::string::npos)
-                {
-                    lbl = trim(t);
-                }
-                else
-                {
-                    size_t rp = t.find(')', lp);
-                    if (rp == std::string::npos)
-                        return false;
-                    lbl = trim(t.substr(0, lp));
-                    std::string argsStr = t.substr(lp + 1, rp - lp - 1);
-                    std::stringstream as(argsStr);
-                    std::string a;
-                    while (std::getline(as, a, ','))
-                    {
-                        a = trim(a);
-                        if (!a.empty())
-                            args.push_back(parseValue(a, st.tempIds));
-                    }
-                }
-                return true;
-            };
-            std::vector<Value> a1, a2;
-            std::string l1, l2;
-            if (!parseTarget(first, l1, a1) || !parseTarget(second, l2, a2))
-            {
-                err << "line " << st.lineNo << ": mismatched ')\n";
-                return false;
-            }
-            in.operands.push_back(parseValue(c, st.tempIds));
-            in.labels.push_back(l1);
-            in.labels.push_back(l2);
-            in.brArgs.push_back(a1);
-            in.brArgs.push_back(a2);
-            size_t n1 = a1.size();
-            auto it1 = st.blockParamCount.find(l1);
-            if (it1 != st.blockParamCount.end())
-            {
-                if (it1->second != n1)
-                {
-                    err << "line " << st.lineNo << ": bad arg count\n";
-                    return false;
-                }
-            }
-            else
-                st.pendingBrs.push_back({l1, n1, st.lineNo});
-            size_t n2 = a2.size();
-            auto it2 = st.blockParamCount.find(l2);
-            if (it2 != st.blockParamCount.end())
-            {
-                if (it2->second != n2)
-                {
-                    err << "line " << st.lineNo << ": bad arg count\n";
-                    return false;
-                }
-            }
-            else
-                st.pendingBrs.push_back({l2, n2, st.lineNo});
-            in.type = Type(Type::Kind::Void);
-            break;
-        }
-        case Opcode::Ret:
-        {
-            std::string v;
-            if (ss >> v)
-                in.operands.push_back(parseValue(v, st.tempIds));
-            in.type = Type(Type::Kind::Void);
-            break;
-        }
-        case Opcode::Trap:
-        {
-            in.type = Type(Type::Kind::Void);
-            break;
-        }
-        default:
-        {
-            bool unary = in.op == Opcode::Sitofp || in.op == Opcode::Fptosi ||
-                         in.op == Opcode::Zext1 || in.op == Opcode::Trunc1;
-            std::string a = readToken(ss);
-            in.operands.push_back(parseValue(a, st.tempIds));
-            if (!unary)
-            {
-                std::string b = readToken(ss);
-                if (!b.empty())
-                    in.operands.push_back(parseValue(b, st.tempIds));
-            }
-            if (op == "fadd" || op == "fsub" || op == "fmul" || op == "fdiv" || op == "sitofp")
-                in.type = Type(Type::Kind::F64);
-            else if (op.rfind("icmp_", 0) == 0 || op.rfind("scmp_", 0) == 0 ||
-                     op.rfind("ucmp_", 0) == 0 || op.rfind("fcmp_", 0) == 0 || op == "trunc1")
-                in.type = Type(Type::Kind::I1);
-            else
-                in.type = Type(Type::Kind::I64);
-            break;
-        }
-    }
+    if (!it->second(rest, in, st, err))
+        return false;
     st.curBB->instructions.push_back(std::move(in));
     return true;
 }


### PR DESCRIPTION
## Summary
- refactor Parser to dispatch instructions via opcode handler map
- simplify parseInstruction to delegate to small parsing functions

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bc8852e2248324b89f0d48d896b387