### PR TITLE
Add ANSI renderer with minimal flushes

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(tui STATIC
   src/term/session.cpp
   src/term/input.cpp
   src/render/screen.cpp
+  src/render/renderer.cpp
 )
 
 target_include_directories(tui PUBLIC include)

--- a/tui/include/tui/render/renderer.hpp
+++ b/tui/include/tui/render/renderer.hpp
@@ -1,0 +1,43 @@
+// tui/include/tui/render/renderer.hpp
+// @brief ANSI renderer emitting minimal sequences to a TermIO.
+// @invariant Maintains cursor position and current style to avoid redundant sequences.
+// @ownership Renderer borrows the TermIO reference; caller retains ownership.
+#pragma once
+
+#include "tui/render/screen.hpp"
+#include "tui/term/term_io.hpp"
+
+namespace viper::tui::render
+{
+
+/// @brief Writes ScreenBuffer diffs as ANSI sequences to a terminal.
+class Renderer
+{
+  public:
+    /// @brief Construct renderer targeting a TermIO.
+    /// @param tio Terminal I/O sink used for writes and flushes.
+    /// @param truecolor Emit 24-bit color codes when true; otherwise 256-color.
+    explicit Renderer(::tui::term::TermIO &tio, bool truecolor = false);
+
+    /// @brief Draw changed spans from screen buffer to terminal.
+    /// @param sb Screen buffer with current and previous state for diffing.
+    void draw(const ScreenBuffer &sb);
+
+    /// @brief Update terminal style if different from current style.
+    /// @param style Desired style to apply.
+    void setStyle(Style style);
+
+    /// @brief Move cursor to given coordinates if not already there.
+    /// @param y Row index starting at 0.
+    /// @param x Column index starting at 0.
+    void moveCursor(int y, int x);
+
+  private:
+    ::tui::term::TermIO &tio_;
+    Style currentStyle_{};
+    int cursorY_{-1};
+    int cursorX_{-1};
+    bool truecolor_{false};
+};
+
+} // namespace viper::tui::render

--- a/tui/src/render/renderer.cpp
+++ b/tui/src/render/renderer.cpp
@@ -1,0 +1,129 @@
+// tui/src/render/renderer.cpp
+// @brief Implementation of ANSI renderer producing minimal terminal updates.
+// @invariant setStyle and moveCursor avoid redundant sequences based on cached state.
+// @ownership Renderer writes through a borrowed TermIO reference.
+
+#include "tui/render/renderer.hpp"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace viper::tui::render
+{
+
+Renderer::Renderer(::tui::term::TermIO &tio, bool truecolor) : tio_(tio), truecolor_(truecolor) {}
+
+namespace
+{
+int toCube(uint8_t c)
+{
+    return c / 51; // map 0-255 to 0-5
+}
+} // namespace
+
+void Renderer::setStyle(Style style)
+{
+    if (style == currentStyle_)
+    {
+        return;
+    }
+
+    std::string seq = "\x1b[0";
+    if (style.attrs & Bold)
+        seq += ";1";
+    if (style.attrs & Faint)
+        seq += ";2";
+    if (style.attrs & Italic)
+        seq += ";3";
+    if (style.attrs & Underline)
+        seq += ";4";
+    if (style.attrs & Blink)
+        seq += ";5";
+    if (style.attrs & Reverse)
+        seq += ";7";
+    if (style.attrs & Invisible)
+        seq += ";8";
+    if (style.attrs & Strike)
+        seq += ";9";
+
+    if (truecolor_)
+    {
+        seq += ";38;2;" + std::to_string(style.fg.r) + ";" + std::to_string(style.fg.g) + ";" +
+               std::to_string(style.fg.b);
+        seq += ";48;2;" + std::to_string(style.bg.r) + ";" + std::to_string(style.bg.g) + ";" +
+               std::to_string(style.bg.b);
+    }
+    else
+    {
+        int idx_fg = 16 + 36 * toCube(style.fg.r) + 6 * toCube(style.fg.g) + toCube(style.fg.b);
+        int idx_bg = 16 + 36 * toCube(style.bg.r) + 6 * toCube(style.bg.g) + toCube(style.bg.b);
+        seq += ";38;5;" + std::to_string(idx_fg);
+        seq += ";48;5;" + std::to_string(idx_bg);
+    }
+
+    seq += 'm';
+    tio_.write(seq);
+    currentStyle_ = style;
+}
+
+void Renderer::moveCursor(int y, int x)
+{
+    if (y == cursorY_ && x == cursorX_)
+    {
+        return;
+    }
+    std::string seq = "\x1b[" + std::to_string(y + 1) + ";" + std::to_string(x + 1) + 'H';
+    tio_.write(seq);
+    cursorY_ = y;
+    cursorX_ = x;
+}
+
+void Renderer::draw(const ScreenBuffer &sb)
+{
+    std::vector<ScreenBuffer::DiffSpan> spans;
+    sb.computeDiff(spans);
+    for (const auto &span : spans)
+    {
+        moveCursor(span.row, span.x0);
+        for (int x = span.x0; x < span.x1; ++x)
+        {
+            const Cell &cell = sb.at(span.row, x);
+            setStyle(cell.style);
+            char32_t ch = cell.ch;
+            char buf[5];
+            int len = 0;
+            if (ch <= 0x7F)
+            {
+                buf[0] = static_cast<char>(ch);
+                len = 1;
+            }
+            else if (ch <= 0x7FF)
+            {
+                buf[0] = static_cast<char>(0xC0 | ((ch >> 6) & 0x1F));
+                buf[1] = static_cast<char>(0x80 | (ch & 0x3F));
+                len = 2;
+            }
+            else if (ch <= 0xFFFF)
+            {
+                buf[0] = static_cast<char>(0xE0 | ((ch >> 12) & 0x0F));
+                buf[1] = static_cast<char>(0x80 | ((ch >> 6) & 0x3F));
+                buf[2] = static_cast<char>(0x80 | (ch & 0x3F));
+                len = 3;
+            }
+            else
+            {
+                buf[0] = static_cast<char>(0xF0 | ((ch >> 18) & 0x07));
+                buf[1] = static_cast<char>(0x80 | ((ch >> 12) & 0x3F));
+                buf[2] = static_cast<char>(0x80 | ((ch >> 6) & 0x3F));
+                buf[3] = static_cast<char>(0x80 | (ch & 0x3F));
+                len = 4;
+            }
+            tio_.write(std::string_view(buf, static_cast<size_t>(len)));
+            cursorX_ += cell.width;
+        }
+    }
+    tio_.flush();
+}
+
+} // namespace viper::tui::render

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -25,3 +25,7 @@ add_test(NAME tui_test_input_csi COMMAND tui_test_input_csi)
 add_executable(tui_test_screen_diff test_screen_diff.cpp)
 target_link_libraries(tui_test_screen_diff PRIVATE tui)
 add_test(NAME tui_test_screen_diff COMMAND tui_test_screen_diff)
