### PR TITLE
feat(il/build): record call results

### DIFF
--- a/src/il/build/IRBuilder.hpp
+++ b/src/il/build/IRBuilder.hpp
@@ -84,8 +84,10 @@ class IRBuilder
     /// @brief Emit call to function @p callee with arguments @p args.
     /// @param callee Name of function to call.
     /// @param args Argument values.
+    /// @param dst Optional destination value to store result.
     void emitCall(const std::string &callee,
                   const std::vector<Value> &args,
+                  const std::optional<Value> &dst,
                   il::support::SourceLoc loc);
 
     /// @brief Emit return from current function.

--- a/src/tools/il-dis/main.cpp
+++ b/src/tools/il-dis/main.cpp
@@ -20,7 +20,7 @@ int main()
     auto &bb = builder.addBlock(fn, "entry");
     builder.setInsertPoint(bb);
     il::core::Value s0 = builder.emitConstStr(".L0", {});
-    builder.emitCall("rt_print_str", {s0}, {});
+    builder.emitCall("rt_print_str", {s0}, std::optional<il::core::Value>{}, {});
     builder.emitRet(il::core::Value::constInt(0), {});
     il::io::Serializer::write(m, std::cout);
     return 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,10 @@ add_executable(test_il_malformed_cbr unit/test_il_malformed_cbr.cpp)
 target_link_libraries(test_il_malformed_cbr PRIVATE il_core il_io support)
 add_test(NAME test_il_malformed_cbr COMMAND test_il_malformed_cbr)
 
+add_executable(test_irbuilder_call_ret unit/test_irbuilder_call_ret.cpp)
+target_link_libraries(test_irbuilder_call_ret PRIVATE il_core il_build support)
+add_test(NAME test_irbuilder_call_ret COMMAND test_irbuilder_call_ret)
+
 add_executable(test_il_roundtrip unit/test_il_roundtrip.cpp)
 target_link_libraries(test_il_roundtrip PRIVATE il_core il_io il_verify support)
 target_compile_definitions(test_il_roundtrip PRIVATE EXAMPLES_DIR="${CMAKE_SOURCE_DIR}/examples" ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/roundtrip")

--- a/tests/unit/test_il_serialize.cpp
+++ b/tests/unit/test_il_serialize.cpp
@@ -16,7 +16,7 @@ int main()
     auto &bb = builder.addBlock(fn, "entry");
     builder.setInsertPoint(bb);
     il::core::Value s0 = builder.emitConstStr(".L0", {});
-    builder.emitCall("rt_print_str", {s0}, {});
+    builder.emitCall("rt_print_str", {s0}, std::optional<il::core::Value>{}, {});
     builder.emitRet(il::core::Value::constInt(0), {});
     std::string out = il::io::Serializer::toString(m);
     std::ifstream in(std::string(TESTS_DIR) + "/golden/hello_expected.il");

--- a/tests/unit/test_irbuilder_call_ret.cpp
+++ b/tests/unit/test_irbuilder_call_ret.cpp
@@ -1,0 +1,29 @@
+// File: tests/unit/test_irbuilder_call_ret.cpp
+// Purpose: Verify IRBuilder::emitCall records results for non-void functions.
+// Key invariants: Call instruction captures result id and return type.
+// Ownership: Test constructs module and inspects instruction.
+// Links: docs/class-catalog.md
+
+#include "il/build/IRBuilder.hpp"
+#include <cassert>
+
+int main()
+{
+    using namespace il::core;
+    Module m;
+    il::build::IRBuilder b(m);
+    b.addExtern("rt_len", Type(Type::Kind::I64), {Type(Type::Kind::Str)});
+    b.addGlobalStr("g", "hi");
+    auto &fn = b.startFunction("main", Type(Type::Kind::I64), {});
+    auto &bb = b.addBlock(fn, "entry");
+    b.setInsertPoint(bb);
+    Value s = b.emitConstStr("g", {});
+    Value dst = Value::temp(0);
+    b.emitCall("rt_len", {s}, dst, {});
+    b.emitRet(dst, {});
+    assert(bb.instructions.size() >= 2);
+    const Instr &call = bb.instructions[1];
+    assert(call.result && *call.result == dst.id);
+    assert(call.type.kind == Type::Kind::I64);
+    return 0;
+}

--- a/tests/unit/test_vm_rt_trap_loc.cpp
+++ b/tests/unit/test_vm_rt_trap_loc.cpp
@@ -22,7 +22,7 @@ int main()
     auto &bb = b.addBlock(fn, "entry");
     b.setInsertPoint(bb);
     Value s = b.emitConstStr("g", {1, 1, 1});
-    b.emitCall("rt_to_int", {s}, {1, 1, 1});
+    b.emitCall("rt_to_int", {s}, std::optional<Value>{}, {1, 1, 1});
     b.emitRet(std::optional<Value>{}, {1, 1, 1});
 
     int fds[2];


### PR DESCRIPTION
## Summary
- allow IRBuilder::emitCall to accept an optional destination and infer return types
- update call sites for new signature and add test covering call results

## Testing
- `cmake -S . -B build && cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c2f19e2e648324b9e8a5d99bceb5ee