### PR TITLE
fix(vm): trap negative alloca size

### DIFF
--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -205,7 +205,16 @@ std::optional<Slot> VM::handleDebugBreak(
 
 VM::ExecResult VM::handleAlloca(Frame &fr, const Instr &in)
 {
-    size_t sz = (size_t)eval(fr, in.operands[0]).i64;
+    int64_t bytes = eval(fr, in.operands[0]).i64;
+    if (bytes < 0)
+    {
+        RuntimeBridge::trap("negative allocation", in.loc, fr.func->name, "");
+        ExecResult r{};
+        r.value.i64 = 0; // unreachable
+        r.returned = true;
+        return r;
+    }
+    size_t sz = static_cast<size_t>(bytes);
     size_t addr = fr.sp;
     assert(addr + sz <= fr.stack.size());
     std::memset(fr.stack.data() + addr, 0, sz);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -399,6 +399,10 @@ add_executable(test_vm_rt_trap_loc unit/test_vm_rt_trap_loc.cpp)
 target_link_libraries(test_vm_rt_trap_loc PRIVATE il_build il_vm support)
 add_test(NAME test_vm_rt_trap_loc COMMAND test_vm_rt_trap_loc)
 
+add_executable(test_vm_alloca_negative unit/test_vm_alloca_negative.cpp)
+target_link_libraries(test_vm_alloca_negative PRIVATE il_build il_vm support)
+add_test(NAME test_vm_alloca_negative COMMAND test_vm_alloca_negative)
+
 add_executable(test_vm_normalize_path unit/test_vm_normalize_path.cpp)
 target_link_libraries(test_vm_normalize_path PRIVATE VMTrace)
 add_test(NAME test_vm_normalize_path COMMAND test_vm_normalize_path)

--- a/tests/unit/test_vm_alloca_negative.cpp
+++ b/tests/unit/test_vm_alloca_negative.cpp
@@ -1,0 +1,52 @@
+// File: tests/unit/test_vm_alloca_negative.cpp
+// Purpose: Ensure VM traps on negative allocation sizes.
+// Key invariants: Alloca with negative bytes must emit "negative allocation" trap.
+// Ownership: Test constructs IL module and executes VM.
+// Links: docs/class-catalog.md
+
+#include "il/build/IRBuilder.hpp"
+#include "vm/VM.hpp"
+#include <cassert>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main()
+{
+    il::core::Module m;
+    il::build::IRBuilder b(m);
+    auto &fn = b.startFunction("main", il::core::Type(il::core::Type::Kind::I64), {});
+    auto &bb = b.addBlock(fn, "entry");
+    il::core::Instr in;
+    in.op = il::core::Opcode::Alloca;
+    in.type = il::core::Type(il::core::Type::Kind::Ptr);
+    in.operands.push_back(il::core::Value::constInt(-8));
+    in.loc = {1, 1, 1};
+    bb.instructions.push_back(in);
+
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        il::vm::VM vm(m);
+        vm.run();
+        _exit(0);
+    }
+    close(fds[1]);
+    char buf[256];
+    ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
+    if (n > 0)
+        buf[n] = '\0';
+    else
+        buf[0] = '\0';
+    int status = 0;
+    waitpid(pid, &status, 0);
+    std::string out(buf);
+    bool ok = out.find("negative allocation") != std::string::npos;
+    assert(ok);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- trap negative allocation sizes in VM alloca
- add unit test for negative alloca trap

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c27fde51d0832482c30b2dc2129e5c