### PR TITLE
fix(vm): trap on missing runtime arguments

### DIFF
--- a/src/vm/RuntimeBridge.cpp
+++ b/src/vm/RuntimeBridge.cpp
@@ -54,145 +54,191 @@ Slot RuntimeBridge::call(const std::string &name,
     curFn = fn;
     curBlock = block;
     Slot res{};
+    auto checkArgs = [&](size_t count)
+    {
+        if (args.size() < count)
+        {
+            std::ostringstream os;
+            os << name << ": expected " << count << " argument(s), got " << args.size();
+            RuntimeBridge::trap(os.str(), loc, fn, block);
+            return false;
+        }
+        return true;
+    };
     if (name == "rt_print_str")
     {
-        rt_print_str(args[0].str);
+        if (checkArgs(1))
+            rt_print_str(args[0].str);
     }
     else if (name == "rt_print_i64")
     {
-        rt_print_i64(args[0].i64);
+        if (checkArgs(1))
+            rt_print_i64(args[0].i64);
     }
     else if (name == "rt_print_f64")
     {
-        rt_print_f64(args[0].f64);
+        if (checkArgs(1))
+            rt_print_f64(args[0].f64);
     }
     else if (name == "rt_len")
     {
-        res.i64 = rt_len(args[0].str);
+        if (checkArgs(1))
+            res.i64 = rt_len(args[0].str);
     }
     else if (name == "rt_concat")
     {
-        res.str = rt_concat(args[0].str, args[1].str);
+        if (checkArgs(2))
+            res.str = rt_concat(args[0].str, args[1].str);
     }
     else if (name == "rt_substr")
     {
-        res.str = rt_substr(args[0].str, args[1].i64, args[2].i64);
+        if (checkArgs(3))
+            res.str = rt_substr(args[0].str, args[1].i64, args[2].i64);
     }
     else if (name == "rt_str_eq")
     {
-        res.i64 = rt_str_eq(args[0].str, args[1].str);
+        if (checkArgs(2))
+            res.i64 = rt_str_eq(args[0].str, args[1].str);
     }
     else if (name == "rt_input_line")
     {
-        res.str = rt_input_line();
+        if (checkArgs(0))
+            res.str = rt_input_line();
     }
     else if (name == "rt_to_int")
     {
-        res.i64 = rt_to_int(args[0].str);
+        if (checkArgs(1))
+            res.i64 = rt_to_int(args[0].str);
     }
     else if (name == "rt_int_to_str")
     {
-        res.str = rt_int_to_str(args[0].i64);
+        if (checkArgs(1))
+            res.str = rt_int_to_str(args[0].i64);
     }
     else if (name == "rt_f64_to_str")
     {
-        res.str = rt_f64_to_str(args[0].f64);
+        if (checkArgs(1))
+            res.str = rt_f64_to_str(args[0].f64);
     }
     else if (name == "rt_alloc")
     {
-        res.ptr = rt_alloc(args[0].i64);
+        if (checkArgs(1))
+            res.ptr = rt_alloc(args[0].i64);
     }
     else if (name == "rt_left")
     {
-        res.str = rt_left(args[0].str, args[1].i64);
+        if (checkArgs(2))
+            res.str = rt_left(args[0].str, args[1].i64);
     }
     else if (name == "rt_right")
     {
-        res.str = rt_right(args[0].str, args[1].i64);
+        if (checkArgs(2))
+            res.str = rt_right(args[0].str, args[1].i64);
     }
     else if (name == "rt_mid2")
     {
-        res.str = rt_mid2(args[0].str, args[1].i64);
+        if (checkArgs(2))
+            res.str = rt_mid2(args[0].str, args[1].i64);
     }
     else if (name == "rt_mid3")
     {
-        res.str = rt_mid3(args[0].str, args[1].i64, args[2].i64);
+        if (checkArgs(3))
+            res.str = rt_mid3(args[0].str, args[1].i64, args[2].i64);
     }
     else if (name == "rt_instr2")
     {
-        res.i64 = rt_instr2(args[0].str, args[1].str);
+        if (checkArgs(2))
+            res.i64 = rt_instr2(args[0].str, args[1].str);
     }
     else if (name == "rt_instr3")
     {
-        res.i64 = rt_instr3(args[0].i64, args[1].str, args[2].str);
+        if (checkArgs(3))
+            res.i64 = rt_instr3(args[0].i64, args[1].str, args[2].str);
     }
     else if (name == "rt_ltrim")
     {
-        res.str = rt_ltrim(args[0].str);
+        if (checkArgs(1))
+            res.str = rt_ltrim(args[0].str);
     }
     else if (name == "rt_rtrim")
     {
-        res.str = rt_rtrim(args[0].str);
+        if (checkArgs(1))
+            res.str = rt_rtrim(args[0].str);
     }
     else if (name == "rt_trim")
     {
-        res.str = rt_trim(args[0].str);
+        if (checkArgs(1))
+            res.str = rt_trim(args[0].str);
     }
     else if (name == "rt_ucase")
     {
-        res.str = rt_ucase(args[0].str);
+        if (checkArgs(1))
+            res.str = rt_ucase(args[0].str);
     }
     else if (name == "rt_lcase")
     {
-        res.str = rt_lcase(args[0].str);
+        if (checkArgs(1))
+            res.str = rt_lcase(args[0].str);
     }
     else if (name == "rt_chr")
     {
-        res.str = rt_chr(args[0].i64);
+        if (checkArgs(1))
+            res.str = rt_chr(args[0].i64);
     }
     else if (name == "rt_asc")
     {
-        res.i64 = rt_asc(args[0].str);
+        if (checkArgs(1))
+            res.i64 = rt_asc(args[0].str);
     }
     else if (name == "rt_sqrt")
     {
-        res.f64 = rt_sqrt(args[0].f64);
+        if (checkArgs(1))
+            res.f64 = rt_sqrt(args[0].f64);
     }
     else if (name == "rt_floor")
     {
-        res.f64 = rt_floor(args[0].f64);
+        if (checkArgs(1))
+            res.f64 = rt_floor(args[0].f64);
     }
     else if (name == "rt_ceil")
     {
-        res.f64 = rt_ceil(args[0].f64);
+        if (checkArgs(1))
+            res.f64 = rt_ceil(args[0].f64);
     }
     else if (name == "rt_sin")
     {
-        res.f64 = rt_sin(args[0].f64);
+        if (checkArgs(1))
+            res.f64 = rt_sin(args[0].f64);
     }
     else if (name == "rt_cos")
     {
-        res.f64 = rt_cos(args[0].f64);
+        if (checkArgs(1))
+            res.f64 = rt_cos(args[0].f64);
     }
     else if (name == "rt_pow")
     {
-        res.f64 = rt_pow(args[0].f64, args[1].f64);
+        if (checkArgs(2))
+            res.f64 = rt_pow(args[0].f64, args[1].f64);
     }
     else if (name == "rt_abs_i64")
     {
-        res.i64 = rt_abs_i64(args[0].i64);
+        if (checkArgs(1))
+            res.i64 = rt_abs_i64(args[0].i64);
     }
     else if (name == "rt_abs_f64")
     {
-        res.f64 = rt_abs_f64(args[0].f64);
+        if (checkArgs(1))
+            res.f64 = rt_abs_f64(args[0].f64);
     }
     else if (name == "rt_randomize_i64")
     {
-        rt_randomize_i64(args[0].i64);
+        if (checkArgs(1))
+            rt_randomize_i64(args[0].i64);
     }
     else if (name == "rt_rnd")
     {
-        res.f64 = rt_rnd();
+        if (checkArgs(0))
+            res.f64 = rt_rnd();
     }
     else
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -435,6 +435,14 @@ add_executable(test_vm_rt_trap_loc unit/test_vm_rt_trap_loc.cpp)
 target_link_libraries(test_vm_rt_trap_loc PRIVATE il_build il_vm support)
 add_test(NAME test_vm_rt_trap_loc COMMAND test_vm_rt_trap_loc)
 
+add_executable(test_vm_rt_missing_arg unit/test_vm_rt_missing_arg.cpp)
+target_link_libraries(test_vm_rt_missing_arg PRIVATE il_build il_vm support)
+add_test(NAME test_vm_rt_missing_arg COMMAND test_vm_rt_missing_arg)
+
+add_executable(test_vm_rt_concat_missing_args unit/test_vm_rt_concat_missing_args.cpp)
+target_link_libraries(test_vm_rt_concat_missing_args PRIVATE il_build il_vm support)
+add_test(NAME test_vm_rt_concat_missing_args COMMAND test_vm_rt_concat_missing_args)
+
 add_executable(test_vm_alloca_negative unit/test_vm_alloca_negative.cpp)
 target_link_libraries(test_vm_alloca_negative PRIVATE il_build il_vm support)
 add_test(NAME test_vm_alloca_negative COMMAND test_vm_alloca_negative)

--- a/tests/unit/test_vm_rt_concat_missing_args.cpp
+++ b/tests/unit/test_vm_rt_concat_missing_args.cpp
@@ -1,0 +1,52 @@
+// File: tests/unit/test_vm_rt_concat_missing_args.cpp
+// Purpose: Ensure runtime bridge traps when rt_concat is called with too few arguments.
+// Key invariants: Calls with insufficient args should emit descriptive trap rather than crash.
+// Ownership: Test constructs IL module and executes VM.
+// Links: docs/class-catalog.md
+
+#include "il/build/IRBuilder.hpp"
+#include "vm/VM.hpp"
+#include <cassert>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main()
+{
+    using namespace il::core;
+    Module m;
+    il::build::IRBuilder b(m);
+    b.addExtern("rt_concat", Type(Type::Kind::Str), {Type(Type::Kind::Str), Type(Type::Kind::Str)});
+    auto &fn = b.startFunction("main", Type(Type::Kind::Void), {});
+    auto &bb = b.addBlock(fn, "entry");
+    b.setInsertPoint(bb);
+    // Deliberately omit both required arguments.
+    b.emitCall("rt_concat", {}, std::optional<Value>{}, {1, 1, 1});
+    b.emitRet(std::optional<Value>{}, {1, 1, 1});
+
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        il::vm::VM vm(m);
+        vm.run();
+        _exit(0);
+    }
+    close(fds[1]);
+    char buf[256];
+    ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
+    if (n > 0)
+        buf[n] = '\0';
+    else
+        buf[0] = '\0';
+    int status = 0;
+    waitpid(pid, &status, 0);
+    std::string out(buf);
+    bool ok = out.find("rt_concat: expected 2 argument") != std::string::npos;
+    assert(ok);
+    return 0;
+}

