### PR TITLE
feat(vm): add const_null opcode handler

### DIFF
--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -593,6 +593,14 @@ VM::ExecResult VM::handleConstStr(Frame &fr, const Instr &in)
     return {};
 }
 
+VM::ExecResult VM::handleConstNull(Frame &fr, const Instr &in)
+{
+    Slot res{};
+    res.ptr = nullptr;
+    storeResult(fr, in, res);
+    return {};
+}
+
 /// Invoke a function or runtime bridge call.
 ///
 /// @param fr Frame providing argument operands.
@@ -797,6 +805,9 @@ VM::ExecResult VM::executeOpcode(Frame &fr,
         t[static_cast<size_t>(Opcode::ConstStr)] =
             [](VM &vm, Frame &fr, const Instr &in, const BlockMap &, const BasicBlock *&, size_t &)
         { return vm.handleConstStr(fr, in); };
+        t[static_cast<size_t>(Opcode::ConstNull)] =
+            [](VM &vm, Frame &fr, const Instr &in, const BlockMap &, const BasicBlock *&, size_t &)
+        { return vm.handleConstNull(fr, in); };
         t[static_cast<size_t>(Opcode::Call)] =
             [](VM &vm, Frame &fr, const Instr &in, const BlockMap &, const BasicBlock *&b, size_t &)
         { return vm.handleCall(fr, in, b); };

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -311,6 +311,9 @@ class VM
     /// @brief Handle const string opcode.
     ExecResult handleConstStr(Frame &fr, const il::core::Instr &in);
 
+    /// @brief Handle const null opcode.
+    ExecResult handleConstNull(Frame &fr, const il::core::Instr &in);
+
     /// @brief Handle call opcode.
     ExecResult handleCall(Frame &fr, const il::core::Instr &in, const il::core::BasicBlock *bb);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -447,6 +447,10 @@ add_executable(test_vm_unknown_global unit/test_vm_unknown_global.cpp)
 target_link_libraries(test_vm_unknown_global PRIVATE il_build il_vm support)
 add_test(NAME test_vm_unknown_global COMMAND test_vm_unknown_global)
 
+add_executable(test_vm_const_null vm/ConstNullTests.cpp)
+target_link_libraries(test_vm_const_null PRIVATE il_core il_io il_vm support)
+add_test(NAME test_vm_const_null COMMAND test_vm_const_null)
+
 add_executable(test_vm_normalize_path unit/test_vm_normalize_path.cpp)
 target_link_libraries(test_vm_normalize_path PRIVATE VMTrace)
 add_test(NAME test_vm_normalize_path COMMAND test_vm_normalize_path)

--- a/tests/vm/ConstNullTests.cpp
+++ b/tests/vm/ConstNullTests.cpp
@@ -1,0 +1,39 @@
+// File: tests/vm/ConstNullTests.cpp
+// Purpose: Verify const_null writes a null pointer to the destination register.
+// Key invariants: execFunction returns Slot with nullptr for const_null result.
+// Ownership/Lifetime: Test constructs IL module and VM instance.
+// Links: docs/testing.md
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#define private public
+#include "vm/VM.hpp"
+#undef private
+#include "il/io/Parser.hpp"
+
+int main()
+{
+    const char *il = R"il(il 0.1
+
+func @main() -> ptr {
+entry:
+  %p = const_null
+  ret %p
+}
+)il";
+    std::istringstream is(il);
+    il::core::Module m;
+    std::ostringstream err;
+    bool ok = il::io::Parser::parse(is, m, err);
+    assert(ok);
+    il::vm::VM vm(m);
+    il::vm::Slot res = vm.execFunction(m.functions[0], {});
+    assert(res.ptr == nullptr);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- handle `const_null` instructions by writing a null pointer slot
- add unit test verifying VM returns nullptr for `const_null`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c4940f67e48324be309123a1bd6641