### PR TITLE
fix(il/verify): report unknown temporaries

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -372,6 +372,13 @@ add_test(NAME il_verify_invalid_param_use_before_entry
           -DEXPECT=use\ before\ def
           -P ${CMAKE_SOURCE_DIR}/tests/golden/invalid_il/check_invalid.cmake)
 
+add_test(NAME il_verify_invalid_unknown_temp
+  COMMAND ${CMAKE_COMMAND}
+          -DIL_VERIFY=${IL_VERIFY}
+          -DFILE=${CMAKE_SOURCE_DIR}/tests/golden/invalid_il/unknown_temp.il
+          -DEXPECT=unknown\ temp
+          -P ${CMAKE_SOURCE_DIR}/tests/golden/invalid_il/check_invalid.cmake)
+
 add_executable(test_basic_lexer unit/test_basic_lexer.cpp)
 target_link_libraries(test_basic_lexer PRIVATE fe_basic support)
 add_test(NAME test_basic_lexer COMMAND test_basic_lexer)

--- a/tests/golden/invalid_il/unknown_temp.il
+++ b/tests/golden/invalid_il/unknown_temp.il
@@ -1,0 +1,6 @@
+il 0.1
+func @unknown_temp() -> void {
+entry:
+  %r = add %u, %u
+  ret
+}


### PR DESCRIPTION
## Summary
- flag missing temp IDs in valueType and report unknown temp diagnostics
- add invalid IL test for unknown temp usage

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c3113662548324a7e2c8fb11f405bd