### PR TITLE
docs(frontends/basic): document DiagnosticEmitter methods

### DIFF
--- a/src/frontends/basic/DiagnosticEmitter.cpp
+++ b/src/frontends/basic/DiagnosticEmitter.cpp
@@ -11,17 +11,32 @@
 namespace il::frontends::basic
 {
 
+/// @brief Initialize an emitter bound to a diagnostic engine and source manager.
+/// @param de Engine used to report diagnostics immediately.
+/// @param sm Manager providing file path lookups for caret output.
+/// Stores references to the engine and manager for later emissions.
 DiagnosticEmitter::DiagnosticEmitter(il::support::DiagnosticEngine &de,
                                      const il::support::SourceManager &sm)
     : de_(de), sm_(sm)
 {
 }
 
+/// @brief Register full source text for a file identifier.
+/// @param fileId Key used by diagnostics to reference this source.
+/// @param source Contents of the file to enable caret printing.
+/// Caches the source so later diagnostics can display relevant lines.
 void DiagnosticEmitter::addSource(uint32_t fileId, std::string source)
 {
     sources_[fileId] = std::move(source);
 }
 
+/// @brief Report a diagnostic and store it for later printing.
+/// @param sev Severity level of the diagnostic.
+/// @param code Project-defined diagnostic code.
+/// @param loc Source location associated with the issue.
+/// @param length Highlight length; zero defaults to one caret.
+/// @param message Human-readable explanation of the problem.
+/// Sends the diagnostic to the engine and records it internally.
 void DiagnosticEmitter::emit(il::support::Severity sev,
                              std::string code,
                              il::support::SourceLoc loc,
@@ -32,6 +47,11 @@ void DiagnosticEmitter::emit(il::support::Severity sev,
     entries_.push_back({sev, std::move(code), std::move(message), loc, length});
 }
 
+/// @brief Emit an error when a different token was encountered than expected.
+/// @param got Token actually observed.
+/// @param expect Token that was required.
+/// @param loc Source location of the unexpected token.
+/// Reports error B0001 describing the mismatch.
 void DiagnosticEmitter::emitExpected(TokenKind got, TokenKind expect, il::support::SourceLoc loc)
 {
     std::string msg =
@@ -81,6 +101,9 @@ std::string DiagnosticEmitter::getLine(uint32_t fileId, uint32_t line) const
     return src.substr(start, end - start);
 }
 
+/// @brief Print all collected diagnostics with caret markers.
+/// @param os Output stream receiving formatted diagnostics.
+/// Writes each stored entry and highlights its source span.
 void DiagnosticEmitter::printAll(std::ostream &os) const
 {
     for (const auto &e : entries_)


### PR DESCRIPTION
## Summary
- add Doxygen comments describing DiagnosticEmitter constructor and helper methods

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c43581c8bc8324b8c5f5d4238ab6bb