### PR TITLE
fix(runtime): trap on negative allocations

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -38,6 +38,8 @@ void rt_trap(const char *msg)
 
 void *rt_alloc(int64_t bytes)
 {
+    if (bytes < 0)
+        return rt_trap("negative allocation"), NULL;
     void *p = malloc((size_t)bytes);
     if (!p)
         rt_trap("out of memory");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -141,6 +141,10 @@ add_executable(test_rt_string_ranges runtime/RTStringRangeTests.cpp)
 target_link_libraries(test_rt_string_ranges PRIVATE rt)
 add_test(NAME test_rt_string_ranges COMMAND test_rt_string_ranges)
 
+add_executable(test_rt_alloc runtime/RTAllocTests.cpp)
+target_link_libraries(test_rt_alloc PRIVATE rt)
+add_test(NAME test_rt_alloc COMMAND test_rt_alloc)
+
 add_executable(float_out e2e/support/FloatOut.cpp)
 
 add_test(NAME vm_strings_example COMMAND ${CMAKE_COMMAND}

--- a/tests/runtime/RTAllocTests.cpp
+++ b/tests/runtime/RTAllocTests.cpp
@@ -1,0 +1,48 @@
+// File: tests/runtime/RTAllocTests.cpp
+// Purpose: Verify rt_alloc traps on negative allocation sizes.
+// Key invariants: rt_alloc reports "negative allocation" when bytes < 0.
+// Ownership: Uses runtime library.
+// Links: docs/runtime-abi.md
+#include "rt.hpp"
+#include <cassert>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static std::string capture(void (*fn)())
+{
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        fn();
+        _exit(0);
+    }
+    close(fds[1]);
+    char buf[256];
+    ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
+    if (n > 0)
+        buf[n] = '\0';
+    else
+        buf[0] = '\0';
+    int status = 0;
+    waitpid(pid, &status, 0);
+    return std::string(buf);
+}
+
+static void call_alloc_negative()
+{
+    rt_alloc(-1);
+}
+
+int main()
+{
+    std::string out = capture(call_alloc_negative);
+    bool ok = out.find("negative allocation") != std::string::npos;
+    assert(ok);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- guard `rt_alloc` against negative byte counts with an explicit trap
- add runtime test verifying `rt_alloc(-1)` traps

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c27686904483249c0c10966c3d2373