### PR TITLE
fix(basic): clamp negative lookahead in Parser::peek

### DIFF
--- a/src/frontends/basic/Parser_Token.cpp
+++ b/src/frontends/basic/Parser_Token.cpp
@@ -29,6 +29,8 @@ bool Parser::at(TokenKind k) const
 /// @note Extends the buffer by reading from the lexer as needed.
 const Token &Parser::peek(int n) const
 {
+    if (n < 0)
+        n = 0;
     while (tokens_.size() <= static_cast<size_t>(n))
     {
         tokens_.push_back(lexer_.next());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -427,6 +427,10 @@ add_executable(test_basic_intrinsics unit/test_basic_intrinsics.cpp)
 target_link_libraries(test_basic_intrinsics PRIVATE fe_basic support)
 add_test(NAME test_basic_intrinsics COMMAND test_basic_intrinsics)
 
+add_executable(test_basic_parser_peek unit/test_basic_parser_peek.cpp)
+target_link_libraries(test_basic_parser_peek PRIVATE fe_basic support)
+add_test(NAME test_basic_parser_peek COMMAND test_basic_parser_peek)
+
 add_executable(test_vm_trap_loc unit/test_vm_trap_loc.cpp)
 target_link_libraries(test_vm_trap_loc PRIVATE il_build il_vm support)
 add_test(NAME test_vm_trap_loc COMMAND test_vm_trap_loc)

--- a/tests/unit/test_basic_parser_peek.cpp
+++ b/tests/unit/test_basic_parser_peek.cpp
@@ -1,0 +1,34 @@
+// File: tests/unit/test_basic_parser_peek.cpp
+// Purpose: Verify Parser::peek clamps negative lookahead without consuming extra tokens.
+// Key invariants: Negative index is treated as zero; lexer not advanced beyond current token.
+// Ownership/Lifetime: Test owns parser and source. Links: docs/class-catalog.md
+
+#define private public
+#include "frontends/basic/Parser.hpp"
+#undef private
+#include "support/source_manager.hpp"
+#include <cassert>
+#include <string>
+
+using namespace il::frontends::basic;
+using namespace il::support;
+
+int main()
+{
+    std::string src = "10 END\n";
+    SourceManager sm;
+    uint32_t fid = sm.addFile("test.bas");
+    Parser p(src, fid);
+
+    size_t before = p.tokens_.size();
+
+    const Token &t = p.peek(-1);
+    assert(t.kind == TokenKind::Number);
+    assert(p.tokens_.size() == before);
+
+    const Token &t0 = p.peek(0);
+    assert(t0.lexeme == t.lexeme);
+    assert(p.tokens_.size() == before);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- clamp negative lookahead indices in `Parser::peek` to avoid runaway lexing
- add regression test covering `peek(-1)`

## Testing
- `cmake -S . -B build && cmake --build build -j`
- `ctest --test-dir build --output-on-failure`
- `ctest --test-dir build -R test_basic_parser_peek --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c49f8762cc83248484126a7ce57b1d