### PR TITLE
docs(il-verify): document CLI usage and exit codes

### DIFF
--- a/src/tools/il-verify/il-verify.cpp
+++ b/src/tools/il-verify/il-verify.cpp
@@ -11,6 +11,14 @@
 #include <sstream>
 #include <string>
 
+/// @brief CLI entry for verifying IL modules.
+/// Usage:
+///   il-verify <file.il>
+///   il-verify --version
+/// @param argc Number of CLI arguments.
+/// @param argv Argument vector.
+/// @return 0 on successful verification or when displaying the version;
+///         1 on invalid usage, I/O, parse, or verification errors.
 int main(int argc, char **argv)
 {
     if (argc == 2 && std::string(argv[1]) == "--version")


### PR DESCRIPTION
## Summary
- document il-verify CLI usage, parameters, and exit codes

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c3465e3e7c832488ff6c599f8433f9