### PR TITLE
tui(render): add ScreenBuffer with diff spans and tests

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -6,7 +6,13 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_library(tui STATIC src/version.cpp src/term/term_io.cpp src/term/session.cpp src/term/input.cpp)
+add_library(tui STATIC
+  src/version.cpp
+  src/term/term_io.cpp
+  src/term/session.cpp
+  src/term/input.cpp
+  src/render/screen.cpp
+)
 
 target_include_directories(tui PUBLIC include)
 

--- a/tui/include/tui/render/screen.hpp
+++ b/tui/include/tui/render/screen.hpp
@@ -1,0 +1,118 @@
+// tui/include/tui/render/screen.hpp
+// @brief Offscreen screen buffer composed of styled cells.
+// @invariant Cells are stored in row-major order.
+// @ownership ScreenBuffer owns its cell storage.
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace viper::tui::render
+{
+struct RGBA
+{
+    uint8_t r{0};
+    uint8_t g{0};
+    uint8_t b{0};
+    uint8_t a{255};
+};
+
+inline bool operator==(const RGBA &a, const RGBA &b)
+{
+    return a.r == b.r && a.g == b.g && a.b == b.b && a.a == b.a;
+}
+
+inline bool operator!=(const RGBA &a, const RGBA &b)
+{
+    return !(a == b);
+}
+
+/// @brief Attribute flags for styled cells.
+enum Attr : uint16_t
+{
+    AttrNone = 0,
+    Bold = 1 << 0,
+    Faint = 1 << 1,
+    Italic = 1 << 2,
+    Underline = 1 << 3,
+    Blink = 1 << 4,
+    Reverse = 1 << 5,
+    Invisible = 1 << 6,
+    Strike = 1 << 7
+};
+
+/// @brief Visual style for a cell.
+struct Style
+{
+    RGBA fg{};
+    RGBA bg{};
+    uint16_t attrs{0};
+};
+
+inline bool operator==(const Style &a, const Style &b)
+{
+    return a.fg == b.fg && a.bg == b.bg && a.attrs == b.attrs;
+}
+
+inline bool operator!=(const Style &a, const Style &b)
+{
+    return !(a == b);
+}
+
+/// @brief Single character cell with style and width.
+struct Cell
+{
+    char32_t ch{U' '};
+    Style style{};
+    uint8_t width{1};
+};
+
+inline bool operator==(const Cell &a, const Cell &b)
+{
+    return a.ch == b.ch && a.width == b.width && a.style == b.style;
+}
+
+inline bool operator!=(const Cell &a, const Cell &b)
+{
+    return !(a == b);
+}
+
+/// @brief 2D grid of styled cells with diff computation.
+class ScreenBuffer
+{
+  public:
+    /// @brief Span of changed cells within a row.
+    struct DiffSpan
+    {
+        int row{0};
+        int x0{0};
+        int x1{0};
+    };
+
+    /// @brief Resize buffer to given rows and columns.
+    void resize(int rows, int cols);
+
+    /// @brief Access cell at position (y, x).
+    [[nodiscard]] Cell &at(int y, int x);
+
+    /// @brief Const access to cell at position (y, x).
+    [[nodiscard]] const Cell &at(int y, int x) const;
+
+    /// @brief Fill all cells with spaces using the given style.
+    void clear(const Style &style);
+
+    /// @brief Snapshot current buffer into previous state for diffing.
+    void snapshotPrev();
+
+    /// @brief Compute differences against previous snapshot.
+    /// @param outSpans Output vector receiving change spans per row.
+    void computeDiff(std::vector<DiffSpan> &outSpans) const;
+
+  private:
+    int rows_{0};
+    int cols_{0};
+    std::vector<Cell> cells_{};
+    std::vector<Cell> prev_{};
+};
+
+} // namespace viper::tui::render

