### PR TITLE
Add ANSI renderer with minimal flushes

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(tui STATIC
   src/term/session.cpp
   src/term/input.cpp
   src/render/screen.cpp
+  src/render/renderer.cpp
 )
 
 target_include_directories(tui PUBLIC include)

--- a/tui/include/tui/render/renderer.hpp
+++ b/tui/include/tui/render/renderer.hpp
@@ -1,0 +1,36 @@
+// tui/include/tui/render/renderer.hpp
+// @brief Renderer translating ScreenBuffer diffs into ANSI sequences.
+// @invariant Maintains current style to avoid redundant SGR codes.
+// @ownership Renderer holds a reference to external TermIO.
+#pragma once
+
+#include "tui/render/screen.hpp"
+#include "tui/term/term_io.hpp"
+
+namespace viper::tui::render
+{
+class Renderer
+{
+  public:
+    /// @brief Construct renderer writing to a TermIO.
+    /// @param io Terminal I/O target.
+    /// @param truecolor Enable 24-bit color SGR if true, else 256-color fallback.
+    explicit Renderer(::tui::term::TermIO &io, bool truecolor = false);
+
+    /// @brief Draw changes from the given screen buffer.
+    void draw(const ScreenBuffer &sb);
+
+    /// @brief Set terminal style.
+    void setStyle(Style style);
+
+    /// @brief Move cursor to position (y, x).
+    void moveCursor(int y, int x);
+
+  private:
+    ::tui::term::TermIO &io_;
+    bool truecolor_{false};
+    Style curr_{};
+    bool haveCurr_{false};
+};
+
+} // namespace viper::tui::render

--- a/tui/src/render/renderer.cpp
+++ b/tui/src/render/renderer.cpp
@@ -1,0 +1,147 @@
+// tui/src/render/renderer.cpp
+// @brief Implementation of ANSI renderer emitting minimal diff sequences.
+// @invariant Avoids redundant SGR by tracking current style.
+// @ownership Renderer holds a reference to external TermIO and borrows ScreenBuffer.
+
+#include "tui/render/renderer.hpp"
+
+#include <string>
+#include <vector>
+
+using ::tui::term::TermIO;
+
+namespace viper::tui::render
+{
+namespace
+{
+std::string encodeUTF8(char32_t cp)
+{
+    std::string out;
+    if (cp <= 0x7F)
+    {
+        out.push_back(static_cast<char>(cp));
+    }
+    else if (cp <= 0x7FF)
+    {
+        out.push_back(static_cast<char>(0xC0 | ((cp >> 6) & 0x1F)));
+        out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    }
+    else if (cp <= 0xFFFF)
+    {
+        out.push_back(static_cast<char>(0xE0 | ((cp >> 12) & 0x0F)));
+        out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+        out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    }
+    else
+    {
+        out.push_back(static_cast<char>(0xF0 | ((cp >> 18) & 0x07)));
+        out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+        out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+        out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    }
+    return out;
+}
+
+int rgbTo256(const RGBA &c)
+{
+    auto map = [](uint8_t v) { return static_cast<int>(v / 51); };
+    return 16 + 36 * map(c.r) + 6 * map(c.g) + map(c.b);
+}
+} // namespace
+
+Renderer::Renderer(TermIO &io, bool truecolor) : io_(io), truecolor_(truecolor) {}
+
+void Renderer::moveCursor(int y, int x)
+{
+    std::string seq = "\x1b[";
+    seq += std::to_string(y + 1);
+    seq.push_back(';');
+    seq += std::to_string(x + 1);
+    seq.push_back('H');
+    io_.write(seq);
+}
+
+void Renderer::setStyle(Style style)
+{
+    if (haveCurr_ && style == curr_)
+    {
+        return;
+    }
+
+    std::string seq = "\x1b[";
+    bool first = true;
+    auto append = [&](int n)
+    {
+        if (!first)
+        {
+            seq.push_back(';');
+        }
+        seq += std::to_string(n);
+        first = false;
+    };
+
+    if (style.attrs & Bold)
+        append(1);
+    if (style.attrs & Faint)
+        append(2);
+    if (style.attrs & Italic)
+        append(3);
+    if (style.attrs & Underline)
+        append(4);
+    if (style.attrs & Blink)
+        append(5);
+    if (style.attrs & Reverse)
+        append(7);
+    if (style.attrs & Invisible)
+        append(8);
+    if (style.attrs & Strike)
+        append(9);
+
+    auto addColor = [&](bool fg, const RGBA &c)
+    {
+        append(fg ? 38 : 48);
+        if (truecolor_)
+        {
+            append(2);
+            append(c.r);
+            append(c.g);
+            append(c.b);
+        }
+        else
+        {
+            append(5);
+            append(rgbTo256(c));
+        }
+    };
+
+    addColor(true, style.fg);
+    addColor(false, style.bg);
+
+    if (first)
+    {
+        seq += '0';
+    }
+    seq.push_back('m');
+    io_.write(seq);
+    curr_ = style;
+    haveCurr_ = true;
+}
+
+void Renderer::draw(const ScreenBuffer &sb)
+{
+    std::vector<ScreenBuffer::DiffSpan> spans;
+    sb.computeDiff(spans);
+    for (const auto &span : spans)
+    {
+        moveCursor(span.row, span.x0);
+        for (int x = span.x0; x < span.x1; ++x)
+        {
+            const Cell &cell = sb.at(span.row, x);
+            setStyle(cell.style);
+            io_.write(encodeUTF8(cell.ch));
+        }
+    }
+    io_.flush();
+}
+
+} // namespace viper::tui::render

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -25,3 +25,7 @@ add_test(NAME tui_test_input_csi COMMAND tui_test_input_csi)
 add_executable(tui_test_screen_diff test_screen_diff.cpp)
 target_link_libraries(tui_test_screen_diff PRIVATE tui)
 add_test(NAME tui_test_screen_diff COMMAND tui_test_screen_diff)
