### PR TITLE
fix(runtime): grow input buffer for long lines

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,6 +153,10 @@ add_executable(test_rt_alloc runtime/RTAllocTests.cpp)
 target_link_libraries(test_rt_alloc PRIVATE rt)
 add_test(NAME test_rt_alloc COMMAND test_rt_alloc)
 
+add_executable(test_rt_input_line runtime/RTInputLineTests.cpp)
+target_link_libraries(test_rt_input_line PRIVATE rt)
+add_test(NAME test_rt_input_line COMMAND test_rt_input_line)
+
 add_executable(float_out e2e/support/FloatOut.cpp)
 
 add_test(NAME vm_strings_example COMMAND ${CMAKE_COMMAND}

--- a/tests/runtime/RTInputLineTests.cpp
+++ b/tests/runtime/RTInputLineTests.cpp
@@ -1,0 +1,39 @@
+// File: tests/runtime/RTInputLineTests.cpp
+// Purpose: Ensure rt_input_line handles lines longer than the initial buffer and EOF-terminated
+// lines. Key invariants: rt_input_line returns full line content for >1023 chars, with or without
+// trailing newline. Ownership: Uses runtime library. Links: docs/runtime-abi.md
+#include "rt.hpp"
+#include <cassert>
+#include <cstring>
+#include <string>
+#include <unistd.h>
+
+static void feed_and_check(size_t len, bool with_newline)
+{
+    std::string input(len, 'x');
+    int fds[2];
+    assert(pipe(fds) == 0);
+    if (with_newline)
+    {
+        std::string data = input + "\n";
+        (void)write(fds[1], data.data(), data.size());
+    }
+    else
+    {
+        (void)write(fds[1], input.data(), input.size());
+    }
+    close(fds[1]);
+    dup2(fds[0], 0);
+    close(fds[0]);
+    rt_string s = rt_input_line();
+    assert(s);
+    assert(s->size == (int64_t)input.size());
+    assert(std::memcmp(s->data, input.data(), input.size()) == 0);
+}
+
+int main()
+{
+    feed_and_check(1500, true);
+    feed_and_check(1500, false);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- replace fixed 1KB buffer in `rt_input_line` with dynamic growth
- add regression test for reading lines >1023 characters

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 4`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c2eb2844d483248d36fd53a00a9494