### PR TITLE
docs(basic): document LoweringContext member ownership

### DIFF
--- a/src/frontends/basic/LoweringContext.hpp
+++ b/src/frontends/basic/LoweringContext.hpp
@@ -33,6 +33,10 @@ namespace il::frontends::basic
 class LoweringContext
 {
   public:
+    /// @brief Create a context to lower into @p builder and populate @p func.
+    /// @ownership References are non-owning; caller must keep builder and
+    /// function alive for the lifetime of this context.
+    /// @notes Initializes name mangling and lookup tables used during lowering.
     LoweringContext(build::IRBuilder &builder, core::Function &func);
 
     /// @brief Get or create stack slot name for BASIC variable @p name.
@@ -45,12 +49,31 @@ class LoweringContext
     std::string getOrAddString(const std::string &value);
 
   private:
+    /// IR builder used to emit instructions and blocks. Non-owning reference.
     build::IRBuilder &builder;
+
+    /// Function currently being lowered. Non-owning reference to caller-owned
+    /// function; builder appends new blocks and instructions to it.
     core::Function &function;
+
+    /// Generates deterministic symbol names for variables and strings. Owned by
+    /// the context and lives for its entire duration.
     NameMangler mangler;
+
+    /// Mapping from BASIC variable names to their stack slot identifiers. Owns
+    /// the strings it stores but not the variables they represent.
     std::unordered_map<std::string, std::string> varSlots;
+
+    /// BASIC line number to IL basic block mapping. Pointers refer to blocks
+    /// owned by @ref function.
     std::unordered_map<int, core::BasicBlock *> blocks;
+
+    /// Deduplicated string literals mapped to generated symbol names. Owns
+    /// copies of the literal values.
     std::unordered_map<std::string, std::string> strings;
+
+    /// Monotonic counter used to create unique names for string literals.
+    /// Lifetime tied to this context instance.
     unsigned nextStringId{0};
 };
 


### PR DESCRIPTION
## Summary
- document constructor and member ownership in `LoweringContext`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c43b2f5d088324b8d0a874298012b1