### PR TITLE
Introduce Widget base, Container with vertical/horizontal stacks, and a minimal App event loop

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -14,6 +14,9 @@ add_library(tui STATIC
   src/util/unicode.cpp
   src/render/screen.cpp
   src/render/renderer.cpp
+  src/ui/widget.cpp
+  src/ui/container.cpp
+  src/app.cpp
 )
 
 target_include_directories(tui PUBLIC include)

--- a/tui/include/tui/app.hpp
+++ b/tui/include/tui/app.hpp
@@ -1,0 +1,52 @@
+// tui/include/tui/app.hpp
+// @brief Minimal application loop managing widgets and rendering.
+// @invariant tick() processes events once and renders current widget tree.
+// @ownership App owns the root widget and screen buffer.
+#pragma once
+
+#include "tui/render/renderer.hpp"
+#include "tui/ui/widget.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace tui::term
+{
+class TermIO;
+}
+
+namespace viper::tui
+{
+
+/// @brief Headless application driving a widget tree.
+class App
+{
+  public:
+    /// @brief Construct application with a root widget and terminal IO.
+    App(std::unique_ptr<ui::Widget> root, ::tui::term::TermIO &tio);
+
+    /// @brief Queue an event for processing on next tick.
+    void pushEvent(const ui::Event &ev);
+
+    /// @brief Resize the backing screen buffer.
+    void resize(int rows, int cols);
+
+    /// @brief Process queued events and render once.
+    void tick();
+
+    /// @brief Access underlying screen buffer.
+    [[nodiscard]] render::ScreenBuffer &screen()
+    {
+        return screen_;
+    }
+
+  private:
+    std::unique_ptr<ui::Widget> root_{};
+    render::ScreenBuffer screen_{};
+    render::Renderer renderer_;
+    std::vector<ui::Event> events_{};
+    int rows_{0};
+    int cols_{0};
+};
+
+} // namespace viper::tui

--- a/tui/include/tui/ui/container.hpp
+++ b/tui/include/tui/ui/container.hpp
@@ -1,0 +1,53 @@
+// tui/include/tui/ui/container.hpp
+// @brief Composite widgets arranging children vertically or horizontally.
+// @invariant Child widgets are laid out without overlap within parent bounds.
+// @ownership Container owns its children via std::unique_ptr.
+#pragma once
+
+#include "tui/ui/widget.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace viper::tui::ui
+{
+
+/// @brief Base container supporting directional stacking of children.
+class Container : public Widget
+{
+  public:
+    /// @brief Add a child widget.
+    void addChild(std::unique_ptr<Widget> child);
+
+  protected:
+    enum class Direction
+    {
+        Horizontal,
+        Vertical
+    };
+
+    explicit Container(Direction dir);
+
+    void layout(Rect rect) override;
+    void paint(render::ScreenBuffer &sb) override;
+    bool onEvent(const Event &ev) override;
+
+    std::vector<std::unique_ptr<Widget>> children_{};
+    Direction dir_;
+};
+
+/// @brief Container stacking children vertically.
+class VStack : public Container
+{
+  public:
+    VStack();
+};
+
+/// @brief Container stacking children horizontally.
+class HStack : public Container
+{
+  public:
+    HStack();
+};
+
+} // namespace viper::tui::ui