+
+add_executable(tui_test_renderer_minimal test_renderer_minimal.cpp)
+target_link_libraries(tui_test_renderer_minimal PRIVATE tui)
+add_test(NAME tui_test_renderer_minimal COMMAND tui_test_renderer_minimal)

--- a/tui/tests/test_renderer_minimal.cpp
+++ b/tui/tests/test_renderer_minimal.cpp
@@ -1,0 +1,63 @@
+// tui/tests/test_renderer_minimal.cpp
+// @brief Ensure renderer emits minimal SGR sequences on diff draws.
+// @invariant Unchanged regions produce no ANSI output.
+// @ownership StringTermIO owns its internal buffer for verification.
+
+#include "tui/render/renderer.hpp"
+#include "tui/render/screen.hpp"
+#include "tui/term/term_io.hpp"
+
+#include <cassert>
+#include <string>
+
+using tui::term::StringTermIO;
+using viper::tui::render::Renderer;
+using viper::tui::render::ScreenBuffer;
+using viper::tui::render::Style;
+
+static int countSGR(const std::string &s)
+{
+    int c = 0;
+    for (char ch : s)
+    {
+        if (ch == 'm')
+        {
+            ++c;
+        }
+    }
+    return c;
+}
+
+int main()
+{
+    ScreenBuffer sb;
+    sb.resize(2, 3);
+    Style style{};
+    sb.clear(style);
+    sb.snapshotPrev();
+
+    const char *row0 = "abc";
+    const char *row1 = "xyz";
+    for (int i = 0; i < 3; ++i)
+    {
+        sb.at(0, i).ch = static_cast<char32_t>(row0[i]);
+        sb.at(1, i).ch = static_cast<char32_t>(row1[i]);
+    }
+
+    StringTermIO tio;
+    Renderer renderer(tio, true);
+
+    renderer.draw(sb);
+    int first = countSGR(tio.buffer());
+    assert(first > 0);
+    tio.clear();
+    sb.snapshotPrev();
+
+    sb.at(0, 1).ch = U'Z';
+
+    renderer.draw(sb);
+    int second = countSGR(tio.buffer());
+    assert(second < first);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement renderer that writes ScreenBuffer diffs as ANSI sequences
- support truecolor and 256-color mapping
- test that subsequent draws avoid redundant SGR sequences

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c4ffdc33d88324a3554ded4ece060c