### PR TITLE
docs(support): document Arena allocation model

### DIFF
--- a/src/support/arena.hpp
+++ b/src/support/arena.hpp
@@ -10,8 +10,12 @@
 
 namespace il::support
 {
-
 /// @brief Simple bump allocator for fast allocations.
+///
+/// Uses a contiguous internal buffer and a bump-pointer strategy to satisfy
+/// allocation requests. Each call to allocate() advances the current position
+/// in the buffer by the requested size and alignment. Individual allocations
+/// cannot be freed; invoke reset() to make the entire buffer reusable.
 /// @invariant Allocations are not individually freed; use reset() to reuse.
 /// @ownership Owns its internal buffer.
 class Arena
@@ -32,7 +36,9 @@ class Arena
     void reset();
 
   private:
+    /// Backing storage for all allocations; owned by the arena.
     std::vector<std::byte> buffer_;
+    /// Current offset within buffer_ for the next allocation.
     size_t offset_ = 0;
 };
 } // namespace il::support


### PR DESCRIPTION
## Summary
- clarify Arena's bump-pointer allocation model
- comment backing storage and allocation offset members

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c33b8ccab883249105d8f805f2945a