### PR TITLE
docs(support): document string interner intern and lookup

### DIFF
--- a/src/support/string_interner.hpp
+++ b/src/support/string_interner.hpp
@@ -20,18 +20,29 @@ namespace il::support
 class StringInterner
 {
   public:
-    /// @brief Intern @p str and return its Symbol.
+    /// Interns a string to produce a stable symbol for repeated use.
+    ///
+    /// Stores a copy of @p str if it has not been seen before and assigns it a
+    /// new Symbol. Subsequent calls with the same string yield the existing
+    /// Symbol without duplicating storage, enabling fast comparisons and
+    /// lookups.
     /// @param str String to intern.
-    /// @return Stable symbol identifying the string.
+    /// @return Symbol uniquely identifying the interned string.
     Symbol intern(std::string_view str);
 
-    /// @brief Look up string for symbol @p sym.
+    /// Retrieves the original string associated with a Symbol.
+    ///
+    /// Use to obtain the text for a symbol returned by intern(), for example in
+    /// diagnostics or reverse mappings. Passing an invalid Symbol yields an
+    /// empty view.
     /// @param sym Symbol previously returned by intern().
     /// @return View of the interned string.
     std::string_view lookup(Symbol sym) const;
 
   private:
+    /// Maps string content to assigned symbols for O(1) lookup during interning.
     std::unordered_map<std::string, Symbol> map_;
+    /// Retains copies of interned strings so lookups return stable views.
     std::vector<std::string> storage_;
 };
 } // namespace il::support


### PR DESCRIPTION
## Summary
- explain how intern stores strings and produces stable symbols
- document lookup usage and internal map_/storage_ responsibilities

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c33b93d4f08324b44dbc2a8660465c