### PR TITLE
docs(support): document string interner functions

### DIFF
--- a/src/support/string_interner.cpp
+++ b/src/support/string_interner.cpp
@@ -9,6 +9,13 @@
 namespace il::support
 {
 
+// Intern the given string by assigning a new symbol if necessary.
+//
+// The interner stores owned strings in `storage_` and maps them to their
+// corresponding `Symbol` via `map_`.  When a string is interned for the first
+// time, a copy is appended to `storage_` and a new symbol is created using the
+// 1-based index of that storage slot.  If the string already exists, the
+// previous symbol is reused.  Symbol id 0 is reserved and never produced.
 Symbol StringInterner::intern(std::string_view str)
 {
     auto it = map_.find(std::string(str));
@@ -20,6 +27,11 @@ Symbol StringInterner::intern(std::string_view str)
     return sym;
 }
 
+// Retrieve the original string for @p sym.
+//
+// A valid symbol has an id in the range [1, storage_.size()].  Requests outside
+// this range, including the reserved id 0, yield an empty view indicating an
+// invalid lookup.
 std::string_view StringInterner::lookup(Symbol sym) const
 {
     if (sym.id == 0 || sym.id > storage_.size())


### PR DESCRIPTION
## Summary
- document how `StringInterner::intern` stores strings and assigns symbol IDs
- clarify `StringInterner::lookup` return for invalid symbols

## Testing
- `cmake -S . -B build && cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c326e90c7883249c19fb949fec2ea5