### PR TITLE
feat(runtime): declare additional string runtime prototypes

### DIFF
--- a/archive/docs/cpp-overview.md
+++ b/archive/docs/cpp-overview.md
@@ -145,12 +145,12 @@ void cbr(Value cond, Label t, Label f);
 - Files: rt_print.c, rt_string.c, rt_input.c, rt_mem.c, rt_math.c
 - Headers: rt.hpp with declarations:
 
-void rt_print_str(rt_str s);
+void rt_print_str(rt_string s);
 void rt_print_i64(int64_t v);
 void rt_print_f64(double v);
-rt_str rt_input_line(void);
-int64_t rt_len(rt_str s);
-rt_str rt_concat(rt_str a, rt_str b);
+rt_string rt_input_line(void);
+int64_t rt_len(rt_string s);
+rt_string rt_concat(rt_string a, rt_string b);
 // ...
 void\* rt_alloc(int64_t bytes); // simple wrapper on malloc for v1
 

--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -38,11 +38,11 @@ void *rt_alloc(int64_t bytes)
     return p;
 }
 
-rt_str rt_const_cstr(const char *c)
+rt_string rt_const_cstr(const char *c)
 {
     if (!c)
         return NULL;
-    rt_str s = (rt_str)rt_alloc(sizeof(*s));
+    rt_string s = (rt_string)rt_alloc(sizeof(*s));
     s->refcnt = 1;
     s->size = (int64_t)strlen(c);
     s->capacity = s->size;
@@ -50,7 +50,7 @@ rt_str rt_const_cstr(const char *c)
     return s;
 }
 
-void rt_print_str(rt_str s)
+void rt_print_str(rt_string s)
 {
     if (s && s->data)
         fwrite(s->data, 1, (size_t)s->size, stdout);
@@ -66,7 +66,7 @@ void rt_print_f64(double v)
     printf("%g", v);
 }
 
-rt_str rt_input_line(void)
+rt_string rt_input_line(void)
 {
     char buf[1024];
     if (!fgets(buf, sizeof(buf), stdin))
@@ -74,7 +74,7 @@ rt_str rt_input_line(void)
     size_t len = strlen(buf);
     if (len && buf[len - 1] == '\n')
         buf[--len] = '\0';
-    rt_str s = (rt_str)rt_alloc(sizeof(*s));
+    rt_string s = (rt_string)rt_alloc(sizeof(*s));
     s->refcnt = 1;
     s->size = (int64_t)len;
     s->capacity = s->size;
@@ -83,16 +83,16 @@ rt_str rt_input_line(void)
     return s;
 }
 
-int64_t rt_len(rt_str s)
+int64_t rt_len(rt_string s)
 {
     return s ? s->size : 0;
 }
 
-rt_str rt_concat(rt_str a, rt_str b)
+rt_string rt_concat(rt_string a, rt_string b)
 {
     int64_t asz = a ? a->size : 0;
     int64_t bsz = b ? b->size : 0;
-    rt_str s = (rt_str)rt_alloc(sizeof(*s));
+    rt_string s = (rt_string)rt_alloc(sizeof(*s));
     s->refcnt = 1;
     s->size = asz + bsz;
     s->capacity = s->size;
@@ -105,7 +105,7 @@ rt_str rt_concat(rt_str a, rt_str b)
     return s;
 }
 
-rt_str rt_substr(rt_str s, int64_t start, int64_t len)
+rt_string rt_substr(rt_string s, int64_t start, int64_t len)
 {
     if (!s)
         rt_trap("rt_substr: null");
@@ -117,7 +117,7 @@ rt_str rt_substr(rt_str s, int64_t start, int64_t len)
         start = s->size;
     if (start + len > s->size)
         len = s->size - start;
-    rt_str r = (rt_str)rt_alloc(sizeof(*r));
+    rt_string r = (rt_string)rt_alloc(sizeof(*r));
     r->refcnt = 1;
     r->size = len;
     r->capacity = len;
@@ -128,29 +128,29 @@ rt_str rt_substr(rt_str s, int64_t start, int64_t len)
     return r;
 }
 
-rt_str rt_left(rt_str s, int64_t n)
+rt_string rt_left(rt_string s, int64_t n)
 {
     return rt_substr(s, 0, n);
 }
 
