### PR TITLE
Create tui/ subproject, CMake integration, and first smoke test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ add_custom_target(format
 option(IL_ENABLE_X64_ASM_SYNTAX_CHECK "Check generated x86_64 asm syntax" ON)
 option(IL_ENABLE_X64_ASM_ASSEMBLE_LINK "Assemble+link x86_64 asm" ON)
 option(IL_ENABLE_X64_NATIVE_RUN "Run x86_64 binaries" ON)
+option(BUILD_TUI "Build ViperTUI subproject" ON)
 
 if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
   set(IL_ENABLE_X64_NATIVE_RUN OFF CACHE BOOL "" FORCE)
@@ -107,6 +108,9 @@ add_subdirectory(lib/Analysis)
 add_subdirectory(lib/IL)
 add_subdirectory(lib/Passes)
 add_subdirectory(lib/VM)
+if(BUILD_TUI)
+  add_subdirectory(tui)
+endif()
 add_subdirectory(tests)
 
 add_custom_target(distclean

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ build/src/tools/ilc/ilc -run examples/il/ex1_hello_cond.il
 - **IL Quickstart**: [docs/il-quickstart.md](docs/il-quickstart.md)
 - [BASIC Reference](docs/basic-reference.md)
 - [IL Reference](docs/il-reference.md)
+- [ViperTUI](tui/): experimental terminal UI library
 
 ## Contributing
 

--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -1,0 +1,14 @@
+# CMake configuration for ViperTUI
+
+cmake_minimum_required(VERSION 3.16)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_library(tui STATIC src/version.cpp)
+
+target_include_directories(tui PUBLIC include)
+
+enable_testing()
+add_subdirectory(tests)

--- a/tui/include/tui/version.hpp
+++ b/tui/include/tui/version.hpp
@@ -1,0 +1,11 @@
+// tui/include/tui/version.hpp
+#pragma once
+
+/// @brief Returns the ViperTUI version string.
+/// @invariant The returned pointer is non-null and points to a null-terminated string.
+/// @ownership The returned string has static storage duration and must not be freed.
+/// @notes Part of the public ViperTUI API.
+namespace viper::tui
+{
+const char *viper_tui_version() noexcept;
+} // namespace viper::tui

--- a/tui/src/version.cpp
+++ b/tui/src/version.cpp
@@ -1,0 +1,14 @@
+// tui/src/version.cpp
+// @brief Implements the viper_tui_version function.
+// @invariant Returns a valid, null-terminated string.
+// @ownership String has static storage duration.
+
+#include "tui/version.hpp"
+
+namespace viper::tui
+{
+const char *viper_tui_version() noexcept
+{
+    return "0.1.0";
+}
+} // namespace viper::tui

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Tests for ViperTUI
+
+add_executable(tui_test_smoke test_smoke.cpp)
+
+target_link_libraries(tui_test_smoke PRIVATE tui)
+
+add_test(NAME tui_test_smoke COMMAND tui_test_smoke)

--- a/tui/tests/test_smoke.cpp
+++ b/tui/tests/test_smoke.cpp
@@ -1,0 +1,13 @@
+// tui/tests/test_smoke.cpp
+// @brief Smoke test for the ViperTUI version API.
+// @invariant The version string is non-null.
+// @ownership No ownership of returned string is taken.
+
+#include "tui/version.hpp"
+#include <iostream>
+
+int main()
+{
+    std::cout << viper::tui::viper_tui_version() << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add optional ViperTUI subproject with CMake integration
- expose viper_tui_version() and simple smoke test

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`
- `ctest --test-dir build -R tui_test_smoke --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c4d224ad5c832482fcaa00ad427fdf