### PR TITLE
tui(ui): add Widget base, VStack/HStack containers, and App loop

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -14,6 +14,9 @@ add_library(tui STATIC
   src/util/unicode.cpp
   src/render/screen.cpp
   src/render/renderer.cpp
+  src/ui/widget.cpp
+  src/ui/container.cpp
+  src/app.cpp
 )
 
 target_include_directories(tui PUBLIC include)

--- a/tui/include/tui/app.hpp
+++ b/tui/include/tui/app.hpp
@@ -1,0 +1,42 @@
+// tui/include/tui/app.hpp
+// @brief Minimal application loop processing events and rendering a widget tree.
+// @invariant Screen buffer dimensions define root layout bounds.
+// @ownership App owns root widget and screen buffer, borrows TermIO via Renderer.
+#pragma once
+
+#include "tui/render/renderer.hpp"
+#include "tui/ui/container.hpp"
+#include "tui/ui/widget.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace viper::tui
+{
+/// @brief Headless app driving a widget tree and renderer.
+class App
+{
+  public:
+    /// @brief Construct app with root widget and terminal I/O.
+    App(std::unique_ptr<ui::Widget> root,
+        ::tui::term::TermIO &tio,
+        int rows,
+        int cols,
+        bool truecolor = false);
+
+    /// @brief Enqueue an input event.
+    void pushEvent(const ui::Event &ev);
+
+    /// @brief Process pending events and render one frame.
+    void tick();
+
+  private:
+    std::unique_ptr<ui::Widget> root_{};
+    render::ScreenBuffer screen_{};
+    render::Renderer renderer_;
+    std::vector<ui::Event> events_{};
+    int rows_{0};
+    int cols_{0};
+};
+
+} // namespace viper::tui

--- a/tui/include/tui/ui/container.hpp
+++ b/tui/include/tui/ui/container.hpp
@@ -1,0 +1,43 @@
+// tui/include/tui/ui/container.hpp
+// @brief Container widget arranging children in vertical or horizontal stacks.
+// @invariant Children are laid out within the container's rectangle.
+// @ownership Container owns child widgets via unique_ptr.
+#pragma once
+
+#include "tui/ui/widget.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace viper::tui::ui
+{
+/// @brief Base container holding child widgets.
+class Container : public Widget
+{
+  public:
+    /// @brief Add child widget to container.
+    void addChild(std::unique_ptr<Widget> child);
+
+    void layout(const Rect &r) override;
+    void paint(render::ScreenBuffer &sb) override;
+
+  protected:
+    virtual void layoutChildren() = 0;
+    std::vector<std::unique_ptr<Widget>> children_{};
+};
+
+/// @brief Vertical stack container.
+class VStack : public Container
+{
+  protected:
+    void layoutChildren() override;
+};
+
+/// @brief Horizontal stack container.
+class HStack : public Container
+{
+  protected:
+    void layoutChildren() override;
+};
+
+} // namespace viper::tui::ui

--- a/tui/include/tui/ui/widget.hpp
+++ b/tui/include/tui/ui/widget.hpp
@@ -1,0 +1,49 @@
+// tui/include/tui/ui/widget.hpp
+// @brief Base class for UI widgets with layout and event handling.
+// @invariant Widgets manage their own rectangular bounds.
+// @ownership Derived classes own their state; Widget stores layout rect.
+#pragma once
+
+#include "tui/render/screen.hpp"
+
+namespace viper::tui::ui
+{
+struct Rect
+{
+    int x{0};
+    int y{0};
+    int w{0};
+    int h{0};
+};
+
+struct Event
+{
+};
+
+/// @brief Abstract base for all widgets.
+class Widget
+{
+  public:
+    virtual ~Widget() = default;
+
+    /// @brief Set widget bounds and layout children.
+    virtual void layout(const Rect &r);
+
+    /// @brief Paint widget contents into a screen buffer.
+    virtual void paint(render::ScreenBuffer &sb);
+
+    /// @brief Handle an input event.
+    /// @return True if the event was consumed.
+    virtual bool onEvent(const Event &ev);
+
+    /// @brief Retrieve widget rectangle.
+    [[nodiscard]] Rect rect() const
+    {
+        return rect_;
+    }
+
+  protected:
+    Rect rect_{};
+};
+
+} // namespace viper::tui::ui

--- a/tui/src/app.cpp
+++ b/tui/src/app.cpp
@@ -1,0 +1,43 @@
+// tui/src/app.cpp
+// @brief Headless application loop implementation.
+// @invariant Renderer draws one frame per tick after processing events.
+// @ownership App owns root widget and screen buffer.
+
+#include "tui/app.hpp"
+
+namespace viper::tui
+{
+App::App(
+    std::unique_ptr<ui::Widget> root, ::tui::term::TermIO &tio, int rows, int cols, bool truecolor)
+    : root_(std::move(root)), renderer_(tio, truecolor), rows_(rows), cols_(cols)
+{
+    screen_.resize(rows, cols);
+}
+
+void App::pushEvent(const ui::Event &ev)
+{
+    events_.push_back(ev);
+}
+
+void App::tick()
+{
+    for (const auto &ev : events_)
+    {
+        if (root_)
+        {
+            root_->onEvent(ev);
+        }
+    }
+    events_.clear();
+    if (root_)
+    {
+        ui::Rect full{0, 0, cols_, rows_};
+        root_->layout(full);
+        screen_.clear(render::Style{});
+        root_->paint(screen_);
+    }
+    renderer_.draw(screen_);
+    screen_.snapshotPrev();
+}
+
+} // namespace viper::tui

