### PR TITLE
fix(support): guard invalid arena alignments

### DIFF
--- a/src/support/arena.cpp
+++ b/src/support/arena.cpp
@@ -13,6 +13,10 @@ Arena::Arena(size_t size) : buffer_(size) {}
 
 void *Arena::allocate(size_t size, size_t align)
 {
+    // Reject zero or non power-of-two alignments.
+    if (align == 0 || (align & (align - 1)) != 0)
+        return nullptr;
+
     size_t current = offset_;
     size_t aligned = (current + align - 1) & ~(align - 1);
     if (aligned + size > buffer_.size())

--- a/src/support/arena.hpp
+++ b/src/support/arena.hpp
@@ -24,7 +24,8 @@ class Arena
     /// @brief Allocate @p size bytes with alignment @p align.
     /// @param size Number of bytes to allocate.
     /// @param align Alignment requirement.
-    /// @return Pointer to allocated memory within the arena.
+    /// @return Pointer to allocated memory or nullptr on failure.
+    /// @notes Fails if @p align is zero, not a power of two, or capacity exceeded.
     void *allocate(size_t size, size_t align);
 
     /// @brief Reset arena, making all allocations available again.

--- a/tests/unit/test_support.cpp
+++ b/tests/unit/test_support.cpp
@@ -2,6 +2,7 @@
 #include "support/diagnostics.hpp"
 #include "support/string_interner.hpp"
 #include <cassert>
+#include <cstdint>
 #include <sstream>
 
 int main()
@@ -29,5 +30,7 @@ int main()
     (void)p1;
     void *p2 = arena.allocate(sizeof(double), alignof(double));
     assert(reinterpret_cast<uintptr_t>(p2) % alignof(double) == 0);
+    assert(arena.allocate(1, 0) == nullptr);
+    assert(arena.allocate(1, 3) == nullptr);
     return 0;
 }


### PR DESCRIPTION
## Summary
- ensure `Arena::allocate` rejects zero or non-power-of-two alignments
- document allocation failure conditions
- test valid and invalid alignment requests

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c27a4941f083248221eec757ff5b1a