-rt_str rt_right(rt_str s, int64_t n)
+rt_string rt_right(rt_string s, int64_t n)
 {
     int64_t len = rt_len(s);
     int64_t start = len - n;
     return rt_substr(s, start, n);
 }
 
-rt_str rt_mid2(rt_str s, int64_t start)
+rt_string rt_mid2(rt_string s, int64_t start)
 {
     return rt_substr(s, start, INT64_MAX);
 }
 
-rt_str rt_mid3(rt_str s, int64_t start, int64_t len)
+rt_string rt_mid3(rt_string s, int64_t start, int64_t len)
 {
     return rt_substr(s, start, len);
 }
 
-static int64_t rt_find(rt_str hay, int64_t start, rt_str needle)
+static int64_t rt_find(rt_string hay, int64_t start, rt_string needle)
 {
     if (!hay || !needle)
         return 0;
@@ -164,17 +164,17 @@ static int64_t rt_find(rt_str hay, int64_t start, rt_str needle)
     return 0;
 }
 
-int64_t rt_instr2(rt_str hay, rt_str needle)
+int64_t rt_instr2(rt_string hay, rt_string needle)
 {
     return rt_find(hay, 0, needle);
 }
 
-int64_t rt_instr3(int64_t start, rt_str hay, rt_str needle)
+int64_t rt_instr3(int64_t start, rt_string hay, rt_string needle)
 {
     return rt_find(hay, start, needle);
 }
 
-int64_t rt_str_eq(rt_str a, rt_str b)
+int64_t rt_str_eq(rt_string a, rt_string b)
 {
     if (!a || !b)
         return 0;
@@ -183,7 +183,7 @@ int64_t rt_str_eq(rt_str a, rt_str b)
     return memcmp(a->data, b->data, (size_t)a->size) == 0;
 }
 
-int64_t rt_to_int(rt_str s)
+int64_t rt_to_int(rt_string s)
 {
     if (!s)
         rt_trap("rt_to_int: null");
@@ -213,13 +213,13 @@ int64_t rt_to_int(rt_str s)
     return (int64_t)v;
 }
 
-rt_str rt_int_to_str(int64_t v)
+rt_string rt_int_to_str(int64_t v)
 {
     char buf[32];
     int n = snprintf(buf, sizeof(buf), "%lld", (long long)v);
     if (n < 0)
         rt_trap("rt_int_to_str: format");
-    rt_str s = (rt_str)rt_alloc(sizeof(*s));
+    rt_string s = (rt_string)rt_alloc(sizeof(*s));
     s->refcnt = 1;
     s->size = n;
     s->capacity = n;
@@ -228,13 +228,13 @@ rt_str rt_int_to_str(int64_t v)
     return s;
 }
 
