### PR TITLE
ci: add basic strings suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,17 @@ jobs:
           if [ -n "$CHANGED_FILES" ]; then
             echo "$CHANGED_FILES" | xargs clang-format --dry-run --Werror
           fi
+  basic-strings:
+    name: basic-strings suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+      - name: Build ilc
+        run: cmake --build build --target ilc -j2
+      - name: Run basic string tests
+        run: ctest --test-dir build --output-on-failure -R basic_strings
   build:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -609,6 +609,10 @@ add_test(NAME basic_to_il_return_nest COMMAND ${CMAKE_COMMAND}
   -DGOLDEN=${CMAKE_SOURCE_DIR}/tests/basic/goldens/ReturnNest.il
   -P ${CMAKE_SOURCE_DIR}/tests/golden/basic_to_il/check_il.cmake)
 
+# BASIC string intrinsic tests
+add_test(NAME basic_strings COMMAND ${CMAKE_SOURCE_DIR}/scripts/test_strings.sh)
+set_tests_properties(basic_strings PROPERTIES LABELS BasicStrings)
+
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/basic/semantics/proc_registration_ok.err EXPECT_PROC_REG)
 string(STRIP "${EXPECT_PROC_REG}" EXPECT_PROC_REG)
 add_test(NAME basic_semantics_proc_registration COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
## Summary
- register BASIC string tests with CTest
- add lightweight GitHub Actions job to run string suite

## Testing
- `cmake -S . -B build`
- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c23aac097c8324bfd5f4e5385e62ec