### PR TITLE
tui: add Unicode width and UTF-8 helpers

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(tui STATIC
   src/term/term_io.cpp
   src/term/session.cpp
   src/term/input.cpp
+  src/util/unicode.cpp
   src/render/screen.cpp
   src/render/renderer.cpp
 )

--- a/tui/include/tui/util/unicode.hpp
+++ b/tui/include/tui/util/unicode.hpp
@@ -1,0 +1,23 @@
+// tui/include/tui/util/unicode.hpp
+// @brief Unicode helper utilities for width and decoding.
+// @invariant char_width follows basic East Asian width rules.
+// @ownership decode_utf8 returns a new string; caller owns the result.
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace viper::tui::util
+{
+/// @brief Determine display width of a Unicode code point.
+/// @param cp Unicode scalar value.
+/// @return 0 for combining marks, 2 for wide CJK, otherwise 1.
+[[nodiscard]] int char_width(char32_t cp);
+
+/// @brief Decode a UTF-8 string into UTF-32 code points.
+/// @param in UTF-8 encoded byte sequence.
+/// @return Decoded UTF-32 string; invalid sequences yield U+FFFD.
+[[nodiscard]] std::u32string decode_utf8(std::string_view in);
+
+} // namespace viper::tui::util

--- a/tui/src/util/unicode.cpp
+++ b/tui/src/util/unicode.cpp
@@ -1,0 +1,109 @@
+// tui/src/util/unicode.cpp
+// @brief Implements Unicode width and UTF-8 decoding helpers.
+// @invariant Width table covers common ranges; others default to width 1.
+// @ownership No ownership beyond returned strings.
+
+#include "tui/util/unicode.hpp"
+
+namespace viper::tui::util
+{
+namespace
+{
+struct Range
+{
+    char32_t first;
+    char32_t last;
+};
+
+constexpr Range wide_ranges[] = {{0x1100, 0x115F},
+                                 {0x2329, 0x232A},
+                                 {0x2E80, 0xA4CF},
+                                 {0xAC00, 0xD7A3},
+                                 {0xF900, 0xFAFF},
+                                 {0xFE10, 0xFE19},
+                                 {0xFE30, 0xFE6F},
+                                 {0xFF00, 0xFF60},
+                                 {0xFFE0, 0xFFE6},
+                                 {0x20000, 0x2FFFD},
+                                 {0x30000, 0x3FFFD}};
+} // namespace
+
+int char_width(char32_t cp)
+{
+    if (cp >= 0x0300 && cp <= 0x036F)
+    {
+        return 0;
+    }
+    for (auto r : wide_ranges)
+    {
+        if (cp >= r.first && cp <= r.last)
+        {
+            return 2;
+        }
+    }
+    return 1;
+}
+
+std::u32string decode_utf8(std::string_view in)
+{
+    std::u32string out;
+    for (size_t i = 0; i < in.size();)
+    {
+        unsigned char c = static_cast<unsigned char>(in[i]);
+        char32_t cp = 0;
+        int len = 0;
+        if (c < 0x80)
+        {
+            cp = c;
+            len = 1;
+        }
+        else if ((c & 0xE0) == 0xC0)
+        {
+            cp = c & 0x1F;
+            len = 2;
+        }
+        else if ((c & 0xF0) == 0xE0)
+        {
+            cp = c & 0x0F;
+            len = 3;
+        }
+        else if ((c & 0xF8) == 0xF0)
+        {
+            cp = c & 0x07;
+            len = 4;
+        }
+        else
+        {
+            out.push_back(0xFFFD);
+            ++i;
+            continue;
+        }
+        if (i + static_cast<size_t>(len) > in.size())
+        {
+            out.push_back(0xFFFD);
+            break;
+        }
+        bool ok = true;
+        for (int j = 1; j < len; ++j)
+        {
+            unsigned char cc = static_cast<unsigned char>(in[i + j]);
+            if ((cc & 0xC0) != 0x80)
+            {
+                ok = false;
+                break;
+            }
+            cp = (cp << 6) | (cc & 0x3F);
+        }
+        if (!ok)
+        {
+            out.push_back(0xFFFD);
+            ++i;
+            continue;
+        }
+        out.push_back(cp);
+        i += len;
+    }
+    return out;
+}
+
+} // namespace viper::tui::util

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -29,3 +29,7 @@ add_test(NAME tui_test_screen_diff COMMAND tui_test_screen_diff)
 add_executable(tui_test_renderer_minimal test_renderer_minimal.cpp)
 target_link_libraries(tui_test_renderer_minimal PRIVATE tui)
 add_test(NAME tui_test_renderer_minimal COMMAND tui_test_renderer_minimal)
+
+add_executable(tui_test_unicode_width test_unicode_width.cpp)
+target_link_libraries(tui_test_unicode_width PRIVATE tui)
+add_test(NAME tui_test_unicode_width COMMAND tui_test_unicode_width)

--- a/tui/tests/test_unicode_width.cpp
+++ b/tui/tests/test_unicode_width.cpp
@@ -1,0 +1,29 @@
+// tui/tests/test_unicode_width.cpp
+// @brief Tests Unicode width calculation and UTF-8 decoding.
+// @invariant Combining marks and CJK ranges have expected widths.
+// @ownership decode_utf8 returns owned strings used locally.
+
+#include "tui/util/unicode.hpp"
+
+#include <cassert>
+
+using viper::tui::util::char_width;
+using viper::tui::util::decode_utf8;
+
+int main()
+{
+    auto s = decode_utf8("A");
+    assert(s.size() == 1);
+    assert(char_width(s[0]) == 1);
+
+    s = decode_utf8("\xE4\xBD\xA0"); // 你
+    assert(s.size() == 1);
+    assert(char_width(s[0]) == 2);
+
+    s = decode_utf8("e\xCC\x81"); // e + combining acute
+    assert(s.size() == 2);
+    assert(char_width(s[0]) == 1);
+    assert(char_width(s[1]) == 0);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `char_width` for basic wcwidth-style East Asian ranges and combining marks
- provide `decode_utf8` utility for tests
- test width handling for ASCII, CJK, and combining sequences

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c5034da23483249bf3e684eceafcb1