### PR TITLE
refactor(fe/basic): split array and variable ref parsing

### DIFF
--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -57,6 +57,8 @@ class Parser
     ExprPtr parseNumber();
     ExprPtr parseString();
     ExprPtr parseBuiltinCall(BuiltinCallExpr::Builtin builtin, il::support::SourceLoc loc);
+    ExprPtr parseVariableRef(std::string name, il::support::SourceLoc loc);
+    ExprPtr parseArrayRef(std::string name, il::support::SourceLoc loc);
     ExprPtr parseArrayOrVar();
     int precedence(TokenKind k);
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -319,6 +319,10 @@ add_executable(test_basic_constfold unit/test_basic_constfold.cpp)
 target_link_libraries(test_basic_constfold PRIVATE fe_basic support)
 add_test(NAME test_basic_constfold COMMAND test_basic_constfold)
 
+add_executable(test_basic_parse_array_var unit/test_basic_parse_array_var.cpp)
+target_link_libraries(test_basic_parse_array_var PRIVATE fe_basic support)
+add_test(NAME test_basic_parse_array_var COMMAND test_basic_parse_array_var)
+
 add_executable(test_vm_trap_loc unit/test_vm_trap_loc.cpp)
 target_link_libraries(test_vm_trap_loc PRIVATE il_build il_vm support)
 add_test(NAME test_vm_trap_loc COMMAND test_vm_trap_loc)

--- a/tests/unit/test_basic_parse_array_var.cpp
+++ b/tests/unit/test_basic_parse_array_var.cpp
@@ -1,0 +1,44 @@
+// File: tests/unit/test_basic_parse_array_var.cpp
+// Purpose: Verify Parser distinguishes variable and array references.
+// Key invariants: Identifier without parentheses yields VarExpr; with index yields ArrayExpr.
+// Ownership/Lifetime: Test owns parser and AST.
+// Links: docs/class-catalog.md
+
+#include "frontends/basic/Parser.hpp"
+#include "support/source_manager.hpp"
+#include <cassert>
+#include <string>
+
+using namespace il::frontends::basic;
+using namespace il::support;
+
+int main()
+{
+    // Variable reference
+    {
+        std::string src = "10 LET Y = X\n20 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("test.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        auto *let = dynamic_cast<LetStmt *>(prog->main[0].get());
+        auto *var = dynamic_cast<VarExpr *>(let->expr.get());
+        assert(var && var->name == "X");
+    }
+
+    // Array reference
+    {
+        std::string src = "10 DIM A(2)\n20 LET Y = A(1)\n30 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("test.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        auto *let = dynamic_cast<LetStmt *>(prog->main[1].get());
+        auto *arr = dynamic_cast<ArrayExpr *>(let->expr.get());
+        assert(arr && arr->name == "A");
+        auto *idx = dynamic_cast<IntExpr *>(arr->index.get());
+        assert(idx && idx->value == 1);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extract `parseVariableRef` and `parseArrayRef` helpers in BASIC parser
- simplify `parseArrayOrVar` by early bracket detection
- add unit test for variable vs array parsing

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bc8c6c07f08324a6d6b1eb838e64db