### PR TITLE
docs(il/core): document extern fields

### DIFF
--- a/src/il/core/Extern.hpp
+++ b/src/il/core/Extern.hpp
@@ -15,8 +15,21 @@ namespace il::core
 /// @brief External function declaration.
 struct Extern
 {
+    /// @brief Identifier of the external function.
+    /// @invariant Unique among externs in a module and non-empty.
+    /// @ownership String data is owned by this struct and lives for the
+    /// lifetime of the parent `Module`.
     std::string name;
+
+    /// @brief Declared return type of the external function.
+    /// @invariant Must correspond to the callee's actual ABI; use `void` for no
+    /// return value.
     Type retType;
+
+    /// @brief Ordered list of parameter types forming the extern's signature.
+    /// @invariant Arity and order must match the target function's signature.
+    /// @ownership Vector and contained `Type` values are owned by this struct
+    /// for the module's lifetime.
     std::vector<Type> params;
 };
 


### PR DESCRIPTION
## Summary
- document `il::core::Extern` members with ownership and invariants

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c42d38f29c83249b73e17449bb61a7