--- a/tui/src/render/screen.cpp
+++ b/tui/src/render/screen.cpp
@@ -1,0 +1,88 @@
+// tui/src/render/screen.cpp
+// @brief Implementation of ScreenBuffer diffing utilities.
+// @invariant prev_ snapshot matches cell dimensions when diffing.
+// @ownership ScreenBuffer owns current and previous cell buffers.
+
+#include "tui/render/screen.hpp"
+
+#include <algorithm>
+
+namespace viper::tui::render
+{
+
+void ScreenBuffer::resize(int rows, int cols)
+{
+    rows_ = rows;
+    cols_ = cols;
+    cells_.resize(static_cast<size_t>(rows) * static_cast<size_t>(cols));
+    prev_.resize(cells_.size());
+}
+
+Cell &ScreenBuffer::at(int y, int x)
+{
+    return cells_[static_cast<size_t>(y) * static_cast<size_t>(cols_) + static_cast<size_t>(x)];
+}
+
+const Cell &ScreenBuffer::at(int y, int x) const
+{
+    return cells_[static_cast<size_t>(y) * static_cast<size_t>(cols_) + static_cast<size_t>(x)];
+}
+
+void ScreenBuffer::clear(const Style &style)
+{
+    Cell blank{};
+    blank.ch = U' ';
+    blank.style = style;
+    blank.width = 1;
+    std::fill(cells_.begin(), cells_.end(), blank);
+}
+
+void ScreenBuffer::snapshotPrev()
+{
+    if (prev_.size() != cells_.size())
+    {
+        prev_.resize(cells_.size());
+    }
+    std::copy(cells_.begin(), cells_.end(), prev_.begin());
+}
+
+void ScreenBuffer::computeDiff(std::vector<DiffSpan> &outSpans) const
+{
+    outSpans.clear();
+    if (prev_.size() != cells_.size())
+    {
+        for (int y = 0; y < rows_; ++y)
+        {
+            if (cols_ > 0)
+            {
+                outSpans.push_back(DiffSpan{y, 0, cols_});
+            }
+        }
+        return;
+    }
+
+    for (int y = 0; y < rows_; ++y)
+    {
+        int row_start = y * cols_;
+        int x = 0;
+        while (x < cols_)
+        {
+            if (cells_[row_start + x] != prev_[row_start + x])
+            {
+                int x0 = x;
+                ++x;
+                while (x < cols_ && cells_[row_start + x] != prev_[row_start + x])
+                {
+                    ++x;
+                }
+                outSpans.push_back(DiffSpan{y, x0, x});
+            }
+            else
+            {
+                ++x;
+            }
+        }
+    }
+}
+
+} // namespace viper::tui::render

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -21,3 +21,7 @@ add_test(NAME tui_test_input_utf8 COMMAND tui_test_input_utf8)
 add_executable(tui_test_input_csi test_input_csi.cpp)
 target_link_libraries(tui_test_input_csi PRIVATE tui)
 add_test(NAME tui_test_input_csi COMMAND tui_test_input_csi)
+
+add_executable(tui_test_screen_diff test_screen_diff.cpp)
+target_link_libraries(tui_test_screen_diff PRIVATE tui)
+add_test(NAME tui_test_screen_diff COMMAND tui_test_screen_diff)

--- a/tui/tests/test_screen_diff.cpp
+++ b/tui/tests/test_screen_diff.cpp
@@ -1,0 +1,52 @@
+// tui/tests/test_screen_diff.cpp
+// @brief Tests diff computation for ScreenBuffer.
+// @invariant computeDiff returns minimal spans of changed cells.
+// @ownership ScreenBuffer owns all buffers; tests take no ownership.
+
+#include "tui/render/screen.hpp"
+
+#include <cassert>
+#include <vector>
+
+using viper::tui::render::ScreenBuffer;
+using viper::tui::render::Style;
+
+int main()
+{
+    ScreenBuffer sb;
+    sb.resize(2, 5);
+    Style style{};
+    sb.clear(style);
+    sb.snapshotPrev();
+
+    const char *line0 = "hello";
+    const char *line1 = "world";
+    for (int i = 0; i < 5; ++i)
+    {
+        sb.at(0, i).ch = static_cast<char32_t>(line0[i]);
+        sb.at(1, i).ch = static_cast<char32_t>(line1[i]);
+    }
+
+    std::vector<ScreenBuffer::DiffSpan> spans;
+    sb.computeDiff(spans);
+    assert(spans.size() == 2);
+    assert(spans[0].row == 0 && spans[0].x0 == 0 && spans[0].x1 == 5);
+    assert(spans[1].row == 1 && spans[1].x0 == 0 && spans[1].x1 == 5);
+
+    sb.snapshotPrev();
+    spans.clear();
+    sb.computeDiff(spans);
+    assert(spans.empty());
+
+    sb.at(0, 1).ch = U'a';
+    sb.at(1, 0).ch = U'W';
+    sb.at(1, 3).ch = U'L';
+
+    sb.computeDiff(spans);
+    assert(spans.size() == 3);
+    assert(spans[0].row == 0 && spans[0].x0 == 1 && spans[0].x1 == 2);
+    assert(spans[1].row == 1 && spans[1].x0 == 0 && spans[1].x1 == 1);
+    assert(spans[2].row == 1 && spans[2].x0 == 3 && spans[2].x1 == 4);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add RGBA, Style, and Cell types for styled screen cells
- implement ScreenBuffer with per-row diff spans
- verify minimal diff computation in new unit test

## Testing
- `cmake -S . -B build && cmake --build build -j`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68c4fdcf2d908324a7dc368211ce73da