### PR TITLE
fix(runtime): handle realloc failure in rt_input_line

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -211,6 +211,7 @@ rt_string rt_input_line(void)
             {
                 free(buf);
                 rt_trap("out of memory");
+                return NULL;
             }
             buf = nbuf;
             cap = new_cap;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -173,6 +173,10 @@ add_executable(test_rt_input_line runtime/RTInputLineTests.cpp)
 target_link_libraries(test_rt_input_line PRIVATE rt)
 add_test(NAME test_rt_input_line COMMAND test_rt_input_line)
 
+add_executable(test_rt_input_line_fail runtime/RTInputLineFailTests.cpp)
+target_link_libraries(test_rt_input_line_fail PRIVATE rt)
+add_test(NAME test_rt_input_line_fail COMMAND test_rt_input_line_fail)
+
 add_executable(float_out e2e/support/FloatOut.cpp)
 
 add_test(NAME vm_strings_example COMMAND ${CMAKE_COMMAND}

--- a/tests/runtime/RTInputLineFailTests.cpp
+++ b/tests/runtime/RTInputLineFailTests.cpp
@@ -1,0 +1,42 @@
+// File: tests/runtime/RTInputLineFailTests.cpp
+// Purpose: Verify rt_input_line returns NULL when buffer expansion fails.
+// Key invariants: Function aborts reading on realloc failure and reports trap.
+// Ownership: Uses runtime library; stubs realloc and trap for simulation.
+// Links: docs/runtime-abi.md
+#include "rt.hpp"
+#include <cassert>
+#include <cstring>
+#include <string>
+#include <unistd.h>
+
+static const char *g_msg = nullptr;
+
+// Stub realloc to simulate allocation failure.
+extern "C" void *realloc(void *ptr, size_t size)
+{
+    (void)ptr;
+    (void)size;
+    return NULL;
+}
+
+// Stub vm_trap to capture message without aborting.
+extern "C" void vm_trap(const char *msg)
+{
+    g_msg = msg;
+}
+
+int main()
+{
+    std::string input(1500, 'x');
+    int fds[2];
+    assert(pipe(fds) == 0);
+    (void)write(fds[1], input.data(), input.size());
+    close(fds[1]);
+    dup2(fds[0], 0);
+    close(fds[0]);
+
+    rt_string s = rt_input_line();
+    assert(!s);
+    assert(g_msg && std::strcmp(g_msg, "out of memory") == 0);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- return NULL after rt_trap on realloc failure in rt_input_line to avoid using freed buffer
- add test harness that stubs realloc and vm_trap to simulate out-of-memory

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c49f9826e88324b6e5413148b90c04