### PR TITLE
fix(runtime): adjust rt_instr3 start index

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -537,7 +537,10 @@ int64_t rt_instr3(int64_t start, rt_string hay, rt_string needle)
         start = len + 1;
     if (needle->size == 0)
         return start;
-    return rt_find(hay, start, needle);
+    int64_t start0 = start - 1;
+    if (start0 < 0)
+        start0 = 0;
+    return rt_find(hay, start0, needle);
 }
 
 /**

--- a/tests/runtime/RTInstrTests.cpp
+++ b/tests/runtime/RTInstrTests.cpp
@@ -14,7 +14,8 @@ int main()
 
     rt_string s3 = rt_const_cstr("ABABAB");
     rt_string s4 = rt_const_cstr("AB");
-    assert(rt_instr3(3, s3, s4) == 5);
+    assert(rt_instr3(3, s3, s4) == 3);
+    assert(rt_instr3(1, s3, s4) == 1);
 
     rt_string s5 = rt_const_cstr("ABC");
     rt_string s6 = rt_const_cstr("X");


### PR DESCRIPTION
## Summary
- convert 1-based start index in `rt_instr3` to 0-based before invoking `rt_find`
- add test for searching from first character and correct existing expectation

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68c48ac3b0948324ac0d4387ff28553d