### PR TITLE
docs(frontend): document BASIC name mangler counters

### DIFF
--- a/src/frontends/basic/NameMangler.cpp
+++ b/src/frontends/basic/NameMangler.cpp
@@ -8,12 +8,16 @@
 
 namespace il::frontends::basic
 {
-
+// Generate a unique temporary name using the "%t" prefix. Each invocation
+// increments `tempCounter`, ensuring sequential numbering for temporaries.
 std::string NameMangler::nextTemp()
 {
     return "%t" + std::to_string(tempCounter++);
 }
 
+// Produce a block label from the given `hint`. The `blockCounters` map tracks
+// how many times each hint has been requested: the first use returns the hint
+// unchanged, while subsequent uses append an incrementing numeric suffix.
 std::string NameMangler::block(const std::string &hint)
 {
     auto &count = blockCounters[hint];

--- a/src/frontends/basic/NameMangler.hpp
+++ b/src/frontends/basic/NameMangler.hpp
@@ -25,7 +25,9 @@ class NameMangler
     std::string block(const std::string &hint);
 
   private:
+    /// @brief Monotonically increasing ID for temporary names.
     unsigned tempCounter{0};
+    /// @brief Map of block name hints to the number of times they've been used.
     std::unordered_map<std::string, unsigned> blockCounters;
 };
 


### PR DESCRIPTION
## Summary
- clarify sequential "%t" temporary naming
- explain block label suffix scheme
- document NameMangler counters

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c33baa23d88324beaa29965a03a6b7