### PR TITLE
fix(vm): trap on unknown global references

### DIFF
--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -112,8 +112,14 @@ Slot VM::eval(Frame &fr, const Value &v)
             s.str = rt_const_cstr(v.str.c_str());
             return s;
         case Value::Kind::GlobalAddr:
-            s.str = strMap[v.str];
+        {
+            auto it = strMap.find(v.str);
+            if (it == strMap.end())
+                RuntimeBridge::trap("unknown global", {}, fr.func->name, "");
+            else
+                s.str = it->second;
             return s;
+        }
         case Value::Kind::NullPtr:
             s.ptr = nullptr;
             return s;
@@ -575,8 +581,7 @@ VM::ExecResult VM::handleRet(Frame &fr, const Instr &in)
 /// @returns ExecResult with no control-flow changes.
 VM::ExecResult VM::handleConstStr(Frame &fr, const Instr &in)
 {
-    Slot res{};
-    res.str = strMap[in.operands[0].str];
+    Slot res = eval(fr, in.operands[0]);
     storeResult(fr, in, res);
     return {};
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -439,6 +439,10 @@ add_executable(test_vm_alloca_negative unit/test_vm_alloca_negative.cpp)
 target_link_libraries(test_vm_alloca_negative PRIVATE il_build il_vm support)
 add_test(NAME test_vm_alloca_negative COMMAND test_vm_alloca_negative)
 
+add_executable(test_vm_unknown_global unit/test_vm_unknown_global.cpp)
+target_link_libraries(test_vm_unknown_global PRIVATE il_build il_vm support)
+add_test(NAME test_vm_unknown_global COMMAND test_vm_unknown_global)
+
 add_executable(test_vm_normalize_path unit/test_vm_normalize_path.cpp)
 target_link_libraries(test_vm_normalize_path PRIVATE VMTrace)
 add_test(NAME test_vm_normalize_path COMMAND test_vm_normalize_path)

--- a/tests/unit/test_vm_unknown_global.cpp
+++ b/tests/unit/test_vm_unknown_global.cpp
@@ -1,0 +1,49 @@
+// File: tests/unit/test_vm_unknown_global.cpp
+// Purpose: Ensure VM traps when referencing undefined globals.
+// Key invariants: Missing global names must emit "unknown global" trap.
+// Ownership: Test constructs IL module and executes VM.
+// Links: docs/class-catalog.md
+
+#include "il/build/IRBuilder.hpp"
+#include "vm/VM.hpp"
+#include <cassert>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main()
+{
+    il::core::Module m;
+    il::build::IRBuilder b(m);
+    auto &fn = b.startFunction("main", il::core::Type(il::core::Type::Kind::I64), {});
+    auto &bb = b.addBlock(fn, "entry");
+    b.setInsertPoint(bb);
+    b.emitConstStr("missing", {1, 1, 1});
+    b.emitRet(std::optional<il::core::Value>{}, {1, 1, 1});
+
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        il::vm::VM vm(m);
+        vm.run();
+        _exit(0);
+    }
+    close(fds[1]);
+    char buf[256];
+    ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
+    if (n > 0)
+        buf[n] = '\0';
+    else
+        buf[0] = '\0';
+    int status = 0;
+    waitpid(pid, &status, 0);
+    std::string out(buf);
+    bool ok = out.find("unknown global") != std::string::npos;
+    assert(ok);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- raise runtime trap when looking up an undefined global name
- route const-string loader through value evaluator for consistent lookup
- test VM trapping on missing global strings

## Testing
- `cmake -S . -B build && cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c45fca43c8832490b1d6877fe28e26