### PR TITLE
docs(runtime): clarify random generator state

### DIFF
--- a/runtime/rt_random.c
+++ b/runtime/rt_random.c
@@ -6,18 +6,45 @@
 
 #include "rt_random.h"
 
-static uint64_t state = 0xDEADBEEFCAFEBABEULL; // default non-zero seed
+// Internal state for the 64-bit linear congruential generator.
+// Initialized to a fixed non-zero seed so that callers who do not
+// explicitly seed still observe a deterministic sequence.
+// Shared globally without synchronization; not thread-safe.
+static uint64_t state = 0xDEADBEEFCAFEBABEULL;
 
+/**
+ * @brief Seed the generator with an unsigned 64-bit value.
+ *
+ * The generator implements a 64-bit linear congruential algorithm.
+ * Given the same seed, subsequent calls to rt_rnd produce a deterministic
+ * sequence. This routine is not thread-safe because it mutates a shared
+ * global state.
+ */
 void rt_randomize_u64(uint64_t seed)
 {
     state = seed;
 }
 
+/**
+ * @brief Seed the generator with a signed 64-bit value.
+ *
+ * The state is set directly, preserving the determinism of the underlying
+ * linear congruential generator. Like rt_randomize_u64, this function is
+ * not thread-safe because the state is shared.
+ */
 void rt_randomize_i64(long long seed)
 {
     state = (uint64_t)seed;
 }
 
+/**
+ * @brief Generate a pseudo-random double in the half-open interval [0, 1).
+ *
+ * Advances the 64-bit linear congruential generator and scales the result to
+ * floating point. The sequence is fully deterministic given an initial seed.
+ * This function is not thread-safe; concurrent calls must synchronize to
+ * protect the shared state.
+ */
 double rt_rnd(void)
 {
     state = state * 6364136223846793005ULL + 1ULL;


### PR DESCRIPTION
## Summary
- document global LCG state initialization and note lack of thread safety
- explain determinism and linear congruential algorithm in seeding and generation routines

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c334cd973883248111c8235a37ca50