### PR TITLE
fix(il/verify): treat traps as block terminators

### DIFF
--- a/src/il/verify/Verifier.cpp
+++ b/src/il/verify/Verifier.cpp
@@ -21,7 +21,7 @@ namespace
 
 bool isTerminator(Opcode op)
 {
-    return op == Opcode::Br || op == Opcode::CBr || op == Opcode::Ret;
+    return op == Opcode::Br || op == Opcode::CBr || op == Opcode::Ret || op == Opcode::Trap;
 }
 
 Type valueType(const Value &v, const std::unordered_map<unsigned, Type> &temps)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,10 @@ target_link_libraries(test_il_roundtrip PRIVATE il_core il_io il_verify support)
 target_compile_definitions(test_il_roundtrip PRIVATE EXAMPLES_DIR="${CMAKE_SOURCE_DIR}/examples" ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/roundtrip")
 add_test(NAME test_il_roundtrip COMMAND test_il_roundtrip)
 
+add_executable(test_il_trap_terminator unit/test_il_trap_terminator.cpp)
+target_link_libraries(test_il_trap_terminator PRIVATE il_core il_verify support)
+add_test(NAME test_il_trap_terminator COMMAND test_il_trap_terminator)
+
 add_executable(test_il_parse_negative unit/test_il_parse_negative.cpp)
 target_link_libraries(test_il_parse_negative PRIVATE il_core il_io support)
 target_compile_definitions(test_il_parse_negative PRIVATE BAD_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse")

--- a/tests/unit/test_il_trap_terminator.cpp
+++ b/tests/unit/test_il_trap_terminator.cpp
@@ -1,0 +1,45 @@
+// File: tests/unit/test_il_trap_terminator.cpp
+// Purpose: Ensure verifier rejects instructions following a trap.
+// Key invariants: A trap terminates a block and must be final.
+// Ownership/Lifetime: Constructs module and verifier on the stack.
+// Links: docs/il-spec.md
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Module.hpp"
+#include "il/core/Type.hpp"
+#include "il/verify/Verifier.hpp"
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    using namespace il::core;
+    Module m;
+    Function f;
+    f.name = "f";
+    f.retType = Type(Type::Kind::Void);
+
+    BasicBlock bb;
+    bb.label = "entry";
+
+    Instr trap;
+    trap.op = Opcode::Trap;
+    trap.type = Type(Type::Kind::Void);
+    bb.instructions.push_back(trap);
+
+    Instr ret;
+    ret.op = Opcode::Ret;
+    ret.type = Type(Type::Kind::Void);
+    bb.instructions.push_back(ret);
+
+    f.blocks.push_back(bb);
+    m.functions.push_back(f);
+
+    std::ostringstream err;
+    bool ok = il::verify::Verifier::verify(m, err);
+    assert(!ok);
+    assert(err.str().find("terminator") != std::string::npos);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- include Opcode::Trap in verifier terminator detection
- ensure traps end basic blocks
- add test covering blocks ending in trap

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure` *(fails: test_vm_break_label, vm_trap_loc)*


------
https://chatgpt.com/codex/tasks/task_e_68c2f774d9ec8324b4a9eb4be0a53467