### PR TITLE
refactor(basic): extract LET assignment helpers

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -113,6 +113,13 @@ class SemanticAnalyzer
     /// @brief Analyze DIM statement @p s.
     void analyzeDim(const DimStmt &s);
 
+    /// @brief Analyze assignment to a simple variable in LET.
+    void analyzeVarAssignment(VarExpr &v, const LetStmt &s);
+    /// @brief Analyze assignment to an array element in LET.
+    void analyzeArrayAssignment(ArrayExpr &a, const LetStmt &s);
+    /// @brief Report error for LET with a non-assignable left-hand side.
+    void analyzeConstExpr(const LetStmt &s);
+
     /// @brief Inferred BASIC value type.
     enum class Type
     {


### PR DESCRIPTION
## Summary
- factor LET variable, array, and constant cases into dedicated helper functions
- document LET helper routines and improve `analyzeLet` readability

## Testing
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bc8c859ffc832491fe9ac0202866fb