### PR TITLE
docs(tools): document basic-ast-dump entry point

### DIFF
--- a/src/tools/basic-ast-dump/main.cpp
+++ b/src/tools/basic-ast-dump/main.cpp
@@ -14,6 +14,17 @@
 using namespace il::frontends::basic;
 using namespace il::support;
 
+/**
+ * @brief Entry point for the BASIC AST dump tool.
+ *
+ * Expects a single argument: the path to a BASIC source file. The
+ * program reads the file, parses it into an AST, and prints the result
+ * to standard output.
+ *
+ * @return 0 on success.
+ * @return 1 if the argument count is incorrect or the file cannot be
+ * opened.
+ */
 int main(int argc, char **argv)
 {
     if (argc != 2)


### PR DESCRIPTION
## Summary
- document basic-ast-dump tool's main entry point with purpose, usage, behavior and exit codes.

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c435798ee88324a2754b2e96b07e86