### PR TITLE
fix(basic): improve intrinsic diagnostics

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -131,9 +131,13 @@ rt_string rt_substr(rt_string s, int64_t start, int64_t len)
 rt_string rt_left(rt_string s, int64_t n)
 {
     if (!s)
-        rt_trap("rt_left: null");
+        rt_trap("LEFT$: null string");
     if (n < 0)
-        rt_trap("rt_left: negative");
+    {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "LEFT$: len must be >= 0 (got %lld)", (long long)n);
+        rt_trap(buf);
+    }
     if (n > s->size)
         n = s->size;
     return rt_substr(s, 0, n);
@@ -142,9 +146,13 @@ rt_string rt_left(rt_string s, int64_t n)
 rt_string rt_right(rt_string s, int64_t n)
 {
     if (!s)
-        rt_trap("rt_right: null");
+        rt_trap("RIGHT$: null string");
     if (n < 0)
-        rt_trap("rt_right: negative");
+    {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "RIGHT$: len must be >= 0 (got %lld)", (long long)n);
+        rt_trap(buf);
+    }
     int64_t len = s->size;
     if (n > len)
         n = len;
@@ -155,9 +163,13 @@ rt_string rt_right(rt_string s, int64_t n)
 rt_string rt_mid2(rt_string s, int64_t start)
 {
     if (!s)
-        rt_trap("rt_mid2: null");
+        rt_trap("MID$: null string");
     if (start < 0)
-        rt_trap("rt_mid2: negative");
+    {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "MID$: start must be >= 0 (got %lld)", (long long)start);
+        rt_trap(buf);
+    }
     int64_t len = s->size;
     if (start > len)
         start = len;
@@ -168,9 +180,19 @@ rt_string rt_mid2(rt_string s, int64_t start)
 rt_string rt_mid3(rt_string s, int64_t start, int64_t len)
 {
     if (!s)
-        rt_trap("rt_mid3: null");
-    if (start < 0 || len < 0)
-        rt_trap("rt_mid3: negative");
+        rt_trap("MID$: null string");
+    if (start < 0)
+    {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "MID$: start must be >= 0 (got %lld)", (long long)start);
+        rt_trap(buf);
+    }
+    if (len < 0)
+    {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "MID$: len must be >= 0 (got %lld)", (long long)len);
+        rt_trap(buf);
+    }
     int64_t slen = s->size;
     if (start > slen)
         start = slen;
@@ -292,7 +314,11 @@ rt_string rt_lcase(rt_string s)
 rt_string rt_chr(int64_t code)
 {
     if (code < 0 || code > 255)
-        rt_trap("rt_chr: range");
+    {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "CHR$: code must be 0-255 (got %lld)", (long long)code);
+        rt_trap(buf);
+    }
     rt_string s = (rt_string)rt_alloc(sizeof(*s));
     s->refcnt = 1;
     s->size = 1;

--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -197,8 +197,6 @@ class SemanticAnalyzer
     /// @brief Analyze POW builtin.
     Type analyzePow(const BuiltinCallExpr &c, const std::vector<Type> &args);
 
-    /// @brief Emit argument type mismatch diagnostic for argument @p idx.
-    void argTypeMismatch(const BuiltinCallExpr &c, size_t idx);
     /// @brief Check argument count is within [@p min,@p max].
     bool checkArgCount(const BuiltinCallExpr &c,
                        const std::vector<Type> &args,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -136,7 +136,10 @@ add_test(NAME test_rt_chr_asc COMMAND test_rt_chr_asc)
 add_executable(test_rt_chr_invalid runtime/RTChrInvalidTests.cpp)
 target_link_libraries(test_rt_chr_invalid PRIVATE rt)
 add_test(NAME test_rt_chr_invalid COMMAND test_rt_chr_invalid)
-set_tests_properties(test_rt_chr_invalid PROPERTIES WILL_FAIL TRUE)
+
+add_executable(test_rt_string_ranges runtime/RTStringRangeTests.cpp)
+target_link_libraries(test_rt_string_ranges PRIVATE rt)
+add_test(NAME test_rt_string_ranges COMMAND test_rt_string_ranges)
 
 add_executable(float_out e2e/support/FloatOut.cpp)
 

--- a/tests/runtime/RTChrInvalidTests.cpp
+++ b/tests/runtime/RTChrInvalidTests.cpp
@@ -4,9 +4,35 @@
 // Ownership: Uses runtime library.
 // Links: docs/runtime-abi.md
 #include "rt.hpp"
+#include <cassert>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
 
 int main()
 {
-    rt_chr(-1);
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        rt_chr(-1);
+        _exit(0);
+    }
+    close(fds[1]);
+    char buf[256];
+    ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
+    if (n > 0)
+        buf[n] = '\0';
+    else
+        buf[0] = '\0';
+    int status = 0;
+    waitpid(pid, &status, 0);
+    std::string out(buf);
+    bool ok = out.find("CHR$: code must be 0-255") != std::string::npos;
+    assert(ok);
     return 0;
 }

--- a/tests/runtime/RTStringRangeTests.cpp
+++ b/tests/runtime/RTStringRangeTests.cpp
@@ -1,0 +1,56 @@
+// File: tests/runtime/RTStringRangeTests.cpp
+// Purpose: Verify runtime string helpers report negative start/length diagnostics.
+// Key invariants: LEFT$ and MID$ trap with specific messages on invalid ranges.
+// Ownership: Uses runtime library.
+// Links: docs/runtime-abi.md
+#include "rt.hpp"
+#include <cassert>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static std::string capture(void (*fn)())
+{
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        fn();
+        _exit(0);
+    }
+    close(fds[1]);
+    char buf[256];
+    ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
+    if (n > 0)
+        buf[n] = '\0';
+    else
+        buf[0] = '\0';
+    int status = 0;
+    waitpid(pid, &status, 0);
+    return std::string(buf);
+}
+
+static void call_left_negative()
+{
+    rt_left(rt_const_cstr("A"), -1);
+}
+
+static void call_mid_negative()
+{
+    rt_mid3(rt_const_cstr("A"), -1, 1);
+}
+
+int main()
+{
+    std::string out = capture(call_left_negative);
+    bool ok = out.find("LEFT$: len must be >= 0") != std::string::npos;
+    assert(ok);
+    out = capture(call_mid_negative);
+    ok = out.find("MID$: start must be >= 0") != std::string::npos;
+    assert(ok);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- provide specific arg-count/type errors for BASIC intrinsics
- add range checks with clear messages for LEFT$/RIGHT$/MID$/CHR$
- test diagnostic substrings and runtime traps

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c23128270483249bc215d6649551e6