### PR TITLE
docs(codegen): document x86-64 placeholder stub

### DIFF
--- a/src/codegen/x86_64/placeholder.cpp
+++ b/src/codegen/x86_64/placeholder.cpp
@@ -6,6 +6,12 @@
 namespace il::codegen::x86_64
 {
 
+/// @brief Stub entry point for the x86-64 code generator.
+///
+/// Exists solely to anchor the code generation library; it accepts no
+/// parameters and performs no work.
+/// @return Always returns 0.
+/// @invariant This function has no side effects.
 int placeholder()
 {
     return 0;


### PR DESCRIPTION
## Summary
- add Doxygen comment describing the x86-64 codegen placeholder function

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c34dc28dc883248708d9b3aa3a9217