-rt_str rt_f64_to_str(double v)
+rt_string rt_f64_to_str(double v)
 {
     char buf[32];
     int n = snprintf(buf, sizeof(buf), "%g", v);
     if (n < 0)
         rt_trap("rt_f64_to_str: format");
-    rt_str s = (rt_str)rt_alloc(sizeof(*s));
+    rt_string s = (rt_string)rt_alloc(sizeof(*s));
     s->refcnt = 1;
     s->size = n;
     s->capacity = n;

--- a/runtime/rt.hpp
+++ b/runtime/rt.hpp
@@ -12,13 +12,13 @@ extern "C"
 {
 #endif
 
-    typedef struct rt_str_impl
+    typedef struct rt_string_impl
     {
         int64_t refcnt;
         int64_t size;
         int64_t capacity;
         char *data;
-    } *rt_str;
+    } *rt_string;
 
     /// @brief Abort execution with message @p msg.
     /// @param msg Null-terminated message string.
@@ -30,7 +30,7 @@ extern "C"
 
     /// @brief Print string @p s to stdout.
     /// @param s Reference-counted string.
-    void rt_print_str(rt_str s);
+    void rt_print_str(rt_string s);
 
     /// @brief Print signed 64-bit integer @p v to stdout.
     /// @param v Value to print.
@@ -42,74 +42,139 @@ extern "C"
 
     /// @brief Read a line from stdin.
     /// @return Newly allocated string without trailing newline.
-    rt_str rt_input_line(void);
+    rt_string rt_input_line(void);
 
     /// @brief Get length of string @p s in bytes.
     /// @param s String to measure.
     /// @return Number of bytes excluding terminator.
-    int64_t rt_len(rt_str s);
+    int64_t rt_len(rt_string s);
 
     /// @brief Concatenate strings @p a and @p b.
     /// @param a Left operand; consumed.
     /// @param b Right operand; consumed.
     /// @return New string containing a followed by b.
-    rt_str rt_concat(rt_str a, rt_str b);
+    rt_string rt_concat(rt_string a, rt_string b);
 
     /// @brief Slice substring of @p s.
     /// @param s Source string.
     /// @param start Starting index (0-based).
     /// @param len Number of bytes to copy.
     /// @return Newly allocated substring.
-    rt_str rt_substr(rt_str s, int64_t start, int64_t len);
+    rt_string rt_substr(rt_string s, int64_t start, int64_t len);
 
     /// @brief Return leftmost @p n characters of @p s.
-    rt_str rt_left(rt_str s, int64_t n);
+    /// @param s Source string; traps if null.
+    /// @param n Number of characters to copy (clamped at [0,len]).
+    /// @return Newly allocated substring of length @c n or less.
+    rt_string rt_left(rt_string s, int64_t n);
 
     /// @brief Return rightmost @p n characters of @p s.
-    rt_str rt_right(rt_str s, int64_t n);
+    /// @param s Source string; traps if null.
+    /// @param n Number of characters to copy (clamped at [0,len]).
+    /// @return Newly allocated substring of length @c n or less.
+    rt_string rt_right(rt_string s, int64_t n);
 
     /// @brief Return substring starting at @p start to end.
-    rt_str rt_mid2(rt_str s, int64_t start);
+    /// @param s Source string; traps if null.
+    /// @param start Starting offset (0-based; negative treated as 0).
+    /// @return Newly allocated substring from @p start to end.
+    rt_string rt_mid2(rt_string s, int64_t start);
 
     /// @brief Return substring of length @p len starting at @p start.
-    rt_str rt_mid3(rt_str s, int64_t start, int64_t len);
+    /// @param s Source string; traps if null.
+    /// @param start Starting offset (0-based; negative treated as 0).
+    /// @param len Number of characters to copy (clamped at end).
+    /// @return Newly allocated substring.
+    rt_string rt_mid3(rt_string s, int64_t start, int64_t len);
 
     /// @brief Find @p needle within @p hay starting at @p start.
-    int64_t rt_instr3(int64_t start, rt_str hay, rt_str needle);
+    /// @param start Starting offset in @p hay (0-based).
+    /// @param hay Haystack string; null returns 0.
+    /// @param needle Needle string; null returns 0.
+    /// @return 1-based index of match or 0 if not found.
+    int64_t rt_instr3(int64_t start, rt_string hay, rt_string needle);
 
     /// @brief Find @p needle within @p hay starting at 0.
-    int64_t rt_instr2(rt_str hay, rt_str needle);
+    /// @param hay Haystack string; null returns 0.
+    /// @param needle Needle string; null returns 0.
+    /// @return 1-based index of match or 0 if not found.
+    int64_t rt_instr2(rt_string hay, rt_string needle);
+
+    /// @brief Remove leading ASCII whitespace.
+    /// @param s Source string; traps if null.
+    /// @return Newly allocated trimmed string.
+    rt_string rt_ltrim(rt_string s);
+
+    /// @brief Remove trailing ASCII whitespace.
+    /// @param s Source string; traps if null.
+    /// @return Newly allocated trimmed string.
+    rt_string rt_rtrim(rt_string s);
+
+    /// @brief Remove leading and trailing ASCII whitespace.
+    /// @param s Source string; traps if null.
+    /// @return Newly allocated trimmed string.
+    rt_string rt_trim(rt_string s);
+
+    /// @brief Convert string to uppercase (ASCII only).
+    /// @param s Source string; traps if null.
+    /// @return Newly allocated uppercase string.
+    rt_string rt_ucase(rt_string s);
+
+    /// @brief Convert string to lowercase (ASCII only).
+    /// @param s Source string; traps if null.
+    /// @return Newly allocated lowercase string.
+    rt_string rt_lcase(rt_string s);
+
+    /// @brief Return single-character string from @p code.
+    /// @param code ASCII code 0-255; traps if out of range.
+    /// @return Newly allocated one-character string.
+    rt_string rt_chr(int64_t code);
+
+    /// @brief Return ASCII code of first character of @p s.
+    /// @param s Source string; traps if null or empty.
+    /// @return Code 0-255 of first character.
+    int64_t rt_asc(rt_string s);
 
     /// @brief Compare strings for equality.
     /// @param a First string.
     /// @param b Second string.
     /// @return 1 if equal, 0 otherwise.
-    int64_t rt_str_eq(rt_str a, rt_str b);
+    int64_t rt_str_eq(rt_string a, rt_string b);
 
     /// @brief Convert decimal string @p s to signed 64-bit integer.
     /// @param s Input decimal string.
     /// @return Parsed integer value.
-    int64_t rt_to_int(rt_str s);
+    int64_t rt_to_int(rt_string s);
 
     /// @brief Convert signed 64-bit integer @p v to decimal string.
     /// @param v Integer to convert.
     /// @return Newly allocated string representation.
-    rt_str rt_int_to_str(int64_t v);
+    rt_string rt_int_to_str(int64_t v);
 
     /// @brief Convert 64-bit float @p v to decimal string.
     /// @param v Float to convert.
     /// @return Newly allocated string representation.
-    rt_str rt_f64_to_str(double v);
+    rt_string rt_f64_to_str(double v);
+
+    /// @brief Parse decimal numeric string @p s.
+    /// @param s Input string; traps on invalid format.
+    /// @return Floating-point value of @p s.
+    double rt_val(rt_string s);
+
+    /// @brief Convert numeric @p v to decimal string.
+    /// @param v Value to convert.
+    /// @return Newly allocated string representation.
+    rt_string rt_str(double v);
 
     /// @brief Allocate @p bytes of zeroed memory.
     /// @param bytes Number of bytes to allocate.
     /// @return Pointer to zeroed block or trap on failure.
     void *rt_alloc(int64_t bytes);
 
-    /// @brief Wrap constant C string @p str as rt_str without copying.
+    /// @brief Wrap constant C string @p str as rt_string without copying.
     /// @param str Null-terminated constant string.
-    /// @return Non-owning rt_str view.
-    rt_str rt_const_cstr(const char *str);
+    /// @return Non-owning rt_string view.
+    rt_string rt_const_cstr(const char *str);
 
 #ifdef __cplusplus
 }

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -226,7 +226,7 @@ VM::ExecResult VM::handleLoad(Frame &fr, const Instr &in)
     else if (in.type.kind == Type::Kind::F64)
         res.f64 = *reinterpret_cast<double *>(ptr);
     else if (in.type.kind == Type::Kind::Str)
