### PR TITLE
feat(basic): register string intrinsics

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(fe_basic STATIC
   frontends/basic/Lowerer.cpp
   frontends/basic/SemanticAnalyzer.cpp
   frontends/basic/ConstFolder.cpp
+  frontends/basic/Intrinsics.cpp
   frontends/basic/DiagnosticEmitter.cpp)
 target_link_libraries(fe_basic PUBLIC support il_build il_core)
 target_include_directories(fe_basic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/frontends/basic/Intrinsics.cpp
+++ b/src/frontends/basic/Intrinsics.cpp
@@ -1,0 +1,74 @@
+// File: src/frontends/basic/Intrinsics.cpp
+// Purpose: Define registry of BASIC intrinsic functions.
+// Key invariants: Table contents remain sorted by declaration order.
+// Ownership/Lifetime: Intrinsic descriptors are static.
+// Links: docs/class-catalog.md
+
+#include "frontends/basic/Intrinsics.hpp"
+
+#include <array>
+
+namespace il::frontends::basic::intrinsics
+{
+namespace
+{
+// Common parameter descriptors.
+constexpr Param strParam[] = {{Type::String, false}};
+constexpr Param intParam[] = {{Type::Int, false}};
+constexpr Param numParam[] = {{Type::Numeric, false}};
+
+constexpr Param leftRightParams[] = {
+    {Type::String, false},
+    {Type::Int, false},
+};
+
+constexpr Param midParams[] = {
+    {Type::String, false},
+    {Type::Int, false},
+    {Type::Int, true},
+};
+
+constexpr Param instrParams[] = {
+    {Type::Int, true},
+    {Type::String, false},
+    {Type::String, false},
+};
+
+// Intrinsic registry table.
+constexpr Intrinsic table[] = {
+    {"LEFT$", Type::String, leftRightParams, std::size(leftRightParams)},
+    {"RIGHT$", Type::String, leftRightParams, std::size(leftRightParams)},
+    {"MID$", Type::String, midParams, std::size(midParams)},
+    {"INSTR", Type::Int, instrParams, std::size(instrParams)},
+    {"LEN", Type::Int, strParam, std::size(strParam)},
+    {"LTRIM$", Type::String, strParam, std::size(strParam)},
+    {"RTRIM$", Type::String, strParam, std::size(strParam)},
+    {"TRIM$", Type::String, strParam, std::size(strParam)},
+    {"UCASE$", Type::String, strParam, std::size(strParam)},
+    {"LCASE$", Type::String, strParam, std::size(strParam)},
+    {"CHR$", Type::String, intParam, std::size(intParam)},
+    {"ASC", Type::Int, strParam, std::size(strParam)},
+    {"VAL", Type::Numeric, strParam, std::size(strParam)},
+    {"STR$", Type::String, numParam, std::size(numParam)},
+};
+} // namespace
+
+const Intrinsic *lookup(std::string_view name)
+{
+    for (const auto &intr : table)
+        if (intr.name == name)
+            return &intr;
+    return nullptr;
+}
+
+void dumpNames(std::ostream &os)
+{
+    for (std::size_t i = 0; i < std::size(table); ++i)
+    {
+        os << table[i].name;
+        if (i + 1 < std::size(table))
+            os << ' ';
+    }
+}
+
+} // namespace il::frontends::basic::intrinsics

--- a/src/frontends/basic/Intrinsics.hpp
+++ b/src/frontends/basic/Intrinsics.hpp
@@ -1,0 +1,50 @@
+// File: src/frontends/basic/Intrinsics.hpp
+// Purpose: Declare registry of BASIC intrinsic functions.
+// Key invariants: Table entries are immutable and cover all supported intrinsics.
+// Ownership/Lifetime: Intrinsic descriptors are static; callers must not free.
+// Links: docs/class-catalog.md
+
+#pragma once
+
+#include <cstddef>
+#include <ostream>
+#include <string_view>
+
+namespace il::frontends::basic::intrinsics
+{
+
+/// @brief Type of parameter or return value for a BASIC intrinsic.
+enum class Type
+{
+    Int,    ///< 64-bit integer.
+    Float,  ///< 64-bit floating point.
+    String, ///< BASIC string.
+    Numeric ///< Either Int or Float.
+};
+
+/// @brief Parameter descriptor.
+struct Param
+{
+    Type type;     ///< Parameter type.
+    bool optional; ///< True if the parameter is optional.
+};
+
+/// @brief Intrinsic function descriptor.
+struct Intrinsic
+{
+    std::string_view name;  ///< BASIC name including $ suffix.
+    Type returnType;        ///< Return type.
+    const Param *params;    ///< Pointer to ordered parameter descriptors.
+    std::size_t paramCount; ///< Number of parameters in @ref params.
+};
+
+/// @brief Lookup intrinsic by BASIC name.
+/// @param name Name such as "LEFT$".
+/// @return Descriptor or nullptr if unknown.
+const Intrinsic *lookup(std::string_view name);
+
+/// @brief Dump all intrinsic names separated by spaces to @p os.
+/// @param os Output stream receiving names.
+void dumpNames(std::ostream &os);
+
+} // namespace il::frontends::basic::intrinsics

--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -5,6 +5,7 @@
 // Links: docs/class-catalog.md
 
 #include "cli.hpp"
+#include "frontends/basic/Intrinsics.hpp"
 #include <iostream>
 #include <string>
 
@@ -22,7 +23,10 @@ void usage()
         << "\nBASIC notes:\n"
         << "  FUNCTION must RETURN a value on all paths.\n"
         << "  SUB cannot be used as an expression.\n"
-        << "  Array parameters are ByRef; pass the array variable, not an index.\n";
+        << "  Array parameters are ByRef; pass the array variable, not an index.\n"
+        << "  Intrinsics: ";
+    il::frontends::basic::intrinsics::dumpNames(std::cerr);
+    std::cerr << "\n";
 }
 
 int main(int argc, char **argv)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -338,6 +338,10 @@ add_executable(test_basic_parse_array_var unit/test_basic_parse_array_var.cpp)
 target_link_libraries(test_basic_parse_array_var PRIVATE fe_basic support)
 add_test(NAME test_basic_parse_array_var COMMAND test_basic_parse_array_var)
 
