### PR TITLE
docs(frontends/basic): document token kind mapping

### DIFF
--- a/src/frontends/basic/Token.cpp
+++ b/src/frontends/basic/Token.cpp
@@ -8,7 +8,17 @@
 
 namespace il::frontends::basic
 {
-
+/**
+ * @brief Maps a token kind to its canonical string representation.
+ *
+ * Each enumerator in TokenKind is handled explicitly. Unrecognized values
+ * fall back to a "?" marker. Because the switch has no default case, adding
+ * a new TokenKind triggers a compiler warning, providing a completeness
+ * guarantee.
+ *
+ * @param k Token kind to convert.
+ * @return Null-terminated string naming @p k, or "?" if no mapping exists.
+ */
 const char *tokenKindToString(TokenKind k)
 {
     switch (k)


### PR DESCRIPTION
## Summary
- document `tokenKindToString` with a Doxygen comment describing behavior and completeness guarantees

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c34de922488324a1be8f79ba2d858b