### PR TITLE
fix(runtime): correct rt_instr3 start index

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -274,7 +274,7 @@ int64_t rt_instr3(int64_t start, rt_string hay, rt_string needle)
         start = len + 1;
     if (needle->size == 0)
         return start;
-    return rt_find(hay, start, needle);
+    return rt_find(hay, start - 1, needle);
 }
 
 rt_string rt_ltrim(rt_string s)

--- a/tests/runtime/RTInstrTests.cpp
+++ b/tests/runtime/RTInstrTests.cpp
@@ -14,11 +14,15 @@ int main()
 
     rt_string s3 = rt_const_cstr("ABABAB");
     rt_string s4 = rt_const_cstr("AB");
-    assert(rt_instr3(3, s3, s4) == 5);
+    assert(rt_instr3(3, s3, s4) == 3);
 
     rt_string s5 = rt_const_cstr("ABC");
     rt_string s6 = rt_const_cstr("X");
     assert(rt_instr2(s5, s6) == 0);
+
+    rt_string s7 = rt_const_cstr("abc");
+    rt_string s8 = rt_const_cstr("a");
+    assert(rt_instr3(1, s7, s8) == 1);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- fix off-by-one in `rt_instr3` by adjusting search start to `start - 1`
- add regression test for `rt_instr3(1, "abc", "a")`
- update existing INSTR test expectations

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c278838d008324bcdacafbc93afa1a