### PR TITLE
fix(support): guard arena allocation overflow

### DIFF
--- a/src/support/arena.cpp
+++ b/src/support/arena.cpp
@@ -25,7 +25,7 @@ void *Arena::allocate(size_t size, size_t align)
 
     size_t current = offset_;
     size_t aligned = (current + align - 1) & ~(align - 1);
-    if (aligned + size > buffer_.size())
+    if (aligned > buffer_.size() || size > buffer_.size() - aligned)
         return nullptr;
     offset_ = aligned + size;
     return buffer_.data() + aligned;

--- a/tests/unit/test_support.cpp
+++ b/tests/unit/test_support.cpp
@@ -3,6 +3,7 @@
 #include "support/string_interner.hpp"
 #include <cassert>
 #include <cstdint>
+#include <limits>
 #include <sstream>
 
 int main()
@@ -32,5 +33,8 @@ int main()
     assert(reinterpret_cast<uintptr_t>(p2) % alignof(double) == 0);
     assert(arena.allocate(1, 0) == nullptr);
     assert(arena.allocate(1, 3) == nullptr);
+    arena.reset();
+    arena.allocate(32, 1);
+    assert(arena.allocate(std::numeric_limits<size_t>::max() - 15, 1) == nullptr);
     return 0;
 }


### PR DESCRIPTION
## Summary
- check for overflow before incrementing Arena offset
- test arena rejects overflowing allocation

## Testing
- `cmake -S . -B build && cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c445d736c083248ed790d3b8c79982