### PR TITLE
tui(input): add CSI/SS3 navigation key parsing with modifiers

### DIFF
--- a/tui/include/tui/term/input.hpp
+++ b/tui/include/tui/term/input.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -18,7 +19,36 @@ struct KeyEvent
         Esc,
         Tab,
         Backspace,
+        Up,
+        Down,
+        Left,
+        Right,
+        Home,
+        End,
+        PageUp,
+        PageDown,
+        Insert,
+        Delete,
+        F1,
+        F2,
+        F3,
+        F4,
+        F5,
+        F6,
+        F7,
+        F8,
+        F9,
+        F10,
+        F11,
+        F12,
         Unknown
+    };
+
+    enum Mods : unsigned
+    {
+        Shift = 1,
+        Alt = 2,
+        Ctrl = 4
     };
 
     uint32_t codepoint{0};
@@ -42,7 +72,20 @@ class InputDecoder
 
   private:
     void emit(uint32_t cp);
+    void handle_csi(char final, std::string_view params);
+    void handle_ss3(char final, std::string_view params);
+    static unsigned decode_mod(int value);
 
+    enum class State
+    {
+        Utf8,
+        Esc,
+        CSI,
+        SS3
+    };
+
+    State state_{State::Utf8};
+    std::string seq_{};
     uint32_t cp_{0};
     unsigned expected_{0};
     std::vector<KeyEvent> events_{};

--- a/tui/src/term/input.cpp
+++ b/tui/src/term/input.cpp
@@ -5,6 +5,8 @@
 
 #include "tui/term/input.hpp"
 
+#include <string_view>
+
 namespace viper::tui::term
 {
 
@@ -40,52 +42,299 @@ void InputDecoder::emit(uint32_t cp)
     events_.push_back(ev);
 }
 
