### PR TITLE
Introduce TerminalSession RAII (POSIX termios; no-op when VIPERTUI_NO_TTY=1)

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_library(tui STATIC src/version.cpp src/term/term_io.cpp)
+add_library(tui STATIC src/version.cpp src/term/term_io.cpp src/term/session.cpp)
 
 target_include_directories(tui PUBLIC include)
 

--- a/tui/include/tui/term/session.hpp
+++ b/tui/include/tui/term/session.hpp
@@ -1,0 +1,28 @@
+// tui/include/tui/term/session.hpp
+// @brief RAII for terminal mode management.
+// @invariant Restores terminal state on destruction when active.
+// @ownership Owns saved termios state when active.
+#pragma once
+
+#if defined(__unix__) || defined(__APPLE__)
+#include <termios.h>
+#endif
+
+namespace viper::tui::term
+{
+class TerminalSession
+{
+  public:
+    TerminalSession();
+    ~TerminalSession();
+
+    TerminalSession(const TerminalSession &) = delete;
+    TerminalSession &operator=(const TerminalSession &) = delete;
+
+  private:
+#if defined(__unix__) || defined(__APPLE__)
+    termios orig_{};
+    bool active_{false};
+#endif
+};
+} // namespace viper::tui::term

--- a/tui/src/term/session.cpp
+++ b/tui/src/term/session.cpp
@@ -1,0 +1,57 @@
+// tui/src/term/session.cpp
+// @brief Implements TerminalSession RAII.
+// @invariant Restores terminal state on destruction when active.
+// @ownership Owns saved termios state when active.
+
+#include "tui/term/session.hpp"
+#include "tui/term/term_io.hpp"
+
+#include <cstdlib>
+
+#if defined(__unix__) || defined(__APPLE__)
+#include <unistd.h>
+#endif
+
+namespace viper::tui::term
+{
+#if defined(__unix__) || defined(__APPLE__)
+TerminalSession::TerminalSession()
+{
+    if (std::getenv("VIPERTUI_NO_TTY") != nullptr)
+    {
+        return;
+    }
+
+    if (tcgetattr(STDIN_FILENO, &orig_) != 0)
+    {
+        return;
+    }
+
+    termios raw = orig_;
+    cfmakeraw(&raw);
+    tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw);
+
+    RealTermIO io;
+    io.write("\x1b[?1049h\x1b[?2004h\x1b[?25l");
+    io.flush();
+    active_ = true;
+}
+
+TerminalSession::~TerminalSession()
+{
+    if (!active_)
+    {
+        return;
+    }
+
+    tcsetattr(STDIN_FILENO, TCSAFLUSH, &orig_);
+
+    RealTermIO io;
+    io.write("\x1b[?1049l\x1b[?2004l\x1b[?25h");
+    io.flush();
+}
+#else
+TerminalSession::TerminalSession() = default;
+TerminalSession::~TerminalSession() = default;
+#endif
+} // namespace viper::tui::term

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -9,3 +9,7 @@ add_test(NAME tui_test_smoke COMMAND tui_test_smoke)
 add_executable(tui_test_term_io test_term_io.cpp)
 target_link_libraries(tui_test_term_io PRIVATE tui)
 add_test(NAME tui_test_term_io COMMAND tui_test_term_io)
+
+add_executable(tui_test_session test_session.cpp)
+target_link_libraries(tui_test_session PRIVATE tui)
+add_test(NAME tui_test_session COMMAND tui_test_session)

--- a/tui/tests/test_session.cpp
+++ b/tui/tests/test_session.cpp
@@ -1,0 +1,35 @@
+// tui/tests/test_session.cpp
+// @brief Tests TerminalSession lifecycle with no-op path.
+// @invariant Setting VIPERTUI_NO_TTY makes TerminalSession no-op.
+// @ownership No ownership transferred.
+
+#include "tui/term/session.hpp"
+#include "tui/term/term_io.hpp"
+
+#include <cassert>
+#include <cstdlib>
+
+using viper::tui::term::StringTermIO;
+using viper::tui::term::TerminalSession;
+using viper::tui::term::TermIO;
+
+static void consume(TermIO &)
+{
+    // No-op placeholder.
+}
+
+int main()
+{
+#if defined(_WIN32)
+    _putenv_s("VIPERTUI_NO_TTY", "1");
+#else
+    setenv("VIPERTUI_NO_TTY", "1", 1);
+#endif
+    {
+        TerminalSession session;
+    }
+    StringTermIO tio;
+    consume(tio);
+    assert(true);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add TerminalSession RAII that saves/restores termios and toggles alt screen, bracketed paste and cursor state
- allow `VIPERTUI_NO_TTY` and non-POSIX builds to skip terminal manipulation
- cover session lifecycle with a no-op test

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c4dd15e8148324818f1c31fe2cea08