### PR TITLE
docs(il/core): document Global struct

### DIFF
--- a/src/il/core/Global.hpp
+++ b/src/il/core/Global.hpp
@@ -10,13 +10,26 @@
 
 namespace il::core
 {
-
-/// @brief Global constant or variable.
+/// @brief Module-scope variable or constant.
+///
+/// Globals provide named storage that is accessible to all functions within a
+/// module. Each global carries its own identifier, declared type, and optional
+/// initializer for constant data. The owning `Module` manages the lifetime of
+/// these objects.
 struct Global
 {
+    /// @brief Identifier of the global within its module.
+    /// @invariant Unique among all globals owned by the module.
     std::string name;
+
+    /// @brief Declared IL type of the global.
+    /// @invariant Must match the type of any provided initializer.
     Type type;
-    std::string init; // used for const str
+
+    /// @brief Serialized initializer data, if any.
+    /// @invariant Non-empty only for globals with constant values (e.g. UTF-8
+    /// string literals).
+    std::string init;
 };
 
 } // namespace il::core


### PR DESCRIPTION
## Summary
- clarify purpose of `il::core::Global`
- document `name`, `type`, and `init` members with ownership and invariants

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c34e03545483249eb82e77fd5716f6