### PR TITLE
tui(input): UTF-8 decoder and basic key events with unit tests

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_library(tui STATIC src/version.cpp src/term/term_io.cpp src/term/session.cpp)
+add_library(tui STATIC src/version.cpp src/term/term_io.cpp src/term/session.cpp src/term/input.cpp)
 
 target_include_directories(tui PUBLIC include)
 

--- a/tui/include/tui/term/input.hpp
+++ b/tui/include/tui/term/input.hpp
@@ -1,0 +1,51 @@
+// tui/include/tui/term/input.hpp
+// @brief Decode UTF-8 byte streams into key events.
+// @invariant Maintains UTF-8 state across feeds.
+// @ownership Does not own input buffers; owns internal event queue.
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+namespace viper::tui::term
+{
+struct KeyEvent
+{
+    enum class Code
+    {
+        Enter,
+        Esc,
+        Tab,
+        Backspace,
+        Unknown
+    };
+
+    uint32_t codepoint{0};
+    Code code{Code::Unknown};
+    unsigned mods{0};
+};
+
+/// @brief Incremental UTF-8 decoder producing key events.
+/// @invariant Handles partial sequences across feed() calls.
+/// @ownership Stores decoded events internally.
+class InputDecoder
+{
+  public:
+    /// @brief Feed bytes into decoder.
+    /// @param bytes UTF-8 encoded data.
+    void feed(std::string_view bytes);
+
+    /// @brief Retrieve decoded events.
+    /// @return Collected key events; internal queue is cleared.
+    [[nodiscard]] std::vector<KeyEvent> drain();
+
+  private:
+    void emit(uint32_t cp);
+
+    uint32_t cp_{0};
+    unsigned expected_{0};
+    std::vector<KeyEvent> events_{};
+};
+
+} // namespace viper::tui::term

--- a/tui/src/term/input.cpp
+++ b/tui/src/term/input.cpp
@@ -1,0 +1,100 @@
+// tui/src/term/input.cpp
+// @brief Implements UTF-8 input decoding into key events.
+// @invariant Partial UTF-8 sequences are preserved across feeds.
+// @ownership Owns decoded event queue; no ownership of input bytes.
+
+#include "tui/term/input.hpp"
+
+namespace viper::tui::term
+{
+
+void InputDecoder::emit(uint32_t cp)
+{
+    KeyEvent ev{};
+    switch (cp)
+    {
+        case '\r':
+        case '\n':
+            ev.code = KeyEvent::Code::Enter;
+            break;
+        case '\t':
+            ev.code = KeyEvent::Code::Tab;
+            break;
+        case 0x1b:
+            ev.code = KeyEvent::Code::Esc;
+            break;
+        case 0x7f:
+            ev.code = KeyEvent::Code::Backspace;
+            break;
+        default:
+            if (cp >= 0x20)
+            {
+                ev.codepoint = cp;
+            }
+            else
+            {
+                ev.code = KeyEvent::Code::Unknown;
+            }
+            break;
+    }
+    events_.push_back(ev);
+}
+
+void InputDecoder::feed(std::string_view bytes)
+{
+    for (size_t i = 0; i < bytes.size(); ++i)
+    {
+        unsigned char b = static_cast<unsigned char>(bytes[i]);
+        if (expected_ == 0)
+        {
+            if (b < 0x80)
+            {
+                emit(b);
+            }
+            else if ((b & 0xE0) == 0xC0)
+            {
+                cp_ = b & 0x1F;
+                expected_ = 1;
+            }
+            else if ((b & 0xF0) == 0xE0)
+            {
+                cp_ = b & 0x0F;
+                expected_ = 2;
+            }
+            else if ((b & 0xF8) == 0xF0)
+            {
+                cp_ = b & 0x07;
+                expected_ = 3;
+            }
+            else
+            {
+                events_.push_back(KeyEvent{});
+            }
+        }
+        else if ((b & 0xC0) == 0x80)
+        {
+            cp_ = (cp_ << 6) | (b & 0x3F);
+            if (--expected_ == 0)
+            {
+                emit(cp_);
+                cp_ = 0;
+            }
+        }
+        else
+        {
+            events_.push_back(KeyEvent{});
+            cp_ = 0;
+            expected_ = 0;
+            --i; // reprocess this byte
+        }
+    }
+}
+
+std::vector<KeyEvent> InputDecoder::drain()
+{
+    auto out = std::move(events_);
+    events_.clear();
+    return out;
+}
+
+} // namespace viper::tui::term

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -13,3 +13,7 @@ add_test(NAME tui_test_term_io COMMAND tui_test_term_io)
 add_executable(tui_test_session test_session.cpp)
 target_link_libraries(tui_test_session PRIVATE tui)
 add_test(NAME tui_test_session COMMAND tui_test_session)
+
+add_executable(tui_test_input_utf8 test_input_utf8.cpp)
+target_link_libraries(tui_test_input_utf8 PRIVATE tui)
+add_test(NAME tui_test_input_utf8 COMMAND tui_test_input_utf8)


### PR DESCRIPTION
## Summary
- add `KeyEvent` struct and `InputDecoder` to translate UTF-8 byte streams into key events
- handle Enter/Esc/Tab/Backspace and emit codepoints for printable characters
- exercise decoder with ASCII, multibyte, partial sequences, and special keys

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c4dfe9355483249979454bf5175408