### PR TITLE
feat(il/verify): check runtime extern signatures

### DIFF
--- a/src/il/verify/Verifier.cpp
+++ b/src/il/verify/Verifier.cpp
@@ -78,6 +78,51 @@ std::string snippet(const Instr &in)
     return os.str();
 }
 
+struct ExternSig
+{
+    Type ret;
+    std::vector<Type> params;
+};
+
+const std::unordered_map<std::string, ExternSig> kExternSigs = {
+    {"rt_trap", {Type(Type::Kind::Void), {Type(Type::Kind::Ptr)}}},
+    {"rt_abort", {Type(Type::Kind::Void), {Type(Type::Kind::Ptr)}}},
+    {"rt_print_str", {Type(Type::Kind::Void), {Type(Type::Kind::Str)}}},
+    {"rt_print_i64", {Type(Type::Kind::Void), {Type(Type::Kind::I64)}}},
+    {"rt_print_f64", {Type(Type::Kind::Void), {Type(Type::Kind::F64)}}},
+    {"rt_input_line", {Type(Type::Kind::Str), {}}},
+    {"rt_len", {Type(Type::Kind::I64), {Type(Type::Kind::Str)}}},
+    {"rt_concat", {Type(Type::Kind::Str), {Type(Type::Kind::Str), Type(Type::Kind::Str)}}},
+    {"rt_substr",
+     {Type(Type::Kind::Str),
+      {Type(Type::Kind::Str), Type(Type::Kind::I64), Type(Type::Kind::I64)}}},
+    {"rt_left", {Type(Type::Kind::Str), {Type(Type::Kind::Str), Type(Type::Kind::I64)}}},
+    {"rt_right", {Type(Type::Kind::Str), {Type(Type::Kind::Str), Type(Type::Kind::I64)}}},
+    {"rt_mid2", {Type(Type::Kind::Str), {Type(Type::Kind::Str), Type(Type::Kind::I64)}}},
+    {"rt_mid3",
+     {Type(Type::Kind::Str),
+      {Type(Type::Kind::Str), Type(Type::Kind::I64), Type(Type::Kind::I64)}}},
+    {"rt_instr3",
+     {Type(Type::Kind::I64),
+      {Type(Type::Kind::I64), Type(Type::Kind::Str), Type(Type::Kind::Str)}}},
+    {"rt_instr2", {Type(Type::Kind::I64), {Type(Type::Kind::Str), Type(Type::Kind::Str)}}},
+    {"rt_ltrim", {Type(Type::Kind::Str), {Type(Type::Kind::Str)}}},
+    {"rt_rtrim", {Type(Type::Kind::Str), {Type(Type::Kind::Str)}}},
+    {"rt_trim", {Type(Type::Kind::Str), {Type(Type::Kind::Str)}}},
+    {"rt_ucase", {Type(Type::Kind::Str), {Type(Type::Kind::Str)}}},
+    {"rt_lcase", {Type(Type::Kind::Str), {Type(Type::Kind::Str)}}},
+    {"rt_chr", {Type(Type::Kind::Str), {Type(Type::Kind::I64)}}},
+    {"rt_asc", {Type(Type::Kind::I64), {Type(Type::Kind::Str)}}},
+    {"rt_str_eq", {Type(Type::Kind::I1), {Type(Type::Kind::Str), Type(Type::Kind::Str)}}},
+    {"rt_to_int", {Type(Type::Kind::I64), {Type(Type::Kind::Str)}}},
+    {"rt_int_to_str", {Type(Type::Kind::Str), {Type(Type::Kind::I64)}}},
+    {"rt_f64_to_str", {Type(Type::Kind::Str), {Type(Type::Kind::F64)}}},
+    {"rt_val", {Type(Type::Kind::F64), {Type(Type::Kind::Str)}}},
+    {"rt_str", {Type(Type::Kind::Str), {Type(Type::Kind::F64)}}},
+    {"rt_alloc", {Type(Type::Kind::Ptr), {Type(Type::Kind::I64)}}},
+    {"rt_const_cstr", {Type(Type::Kind::Str), {Type(Type::Kind::Ptr)}}},
+};
+
 bool expectOperandCount(
     const Function &fn, const BasicBlock &bb, const Instr &in, size_t expected, std::ostream &err)
 {
@@ -708,6 +753,23 @@ bool Verifier::verifyExterns(const Module &m,
                 err << " with mismatched signature";
             err << "\n";
             ok = false;
+            continue;
+        }
+
+        auto itKnown = kExternSigs.find(e.name);
+        if (itKnown != kExternSigs.end())
+        {
+            const ExternSig &sig = itKnown->second;
+            bool sigOk = e.retType.kind == sig.ret.kind && e.params.size() == sig.params.size();
+            if (sigOk)
+                for (size_t i = 0; i < sig.params.size(); ++i)
+                    if (e.params[i].kind != sig.params[i].kind)
+                        sigOk = false;
+            if (!sigOk)
+            {
+                err << "extern @" << e.name << " signature mismatch\n";
+                ok = false;
+            }
         }
     }
     return ok;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -306,6 +306,19 @@ add_test(NAME il_verify_invalid_bad_load_store
           -DEXPECT=pointer\ type\ mismatch
           -P ${CMAKE_SOURCE_DIR}/tests/golden/invalid_il/check_invalid.cmake)
 
+add_test(NAME il_verify_invalid_wrong_extern_sig
+  COMMAND ${CMAKE_COMMAND}
+          -DIL_VERIFY=${IL_VERIFY}
+          -DFILE=${CMAKE_SOURCE_DIR}/tests/golden/invalid_il/wrong_extern_sig.il
+          -DEXPECT=extern\ @rt_print_str\ signature\ mismatch
+          -P ${CMAKE_SOURCE_DIR}/tests/golden/invalid_il/check_invalid.cmake)
+add_test(NAME il_verify_invalid_wrong_extern_call
+  COMMAND ${CMAKE_COMMAND}
+          -DIL_VERIFY=${IL_VERIFY}
+          -DFILE=${CMAKE_SOURCE_DIR}/tests/golden/invalid_il/wrong_extern_call.il
+          -DEXPECT=call\ arg\ type\ mismatch
+          -P ${CMAKE_SOURCE_DIR}/tests/golden/invalid_il/check_invalid.cmake)
+
 add_test(NAME il_verify_invalid_wrong_block_arg_arity
   COMMAND ${CMAKE_COMMAND}
           -DIL_VERIFY=${IL_VERIFY}

--- a/tests/golden/invalid_il/wrong_extern_call.il
+++ b/tests/golden/invalid_il/wrong_extern_call.il
@@ -1,0 +1,8 @@
+il 0.1
+extern @rt_print_str(str) -> void
+func @main() -> i32 {
+entry:
+  call @rt_print_str(42)
+  ret 0
+}
+

--- a/tests/golden/invalid_il/wrong_extern_sig.il
+++ b/tests/golden/invalid_il/wrong_extern_sig.il
@@ -1,0 +1,7 @@
+il 0.1
+extern @rt_print_str(i64) -> void
+func @main() -> i32 {
+entry:
+  ret 0
+}
+


### PR DESCRIPTION
## Summary
- enforce known runtime extern type signatures in the IL verifier
- add negative tests for extern signature and call type mismatches

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c2383cd5b8832482f737b36db6a04b