### PR TITLE
docs(frontends): document AstPrinter helpers

### DIFF
--- a/src/frontends/basic/AstPrinter.hpp
+++ b/src/frontends/basic/AstPrinter.hpp
@@ -13,33 +13,59 @@
 
 namespace il::frontends::basic
 {
-
+/// @brief Emits a textual representation of BASIC programs for debugging.
+///
+/// AstPrinter walks the Program, Stmt, and Expr nodes to produce a
+/// human-readable dump using an internal Printer helper to manage
+/// indentation.
 class AstPrinter
 {
   public:
+    /// @brief Produce a formatted dump of the given program.
+    /// @param prog Program AST to print.
+    /// @return String containing the formatted dump.
     std::string dump(const Program &prog);
 
   private:
+    /// @brief Stateful helper that writes lines with indentation.
     struct Printer
     {
+        /// Output stream where text is emitted.
         std::ostream &os;
+
+        /// Current indentation level.
         int indent = 0;
+
+        /// @brief Write @p text followed by a newline, honoring indentation.
+        /// @param text Line content to write.
         void line(std::string_view text);
 
+        /// @brief RAII guard that decreases indentation on destruction.
         struct Indent
         {
+            /// Printer whose indentation is managed.
             Printer &p;
 
+            /// @brief Restore previous indentation level when destroyed.
             ~Indent()
             {
                 --p.indent;
             }
         };
 
+        /// @brief Increase indentation for the next scope.
+        /// @return Guard that restores previous indentation when destroyed.
         Indent push();
     };
 
+    /// @brief Dump a statement node to the printer.
+    /// @param stmt Statement to serialize.
+    /// @param p Printer receiving the output.
     void dump(const Stmt &stmt, Printer &p);
+
+    /// @brief Dump an expression node to the printer.
+    /// @param expr Expression to serialize.
+    /// @param p Printer receiving the output.
     void dump(const Expr &expr, Printer &p);
 };
 


### PR DESCRIPTION
## Summary
- document purpose of `AstPrinter` and its recursive dump helpers
- add Doxygen comments for internal `Printer` indentation helper and members

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c33b9f4e2483249345e01d170662f4