### PR TITLE
fix(il/io): report error when instruction lacks '='

### DIFF
--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -684,6 +684,12 @@ bool parseInstruction(const std::string &line, ParserState &st, std::ostream &er
     if (work[0] == '%')
     {
         size_t eq = work.find('=');
+        if (eq == std::string::npos)
+        {
+            err << "line " << st.lineNo << ": missing '='\n";
+            st.hasError = true;
+            return false;
+        }
         std::string res = trim(work.substr(1, eq - 1));
         auto [it, inserted] = st.tempIds.emplace(res, st.nextTemp);
         if (inserted)
@@ -930,6 +936,12 @@ bool parseModuleHeader(std::istream &is, std::string &line, ParserState &st, std
     {
         size_t at = line.find('@');
         size_t eq = line.find('=', at);
+        if (eq == std::string::npos)
+        {
+            err << "line " << st.lineNo << ": missing '='\n";
+            st.hasError = true;
+            return false;
+        }
         size_t q1 = line.find('"', eq);
         size_t q2 = line.rfind('"');
         std::string name = trim(line.substr(at + 1, eq - at - 1));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,10 @@ add_executable(test_il_comments unit/test_il_comments.cpp)
 target_link_libraries(test_il_comments PRIVATE il_core il_io support)
 add_test(NAME test_il_comments COMMAND test_il_comments)
 
+add_executable(test_il_parse_missing_eq unit/test_il_parse_missing_eq.cpp)
+target_link_libraries(test_il_parse_missing_eq PRIVATE il_core il_io support)
+add_test(NAME test_il_parse_missing_eq COMMAND test_il_parse_missing_eq)
+
 add_executable(test_basic_lexer_high_bit unit/test_basic_lexer_high_bit.cpp)
 target_link_libraries(test_basic_lexer_high_bit PRIVATE fe_basic support)
 add_test(NAME test_basic_lexer_high_bit COMMAND test_basic_lexer_high_bit)

--- a/tests/unit/test_il_parse_missing_eq.cpp
+++ b/tests/unit/test_il_parse_missing_eq.cpp
@@ -1,0 +1,27 @@
+// File: tests/unit/test_il_parse_missing_eq.cpp
+// Purpose: Ensure IL parser reports error when result assignment lacks '='.
+// Key invariants: Parser sets hasError and returns false for malformed instruction.
+// Ownership/Lifetime: Test constructs modules and buffers locally.
+// Links: docs/il-spec.md
+
+#include "il/io/Parser.hpp"
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    const char *src = R"(il 0.1.2
+func @main() -> i32 {
+entry:
+  %0 add 1, 2
+}
+)";
+    std::istringstream in(src);
+    il::core::Module m;
+    std::ostringstream err;
+    bool ok = il::io::Parser::parse(in, m, err);
+    assert(!ok);
+    std::string msg = err.str();
+    assert(msg.find("missing '='") != std::string::npos);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- validate presence of '=' in assignment parsing and global declarations
- add unit test for malformed instruction missing '='

## Testing
- `cmake -S . -B build && cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c447fa753c832491844cf7684910b2