### PR TITLE
fix(runtime): clamp substring bounds

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -130,23 +130,52 @@ rt_string rt_substr(rt_string s, int64_t start, int64_t len)
 
 rt_string rt_left(rt_string s, int64_t n)
 {
+    if (!s)
+        rt_trap("rt_left: null");
+    if (n < 0)
+        rt_trap("rt_left: negative");
+    if (n > s->size)
+        n = s->size;
     return rt_substr(s, 0, n);
 }
 
 rt_string rt_right(rt_string s, int64_t n)
 {
-    int64_t len = rt_len(s);
+    if (!s)
+        rt_trap("rt_right: null");
+    if (n < 0)
+        rt_trap("rt_right: negative");
+    int64_t len = s->size;
+    if (n > len)
+        n = len;
     int64_t start = len - n;
     return rt_substr(s, start, n);
 }
 
 rt_string rt_mid2(rt_string s, int64_t start)
 {
-    return rt_substr(s, start, INT64_MAX);
+    if (!s)
+        rt_trap("rt_mid2: null");
+    if (start < 0)
+        rt_trap("rt_mid2: negative");
+    int64_t len = s->size;
+    if (start > len)
+        start = len;
+    int64_t n = len - start;
+    return rt_substr(s, start, n);
 }
 
 rt_string rt_mid3(rt_string s, int64_t start, int64_t len)
 {
+    if (!s)
+        rt_trap("rt_mid3: null");
+    if (start < 0 || len < 0)
+        rt_trap("rt_mid3: negative");
+    int64_t slen = s->size;
+    if (start > slen)
+        start = slen;
+    if (len > slen - start)
+        len = slen - start;
     return rt_substr(s, start, len);
 }
 

--- a/runtime/rt.hpp
+++ b/runtime/rt.hpp
@@ -64,26 +64,26 @@ extern "C"
 
     /// @brief Return leftmost @p n characters of @p s.
     /// @param s Source string; traps if null.
-    /// @param n Number of characters to copy (clamped at [0,len]).
+    /// @param n Number of characters to copy; traps if negative.
     /// @return Newly allocated substring of length @c n or less.
     rt_string rt_left(rt_string s, int64_t n);
 
     /// @brief Return rightmost @p n characters of @p s.
     /// @param s Source string; traps if null.
-    /// @param n Number of characters to copy (clamped at [0,len]).
+    /// @param n Number of characters to copy; traps if negative.
     /// @return Newly allocated substring of length @c n or less.
     rt_string rt_right(rt_string s, int64_t n);
 
     /// @brief Return substring starting at @p start to end.
     /// @param s Source string; traps if null.
-    /// @param start Starting offset (0-based; negative treated as 0).
+    /// @param start Starting offset (0-based); traps if negative.
     /// @return Newly allocated substring from @p start to end.
     rt_string rt_mid2(rt_string s, int64_t start);
 
     /// @brief Return substring of length @p len starting at @p start.
     /// @param s Source string; traps if null.
-    /// @param start Starting offset (0-based; negative treated as 0).
-    /// @param len Number of characters to copy (clamped at end).
+    /// @param start Starting offset (0-based); traps if negative.
+    /// @param len Number of characters to copy; traps if negative.
     /// @return Newly allocated substring.
     rt_string rt_mid3(rt_string s, int64_t start, int64_t len);
 

--- a/tests/unit/test_rt_string.cpp
+++ b/tests/unit/test_rt_string.cpp
@@ -34,5 +34,23 @@ int main()
     rt_string num = rt_const_cstr("  -42 ");
     assert(rt_to_int(num) == -42);
 
+    rt_string abcde = rt_const_cstr("ABCDE");
+
+    rt_string left = rt_left(abcde, 2);
+    rt_string ab = rt_const_cstr("AB");
+    assert(rt_str_eq(left, ab));
+
+    rt_string right = rt_right(abcde, 3);
+    rt_string cde = rt_const_cstr("CDE");
+    assert(rt_str_eq(right, cde));
+
+    rt_string mid_full = rt_mid2(abcde, 1);
+    rt_string bcde = rt_const_cstr("BCDE");
+    assert(rt_str_eq(mid_full, bcde));
+
+    rt_string mid_part = rt_mid3(abcde, 1, 2);
+    rt_string bc = rt_const_cstr("BC");
+    assert(rt_str_eq(mid_part, bc));
+
     return 0;
 }

--- a/tests/unit/test_rt_string_invalid.cpp
+++ b/tests/unit/test_rt_string_invalid.cpp
@@ -2,7 +2,7 @@
 
 int main()
 {
-    rt_string bad = rt_const_cstr("12x");
-    rt_to_int(bad);
+    rt_string abcde = rt_const_cstr("ABCDE");
+    rt_mid2(abcde, -1);
     return 0;
 }


### PR DESCRIPTION
## Summary
- validate and clamp LEFT$/RIGHT$/MID$ arguments in runtime
- document bounds behavior in runtime headers
- add runtime tests for substring helpers

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c1d9d788f08324ad045598970bbba5