### PR TITLE
fix: treat trap as terminator in verifier

### DIFF
--- a/examples/il/break_label.il
+++ b/examples/il/break_label.il
@@ -5,5 +5,4 @@ entry:
   br L3
 L3:
   trap
-  ret 0
 }

--- a/src/il/verify/Verifier.cpp
+++ b/src/il/verify/Verifier.cpp
@@ -27,7 +27,7 @@ namespace
 /// itself performs no error reporting.
 bool isTerminator(Opcode op)
 {
-    return op == Opcode::Br || op == Opcode::CBr || op == Opcode::Ret;
+    return op == Opcode::Br || op == Opcode::CBr || op == Opcode::Ret || op == Opcode::Trap;
 }
 
 /// @brief Computes the static type of a value for verification.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,10 @@ add_executable(test_il_parse_invalid_type unit/test_il_parse_invalid_type.cpp)
 target_link_libraries(test_il_parse_invalid_type PRIVATE il_core il_io support)
 add_test(NAME test_il_parse_invalid_type COMMAND test_il_parse_invalid_type)
 
+add_executable(test_il_verify_trap unit/test_il_verify_trap.cpp)
+target_link_libraries(test_il_verify_trap PRIVATE il_core il_verify support)
+add_test(NAME test_il_verify_trap COMMAND test_il_verify_trap)
+
 add_executable(test_basic_lexer_high_bit unit/test_basic_lexer_high_bit.cpp)
 target_link_libraries(test_basic_lexer_high_bit PRIVATE fe_basic support)
 add_test(NAME test_basic_lexer_high_bit COMMAND test_basic_lexer_high_bit)

--- a/tests/golden/vm_trap_loc.il
+++ b/tests/golden/vm_trap_loc.il
@@ -3,5 +3,4 @@ func @main() -> i64 {
 entry:
   .loc 1 1 1
   trap
-  ret 0
 }

--- a/tests/unit/test_il_verify_trap.cpp
+++ b/tests/unit/test_il_verify_trap.cpp
@@ -1,0 +1,42 @@
+// File: tests/unit/test_il_verify_trap.cpp
+// Purpose: Ensure Verifier accepts blocks terminated by trap.
+// Key invariants: Blocks ending with Opcode::Trap pass verification.
+// Ownership/Lifetime: Constructs module locally for verification.
+// Links: docs/il-spec.md
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Module.hpp"
+#include "il/core/Opcode.hpp"
+#include "il/verify/Verifier.hpp"
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    using namespace il::core;
+
+    Module m;
+    Function fn;
+    fn.name = "f";
+    fn.retType = Type(Type::Kind::Void);
+
+    BasicBlock bb;
+    bb.label = "entry";
+
+    Instr trap;
+    trap.op = Opcode::Trap;
+    bb.instructions.push_back(trap);
+    bb.terminated = true;
+
+    fn.blocks.push_back(bb);
+    m.functions.push_back(fn);
+
+    std::ostringstream err;
+    bool ok = il::verify::Verifier::verify(m, err);
+    assert(ok);
+    assert(err.str().empty());
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- handle `trap` opcode as a block terminator in the verifier
- add unit test ensuring a block ending in `trap` verifies cleanly
- update IL samples removing unreachable returns after traps

## Testing
- `cmake -S . -B build && cmake --build build`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68c45a1b40a4832484dd105e537ec97a