+static std::vector<int> parse_params(std::string_view params)
+{
+    std::vector<int> out;
+    int val = 0;
+    bool have = false;
+    for (char c : params)
+    {
+        if (c >= '0' && c <= '9')
+        {
+            val = val * 10 + (c - '0');
+            have = true;
+        }
+        else if (c == ';')
+        {
+            out.push_back(have ? val : 0);
+            val = 0;
+            have = false;
+        }
+    }
+    if (have)
+    {
+        out.push_back(val);
+    }
+    return out;
+}
+
+unsigned InputDecoder::decode_mod(int value)
+{
+    if (value < 2)
+    {
+        return 0;
+    }
+    return static_cast<unsigned>(value - 1);
+}
+
+void InputDecoder::handle_csi(char final, std::string_view params)
+{
+    auto nums = parse_params(params);
+    unsigned mods = 0;
+    if (final == '~')
+    {
+        if (nums.size() >= 2)
+        {
+            mods = decode_mod(nums[1]);
+        }
+        if (nums.empty())
+        {
+            return;
+        }
+        KeyEvent ev{};
+        ev.mods = mods;
+        switch (nums[0])
+        {
+            case 1:
+                ev.code = KeyEvent::Code::Home;
+                break;
+            case 2:
+                ev.code = KeyEvent::Code::Insert;
+                break;
+            case 3:
+                ev.code = KeyEvent::Code::Delete;
+                break;
+            case 4:
+                ev.code = KeyEvent::Code::End;
+                break;
+            case 5:
+                ev.code = KeyEvent::Code::PageUp;
+                break;
+            case 6:
+                ev.code = KeyEvent::Code::PageDown;
+                break;
+            case 11:
+                ev.code = KeyEvent::Code::F1;
+                break;
+            case 12:
+                ev.code = KeyEvent::Code::F2;
+                break;
+            case 13:
+                ev.code = KeyEvent::Code::F3;
+                break;
+            case 14:
+                ev.code = KeyEvent::Code::F4;
+                break;
+            case 15:
+                ev.code = KeyEvent::Code::F5;
+                break;
+            case 17:
+                ev.code = KeyEvent::Code::F6;
+                break;
+            case 18:
+                ev.code = KeyEvent::Code::F7;
+                break;
+            case 19:
+                ev.code = KeyEvent::Code::F8;
+                break;
+            case 20:
+                ev.code = KeyEvent::Code::F9;
+                break;
+            case 21:
+                ev.code = KeyEvent::Code::F10;
+                break;
+            case 23:
+                ev.code = KeyEvent::Code::F11;
+                break;
+            case 24:
+                ev.code = KeyEvent::Code::F12;
+                break;
+            default:
+                return;
+        }
+        events_.push_back(ev);
+        return;
+    }
+
+    if (nums.size() >= 2)
+    {
+        mods = decode_mod(nums[1]);
+    }
+
+    KeyEvent ev{};
+    ev.mods = mods;
+    switch (final)
+    {
+        case 'A':
+            ev.code = KeyEvent::Code::Up;
+            break;
+        case 'B':
+            ev.code = KeyEvent::Code::Down;
+            break;
+        case 'C':
+            ev.code = KeyEvent::Code::Right;
+            break;
+        case 'D':
+            ev.code = KeyEvent::Code::Left;
+            break;
+        case 'H':
+            ev.code = KeyEvent::Code::Home;
+            break;
+        case 'F':
+            ev.code = KeyEvent::Code::End;
+            break;
+        default:
+            return;
+    }
+    events_.push_back(ev);
+}
+
+void InputDecoder::handle_ss3(char final, std::string_view params)
+{
+    auto nums = parse_params(params);
+    unsigned mods = 0;
+    if (nums.size() >= 2)
+    {
+        mods = decode_mod(nums[1]);
+    }
+
+    KeyEvent ev{};
+    ev.mods = mods;
+    switch (final)
+    {
+        case 'A':
+            ev.code = KeyEvent::Code::Up;
+            break;
+        case 'B':
+            ev.code = KeyEvent::Code::Down;
+            break;
+        case 'C':
+            ev.code = KeyEvent::Code::Right;
+            break;
+        case 'D':
+            ev.code = KeyEvent::Code::Left;
+            break;
+        case 'H':
+            ev.code = KeyEvent::Code::Home;
+            break;
+        case 'F':
+            ev.code = KeyEvent::Code::End;
+            break;
+        case 'P':
+            ev.code = KeyEvent::Code::F1;
+            break;
+        case 'Q':
+            ev.code = KeyEvent::Code::F2;
+            break;
+        case 'R':
+            ev.code = KeyEvent::Code::F3;
+            break;
+        case 'S':
+            ev.code = KeyEvent::Code::F4;
+            break;
+        default:
+            return;
+    }
+    events_.push_back(ev);
+}
+
 void InputDecoder::feed(std::string_view bytes)
 {
     for (size_t i = 0; i < bytes.size(); ++i)
     {
         unsigned char b = static_cast<unsigned char>(bytes[i]);
-        if (expected_ == 0)
+        switch (state_)
         {
-            if (b < 0x80)
-            {
-                emit(b);
-            }
-            else if ((b & 0xE0) == 0xC0)
-            {
-                cp_ = b & 0x1F;
-                expected_ = 1;
-            }
-            else if ((b & 0xF0) == 0xE0)
-            {
-                cp_ = b & 0x0F;
-                expected_ = 2;
-            }
-            else if ((b & 0xF8) == 0xF0)
-            {
-                cp_ = b & 0x07;
-                expected_ = 3;
-            }
-            else
-            {
-                events_.push_back(KeyEvent{});
-            }
-        }
-        else if ((b & 0xC0) == 0x80)
-        {
-            cp_ = (cp_ << 6) | (b & 0x3F);
-            if (--expected_ == 0)
-            {
-                emit(cp_);
-                cp_ = 0;
-            }
-        }
-        else
-        {
-            events_.push_back(KeyEvent{});
-            cp_ = 0;
-            expected_ = 0;
-            --i; // reprocess this byte
+            case State::Utf8:
+                if (expected_ == 0)
+                {
+                    if (b == 0x1b)
+                    {
+                        state_ = State::Esc;
+                    }
+                    else if (b < 0x80)
+                    {
+                        emit(b);
+                    }
+                    else if ((b & 0xE0) == 0xC0)
+                    {
+                        cp_ = b & 0x1F;
+                        expected_ = 1;
+                    }
+                    else if ((b & 0xF0) == 0xE0)
+                    {
+                        cp_ = b & 0x0F;
+                        expected_ = 2;
+                    }
+                    else if ((b & 0xF8) == 0xF0)
+                    {
+                        cp_ = b & 0x07;
+                        expected_ = 3;
+                    }
+                    else
+                    {
+                        events_.push_back(KeyEvent{});
+                    }
+                }
+                else if ((b & 0xC0) == 0x80)
+                {
+                    cp_ = (cp_ << 6) | (b & 0x3F);
+                    if (--expected_ == 0)
+                    {
+                        emit(cp_);
+                        cp_ = 0;
+                    }
+                }
+                else
+                {
+                    events_.push_back(KeyEvent{});
+                    cp_ = 0;
+                    expected_ = 0;
+                    --i;
+                }
+                break;
+            case State::Esc:
+                if (b == '[')
+                {
+                    state_ = State::CSI;
+                    seq_.clear();
+                }
+                else if (b == 'O')
+                {
+                    state_ = State::SS3;
+                    seq_.clear();
+                }
+                else
+                {
+                    emit(0x1b);
+                    state_ = State::Utf8;
+                    --i;
+                }
+                break;
+            case State::CSI:
+                if (b >= 0x40 && b <= 0x7E)
+                {
+                    handle_csi(static_cast<char>(b), seq_);
+                    state_ = State::Utf8;
+                    seq_.clear();
+                }
+                else
+                {
+                    seq_.push_back(static_cast<char>(b));
+                }
+                break;
+            case State::SS3:
+                if (b >= 0x40 && b <= 0x7E)
+                {
+                    handle_ss3(static_cast<char>(b), seq_);
+                    state_ = State::Utf8;
+                    seq_.clear();
+                }
+                else
+                {
+                    seq_.push_back(static_cast<char>(b));
+                }
+                break;
         }
     }
 }

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -17,3 +17,7 @@ add_test(NAME tui_test_session COMMAND tui_test_session)
 add_executable(tui_test_input_utf8 test_input_utf8.cpp)
 target_link_libraries(tui_test_input_utf8 PRIVATE tui)
 add_test(NAME tui_test_input_utf8 COMMAND tui_test_input_utf8)
