### PR TITLE
docs(vm): document RuntimeBridge trap

### DIFF
--- a/src/vm/RuntimeBridge.cpp
+++ b/src/vm/RuntimeBridge.cpp
@@ -204,6 +204,14 @@ Slot RuntimeBridge::call(const std::string &name,
     return res;
 }
 
+/// @brief Report a trap originating from the C runtime.
+/// @details Invoked by `vm_trap` when a runtime builtin signals a fatal
+/// condition. Formats the message with optional function, block, and source
+/// location before forwarding it to `rt_abort`.
+/// @param msg   Description of the trap condition.
+/// @param loc   Source location of the trapping instruction, if available.
+/// @param fn    Fully qualified function name containing the call.
+/// @param block Label of the basic block with the trapping call.
 void RuntimeBridge::trap(const std::string &msg,
                          const SourceLoc &loc,
                          const std::string &fn,


### PR DESCRIPTION
## Summary
- document when RuntimeBridge::trap is called and what its parameters mean
## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c43b424d248324b63b6c55bb8f0c8d