### PR TITLE
tui(term): add TerminalSession RAII with CI-safe no-op path

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_library(tui STATIC src/version.cpp src/term/term_io.cpp)
+add_library(tui STATIC src/version.cpp src/term/term_io.cpp src/term/session.cpp)
 
 target_include_directories(tui PUBLIC include)
 

--- a/tui/include/tui/term/session.hpp
+++ b/tui/include/tui/term/session.hpp
@@ -1,0 +1,41 @@
+// tui/include/tui/term/session.hpp
+// @brief RAII wrapper for terminal session state (raw mode, alt screen).
+// @invariant Restores terminal state on destruction; no-op if VIPERTUI_NO_TTY=1 or non-POSIX.
+// @ownership Does not own the terminal; manipulates stdio state only when active.
+#pragma once
+
+#if defined(__unix__) || defined(__APPLE__)
+#include <termios.h>
+#endif
+
+namespace viper::tui::term
+{
+/// @brief Manages a terminal session by entering raw mode and enabling UI features.
+/// @details On construction, the session switches the terminal to raw mode,
+///          enables the alternate screen buffer, enables bracketed paste, and hides the cursor.
+///          On destruction, the original terminal settings are restored.
+///          If the environment variable `VIPERTUI_NO_TTY` is set to `1`,
+///          or on non-POSIX platforms, the session performs no operations.
+/// @invariant Terminal state is restored when the object is destroyed.
+/// @ownership Does not own the underlying terminal.
+class TerminalSession
+{
+  public:
+    /// @brief Construct a terminal session.
+    /// @invariant No-op when `VIPERTUI_NO_TTY=1` or unsupported platform.
+    TerminalSession() noexcept;
+
+    /// @brief Restore terminal state.
+    ~TerminalSession();
+
+    TerminalSession(const TerminalSession &) = delete;
+    TerminalSession &operator=(const TerminalSession &) = delete;
+
+  private:
+#if defined(__unix__) || defined(__APPLE__)
+    bool active_{false};
+    struct termios old_termios_{};
+#endif
+};
+
+} // namespace viper::tui::term

--- a/tui/src/term/session.cpp
+++ b/tui/src/term/session.cpp
@@ -1,0 +1,60 @@
+// tui/src/term/session.cpp
+// @brief Implements TerminalSession for managing terminal modes.
+// @invariant Restores prior terminal state on destruction when active.
+// @ownership Does not own the underlying terminal.
+
+#include "tui/term/session.hpp"
+
+#if defined(__unix__) || defined(__APPLE__)
+#include <cstdio>
+#include <cstdlib>
+#include <unistd.h>
+#endif
+
+namespace viper::tui::term
+{
+#if defined(__unix__) || defined(__APPLE__)
+TerminalSession::TerminalSession() noexcept
+{
+    const char *no_tty = std::getenv("VIPERTUI_NO_TTY");
+    if (no_tty && no_tty[0] == '1')
+    {
+        active_ = false;
+        return;
+    }
+
+    if (tcgetattr(STDIN_FILENO, &old_termios_) != 0)
+    {
+        active_ = false;
+        return;
+    }
+
+    struct termios raw = old_termios_;
+    cfmakeraw(&raw);
+    if (tcsetattr(STDIN_FILENO, TCSANOW, &raw) != 0)
+    {
+        active_ = false;
+        return;
+    }
+
+    std::fputs("\x1b[?1049h\x1b[?2004h\x1b[?25l", stdout);
+    std::fflush(stdout);
+    active_ = true;
+}
+
+TerminalSession::~TerminalSession()
+{
+    if (!active_)
+    {
+        return;
+    }
+
+    tcsetattr(STDIN_FILENO, TCSANOW, &old_termios_);
+    std::fputs("\x1b[?1049l\x1b[?2004l\x1b[?25h", stdout);
+    std::fflush(stdout);
+}
+#else
+TerminalSession::TerminalSession() noexcept = default;
+TerminalSession::~TerminalSession() = default;
+#endif
+} // namespace viper::tui::term

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -9,3 +9,7 @@ add_test(NAME tui_test_smoke COMMAND tui_test_smoke)
 add_executable(tui_test_term_io test_term_io.cpp)
 target_link_libraries(tui_test_term_io PRIVATE tui)
 add_test(NAME tui_test_term_io COMMAND tui_test_term_io)
+
+add_executable(tui_test_session test_session.cpp)
+target_link_libraries(tui_test_session PRIVATE tui)
+add_test(NAME tui_test_session COMMAND tui_test_session)

--- a/tui/tests/test_session.cpp
+++ b/tui/tests/test_session.cpp
@@ -1,0 +1,33 @@
+// tui/tests/test_session.cpp
+// @brief Lifecycle test for TerminalSession with CI-safe no-op path.
+// @invariant TerminalSession performs no terminal I/O when VIPERTUI_NO_TTY=1.
+// @ownership No ownership of passed TermIO instances.
+
+#include "tui/term/session.hpp"
+#include "tui/term/term_io.hpp"
+
+#include <cassert>
+#include <cstdlib>
+
+using namespace viper::tui::term;
+
+static void consume(TermIO &io)
+{
+    (void)io;
+}
+
+int main()
+{
+#ifdef _WIN32
+    _putenv_s("VIPERTUI_NO_TTY", "1");
+#else
+    setenv("VIPERTUI_NO_TTY", "1", 1);
+#endif
+    {
+        TerminalSession session; // Should be a no-op and not crash.
+    }
+    StringTermIO tio;
+    consume(tio);
+    assert(true);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add TerminalSession RAII that switches to raw mode, enables alt screen and bracketed paste, and hides cursor
- skip terminal manipulation when `VIPERTUI_NO_TTY=1` or on non-POSIX platforms
- exercise the no-op path in a headless lifecycle test

## Testing
- `cmake -S . -B build && cmake --build build -j && ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c4dd15e8148324818f1c31fe2cea08