### PR TITLE
feat(basic): add unknown token kind

### DIFF
--- a/src/frontends/basic/Lexer.cpp
+++ b/src/frontends/basic/Lexer.cpp
@@ -336,7 +336,7 @@ Token Lexer::next()
         case ':':
             return {TokenKind::Colon, ":", loc};
     }
-    return {TokenKind::EndOfFile, "", loc};
+    return {TokenKind::Unknown, std::string(1, c), loc};
 }
 
 } // namespace il::frontends::basic

--- a/src/frontends/basic/Token.cpp
+++ b/src/frontends/basic/Token.cpp
@@ -23,6 +23,8 @@ const char *tokenKindToString(TokenKind k)
 {
     switch (k)
     {
+        case TokenKind::Unknown:
+            return "?";
         case TokenKind::EndOfFile:
             return "eof";
         case TokenKind::EndOfLine:

--- a/src/frontends/basic/Token.hpp
+++ b/src/frontends/basic/Token.hpp
@@ -16,6 +16,7 @@ namespace il::frontends::basic
 enum class TokenKind
 {
     // Markers ---------------------------------------------------------------
+    Unknown,   ///< Unrecognized or invalid token.
     EndOfFile, ///< Reached end of the source buffer.
     EndOfLine, ///< End of a line.
 

--- a/tests/unit/test_basic_lexer_high_bit.cpp
+++ b/tests/unit/test_basic_lexer_high_bit.cpp
@@ -11,13 +11,16 @@ using namespace il::frontends::basic;
 
 int main()
 {
+    assert(std::string(tokenKindToString(TokenKind::Unknown)) == "?");
     {
         std::string input = std::string("1") + static_cast<char>(0x80);
         Lexer lex(input, 0);
         Token t1 = lex.next();
         assert(t1.kind == TokenKind::Number);
         Token t2 = lex.next();
-        assert(t2.kind == TokenKind::EndOfFile);
+        assert(t2.kind == TokenKind::Unknown);
+        assert(t2.lexeme == std::string(1, static_cast<char>(0x80)));
+        assert(lex.next().kind == TokenKind::EndOfFile);
     }
     {
         std::string input = std::string("A") + static_cast<char>(0x80);
@@ -25,13 +28,17 @@ int main()
         Token t1 = lex.next();
         assert(t1.kind == TokenKind::Identifier);
         Token t2 = lex.next();
-        assert(t2.kind == TokenKind::EndOfFile);
+        assert(t2.kind == TokenKind::Unknown);
+        assert(t2.lexeme == std::string(1, static_cast<char>(0x80)));
+        assert(lex.next().kind == TokenKind::EndOfFile);
     }
     {
         std::string input(1, static_cast<char>(0x80));
         Lexer lex(input, 0);
         Token t = lex.next();
-        assert(t.kind == TokenKind::EndOfFile);
+        assert(t.kind == TokenKind::Unknown);
+        assert(t.lexeme == std::string(1, static_cast<char>(0x80)));
+        assert(lex.next().kind == TokenKind::EndOfFile);
     }
     {
         std::string input = std::string("REM") + static_cast<char>(0x80) + "\n1";


### PR DESCRIPTION
## Summary
- add Unknown token kind to BASIC lexer
- return '?' for Unknown token in tokenKindToString
- emit Unknown token for unrecognized characters and update lexer tests

## Testing
- `cmake -S . -B build && cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c47dfe245c8324a0e56fcae76211b3