--- a/tui/include/tui/ui/widget.hpp
+++ b/tui/include/tui/ui/widget.hpp
@@ -1,0 +1,55 @@
+// tui/include/tui/ui/widget.hpp
+// @brief Base UI widget interface and supporting geometry/event types.
+// @invariant layout() stores bounds for paint and event handling.
+// @ownership Widgets are owned via unique_ptr within containers and App.
+#pragma once
+
+#include "tui/render/screen.hpp"
+
+namespace viper::tui::ui
+{
+
+/// @brief Axis-aligned rectangle in screen coordinates.
+struct Rect
+{
+    int x{0};
+    int y{0};
+    int w{0};
+    int h{0};
+};
+
+/// @brief Generic event placeholder processed by widgets.
+struct Event
+{
+};
+
+/// @brief Base class for all widgets.
+class Widget
+{
+  public:
+    virtual ~Widget() = default;
+
+    /// @brief Receive layout rectangle for this widget.
+    /// @param rect Bounds allocated by parent container.
+    virtual void layout(Rect rect);
+
+    /// @brief Paint the widget into a screen buffer.
+    /// @param sb Target screen buffer to modify.
+    virtual void paint(render::ScreenBuffer &sb);
+
+    /// @brief Handle an input event.
+    /// @param ev Event to process.
+    /// @return True if event was handled.
+    virtual bool onEvent(const Event &ev);
+
+    /// @brief Bounds assigned during layout.
+    [[nodiscard]] Rect bounds() const
+    {
+        return bounds_;
+    }
+
+  protected:
+    Rect bounds_{};
+};
+
+} // namespace viper::tui::ui

--- a/tui/src/app.cpp
+++ b/tui/src/app.cpp
@@ -1,0 +1,51 @@
+// tui/src/app.cpp
+// @brief Implementation of the minimal application loop.
+// @invariant Each tick processes all queued events exactly once.
+// @ownership App owns its screen buffer and root widget.
+
+#include "tui/app.hpp"
+
+#include "tui/term/term_io.hpp"
+
+namespace viper::tui
+{
+
+App::App(std::unique_ptr<ui::Widget> root, ::tui::term::TermIO &tio)
+    : root_(std::move(root)), renderer_(tio, false)
+{
+}
+
+void App::pushEvent(const ui::Event &ev)
+{
+    events_.push_back(ev);
+}
+
+void App::resize(int rows, int cols)
+{
+    rows_ = rows;
+    cols_ = cols;
+    screen_.resize(rows, cols);
+}
+
+void App::tick()
+{
+    for (const auto &ev : events_)
+    {
+        if (root_)
+        {
+            root_->onEvent(ev);
+        }
+    }
+    events_.clear();
+    if (root_)
+    {
+        root_->layout(ui::Rect{0, 0, cols_, rows_});
+        render::Style style{};
+        screen_.clear(style);
+        root_->paint(screen_);
+    }
+    renderer_.draw(screen_);
+    screen_.snapshotPrev();
+}
+
+} // namespace viper::tui

