### PR TITLE
refactor(fe/basic): extract call analysis helpers

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -186,6 +186,12 @@ class SemanticAnalyzer
                       size_t idx,
                       Type argTy,
                       std::initializer_list<Type> allowed);
+    /// @brief Resolve callee of user-defined call.
+    const ProcSignature *resolveCallee(const CallExpr &c);
+    /// @brief Collect and validate argument types for user-defined call.
+    std::vector<Type> checkCallArgs(const CallExpr &c, const ProcSignature *sig);
+    /// @brief Infer return type for user-defined call.
+    Type inferCallType(const CallExpr &c, const ProcSignature *sig);
     /// @brief Analyze user-defined procedure call.
     Type analyzeCall(const CallExpr &c);
     /// @brief Analyze array access expression.


### PR DESCRIPTION
## Summary
- split user-defined call analysis into separate resolveCallee, checkCallArgs, and inferCallType helpers
- simplify analyzeCall to orchestrate callee resolution, argument checks, and return type inference

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bc892c669883248bda912e19826bb2