### PR TITLE
fix(il,vm): reject alloca without size operand

### DIFF
--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -352,8 +352,15 @@ bool parseAllocaInstr(const std::string &rest, Instr &in, ParserState &st, std::
     std::istringstream ss(rest);
     std::string sz = readToken(ss);
     in.op = Opcode::Alloca;
-    if (!sz.empty())
+    if (sz.empty())
+    {
+        err << "line " << st.lineNo << ": missing size for alloca\n";
+        st.hasError = true;
+    }
+    else
+    {
         in.operands.push_back(parseValue(sz, st, err));
+    }
     in.type = Type(Type::Kind::Ptr);
     return true;
 }

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -282,6 +282,13 @@ std::optional<Slot> VM::handleDebugBreak(
 /// @returns ExecResult with no control-flow effects; result slot holds pointer.
 VM::ExecResult VM::handleAlloca(Frame &fr, const Instr &in)
 {
+    if (in.operands.size() < 1)
+    {
+        RuntimeBridge::trap("missing allocation size", in.loc, fr.func->name, "");
+        ExecResult r{};
+        r.returned = true;
+        return r;
+    }
     int64_t bytes = eval(fr, in.operands[0]).i64;
     if (bytes < 0)
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -439,6 +439,10 @@ add_executable(test_vm_alloca_negative unit/test_vm_alloca_negative.cpp)
 target_link_libraries(test_vm_alloca_negative PRIVATE il_build il_vm support)
 add_test(NAME test_vm_alloca_negative COMMAND test_vm_alloca_negative)
 
+add_executable(test_vm_alloca_missing_size unit/test_vm_alloca_missing_size.cpp)
+target_link_libraries(test_vm_alloca_missing_size PRIVATE il_build il_vm support)
+add_test(NAME test_vm_alloca_missing_size COMMAND test_vm_alloca_missing_size)
+
 add_executable(test_vm_unknown_global unit/test_vm_unknown_global.cpp)
 target_link_libraries(test_vm_unknown_global PRIVATE il_build il_vm support)
 add_test(NAME test_vm_unknown_global COMMAND test_vm_unknown_global)

--- a/tests/il/parse/alloca_missing_size.il
+++ b/tests/il/parse/alloca_missing_size.il
@@ -1,0 +1,6 @@
+il 0.1.2
+func @f() -> i32 {
+entry:
+  %t0 = alloca
+  ret 0
+}

--- a/tests/unit/test_il_parse_negative.cpp
+++ b/tests/unit/test_il_parse_negative.cpp
@@ -15,7 +15,8 @@ int main()
                            BAD_DIR "/unknown_param_type.il",
                            BAD_DIR "/bad_i32.il",
                            BAD_DIR "/bad_int_literal.il",
-                           BAD_DIR "/bad_float_literal.il"};
+                           BAD_DIR "/bad_float_literal.il",
+                           BAD_DIR "/alloca_missing_size.il"};
     for (const char *path : files)
     {
         std::ifstream in(path);

--- a/tests/unit/test_vm_alloca_missing_size.cpp
+++ b/tests/unit/test_vm_alloca_missing_size.cpp
@@ -1,0 +1,51 @@
+// File: tests/unit/test_vm_alloca_missing_size.cpp
+// Purpose: Ensure VM traps when alloca is missing size operand.
+// Key invariants: Alloca without size must emit "missing allocation size" trap.
+// Ownership: Test constructs IL module and executes VM.
+// Links: docs/class-catalog.md
+
+#include "il/build/IRBuilder.hpp"
+#include "vm/VM.hpp"
+#include <cassert>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main()
+{
+    il::core::Module m;
+    il::build::IRBuilder b(m);
+    auto &fn = b.startFunction("main", il::core::Type(il::core::Type::Kind::I64), {});
+    auto &bb = b.addBlock(fn, "entry");
+    il::core::Instr in;
+    in.op = il::core::Opcode::Alloca;
+    in.type = il::core::Type(il::core::Type::Kind::Ptr);
+    in.loc = {1, 1, 1};
+    bb.instructions.push_back(in);
+
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        il::vm::VM vm(m);
+        vm.run();
+        _exit(0);
+    }
+    close(fds[1]);
+    char buf[256];
+    ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
+    if (n > 0)
+        buf[n] = '\0';
+    else
+        buf[0] = '\0';
+    int status = 0;
+    waitpid(pid, &status, 0);
+    std::string out(buf);
+    bool ok = out.find("missing allocation size") != std::string::npos;
+    assert(ok);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ensure parser errors when alloca missing size token
- trap at runtime if alloca operand absent
- add parser and VM tests for missing size

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c4642622cc8324858e91e203d7fa10