### PR TITLE
docs(il/core): clarify instruction field semantics

### DIFF
--- a/src/il/core/Instr.hpp
+++ b/src/il/core/Instr.hpp
@@ -19,14 +19,45 @@ namespace il::core
 /// @brief Instruction within a basic block.
 struct Instr
 {
-    std::optional<unsigned> result; ///< destination temp id
+    /// Destination temporary id.
+    /// Owned by the instruction.
+    /// Non-negative; disengaged if the instruction has no result.
+    std::optional<unsigned> result;
+
+    /// Operation code selecting semantics.
+    /// Owned by the instruction.
+    /// Must be a valid Opcode enumerator.
     Opcode op;
-    Type type;                              ///< result type (or void)
-    std::vector<Value> operands;            ///< general operands
-    std::string callee;                     ///< for call
-    std::vector<std::string> labels;        ///< branch targets
-    std::vector<std::vector<Value>> brArgs; ///< branch arguments per target
-    il::support::SourceLoc loc;             ///< source location
+
+    /// Result type or void.
+    /// Owned by the instruction.
+    /// Must be void when result is absent.
+    Type type;
+
+    /// General operands.
+    /// Vector owns each Value element.
+    /// Size and content depend on opcode.
+    std::vector<Value> operands;
+
+    /// Callee name for call instructions.
+    /// Owned by the instruction.
+    /// Must be non-empty when op == Opcode::Call.
+    std::string callee;
+
+    /// Branch target labels.
+    /// Vector owns each label string.
+    /// Each must correspond to a basic block in the same function.
+    std::vector<std::string> labels;
+
+    /// Branch arguments per target.
+    /// Outer vector matches labels in size; inner vectors own their Value elements.
+    /// Types must match the parameters of the corresponding block.
+    std::vector<std::vector<Value>> brArgs;
+
+    /// Source location.
+    /// Owned by the instruction.
+    /// Line and column are >=1 when known; {0,0} denotes unknown.
+    il::support::SourceLoc loc;
 };
 
 } // namespace il::core


### PR DESCRIPTION
## Summary
- expand comments on `il::core::Instr` members
- document ownership and valid ranges for instruction fields

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c42d2b1a88832489ec6199645c2541