### PR TITLE
docs(il/core): document module member initialization

### DIFF
--- a/src/il/core/Module.hpp
+++ b/src/il/core/Module.hpp
@@ -17,9 +17,25 @@ namespace il::core
 /// @brief IL module aggregating externs, globals, and functions.
 struct Module
 {
-    std::string version = "0.1.2"; ///< Parsed module version
+    /// @brief Module format version string.
+    ///
+    /// Defaults to "0.1.2" for newly constructed modules and may be
+    /// overwritten by parsers when reading serialized IL.
+    std::string version = "0.1.2";
+
+    /// @brief Declared external functions available to the module.
+    ///
+    /// Starts empty and is populated as extern declarations are processed.
     std::vector<Extern> externs;
+
+    /// @brief Global variable declarations.
+    ///
+    /// Initialized empty; parsers append entries for each global encountered.
     std::vector<Global> globals;
+
+    /// @brief Function definitions contained in the module.
+    ///
+    /// Begins empty and receives entries as functions are defined or parsed.
     std::vector<Function> functions;
 };
 


### PR DESCRIPTION
## Summary
- clarify purpose and default initialization of Module version, externs, globals, and functions fields

## Testing
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c42d42ae108324809f5d1c5f3b4eed