### PR TITLE
docs(support): document arena allocator functions

### DIFF
--- a/src/support/arena.cpp
+++ b/src/support/arena.cpp
@@ -8,9 +8,15 @@
 
 namespace il::support
 {
-
+/// @brief Construct an arena with a fixed capacity.
+/// @param size Number of bytes reserved for allocations.
 Arena::Arena(size_t size) : buffer_(size) {}
 
+/// @brief Allocate memory with a specified alignment.
+/// @param size Number of bytes to allocate.
+/// @param align Alignment in bytes; must be a non-zero power of two.
+/// @return Pointer to aligned memory or nullptr on failure.
+/// @note Fails if alignment is invalid or if remaining capacity is insufficient.
 void *Arena::allocate(size_t size, size_t align)
 {
     // Reject zero or non power-of-two alignments.
@@ -25,6 +31,8 @@ void *Arena::allocate(size_t size, size_t align)
     return buffer_.data() + aligned;
 }
 
+/// @brief Reset the arena, allowing memory to be reused.
+/// @note All previously returned pointers become invalid after this call.
 void Arena::reset()
 {
     offset_ = 0;


### PR DESCRIPTION
## Summary
- add Doxygen comments for Arena constructor
- clarify allocate alignment requirements and failure cases
- document reset behavior

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c3278d155483248436c532ae6eb6f1