### PR TITLE
fix(fe_basic): cast char inputs for ctype calls

### DIFF
--- a/src/frontends/basic/Lexer.cpp
+++ b/src/frontends/basic/Lexer.cpp
@@ -69,11 +69,12 @@ void Lexer::skipWhitespaceAndComments()
             continue;
         }
 
-        if (std::toupper(peek()) == 'R' && pos_ + 2 < src_.size() &&
-            std::toupper(src_[pos_ + 1]) == 'E' && std::toupper(src_[pos_ + 2]) == 'M')
+        if (std::toupper(static_cast<unsigned char>(peek())) == 'R' && pos_ + 2 < src_.size() &&
+            std::toupper(static_cast<unsigned char>(src_[pos_ + 1])) == 'E' &&
+            std::toupper(static_cast<unsigned char>(src_[pos_ + 2])) == 'M')
         {
             char after = (pos_ + 3 < src_.size()) ? src_[pos_ + 3] : '\0';
-            if (!std::isalnum(after) && after != '$' && after != '#')
+            if (!std::isalnum(static_cast<unsigned char>(after)) && after != '$' && after != '#')
             {
                 get();
                 get();
@@ -100,13 +101,13 @@ Token Lexer::lexNumber()
         seenDot = true;
         s.push_back(get());
     }
-    while (std::isdigit(peek()))
+    while (std::isdigit(static_cast<unsigned char>(peek())))
         s.push_back(get());
     if (!seenDot && peek() == '.')
     {
         seenDot = true;
         s.push_back(get());
-        while (std::isdigit(peek()))
+        while (std::isdigit(static_cast<unsigned char>(peek())))
             s.push_back(get());
     }
     if ((peek() == 'e' || peek() == 'E'))
@@ -115,7 +116,7 @@ Token Lexer::lexNumber()
         s.push_back(get());
         if (peek() == '+' || peek() == '-')
             s.push_back(get());
-        while (std::isdigit(peek()))
+        while (std::isdigit(static_cast<unsigned char>(peek())))
             s.push_back(get());
     }
     if (peek() == '#')
@@ -134,10 +135,10 @@ Token Lexer::lexIdentifierOrKeyword()
 {
     il::support::SourceLoc loc{file_id_, line_, column_};
     std::string s;
-    while (std::isalnum(peek()))
-        s.push_back(std::toupper(get()));
+    while (std::isalnum(static_cast<unsigned char>(peek())))
+        s.push_back(std::toupper(static_cast<unsigned char>(get())));
     if (peek() == '$' || peek() == '#')
-        s.push_back(std::toupper(get()));
+        s.push_back(std::toupper(static_cast<unsigned char>(get())));
     // keywords
     if (s == "PRINT")
         return {TokenKind::KeywordPrint, s, loc};
@@ -236,7 +237,9 @@ Token Lexer::next()
         return {TokenKind::EndOfLine, "\n", loc};
     }
 
-    if (std::isdigit(c) || (c == '.' && pos_ + 1 < src_.size() && std::isdigit(src_[pos_ + 1])))
+    if (std::isdigit(static_cast<unsigned char>(c)) ||
+        (c == '.' && pos_ + 1 < src_.size() &&
+         std::isdigit(static_cast<unsigned char>(src_[pos_ + 1]))))
         return lexNumber();
     if (std::isalpha(c))
         return lexIdentifierOrKeyword();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,10 @@ add_executable(test_il_comments unit/test_il_comments.cpp)
 target_link_libraries(test_il_comments PRIVATE il_core il_io support)
 add_test(NAME test_il_comments COMMAND test_il_comments)
 
+add_executable(test_basic_lexer_high_bit unit/test_basic_lexer_high_bit.cpp)
+target_link_libraries(test_basic_lexer_high_bit PRIVATE fe_basic support)
+add_test(NAME test_basic_lexer_high_bit COMMAND test_basic_lexer_high_bit)
+
 add_executable(test_il_utils il/UtilsTests.cpp)
 target_link_libraries(test_il_utils PRIVATE IL)
 add_test(NAME test_il_utils COMMAND test_il_utils)

--- a/tests/unit/test_basic_lexer_high_bit.cpp
+++ b/tests/unit/test_basic_lexer_high_bit.cpp
@@ -1,0 +1,45 @@
+// File: tests/unit/test_basic_lexer_high_bit.cpp
+// Purpose: Ensure BASIC lexer handles high-bit characters without UB.
+// Key invariants: None.
+// Ownership/Lifetime: N/A (test).
+// Links: docs/class-catalog.md
+#include "frontends/basic/Lexer.hpp"
+#include <cassert>
+#include <string>
+
+using namespace il::frontends::basic;
+
+int main()
+{
+    {
+        std::string input = std::string("1") + static_cast<char>(0x80);
+        Lexer lex(input, 0);
+        Token t1 = lex.next();
+        assert(t1.kind == TokenKind::Number);
+        Token t2 = lex.next();
+        assert(t2.kind == TokenKind::EndOfFile);
+    }
+    {
+        std::string input = std::string("A") + static_cast<char>(0x80);
+        Lexer lex(input, 0);
+        Token t1 = lex.next();
+        assert(t1.kind == TokenKind::Identifier);
+        Token t2 = lex.next();
+        assert(t2.kind == TokenKind::EndOfFile);
+    }
+    {
+        std::string input(1, static_cast<char>(0x80));
+        Lexer lex(input, 0);
+        Token t = lex.next();
+        assert(t.kind == TokenKind::EndOfFile);
+    }
+    {
+        std::string input = std::string("REM") + static_cast<char>(0x80) + "\n1";
+        Lexer lex(input, 0);
+        Token t1 = lex.next();
+        assert(t1.kind == TokenKind::EndOfLine);
+        Token t2 = lex.next();
+        assert(t2.kind == TokenKind::Number);
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- avoid UB in BASIC lexer by casting chars passed to std::toupper/isalnum/isdigit
- add regression test covering high-bit characters

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68c27cff8ff48324888bc6284f16ace7