### PR TITLE
fix: handle missing labels during CBr serialization

### DIFF
--- a/src/il/io/Serializer.cpp
+++ b/src/il/io/Serializer.cpp
@@ -74,29 +74,44 @@ void printInstr(const Instr &in, std::ostream &os)
     }
     else if (in.op == Opcode::CBr)
     {
-        os << " " << il::core::toString(in.operands[0]) << ", " << in.labels[0];
-        if (!in.brArgs.empty() && !in.brArgs[0].empty())
+        os << " " << il::core::toString(in.operands[0]);
+        if (in.labels.empty())
         {
-            os << "(";
-            for (size_t i = 0; i < in.brArgs[0].size(); ++i)
-            {
-                if (i)
-                    os << ", ";
-                os << il::core::toString(in.brArgs[0][i]);
-            }
-            os << ")";
+            os << " ; missing label";
         }
-        os << ", " << in.labels[1];
-        if (in.brArgs.size() > 1 && !in.brArgs[1].empty())
+        else
         {
-            os << "(";
-            for (size_t i = 0; i < in.brArgs[1].size(); ++i)
+            os << ", " << in.labels[0];
+            if (!in.brArgs.empty() && !in.brArgs[0].empty())
             {
-                if (i)
-                    os << ", ";
-                os << il::core::toString(in.brArgs[1][i]);
+                os << "(";
+                for (size_t i = 0; i < in.brArgs[0].size(); ++i)
+                {
+                    if (i)
+                        os << ", ";
+                    os << il::core::toString(in.brArgs[0][i]);
+                }
+                os << ")";
             }
-            os << ")";
+            if (in.labels.size() >= 2)
+            {
+                os << ", " << in.labels[1];
+                if (in.brArgs.size() > 1 && !in.brArgs[1].empty())
+                {
+                    os << "(";
+                    for (size_t i = 0; i < in.brArgs[1].size(); ++i)
+                    {
+                        if (i)
+                            os << ", ";
+                        os << il::core::toString(in.brArgs[1][i]);
+                    }
+                    os << ")";
+                }
+            }
+            else
+            {
+                os << " ; missing label";
+            }
         }
     }
     else if (in.op == Opcode::Load)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,10 @@ target_link_libraries(test_il_serialize PRIVATE il_core il_build il_io support)
 target_compile_definitions(test_il_serialize PRIVATE TESTS_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 add_test(NAME test_il_serialize COMMAND test_il_serialize)
 
+add_executable(test_il_malformed_cbr unit/test_il_malformed_cbr.cpp)
+target_link_libraries(test_il_malformed_cbr PRIVATE il_core il_io support)
+add_test(NAME test_il_malformed_cbr COMMAND test_il_malformed_cbr)
+
 add_executable(test_il_roundtrip unit/test_il_roundtrip.cpp)
 target_link_libraries(test_il_roundtrip PRIVATE il_core il_io il_verify support)
 target_compile_definitions(test_il_roundtrip PRIVATE EXAMPLES_DIR="${CMAKE_SOURCE_DIR}/examples" ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/roundtrip")

--- a/tests/unit/test_il_malformed_cbr.cpp
+++ b/tests/unit/test_il_malformed_cbr.cpp
@@ -1,0 +1,41 @@
+// File: tests/unit/test_il_malformed_cbr.cpp
+// Purpose: Ensure serializer handles conditional branches with missing labels.
+// Key invariants: Serializer should not crash on malformed cbr instructions.
+// Ownership/Lifetime: Test constructs modules on stack.
+// Links: docs/il-spec.md
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Module.hpp"
+#include "il/core/Type.hpp"
+#include "il/core/Value.hpp"
+#include "il/io/Serializer.hpp"
+#include <cassert>
+#include <string>
+
+int main()
+{
+    using namespace il::core;
+    Module m;
+    Function f;
+    f.name = "f";
+    f.retType = Type(Type::Kind::Void);
+
+    BasicBlock bb;
+    bb.label = "entry";
+
+    Instr cbr;
+    cbr.op = Opcode::CBr;
+    cbr.type = Type(Type::Kind::Void);
+    cbr.operands.push_back(Value::constInt(1));
+    cbr.labels.push_back("L1"); // Missing second label
+    bb.instructions.push_back(std::move(cbr));
+
+    f.blocks.push_back(std::move(bb));
+    m.functions.push_back(std::move(f));
+
+    std::string out = il::io::Serializer::toString(m);
+    assert(out.find("missing label") != std::string::npos);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- guard Serializer against conditional branches with missing labels
- add regression test for malformed conditional branches

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c2dde43088832492ab4cc36611a9e5