### PR TITLE
feat(runtime): add trim and case mapping helpers

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -216,6 +216,79 @@ int64_t rt_instr3(int64_t start, rt_string hay, rt_string needle)
     return rt_find(hay, start, needle);
 }
 
+rt_string rt_ltrim(rt_string s)
+{
+    if (!s)
+        rt_trap("rt_ltrim: null");
+    int64_t i = 0;
+    while (i < s->size && (s->data[i] == ' ' || s->data[i] == '\t'))
+        ++i;
+    return rt_substr(s, i, s->size - i);
+}
+
+rt_string rt_rtrim(rt_string s)
+{
+    if (!s)
+        rt_trap("rt_rtrim: null");
+    int64_t end = s->size;
+    while (end > 0 && (s->data[end - 1] == ' ' || s->data[end - 1] == '\t'))
+        --end;
+    return rt_substr(s, 0, end);
+}
+
+rt_string rt_trim(rt_string s)
+{
+    if (!s)
+        rt_trap("rt_trim: null");
+    int64_t start = 0;
+    int64_t end = s->size;
+    while (start < end && (s->data[start] == ' ' || s->data[start] == '\t'))
+        ++start;
+    while (end > start && (s->data[end - 1] == ' ' || s->data[end - 1] == '\t'))
+        --end;
+    return rt_substr(s, start, end - start);
+}
+
+rt_string rt_ucase(rt_string s)
+{
+    if (!s)
+        rt_trap("rt_ucase: null");
+    rt_string r = (rt_string)rt_alloc(sizeof(*r));
+    r->refcnt = 1;
+    r->size = s->size;
+    r->capacity = r->size;
+    r->data = (char *)rt_alloc(r->size + 1);
+    for (int64_t i = 0; i < r->size; ++i)
+    {
+        unsigned char c = (unsigned char)s->data[i];
+        if (c >= 'a' && c <= 'z')
+            c = (unsigned char)(c - 'a' + 'A');
+        r->data[i] = (char)c;
+    }
+    r->data[r->size] = '\0';
+    return r;
+}
+
+rt_string rt_lcase(rt_string s)
+{
+    if (!s)
+        rt_trap("rt_lcase: null");
+    rt_string r = (rt_string)rt_alloc(sizeof(*r));
+    r->refcnt = 1;
+    r->size = s->size;
+    r->capacity = r->size;
+    r->data = (char *)rt_alloc(r->size + 1);
+    for (int64_t i = 0; i < r->size; ++i)
+    {
+        unsigned char c = (unsigned char)s->data[i];
+        if (c >= 'A' && c <= 'Z')
+            c = (unsigned char)(c - 'A' + 'a');
+        r->data[i] = (char)c;
+    }
+    r->data[r->size] = '\0';
+    return r;
+}
+
 int64_t rt_str_eq(rt_string a, rt_string b)
 {
     if (!a || !b)

--- a/runtime/rt.hpp
+++ b/runtime/rt.hpp
@@ -100,27 +100,32 @@ extern "C"
     /// @return 1-based index of match or 0 if not found. Empty @p needle returns 1.
     int64_t rt_instr2(rt_string hay, rt_string needle);
 
-    /// @brief Remove leading ASCII whitespace.
+    /// @brief Remove leading spaces and tabs.
+    /// Whitespace is ASCII space (0x20) or tab (0x09).
     /// @param s Source string; traps if null.
     /// @return Newly allocated trimmed string.
     rt_string rt_ltrim(rt_string s);
 
-    /// @brief Remove trailing ASCII whitespace.
+    /// @brief Remove trailing spaces and tabs.
+    /// Whitespace is ASCII space (0x20) or tab (0x09).
     /// @param s Source string; traps if null.
     /// @return Newly allocated trimmed string.
     rt_string rt_rtrim(rt_string s);
 
-    /// @brief Remove leading and trailing ASCII whitespace.
+    /// @brief Remove leading and trailing spaces and tabs.
+    /// Whitespace is ASCII space (0x20) or tab (0x09).
     /// @param s Source string; traps if null.
     /// @return Newly allocated trimmed string.
     rt_string rt_trim(rt_string s);
 
-    /// @brief Convert string to uppercase (ASCII only).
+    /// @brief Convert string to uppercase (ASCII a-z).
+    /// Non-ASCII bytes are left unchanged.
     /// @param s Source string; traps if null.
     /// @return Newly allocated uppercase string.
     rt_string rt_ucase(rt_string s);
 
-    /// @brief Convert string to lowercase (ASCII only).
+    /// @brief Convert string to lowercase (ASCII A-Z).
+    /// Non-ASCII bytes are left unchanged.
     /// @param s Source string; traps if null.
     /// @return Newly allocated lowercase string.
     rt_string rt_lcase(rt_string s);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -121,6 +121,10 @@ add_executable(test_rt_instr runtime/RTInstrTests.cpp)
 target_link_libraries(test_rt_instr PRIVATE rt)
 add_test(NAME test_rt_instr COMMAND test_rt_instr)
 
+add_executable(test_rt_trim_case runtime/RTTrimCaseTests.cpp)
+target_link_libraries(test_rt_trim_case PRIVATE rt)
+add_test(NAME test_rt_trim_case COMMAND test_rt_trim_case)
+
 add_executable(float_out e2e/support/FloatOut.cpp)
 
 add_test(NAME vm_strings_example COMMAND ${CMAKE_COMMAND}

--- a/tests/runtime/RTTrimCaseTests.cpp
+++ b/tests/runtime/RTTrimCaseTests.cpp
@@ -1,0 +1,31 @@
+// File: tests/runtime/RTTrimCaseTests.cpp
+// Purpose: Validate string trimming and case mapping runtime helpers.
+// Key invariants: Whitespace includes only space and tab; case maps affect ASCII letters only.
+// Ownership: Uses runtime library.
+// Links: docs/runtime-abi.md
+#include "rt.hpp"
+#include <cassert>
+
+int main()
+{
+    rt_string lt = rt_ltrim(rt_const_cstr(" hi"));
+    assert(rt_str_eq(lt, rt_const_cstr("hi")));
+
+    rt_string rt = rt_rtrim(rt_const_cstr("hi "));
+    assert(rt_str_eq(rt, rt_const_cstr("hi")));
+
+    rt_string t = rt_trim(rt_const_cstr(" hi "));
+    assert(rt_str_eq(t, rt_const_cstr("hi")));
+
+    rt_string u = rt_ucase(rt_const_cstr("Abc!"));
+    assert(rt_str_eq(u, rt_const_cstr("ABC!")));
+
+    rt_string l = rt_lcase(rt_const_cstr("AbC!"));
+    assert(rt_str_eq(l, rt_const_cstr("abc!")));
+
+    rt_string empty = rt_const_cstr("");
+    rt_string et = rt_trim(empty);
+    assert(rt_str_eq(et, empty));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add LTRIM$, RTRIM$, TRIM$, UCASE$, and LCASE$ helpers to runtime
- document ASCII-only behavior and whitespace rules
- cover new helpers with runtime tests

## Testing
- `cmake -S . -B build && cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c1e13796948324b76a2ba11eb1155a