### PR TITLE
docs(support): clarify Options purpose and flags

### DIFF
--- a/src/support/options.hpp
+++ b/src/support/options.hpp
@@ -10,13 +10,19 @@
 namespace il::support
 {
 
-/// @brief Global options controlling compiler behavior.
+/// @brief Holds global command-line settings that influence compiler behavior.
+/// These options control tracing, verification, and target architecture.
 /// @invariant Flags are independent booleans.
 /// @ownership Value type.
 struct Options
 {
+    /// @brief Enable verbose tracing of compilation steps.
     bool trace = false;
+
+    /// @brief Run the IL verifier before execution or code generation.
     bool verify = true;
+
+    /// @brief Target architecture triple for code generation.
     std::string target = "x86_64";
 };
 } // namespace il::support


### PR DESCRIPTION
## Summary
- explain role of global Options structure and what it configures
- document trace, verify, and target fields

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c33b828848832497f510cb40966962