+add_executable(test_basic_intrinsics unit/test_basic_intrinsics.cpp)
+target_link_libraries(test_basic_intrinsics PRIVATE fe_basic support)
+add_test(NAME test_basic_intrinsics COMMAND test_basic_intrinsics)
+
 add_executable(test_vm_trap_loc unit/test_vm_trap_loc.cpp)
 target_link_libraries(test_vm_trap_loc PRIVATE il_build il_vm support)
 add_test(NAME test_vm_trap_loc COMMAND test_vm_trap_loc)

--- a/tests/unit/test_basic_intrinsics.cpp
+++ b/tests/unit/test_basic_intrinsics.cpp
@@ -1,0 +1,31 @@
+// File: tests/unit/test_basic_intrinsics.cpp
+// Purpose: Unit test for BASIC intrinsic registry lookups.
+// Key invariants: Verifies parameter counts/types for selected intrinsics.
+// Ownership/Lifetime: Test owns nothing.
+// Links: docs/class-catalog.md
+
+#include "frontends/basic/Intrinsics.hpp"
+#include <cassert>
+
+using namespace il::frontends::basic::intrinsics;
+
+int main()
+{
+    const Intrinsic *i = lookup("LEFT$");
+    assert(i && i->returnType == Type::String && i->paramCount == 2);
+    assert(i->params[0].type == Type::String && !i->params[0].optional);
+    assert(i->params[1].type == Type::Int && !i->params[1].optional);
+
+    i = lookup("MID$");
+    assert(i && i->paramCount == 3 && i->params[2].optional);
+
+    i = lookup("INSTR");
+    assert(i && i->returnType == Type::Int && i->paramCount == 3);
+    assert(i->params[0].optional && i->params[0].type == Type::Int);
+
+    i = lookup("STR$");
+    assert(i && i->params[0].type == Type::Numeric);
+
+    assert(lookup("NOPE") == nullptr);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add registry describing BASIC string intrinsics and their signatures
- surface intrinsic names in `ilc --help`
- test intrinsic lookup behaviour

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`
- `build/src/tools/ilc/ilc --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c1b6809ce88324a5fe165012f8df70