--- a/tui/src/ui/container.cpp
+++ b/tui/src/ui/container.cpp
@@ -1,0 +1,67 @@
+// tui/src/ui/container.cpp
+// @brief Container widget implementations for vertical and horizontal stacks.
+// @invariant Child layouts cover container rect without overlap.
+// @ownership Container owns child widgets and delegates painting.
+
+#include "tui/ui/container.hpp"
+
+namespace viper::tui::ui
+{
+void Container::addChild(std::unique_ptr<Widget> child)
+{
+    children_.push_back(std::move(child));
+}
+
+void Container::layout(const Rect &r)
+{
+    Widget::layout(r);
+    layoutChildren();
+}
+
+void Container::paint(render::ScreenBuffer &sb)
+{
+    for (auto &ch : children_)
+    {
+        ch->paint(sb);
+    }
+}
+
+void VStack::layoutChildren()
+{
+    int count = static_cast<int>(children_.size());
+    if (count == 0)
+    {
+        return;
+    }
+    int base = rect_.h / count;
+    int rem = rect_.h - base * count;
+    int y = rect_.y;
+    for (int i = 0; i < count; ++i)
+    {
+        int h = base + (i == count - 1 ? rem : 0);
+        Rect cr{rect_.x, y, rect_.w, h};
+        children_[i]->layout(cr);
+        y += h;
+    }
+}
+
+void HStack::layoutChildren()
+{
+    int count = static_cast<int>(children_.size());
+    if (count == 0)
+    {
+        return;
+    }
+    int base = rect_.w / count;
+    int rem = rect_.w - base * count;
+    int x = rect_.x;
+    for (int i = 0; i < count; ++i)
+    {
+        int w = base + (i == count - 1 ? rem : 0);
+        Rect cr{x, rect_.y, w, rect_.h};
+        children_[i]->layout(cr);
+        x += w;
+    }
+}
+
+} // namespace viper::tui::ui

--- a/tui/src/ui/widget.cpp
+++ b/tui/src/ui/widget.cpp
@@ -1,0 +1,22 @@
+// tui/src/ui/widget.cpp
+// @brief Default implementations for Widget base class.
+// @invariant Rect stored matches last layout call.
+// @ownership Widget does not own external resources.
+
+#include "tui/ui/widget.hpp"
+
+namespace viper::tui::ui
+{
+void Widget::layout(const Rect &r)
+{
+    rect_ = r;
+}
+
+void Widget::paint(render::ScreenBuffer &) {}
+
+bool Widget::onEvent(const Event &)
+{
+    return false;
+}
+
+} // namespace viper::tui::ui

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -33,3 +33,7 @@ add_test(NAME tui_test_renderer_minimal COMMAND tui_test_renderer_minimal)
 add_executable(tui_test_unicode_width test_unicode_width.cpp)
 target_link_libraries(tui_test_unicode_width PRIVATE tui)
 add_test(NAME tui_test_unicode_width COMMAND tui_test_unicode_width)
+
+add_executable(tui_test_app_layout test_app_layout.cpp)
+target_link_libraries(tui_test_app_layout PRIVATE tui)
+add_test(NAME tui_test_app_layout COMMAND tui_test_app_layout)

--- a/tui/tests/test_app_layout.cpp
+++ b/tui/tests/test_app_layout.cpp
@@ -1,0 +1,58 @@
+// tui/tests/test_app_layout.cpp
+// @brief Verify App layouts and paints stacked widgets correctly.
+// @invariant Top widget occupies first row, bottom widget second row.
+// @ownership Test owns widgets, app, and TermIO.
+
+#include "tui/app.hpp"
+#include "tui/render/screen.hpp"
+#include "tui/term/term_io.hpp"
+#include "tui/ui/container.hpp"
+
+#include <cassert>
+#include <memory>
+#include <string>
+
+using tui::term::StringTermIO;
+using viper::tui::App;
+using viper::tui::render::ScreenBuffer;
+using viper::tui::ui::VStack;
+using viper::tui::ui::Widget;
+
+struct CharWidget : Widget
+{
+    char ch;
+
+    explicit CharWidget(char c) : ch(c) {}
+
+    void paint(ScreenBuffer &sb) override
+    {
+        auto r = rect();
+        for (int y = r.y; y < r.y + r.h; ++y)
+        {
+            for (int x = r.x; x < r.x + r.w; ++x)
+            {
+                sb.at(y, x).ch = ch;
+            }
+        }
+    }
+};
+
+int main()
+{
+    auto root = std::make_unique<VStack>();
+    auto a = std::make_unique<CharWidget>('A');
+    auto b = std::make_unique<CharWidget>('B');
+    CharWidget *ap = a.get();
+    CharWidget *bp = b.get();
+    root->addChild(std::move(a));
+    root->addChild(std::move(b));
+    StringTermIO tio;
+    App app(std::move(root), tio, 2, 2);
+    app.tick();
+    assert(ap->rect().h == 1);
+    assert(bp->rect().y == 1);
+    const std::string &out = tio.buffer();
+    assert(out.find('A') != std::string::npos);
+    assert(out.find('B') != std::string::npos);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add base `Widget` with layout, paint, and event hooks
- introduce `VStack`/`HStack` containers and `App` event loop
- test layout math and rendering through fake stacked widgets

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c50665d6308324a42a1382eeacb931