### PR TITLE
Add TermIO interface with RealTermIO (stdout) and StringTermIO (test capture)

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_library(tui STATIC src/version.cpp)
+add_library(tui STATIC src/version.cpp src/term/term_io.cpp)
 
 target_include_directories(tui PUBLIC include)
 

--- a/tui/include/tui/term/term_io.hpp
+++ b/tui/include/tui/term/term_io.hpp
@@ -1,0 +1,58 @@
+// tui/include/tui/term/term_io.hpp
+// @brief Terminal I/O abstraction interfaces.
+// @invariant No terminal mode changes are performed.
+// @ownership RealTermIO writes to std::cout; StringTermIO owns its buffer.
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace viper::tui::term
+{
+/// @brief Abstract interface for terminal I/O backends.
+/// @invariant Implementations must not throw.
+/// @ownership Does not own passed data.
+class TermIO
+{
+  public:
+    virtual ~TermIO() = default;
+
+    /// @brief Write a sequence of bytes to the terminal.
+    /// @param data Bytes to write.
+    virtual void write(std::string_view data) = 0;
+
+    /// @brief Flush any buffered output to the terminal.
+    virtual void flush() = 0;
+};
+
+/// @brief Real terminal backend writing to std::cout.
+/// @invariant std::cout's rdbuf must be valid.
+/// @ownership Does not own std::cout.
+class RealTermIO final : public TermIO
+{
+  public:
+    void write(std::string_view data) override;
+    void flush() override;
+};
+
+/// @brief In-memory terminal backend capturing output into a string.
+/// @invariant Buffer grows to accommodate written data.
+/// @ownership Owns its internal buffer.
+class StringTermIO final : public TermIO
+{
+  public:
+    void write(std::string_view data) override;
+    void flush() override;
+
+    /// @brief Access the captured output buffer.
+    /// @return Reference to internal string buffer.
+    [[nodiscard]] const std::string &buffer() const noexcept
+    {
+        return buffer_;
+    }
+
+  private:
+    std::string buffer_{};
+};
+
+} // namespace viper::tui::term

--- a/tui/src/term/term_io.cpp
+++ b/tui/src/term/term_io.cpp
@@ -1,0 +1,36 @@
+// tui/src/term/term_io.cpp
+// @brief Implements TermIO backends.
+// @invariant RealTermIO writes to std::cout; StringTermIO buffers internally.
+// @ownership RealTermIO has no ownership; StringTermIO owns its buffer.
+
+#include "tui/term/term_io.hpp"
+
+#include <iostream>
+
+namespace viper::tui::term
+{
+
+void RealTermIO::write(std::string_view data)
+{
+#ifdef _WIN32
+    // Future: ensure stdout is in binary mode.
+#endif
+    std::cout.rdbuf()->sputn(data.data(), static_cast<std::streamsize>(data.size()));
+}
+
+void RealTermIO::flush()
+{
+    std::cout.flush();
+}
+
+void StringTermIO::write(std::string_view data)
+{
+    buffer_.append(data.data(), data.size());
+}
+
+void StringTermIO::flush()
+{
+    // No-op for in-memory buffer.
+}
+
+} // namespace viper::tui::term

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -5,3 +5,7 @@ add_executable(tui_test_smoke test_smoke.cpp)
 target_link_libraries(tui_test_smoke PRIVATE tui)
 
 add_test(NAME tui_test_smoke COMMAND tui_test_smoke)
+
+add_executable(tui_test_term_io test_term_io.cpp)
+target_link_libraries(tui_test_term_io PRIVATE tui)
+add_test(NAME tui_test_term_io COMMAND tui_test_term_io)

--- a/tui/tests/test_term_io.cpp
+++ b/tui/tests/test_term_io.cpp
@@ -1,0 +1,17 @@
+// tui/tests/test_term_io.cpp
+// @brief Tests for TermIO implementations.
+// @invariant StringTermIO captures writes verbatim.
+// @ownership StringTermIO owns its buffer.
+
+#include "tui/term/term_io.hpp"
+
+#include <cassert>
+
+int main()
+{
+    viper::tui::term::StringTermIO tio;
+    tio.write("hello");
+    tio.flush();
+    assert(tio.buffer() == "hello");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Introduce `TermIO` abstraction with `RealTermIO` writing to `std::cout` and `StringTermIO` buffering output for tests.
- Provide implementations for stdout and in-memory backends.
- Add headless unit test verifying captured output.
- Update build configuration to include new sources and test.

## Testing
- `cmake --build build --target tui_test_term_io`
- `cmake --build build --target tui_test_smoke`
- `ctest --test-dir build -R tui_test_term_io --output-on-failure`
- `ctest --test-dir build -R tui_test_smoke --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c4da78bdf083248c34e21d03890a5a