### PR TITLE
docs(frontends/basic): document intrinsic signatures

### DIFF
--- a/src/frontends/basic/Intrinsics.cpp
+++ b/src/frontends/basic/Intrinsics.cpp
@@ -13,28 +13,34 @@ namespace il::frontends::basic::intrinsics
 namespace
 {
 // Common parameter descriptors.
+/// Signature: (string)
 constexpr Param strParam[] = {{Type::String, false}};
+/// Signature: (int)
 constexpr Param intParam[] = {{Type::Int, false}};
+/// Signature: (numeric)
 constexpr Param numParam[] = {{Type::Numeric, false}};
 
+/// Signature: (string, int)
 constexpr Param leftRightParams[] = {
     {Type::String, false},
     {Type::Int, false},
 };
 
+/// Signature: (string, int, [int])
 constexpr Param midParams[] = {
     {Type::String, false},
     {Type::Int, false},
     {Type::Int, true},
 };
 
+/// Signature: ([int], string, string)
 constexpr Param instrParams[] = {
     {Type::Int, true},
     {Type::String, false},
     {Type::String, false},
 };
 
-// Intrinsic registry table.
+/// Registry mapping intrinsic names to return types and parameter signatures.
 constexpr Intrinsic table[] = {
     {"LEFT$", Type::String, leftRightParams, std::size(leftRightParams)},
     {"RIGHT$", Type::String, leftRightParams, std::size(leftRightParams)},


### PR DESCRIPTION
## Summary
- add signature comments for BASIC intrinsic parameter descriptors
- document intrinsic registry mapping names to signatures

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c346329e60832483a4b5b07d999224