--- a/tui/src/ui/container.cpp
+++ b/tui/src/ui/container.cpp
@@ -1,0 +1,74 @@
+// tui/src/ui/container.cpp
+// @brief Implementation of stacking container widgets.
+// @invariant Children are laid out sequentially along the container's axis.
+// @ownership Container owns its children and delegates painting and events.
+
+#include "tui/ui/container.hpp"
+
+namespace viper::tui::ui
+{
+
+Container::Container(Direction dir) : dir_(dir) {}
+
+void Container::addChild(std::unique_ptr<Widget> child)
+{
+    children_.push_back(std::move(child));
+}
+
+void Container::layout(Rect rect)
+{
+    Widget::layout(rect);
+    if (children_.empty())
+    {
+        return;
+    }
+    int count = static_cast<int>(children_.size());
+    if (dir_ == Direction::Vertical)
+    {
+        int each = rect.h / count;
+        int y = rect.y;
+        for (int i = 0; i < count; ++i)
+        {
+            int h = (i == count - 1) ? (rect.y + rect.h - y) : each;
+            children_[i]->layout({rect.x, y, rect.w, h});
+            y += h;
+        }
+    }
+    else
+    {
+        int each = rect.w / count;
+        int x = rect.x;
+        for (int i = 0; i < count; ++i)
+        {
+            int w = (i == count - 1) ? (rect.x + rect.w - x) : each;
+            children_[i]->layout({x, rect.y, w, rect.h});
+            x += w;
+        }
+    }
+}
+
+void Container::paint(render::ScreenBuffer &sb)
+{
+    for (auto &child : children_)
+    {
+        child->paint(sb);
+    }
+}
+
+bool Container::onEvent(const Event &ev)
+{
+    for (auto &child : children_)
+    {
+        if (child->onEvent(ev))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+VStack::VStack() : Container(Direction::Vertical) {}
+
+HStack::HStack() : Container(Direction::Horizontal) {}
+
+} // namespace viper::tui::ui

--- a/tui/src/ui/widget.cpp
+++ b/tui/src/ui/widget.cpp
@@ -1,0 +1,26 @@
+// tui/src/ui/widget.cpp
+// @brief Default implementations for Widget base class.
+// @invariant Bounds are stored as provided to layout().
+// @ownership Widget does not own external resources.
+
+#include "tui/ui/widget.hpp"
+
+namespace viper::tui::ui
+{
+
+void Widget::layout(Rect rect)
+{
+    bounds_ = rect;
+}
+
+void Widget::paint(render::ScreenBuffer &)
+{
+    // default no-op
+}
+
+bool Widget::onEvent(const Event &)
+{
+    return false;
+}
+
+} // namespace viper::tui::ui

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -33,3 +33,7 @@ add_test(NAME tui_test_renderer_minimal COMMAND tui_test_renderer_minimal)
 add_executable(tui_test_unicode_width test_unicode_width.cpp)
 target_link_libraries(tui_test_unicode_width PRIVATE tui)
 add_test(NAME tui_test_unicode_width COMMAND tui_test_unicode_width)
+
+add_executable(tui_test_app_layout test_app_layout.cpp)
+target_link_libraries(tui_test_app_layout PRIVATE tui)
+add_test(NAME tui_test_app_layout COMMAND tui_test_app_layout)

--- a/tui/tests/test_app_layout.cpp
+++ b/tui/tests/test_app_layout.cpp
@@ -1,0 +1,62 @@
+// tui/tests/test_app_layout.cpp
+// @brief Verify App layouts containers and renders painted output.
+// @invariant Fake widgets fill their assigned rectangles without overlap.
+// @ownership App owns widgets; test observes layout via raw pointers.
+
+#include "tui/app.hpp"
+#include "tui/term/term_io.hpp"
+#include "tui/ui/container.hpp"
+
+#include <cassert>
+#include <memory>
+#include <string>
+
+using tui::term::StringTermIO;
+using viper::tui::App;
+using viper::tui::render::ScreenBuffer;
+using viper::tui::ui::Event;
+using viper::tui::ui::Rect;
+using viper::tui::ui::VStack;
+using viper::tui::ui::Widget;
+
+struct FakeWidget : Widget
+{
+    char ch;
+    Rect last{};
+
+    explicit FakeWidget(char c) : ch(c) {}
+
+    void layout(Rect r) override
+    {
+        last = r;
+        Widget::layout(r);
+    }
+
+    void paint(ScreenBuffer &sb) override
+    {
+        for (int y = last.y; y < last.y + last.h; ++y)
+            for (int x = last.x; x < last.x + last.w; ++x)
+                sb.at(y, x).ch = ch;
+    }
+};
+
+int main()
+{
+    StringTermIO tio;
+    auto root = std::make_unique<VStack>();
+    auto fw1 = std::make_unique<FakeWidget>('X');
+    auto fw2 = std::make_unique<FakeWidget>('O');
+    FakeWidget *p1 = fw1.get();
+    FakeWidget *p2 = fw2.get();
+    root->addChild(std::move(fw1));
+    root->addChild(std::move(fw2));
+    App app(std::move(root), tio);
+    app.resize(2, 2);
+    app.tick();
+    assert(p1->last.x == 0 && p1->last.y == 0 && p1->last.w == 2 && p1->last.h == 1);
+    assert(p2->last.x == 0 && p2->last.y == 1 && p2->last.w == 2 && p2->last.h == 1);
+    const std::string &out = tio.buffer();
+    assert(out.find('X') != std::string::npos);
+    assert(out.find('O') != std::string::npos);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add base Widget interface with layout, paint and event hooks
- implement VStack/HStack containers to allocate child rectangles
- add minimal App loop with event queue and rendering

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c50665d6308324a42a1382eeacb931