### PR TITLE
docs(frontend/basic): expand parser token helper comments

### DIFF
--- a/src/frontends/basic/Parser_Token.hpp
+++ b/src/frontends/basic/Parser_Token.hpp
@@ -5,13 +5,29 @@
 // Links: docs/class-catalog.md
 #pragma once
 
-/// @brief Test if the current token matches kind @p k.
+/// @brief Test whether the current token matches a given kind.
+/// @param k Token kind to compare against the current token.
+/// @return True if the current token is of kind @p k; otherwise false.
+/// @note Does not modify parser state.
 bool at(TokenKind k) const;
-/// @brief Peek @p n tokens ahead without consuming.
+
+/// @brief Look ahead without consuming tokens.
+/// @param n Number of tokens ahead to inspect; 0 refers to the current token.
+/// @return Reference to the token at the specified lookahead position.
+/// @note Does not advance the parser or alter the token buffer.
 const Token &peek(int n = 0) const;
-/// @brief Consume and return the current token.
+
+/// @brief Consume the current token and advance.
+/// @return The token that was at the current position before advancing.
+/// @note Advances the parser by one token.
 Token consume();
-/// @brief Consume a token of kind @p k or report a mismatch.
+
+/// @brief Consume a token of the expected kind or report a mismatch.
+/// @param k Required token kind.
+/// @return The consumed token, even if it did not match @p k.
+/// @note Advances the parser and may emit a diagnostic on mismatch.
 Token expect(TokenKind k);
-/// @brief Advance to the next statement boundary token.
+
+/// @brief Skip tokens until reaching a statement boundary.
+/// @note Consumes tokens until a boundary token (e.g., newline or EOF) is encountered.
 void syncToStmtBoundary();


### PR DESCRIPTION
## Summary
- document parser token helpers with detailed doxygen comments

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c437d4dcf08324b949b130b6968ea4