-        res.str = *reinterpret_cast<rt_str *>(ptr);
+        res.str = *reinterpret_cast<rt_string *>(ptr);
     else if (in.type.kind == Type::Kind::Ptr)
         res.ptr = *reinterpret_cast<void **>(ptr);
     storeResult(fr, in, res);
@@ -243,7 +243,7 @@ VM::ExecResult VM::handleStore(Frame &fr, const Instr &in, const BasicBlock *bb,
     else if (in.type.kind == Type::Kind::F64)
         *reinterpret_cast<double *>(ptr) = val.f64;
     else if (in.type.kind == Type::Kind::Str)
-        *reinterpret_cast<rt_str *>(ptr) = val.str;
+        *reinterpret_cast<rt_string *>(ptr) = val.str;
     else if (in.type.kind == Type::Kind::Ptr)
         *reinterpret_cast<void **>(ptr) = val.ptr;
     if (in.operands[0].kind == Value::Kind::Temp)

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -26,10 +26,10 @@ class DebugScript;
 /// @invariant Only one member is valid based on value type.
 union Slot
 {
-    int64_t i64; ///< Signed integer value
-    double f64;  ///< Floating-point value
-    void *ptr;   ///< Generic pointer
-    rt_str str;  ///< Runtime string handle
+    int64_t i64;   ///< Signed integer value
+    double f64;    ///< Floating-point value
+    void *ptr;     ///< Generic pointer
+    rt_string str; ///< Runtime string handle
 };
 
 /// @brief Call frame storing registers and operand stack.
@@ -70,7 +70,7 @@ class VM
     uint64_t instrCount = 0;     ///< Executed instruction count
     uint64_t stepBudget = 0;     ///< Remaining instructions to step before pausing
     std::unordered_map<std::string, const il::core::Function *> fnMap; ///< Name lookup
-    std::unordered_map<std::string, rt_str> strMap;                    ///< String pool
+    std::unordered_map<std::string, rt_string> strMap;                 ///< String pool
 
     /// @brief Execute function @p fn with optional arguments.
     /// @param fn Function to execute.

--- a/tests/unit/test_rt_conv.cpp
+++ b/tests/unit/test_rt_conv.cpp
@@ -9,9 +9,9 @@
 
 int main()
 {
-    rt_str si = rt_int_to_str(-42);
+    rt_string si = rt_int_to_str(-42);
     assert(si && std::string(si->data, (size_t)si->size) == "-42");
-    rt_str sf = rt_f64_to_str(3.5);
+    rt_string sf = rt_f64_to_str(3.5);
     std::string s(sf->data, (size_t)sf->size);
     assert(s.find("3.5") != std::string::npos);
     return 0;

--- a/tests/unit/test_rt_string.cpp
+++ b/tests/unit/test_rt_string.cpp
@@ -3,35 +3,35 @@
 
 int main()
 {
-    rt_str empty = rt_const_cstr("");
+    rt_string empty = rt_const_cstr("");
     assert(rt_len(empty) == 0);
 
-    rt_str hello = rt_const_cstr("hello");
-    rt_str world = rt_const_cstr("world");
-    rt_str hw = rt_concat(hello, world);
+    rt_string hello = rt_const_cstr("hello");
+    rt_string world = rt_const_cstr("world");
+    rt_string hw = rt_concat(hello, world);
     assert(rt_len(hw) == 10);
-    rt_str helloworld = rt_const_cstr("helloworld");
+    rt_string helloworld = rt_const_cstr("helloworld");
     assert(rt_str_eq(hw, helloworld));
 
-    rt_str sub0 = rt_substr(hw, 0, 5);
+    rt_string sub0 = rt_substr(hw, 0, 5);
     assert(rt_str_eq(sub0, hello));
-    rt_str sub1 = rt_substr(hw, 5, 5);
+    rt_string sub1 = rt_substr(hw, 5, 5);
     assert(rt_str_eq(sub1, world));
-    rt_str subempty = rt_substr(hw, 10, 0);
+    rt_string subempty = rt_substr(hw, 10, 0);
     assert(rt_len(subempty) == 0);
 
-    rt_str clamp1 = rt_substr(hw, 8, 10);
-    rt_str ld = rt_const_cstr("ld");
+    rt_string clamp1 = rt_substr(hw, 8, 10);
+    rt_string ld = rt_const_cstr("ld");
     assert(rt_str_eq(clamp1, ld));
-    rt_str clamp2 = rt_substr(hw, -3, 4);
-    rt_str hell = rt_const_cstr("hell");
+    rt_string clamp2 = rt_substr(hw, -3, 4);
+    rt_string hell = rt_const_cstr("hell");
     assert(rt_str_eq(clamp2, hell));
-    rt_str clamp3 = rt_substr(hw, 2, -5);
+    rt_string clamp3 = rt_substr(hw, 2, -5);
     assert(rt_len(clamp3) == 0);
 
     assert(!rt_str_eq(hello, world));
 
-    rt_str num = rt_const_cstr("  -42 ");
+    rt_string num = rt_const_cstr("  -42 ");
     assert(rt_to_int(num) == -42);
 
     return 0;

--- a/tests/unit/test_rt_string_invalid.cpp
+++ b/tests/unit/test_rt_string_invalid.cpp
@@ -2,7 +2,7 @@
 
 int main()
 {
-    rt_str bad = rt_const_cstr("12x");
+    rt_string bad = rt_const_cstr("12x");
     rt_to_int(bad);
     return 0;
 }


### PR DESCRIPTION
## Summary
- expand C runtime header with new string helpers and numeric conversions
- rename string handle type to `rt_string`
- adjust VM and tests for new type

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c1d61308b483248f113d41fb2dc4d9