+
+add_executable(tui_test_renderer_minimal test_renderer_minimal.cpp)
+target_link_libraries(tui_test_renderer_minimal PRIVATE tui)
+add_test(NAME tui_test_renderer_minimal COMMAND tui_test_renderer_minimal)

--- a/tui/tests/test_renderer_minimal.cpp
+++ b/tui/tests/test_renderer_minimal.cpp
@@ -1,0 +1,61 @@
+// tui/tests/test_renderer_minimal.cpp
+// @brief Ensure Renderer emits minimal sequences across frames.
+// @invariant Unchanged rows produce no output after diff render.
+// @ownership Renderer and ScreenBuffer owned locally within test.
+
+#include "tui/render/renderer.hpp"
+#include "tui/render/screen.hpp"
+#include "tui/term/term_io.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <string>
+
+using tui::term::StringTermIO;
+using viper::tui::render::Renderer;
+using viper::tui::render::ScreenBuffer;
+using viper::tui::render::Style;
+
+static int countChar(const std::string &s, char c)
+{
+    return static_cast<int>(std::count(s.begin(), s.end(), c));
+}
+
+int main()
+{
+    StringTermIO tio;
+    Renderer r(tio, true);
+    ScreenBuffer sb;
+    sb.resize(2, 3);
+    Style style{};
+    style.fg = {255, 0, 0, 255};
+    style.bg = {0, 0, 0, 255};
+    sb.clear(style);
+    const char *row0 = "xyz";
+    const char *row1 = "uvw";
+    for (int i = 0; i < 3; ++i)
+    {
+        sb.at(0, i).ch = row0[i];
+        sb.at(1, i).ch = row1[i];
+        sb.at(0, i).style = style;
+        sb.at(1, i).style = style;
+    }
+    r.draw(sb);
+    sb.snapshotPrev();
+    int first_sgr = countChar(tio.buffer(), 'm');
+    tio.clear();
+
+    const char *row1b = "UVW";
+    for (int i = 0; i < 3; ++i)
+    {
+        sb.at(1, i).ch = row1b[i];
+    }
+    r.draw(sb);
+    int second_sgr = countChar(tio.buffer(), 'm');
+    const std::string &out = tio.buffer();
+    assert(second_sgr <= first_sgr);
+    assert(out.find('x') == std::string::npos);
+    assert(out.find('y') == std::string::npos);
+    assert(out.find('z') == std::string::npos);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `Renderer` to emit minimal ANSI sequences from `ScreenBuffer` updates
- Support truecolor and 256-color mappings with cached style and cursor
- Test renderer diffing to avoid redundant SGR sequences

## Testing
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68c4ffdc33d88324a3554ded4ece060c