### PR TITLE
test(basic-lexer): document lexer unit test scenarios

### DIFF
--- a/tests/unit/test_basic_lexer.cpp
+++ b/tests/unit/test_basic_lexer.cpp
@@ -1,3 +1,9 @@
+// File: tests/unit/test_basic_lexer.cpp
+// Purpose: Unit tests for BASIC lexer tokenization across common statements.
+// Key invariants: Tokens emitted match expected kinds and lexemes.
+// Ownership/Lifetime: N/A (test).
+// Links: docs/class-catalog.md
+
 #include "frontends/basic/Lexer.hpp"
 #include <cassert>
 #include <string>
@@ -6,10 +12,15 @@
 using namespace il::frontends::basic;
 using il::support::SourceManager;
 
+// Test strategy: These tests cover representative BASIC constructs to ensure the lexer
+// recognizes keywords, identifiers, literals, and punctuation correctly. Scenarios include a
+// PRINT statement with concatenation, a LET assignment, fractional numbers with type-suffixed
+// identifiers, and a function call using parentheses and a string argument.
 int main()
 {
     SourceManager sm;
     uint32_t fid = sm.addFile("test.bas");
+    // Expect correct tokens for a PRINT statement combining a string literal and arithmetic.
     {
         std::string src = "10 PRINT \"HI\"+20\n";
         Lexer lex(src, fid);
@@ -24,6 +35,7 @@ int main()
                                            TokenKind::EndOfLine};
         assert(kinds == expected);
     }
+    // Verify recognition of a LET assignment with identifier and numeric literal.
     {
         std::string src = "LET X=1\n";
         Lexer lex(src, fid);
@@ -36,6 +48,7 @@ int main()
         t = lex.next();
         assert(t.kind == TokenKind::Number);
     }
+    // Confirm support for fractional numbers and type-suffixed identifiers.
     {
         std::string src = ".5  X#\n";
         Lexer lex(src, fid);
@@ -44,6 +57,7 @@ int main()
         t = lex.next();
         assert(t.kind == TokenKind::Identifier && t.lexeme == "X#");
     }
+    // Check lexing of a function call with string argument and parentheses.
     {
         std::string src = "LEN(\"A\")\n";
         Lexer lex(src, fid);


### PR DESCRIPTION
## Summary
- clarify BASIC lexer unit tests with a descriptive file header
- outline test strategy and comment each scenario

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c33bc1a39483248da107ab56d57d78