### PR TITLE
refactor(frontend/basic): split scanExpr into helpers

### DIFF
--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -374,6 +374,10 @@ class Lowerer
         Bool,
     };
     ExprType scanExpr(const Expr &e);
+    ExprType scanUnaryExpr(const UnaryExpr &u);
+    ExprType scanBinaryExpr(const BinaryExpr &b);
+    ExprType scanArrayExpr(const ArrayExpr &arr);
+    ExprType scanBuiltinCallExpr(const BuiltinCallExpr &c);
     void scanStmt(const Stmt &s);
     /// @brief Analyze @p prog for runtime usage prior to emission.
     void scanProgram(const Program &prog);


### PR DESCRIPTION
## Summary
- factor unary, binary, array, and builtin expression scanning into dedicated helper methods
- dispatch scanExpr to the new helpers instead of an in-line dynamic_cast cascade

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bc8c625d9883249404a42d2d0a2c10