### PR TITLE
feat(vm): add addr_of opcode handler

### DIFF
--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -580,6 +580,21 @@ VM::ExecResult VM::handleRet(Frame &fr, const Instr &in)
     return r;
 }
 
+/// Load the address of a global string into the destination register.
+///
+/// @param fr Frame receiving the pointer slot.
+/// @param in Instruction referencing a global symbol by name.
+/// @sideeffects Writes the runtime string pointer to the result register.
+/// @returns ExecResult with no control-flow changes.
+VM::ExecResult VM::handleAddrOf(Frame &fr, const Instr &in)
+{
+    Slot tmp = eval(fr, in.operands[0]);
+    Slot res{};
+    res.ptr = tmp.str;
+    storeResult(fr, in, res);
+    return {};
+}
+
 /// Load a constant string from the global table.
 ///
 /// @param fr Frame receiving the string slot.
@@ -794,6 +809,9 @@ VM::ExecResult VM::executeOpcode(Frame &fr,
         t[static_cast<size_t>(Opcode::Ret)] =
             [](VM &vm, Frame &fr, const Instr &in, const BlockMap &, const BasicBlock *&, size_t &)
         { return vm.handleRet(fr, in); };
+        t[static_cast<size_t>(Opcode::AddrOf)] =
+            [](VM &vm, Frame &fr, const Instr &in, const BlockMap &, const BasicBlock *&, size_t &)
+        { return vm.handleAddrOf(fr, in); };
         t[static_cast<size_t>(Opcode::ConstStr)] =
             [](VM &vm, Frame &fr, const Instr &in, const BlockMap &, const BasicBlock *&, size_t &)
         { return vm.handleConstStr(fr, in); };

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -308,6 +308,9 @@ class VM
     /// @brief Handle return opcode.
     ExecResult handleRet(Frame &fr, const il::core::Instr &in);
 
+    /// @brief Handle address-of global string opcode.
+    ExecResult handleAddrOf(Frame &fr, const il::core::Instr &in);
+
     /// @brief Handle const string opcode.
     ExecResult handleConstStr(Frame &fr, const il::core::Instr &in);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -447,6 +447,10 @@ add_executable(test_vm_unknown_global unit/test_vm_unknown_global.cpp)
 target_link_libraries(test_vm_unknown_global PRIVATE il_build il_vm support)
 add_test(NAME test_vm_unknown_global COMMAND test_vm_unknown_global)
 
+add_executable(test_vm_addr_of unit/test_vm_addr_of.cpp)
+target_link_libraries(test_vm_addr_of PRIVATE il_io il_vm support)
+add_test(NAME test_vm_addr_of COMMAND test_vm_addr_of)
+
 add_executable(test_vm_normalize_path unit/test_vm_normalize_path.cpp)
 target_link_libraries(test_vm_normalize_path PRIVATE VMTrace)
 add_test(NAME test_vm_normalize_path COMMAND test_vm_normalize_path)

--- a/tests/unit/test_vm_addr_of.cpp
+++ b/tests/unit/test_vm_addr_of.cpp
@@ -1,0 +1,38 @@
+// File: tests/unit/test_vm_addr_of.cpp
+// Purpose: Verify VM addr_of instruction returns pointer to global string.
+// Key invariants: Returned pointer's data matches global initializer.
+// Ownership: Test constructs IL module and executes VM.
+// Links: docs/il-reference.md
+
+#include "il/io/Parser.hpp"
+#include "rt.hpp"
+#include "vm/VM.hpp"
+#include <cassert>
+#include <sstream>
+#include <string>
+
+int main()
+{
+    const char *il = "il 0.1\n"
+                     "global const str @g = \"hi\"\n\n"
+                     "func @main() -> i64 {\n"
+                     "entry:\n"
+                     "  %p = addr_of @g\n"
+                     "  %a = alloca 8\n"
+                     "  store ptr, %a, %p\n"
+                     "  %v = load i64, %a\n"
+                     "  ret %v\n"
+                     "}\n";
+
+    il::core::Module m;
+    std::istringstream is(il);
+    std::ostringstream err;
+    bool ok = il::io::Parser::parse(is, m, err);
+    assert(ok && err.str().empty());
+
+    il::vm::VM vm(m);
+    int64_t rv = vm.run();
+    rt_string s = reinterpret_cast<rt_string>(static_cast<uintptr_t>(rv));
+    assert(s->data == m.globals.front().init.c_str());
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement AddrOf handler to return global string address
- register AddrOf in opcode dispatch
- add unit test for addr_of pointer semantics

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68c496dc79748324a6a15ae4949be1dd