### PR TITLE
fix(runtime): clamp rt_instr3 start using 0-based semantics

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -522,7 +522,8 @@ int64_t rt_instr2(rt_string hay, rt_string needle)
  *   needle - Needle string to locate.
  *
  * Returns: 1-based index of the first occurrence at or after start, or 0 if
- * not found. An empty needle returns start clamped to [1, len+1].
+ * not found. An empty needle returns the clamped start + 1 (yielding a result
+ * in [1, len + 1]).
  *
  * Side effects: None.
  */
@@ -531,16 +532,14 @@ int64_t rt_instr3(int64_t start, rt_string hay, rt_string needle)
     if (!hay || !needle)
         return 0;
     int64_t len = hay->size;
-    if (start < 1)
-        start = 1;
-    if (start > len + 1)
-        start = len + 1;
+    start -= 1;
+    if (start < 0)
+        start = 0;
+    if (start > len)
+        start = len;
     if (needle->size == 0)
-        return start;
-    int64_t start0 = start - 1;
-    if (start0 < 0)
-        start0 = 0;
-    return rt_find(hay, start0, needle);
+        return start + 1;
+    return rt_find(hay, start, needle);
 }
 
 /**

--- a/tests/runtime/RTInstrTests.cpp
+++ b/tests/runtime/RTInstrTests.cpp
@@ -1,6 +1,6 @@
 // File: tests/runtime/RTInstrTests.cpp
 // Purpose: Validate runtime INSTR search functions.
-// Key invariants: 1-based indexing semantics; empty needle returns start.
+// Key invariants: 1-based indexing semantics; empty needle returns clamped start.
 // Ownership: Uses runtime library.
 // Links: docs/runtime-abi.md
 #include "rt.hpp"
@@ -16,6 +16,11 @@ int main()
     rt_string s4 = rt_const_cstr("AB");
     assert(rt_instr3(3, s3, s4) == 3);
     assert(rt_instr3(1, s3, s4) == 1);
+
+    rt_string empty = rt_const_cstr("");
+    assert(rt_instr3(3, s3, empty) == 3);
+    assert(rt_instr3(10, s3, empty) == 7);
+    assert(rt_instr3(-2, s3, empty) == 1);
 
     rt_string s5 = rt_const_cstr("ABC");
     rt_string s6 = rt_const_cstr("X");


### PR DESCRIPTION
## Summary
- clamp rt_instr3's start offset in 0-based terms and return start + 1 for empty needles
- test empty-needle and out-of-range start behavior in rt_instr

## Testing
- `cmake -S . -B build && cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c4940261d88324ab3b8fe844b51b44