### PR TITLE
refactor(basic): factor expression parsing helpers

### DIFF
--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -53,6 +53,8 @@ class Parser
     Type typeFromSuffix(std::string_view name);
 
     ExprPtr parseExpression(int min_prec = 0);
+    ExprPtr parseUnaryExpression();
+    ExprPtr parseInfixRhs(ExprPtr left, int min_prec);
     ExprPtr parsePrimary();
     ExprPtr parseNumber();
     ExprPtr parseString();

--- a/src/frontends/basic/Parser_Expr.cpp
+++ b/src/frontends/basic/Parser_Expr.cpp
@@ -42,7 +42,12 @@ int Parser::precedence(TokenKind k)
 
 ExprPtr Parser::parseExpression(int min_prec)
 {
-    ExprPtr left;
+    auto left = parseUnaryExpression();
+    return parseInfixRhs(std::move(left), min_prec);
+}
+
+ExprPtr Parser::parseUnaryExpression()
+{
     if (at(TokenKind::KeywordNot))
     {
         auto loc = peek().loc;
@@ -52,12 +57,13 @@ ExprPtr Parser::parseExpression(int min_prec)
         u->loc = loc;
         u->op = UnaryExpr::Op::Not;
         u->expr = std::move(operand);
-        left = std::move(u);
+        return u;
     }
-    else
-    {
-        left = parsePrimary();
-    }
+    return parsePrimary();
+}
+
+ExprPtr Parser::parseInfixRhs(ExprPtr left, int min_prec)
+{
     while (true)
     {
         int prec = precedence(peek().kind);


### PR DESCRIPTION
## Summary
- split unary prefix handling into `parseUnaryExpression`
- extract infix precedence loop into `parseInfixRhs`
- keep `parseExpression` as orchestrator for unary and infix parsing

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bc8f31e8348324b3f23133ec6c21f3