### PR TITLE
fix(fe/basic): widen IntExpr to 64-bit

### DIFF
--- a/src/frontends/basic/AST.hpp
+++ b/src/frontends/basic/AST.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "support/source_manager.hpp"
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -36,8 +37,8 @@ enum class Type
 /// @brief Signed integer literal expression.
 struct IntExpr : Expr
 {
-    /// Literal numeric value parsed from the source.
-    int value;
+    /// Literal 64-bit numeric value parsed from the source.
+    int64_t value;
 };
 
 /// @brief Floating-point literal expression.

--- a/src/frontends/basic/ConstFolder.cpp
+++ b/src/frontends/basic/ConstFolder.cpp
@@ -97,7 +97,7 @@ template <typename F> ExprPtr detail::foldNumericBinary(const Expr &l, const Exp
         return out;
     }
     auto out = std::make_unique<IntExpr>();
-    out->value = static_cast<int>(res->i);
+    out->value = res->i;
     return out;
 }
 
@@ -163,7 +163,7 @@ static void replaceWithInt(ExprPtr &e, long long v, support::SourceLoc loc)
 {
     auto ni = std::make_unique<IntExpr>();
     ni->loc = loc;
-    ni->value = static_cast<int>(v);
+    ni->value = v;
     e = std::move(ni);
 }
 

--- a/src/frontends/basic/Lowerer.cpp
+++ b/src/frontends/basic/Lowerer.cpp
@@ -2197,12 +2197,12 @@ Lowerer::ForBlocks Lowerer::setupForBlocks(bool varStep)
 }
 
 // Purpose: lower for const step.
-// Parameters: const ForStmt &stmt, Value slot, RVal end, RVal step, long stepConst.
+// Parameters: const ForStmt &stmt, Value slot, RVal end, RVal step, int64_t stepConst.
 // Returns: void.
 // Side effects: may modify lowering state or emit IL. Relies on deterministic block naming via
 // BlockNamer.
 void Lowerer::lowerForConstStep(
-    const ForStmt &stmt, Value slot, RVal end, RVal step, long stepConst)
+    const ForStmt &stmt, Value slot, RVal end, RVal step, int64_t stepConst)
 {
     ForBlocks fb = setupForBlocks(false);
     curLoc = stmt.loc;
@@ -2303,7 +2303,7 @@ void Lowerer::lowerFor(const ForStmt &stmt)
     emitStore(Type(Type::Kind::I64), slot, start.value);
 
     bool constStep = !stmt.step || dynamic_cast<const IntExpr *>(stmt.step.get());
-    long stepConst = 1;
+    int64_t stepConst = 1;
     if (constStep && stmt.step)
     {
         if (auto *ie = dynamic_cast<const IntExpr *>(stmt.step.get()))

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -300,7 +300,7 @@ class Lowerer
     void lowerIf(const IfStmt &stmt);
     void lowerWhile(const WhileStmt &stmt);
     void lowerFor(const ForStmt &stmt);
-    void lowerForConstStep(const ForStmt &stmt, Value slot, RVal end, RVal step, long stepConst);
+    void lowerForConstStep(const ForStmt &stmt, Value slot, RVal end, RVal step, int64_t stepConst);
     void lowerForVarStep(const ForStmt &stmt, Value slot, RVal end, RVal step);
     ForBlocks setupForBlocks(bool varStep);
     void emitForStep(Value slot, Value step);

--- a/src/frontends/basic/Parser_Expr.cpp
+++ b/src/frontends/basic/Parser_Expr.cpp
@@ -153,7 +153,7 @@ ExprPtr Parser::parseNumber()
         consume();
         return e;
     }
-    int v = std::atoi(lex.c_str());
+    int64_t v = std::strtoll(lex.c_str(), nullptr, 10);
     auto e = std::make_unique<IntExpr>();
     e->loc = loc;
     e->value = v;


### PR DESCRIPTION
## Summary
- store BASIC integer literals as `int64_t`
- parse integers using `std::strtoll`
- handle 64-bit constants in folding and lowering

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68c482bfad9c8324a485c4dd070e748b