### PR TITLE
feat(runtime): add VAL and STR$ helpers

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -380,3 +380,19 @@ rt_string rt_f64_to_str(double v)
     memcpy(s->data, buf, (size_t)n + 1);
     return s;
 }
+
+double rt_val(rt_string s)
+{
+    if (!s)
+        rt_trap("rt_val: null");
+    char *endp = NULL;
+    double v = strtod(s->data, &endp);
+    if (endp == s->data)
+        return 0.0;
+    return v;
+}
+
+rt_string rt_str(double v)
+{
+    return rt_f64_to_str(v);
+}

--- a/runtime/rt.hpp
+++ b/runtime/rt.hpp
@@ -161,9 +161,9 @@ extern "C"
     /// @return Newly allocated string representation.
     rt_string rt_f64_to_str(double v);
 
-    /// @brief Parse decimal numeric string @p s.
-    /// @param s Input string; traps on invalid format.
-    /// @return Floating-point value of @p s.
+    /// @brief Parse leading decimal numeric prefix of @p s.
+    /// @param s Input string; leading spaces allowed.
+    /// @return Parsed value or 0 if no digits found.
     double rt_val(rt_string s);
 
     /// @brief Convert numeric @p v to decimal string.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -109,6 +109,10 @@ add_executable(test_rt_conv unit/test_rt_conv.cpp)
 target_link_libraries(test_rt_conv PRIVATE rt)
 add_test(NAME test_rt_conv COMMAND test_rt_conv)
 
+add_executable(test_rt_val_str runtime/RTValStrTests.cpp)
+target_link_libraries(test_rt_val_str PRIVATE rt)
+add_test(NAME test_rt_val_str COMMAND test_rt_val_str)
+
 add_executable(test_rt_math_core runtime/RTMathCoreTests.cpp)
 target_link_libraries(test_rt_math_core PRIVATE rt)
 add_test(NAME test_rt_math_core COMMAND test_rt_math_core)

--- a/tests/runtime/RTValStrTests.cpp
+++ b/tests/runtime/RTValStrTests.cpp
@@ -1,0 +1,30 @@
+// File: tests/runtime/RTValStrTests.cpp
+// Purpose: Validate VAL and STR$ runtime conversions.
+// Key invariants: Parsing stops at non-numeric; round-trip within tolerance.
+// Ownership: Uses runtime library.
+// Links: docs/class-catalog.md
+#include "rt.hpp"
+#include <cassert>
+#include <cmath>
+#include <string>
+
+int main()
+{
+    rt_string s = rt_const_cstr(" -12.5xyz");
+    assert(std::fabs(rt_val(s) + 12.5) < 1e-12);
+    assert(rt_val(rt_const_cstr("")) == 0.0);
+
+    rt_string s42 = rt_str(42.0);
+    assert(std::string(s42->data, (size_t)s42->size) == "42");
+    rt_string sn = rt_str(-3.5);
+    assert(std::string(sn->data, (size_t)sn->size) == "-3.5");
+
+    double vals[] = {0.0, 1.25, -2.5, 123.456};
+    for (double v : vals)
+    {
+        rt_string t = rt_str(v);
+        double r = rt_val(t);
+        assert(std::fabs(r - v) < 1e-9 * std::fmax(1.0, std::fabs(v)));
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement BASIC-like VAL to parse leading numeric prefixes
- add STR$ for minimal number formatting
- cover VAL/STR$ round-trips with unit tests

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c1ecb8af60832482a492fd796aeda8