+
+add_executable(tui_test_input_csi test_input_csi.cpp)
+target_link_libraries(tui_test_input_csi PRIVATE tui)
+add_test(NAME tui_test_input_csi COMMAND tui_test_input_csi)

--- a/tui/tests/test_input_csi.cpp
+++ b/tui/tests/test_input_csi.cpp
@@ -1,0 +1,51 @@
+// tui/tests/test_input_csi.cpp
+// @brief Tests decoding of CSI/SS3 sequences for navigation and function keys.
+// @invariant Decoder handles escape sequences and modifiers across feeds.
+// @ownership InputDecoder owns its event queue only.
+
+#include "tui/term/input.hpp"
+
+#include <cassert>
+
+using viper::tui::term::InputDecoder;
+using viper::tui::term::KeyEvent;
+
+int main()
+{
+    InputDecoder d;
+
+    d.feed("\x1b[A");
+    auto ev = d.drain();
+    assert(ev.size() == 1);
+    assert(ev[0].code == KeyEvent::Code::Up);
+    assert(ev[0].mods == 0);
+
+    d.feed("\x1b[1;5C");
+    ev = d.drain();
+    assert(ev.size() == 1);
+    assert(ev[0].code == KeyEvent::Code::Right);
+    assert(ev[0].mods == KeyEvent::Ctrl);
+
+    d.feed("\x1b[3~");
+    ev = d.drain();
+    assert(ev.size() == 1);
+    assert(ev[0].code == KeyEvent::Code::Delete);
+
+    d.feed("\x1bOP");
+    ev = d.drain();
+    assert(ev.size() == 1);
+    assert(ev[0].code == KeyEvent::Code::F1);
+
+    d.feed("\x1b[15~");
+    ev = d.drain();
+    assert(ev.size() == 1);
+    assert(ev[0].code == KeyEvent::Code::F5);
+
+    d.feed("\x1b[1;2H");
+    ev = d.drain();
+    assert(ev.size() == 1);
+    assert(ev[0].code == KeyEvent::Code::Home);
+    assert(ev[0].mods == KeyEvent::Shift);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extend InputDecoder with navigation and function key codes and modifier mask
- parse xterm-style CSI/SS3 sequences for arrows, navigation keys, and F1-F12
- add tests for CSI/SS3 decoding with modifiers

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c4e8a43c14832493e6aa792afb3208