### PR TITLE
build(tests): gate docs comment lint behind option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<!--
+File: README.md
+Purpose: Project overview, build, and testing instructions.
+-->
+
 # Viper
 
 **IL Compiler & BASIC Frontend (VM-first)**
@@ -16,6 +21,22 @@ cmake --build build
 # Run a BASIC example on the VM
 ./build/src/tools/ilc/ilc front basic -run docs/examples/basic/ex1_hello_cond.bas
 ```
+## Testing
+
+Run the full test suite after building:
+
+```sh
+ctest --test-dir build --output-on-failure
+```
+
+To enable the optional docs comment lint test (disabled by default), configure with:
+
+```sh
+cmake -S . -B build -DIL_ENABLE_DOCS_LINT=ON
+```
+
+This runs `scripts/check_comments.py` to verify header and Doxygen comments.
+
 
 ## Cleaning
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,22 @@
-find_package(Python3 COMPONENTS Interpreter REQUIRED)
+# File: tests/CMakeLists.txt
+# Purpose: Configure test targets and optional docs comment lint.
 
-add_test(NAME docs_comment_check
-  COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/check_comments.py)
-set_tests_properties(docs_comment_check PROPERTIES LABELS Docs)
+option(IL_ENABLE_DOCS_LINT "Run header/Doxygen docs check (scripts/check_comments.py)" OFF)
+
+if(IL_ENABLE_DOCS_LINT)
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  execute_process(COMMAND git rev-parse --is-inside-work-tree
+                  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                  RESULT_VARIABLE GIT_OK
+                  OUTPUT_QUIET ERROR_QUIET)
+  if(GIT_OK EQUAL 0)
+    add_test(NAME docs_comment_check
+      COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/check_comments.py)
+    set_tests_properties(docs_comment_check PROPERTIES LABELS Docs)
+  else()
+    message(STATUS "Skipping docs_comment_check (not a Git working tree)")
+  endif()
+endif()
 
 add_executable(test_support unit/test_support.cpp)
 target_link_libraries(test_support PRIVATE support)


### PR DESCRIPTION
## Summary
- add IL_ENABLE_DOCS_LINT CMake option (default OFF)
- run docs_comment_check only when docs lint enabled
- document IL_ENABLE_DOCS_LINT and testing instructions

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bf3c06a3d483249366c0c58fb3942d