### PR TITLE
feat(runtime): implement INSTR helpers

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -195,11 +195,24 @@ static int64_t rt_find(rt_string hay, int64_t start, rt_string needle)
 
 int64_t rt_instr2(rt_string hay, rt_string needle)
 {
+    if (!hay || !needle)
+        return 0;
+    if (needle->size == 0)
+        return 1;
     return rt_find(hay, 0, needle);
 }
 
 int64_t rt_instr3(int64_t start, rt_string hay, rt_string needle)
 {
+    if (!hay || !needle)
+        return 0;
+    int64_t len = hay->size;
+    if (start < 1)
+        start = 1;
+    if (start > len + 1)
+        start = len + 1;
+    if (needle->size == 0)
+        return start;
     return rt_find(hay, start, needle);
 }
 

--- a/runtime/rt.hpp
+++ b/runtime/rt.hpp
@@ -88,16 +88,16 @@ extern "C"
     rt_string rt_mid3(rt_string s, int64_t start, int64_t len);
 
     /// @brief Find @p needle within @p hay starting at @p start.
-    /// @param start Starting offset in @p hay (0-based).
+    /// @param start 1-based index after which search begins; clamped to [1, rt_len(hay) + 1].
     /// @param hay Haystack string; null returns 0.
     /// @param needle Needle string; null returns 0.
-    /// @return 1-based index of match or 0 if not found.
+    /// @return 1-based index of match or 0 if not found. Empty @p needle returns @p start.
     int64_t rt_instr3(int64_t start, rt_string hay, rt_string needle);
 
-    /// @brief Find @p needle within @p hay starting at 0.
+    /// @brief Find @p needle within @p hay starting at index 1.
     /// @param hay Haystack string; null returns 0.
     /// @param needle Needle string; null returns 0.
-    /// @return 1-based index of match or 0 if not found.
+    /// @return 1-based index of match or 0 if not found. Empty @p needle returns 1.
     int64_t rt_instr2(rt_string hay, rt_string needle);
 
     /// @brief Remove leading ASCII whitespace.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,10 @@ add_executable(test_rt_random runtime/RTRandomTests.cpp)
 target_link_libraries(test_rt_random PRIVATE rt)
 add_test(NAME test_rt_random COMMAND test_rt_random)
 
+add_executable(test_rt_instr runtime/RTInstrTests.cpp)
+target_link_libraries(test_rt_instr PRIVATE rt)
+add_test(NAME test_rt_instr COMMAND test_rt_instr)
+
 add_executable(float_out e2e/support/FloatOut.cpp)
 
 add_test(NAME vm_strings_example COMMAND ${CMAKE_COMMAND}

--- a/tests/runtime/RTInstrTests.cpp
+++ b/tests/runtime/RTInstrTests.cpp
@@ -1,0 +1,24 @@
+// File: tests/runtime/RTInstrTests.cpp
+// Purpose: Validate runtime INSTR search functions.
+// Key invariants: 1-based indexing semantics; empty needle returns start.
+// Ownership: Uses runtime library.
+// Links: docs/runtime-abi.md
+#include "rt.hpp"
+#include <cassert>
+
+int main()
+{
+    rt_string s1 = rt_const_cstr("ABCD");
+    rt_string s2 = rt_const_cstr("BC");
+    assert(rt_instr2(s1, s2) == 2);
+
+    rt_string s3 = rt_const_cstr("ABABAB");
+    rt_string s4 = rt_const_cstr("AB");
+    assert(rt_instr3(3, s3, s4) == 5);
+
+    rt_string s5 = rt_const_cstr("ABC");
+    rt_string s6 = rt_const_cstr("X");
+    assert(rt_instr2(s5, s6) == 0);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add rt_instr2 and rt_instr3 string search helpers with 1-based indexing and empty needle handling
- document INSTR semantics in runtime header
- add runtime test and register it in CMake

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c1ddd8b2f483249f4f764ee7427858