### PR TITLE
docs(runtime): document deterministic random helpers

### DIFF
--- a/runtime/rt_random.h
+++ b/runtime/rt_random.h
@@ -12,8 +12,18 @@ extern "C"
 {
 #endif
 
+    /// @brief Seed the random number generator with an unsigned 64-bit value.
+    /// @param seed New seed value used to initialize the internal state.
     void rt_randomize_u64(uint64_t seed);
+
+    /// @brief Seed the random number generator with a signed 64-bit value.
+    /// @param seed New seed value cast to unsigned and stored as internal state.
     void rt_randomize_i64(long long seed);
+
+    /// @brief Generate the next deterministic pseudo-random number.
+    /// @return A double in the half-open interval [0, 1).
+    /// @details Advances a 64-bit linear congruential generator and maps the
+    /// resulting bits to a double in the range [0,1) with 53 bits of precision.
     double rt_rnd(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- document seeding functions and rnd generator in `rt_random.h`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c334dd9b388324a1322929d6612249