--- a/tests/unit/test_vm_rt_missing_arg.cpp
+++ b/tests/unit/test_vm_rt_missing_arg.cpp
@@ -1,0 +1,52 @@
+// File: tests/unit/test_vm_rt_missing_arg.cpp
+// Purpose: Ensure runtime bridge traps when rt_print_str is called without required argument.
+// Key invariants: Calls with insufficient args should emit descriptive trap rather than crash.
+// Ownership: Test constructs IL module and executes VM.
+// Links: docs/class-catalog.md
+
+#include "il/build/IRBuilder.hpp"
+#include "vm/VM.hpp"
+#include <cassert>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main()
+{
+    using namespace il::core;
+    Module m;
+    il::build::IRBuilder b(m);
+    b.addExtern("rt_print_str", Type(Type::Kind::Void), {Type(Type::Kind::Str)});
+    auto &fn = b.startFunction("main", Type(Type::Kind::Void), {});
+    auto &bb = b.addBlock(fn, "entry");
+    b.setInsertPoint(bb);
+    // Deliberately omit required argument.
+    b.emitCall("rt_print_str", {}, std::optional<Value>{}, {1, 1, 1});
+    b.emitRet(std::optional<Value>{}, {1, 1, 1});
+
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        il::vm::VM vm(m);
+        vm.run();
+        _exit(0);
+    }
+    close(fds[1]);
+    char buf[256];
+    ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
+    if (n > 0)
+        buf[n] = '\0';
+    else
+        buf[0] = '\0';
+    int status = 0;
+    waitpid(pid, &status, 0);
+    std::string out(buf);
+    bool ok = out.find("rt_print_str: expected 1 argument") != std::string::npos;
+    assert(ok);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- check runtime bridge argument counts before dispatch
- trap with descriptive message on insufficient args
- add VM tests for under-supplied runtime calls

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c49f9210dc8324a8b6c77cb8862b1c