### PR TITLE
fix(il/io): reject i32 type mnemonic

### DIFF
--- a/examples/il/ex1_hello_cond.il
+++ b/examples/il/ex1_hello_cond.il
@@ -6,7 +6,7 @@ global const str @.L0 = "HELLO"
 global const str @.L1 = "READY"
 global const str @.L2 = "\n"
 
-func @main() -> i32 {
+func @main() -> i64 {
 entry:
   %x_slot = alloca 8
   %y_slot = alloca 8

--- a/examples/il/ex2_sum_1_to_10.il
+++ b/examples/il/ex2_sum_1_to_10.il
@@ -6,7 +6,7 @@ global const str @.L0 = "SUM 1..10"
 global const str @.L1 = "DONE"
 global const str @.L2 = "\n"
 
-func @main() -> i32 {
+func @main() -> i64 {
 entry:
   %i_slot = alloca 8
   %s_slot = alloca 8

--- a/examples/il/ex3_table_5x5.il
+++ b/examples/il/ex3_table_5x5.il
@@ -4,7 +4,7 @@ extern @rt_print_i64(i64) -> void
 
 global const str @.L0 = "TABLE 5x5"
 
-func @main() -> i32 {
+func @main() -> i64 {
 entry:
   %n_slot = alloca 8
   %i_slot = alloca 8

--- a/examples/il/ex4_factorial.il
+++ b/examples/il/ex4_factorial.il
@@ -7,7 +7,7 @@ extern @rt_to_int(str) -> i64
 global const str @.L0 = "FACTORIAL"
 global const str @.L1 = "ENTER N:"
 
-func @main() -> i32 {
+func @main() -> i64 {
 entry:
   %s_slot = alloca 8
   %n_slot = alloca 8

--- a/examples/il/ex5_strings.il
+++ b/examples/il/ex5_strings.il
@@ -12,7 +12,7 @@ global const str @.L2 = " "
 global const str @.L3 = "JOHN DOE"
 global const str @.L4 = "\n"
 
-func @main() -> i32 {
+func @main() -> i64 {
 entry:
   %a_slot = alloca 8
   %b_slot = alloca 8

--- a/examples/il/ex6_heap_array_avg.il
+++ b/examples/il/ex6_heap_array_avg.il
@@ -5,7 +5,7 @@ extern @rt_print_str(str) -> void
 
 global const str @.L0 = "DONE"
 
-func @main() -> i32 {
+func @main() -> i64 {
 entry:
   %n_slot = alloca 8
   %i_slot = alloca 8

--- a/examples/il/random_three.il
+++ b/examples/il/random_three.il
@@ -7,7 +7,7 @@ extern @rt_print_str(str) -> void
 
 global const str @.L0 = "\n"
 
-func @main() -> i32 {
+func @main() -> i64 {
 entry:
   call @rt_randomize_i64(42)
   %r0 = call @rt_rnd()

--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -35,7 +35,7 @@ std::string trim(const std::string &s)
 
 Type parseType(const std::string &t, bool *ok = nullptr)
 {
-    if (t == "i64" || t == "i32")
+    if (t == "i64")
     {
         if (ok)
             *ok = true;
@@ -73,7 +73,7 @@ Type parseType(const std::string &t, bool *ok = nullptr)
     }
     if (ok)
         *ok = false;
-    return Type(Type::Kind::Void);
+    return Type(); // error indicator
 }
 
 Value parseValue(const std::string &tok, const std::unordered_map<std::string, unsigned> &temps)

--- a/tests/il/parse/bad_i32.il
+++ b/tests/il/parse/bad_i32.il
@@ -1,0 +1,5 @@
+il 0.1.2
+func @f() -> void {
+entry(%x:i32):
+  ret 0
+}

--- a/tests/unit/test_il_parse_negative.cpp
+++ b/tests/unit/test_il_parse_negative.cpp
@@ -13,7 +13,8 @@ int main()
 {
     const char *files[] = {BAD_DIR "/mismatched_paren.il",
                            BAD_DIR "/bad_arg_count.il",
-                           BAD_DIR "/unknown_param_type.il"};
+                           BAD_DIR "/unknown_param_type.il",
+                           BAD_DIR "/bad_i32.il"};
     for (const char *path : files)
     {
         std::ifstream in(path);


### PR DESCRIPTION
## Summary
- treat `i32` as an invalid type mnemonic and signal failure
- refresh sample IL programs to use `i64`
- add test case exercising rejection of `i32`

## Testing
- `cmake -S . -B build && cmake --build build && ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c2d72b03308324a915c1c54cf8b18b