### PR TITLE
tui(ui): implement focus management and key routing with tests

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(tui STATIC
   src/render/renderer.cpp
   src/ui/widget.cpp
   src/ui/container.cpp
+  src/ui/focus.cpp
   src/app.cpp
 )
 

--- a/tui/include/tui/app.hpp
+++ b/tui/include/tui/app.hpp
@@ -6,6 +6,7 @@
 
 #include "tui/render/renderer.hpp"
 #include "tui/ui/container.hpp"
+#include "tui/ui/focus.hpp"
 #include "tui/ui/widget.hpp"
 
 #include <memory>
@@ -30,11 +31,18 @@ class App
     /// @brief Process pending events and render one frame.
     void tick();
 
+    /// @brief Access focus manager for widget registration.
+    [[nodiscard]] ui::FocusManager &focus()
+    {
+        return focus_;
+    }
+
   private:
     std::unique_ptr<ui::Widget> root_{};
     render::ScreenBuffer screen_{};
     render::Renderer renderer_;
     std::vector<ui::Event> events_{};
+    ui::FocusManager focus_{};
     int rows_{0};
     int cols_{0};
 };

--- a/tui/include/tui/ui/focus.hpp
+++ b/tui/include/tui/ui/focus.hpp
@@ -1,0 +1,37 @@
+// tui/include/tui/ui/focus.hpp
+// @brief Manage a ring of focusable widgets and track focused widget.
+// @invariant Stored pointers are non-null and index is -1 or a valid element.
+// @ownership FocusManager does not own widgets; callers must unregister destroyed widgets.
+#pragma once
+
+#include <vector>
+
+namespace viper::tui::ui
+{
+class Widget;
+
+/// @brief Manages focus among registered widgets.
+class FocusManager
+{
+  public:
+    /// @brief Register a widget if it wants focus.
+    void registerWidget(Widget *w);
+
+    /// @brief Remove a widget from focus list.
+    void unregisterWidget(Widget *w);
+
+    /// @brief Advance focus to next widget.
+    Widget *next();
+
+    /// @brief Move focus to previous widget.
+    Widget *prev();
+
+    /// @brief Get the currently focused widget.
+    [[nodiscard]] Widget *focused() const;
+
+  private:
+    std::vector<Widget *> ring_{};
+    int current_{-1};
+};
+
+} // namespace viper::tui::ui

--- a/tui/include/tui/ui/widget.hpp
+++ b/tui/include/tui/ui/widget.hpp
@@ -16,8 +16,24 @@ struct Rect
     int h{0};
 };
 
+/// @brief Keys supported by the event system.
+enum class Key
+{
+    Enter,
+    Tab
+};
+
+/// @brief Keyboard event with key code and optional shift modifier.
+struct KeyEvent
+{
+    Key key{Key::Enter};
+    bool shift{false};
+};
+
+/// @brief Input event wrapper (currently only keyboard events).
 struct Event
 {
+    KeyEvent key{};
 };
 
 /// @brief Abstract base for all widgets.
@@ -35,6 +51,9 @@ class Widget
     /// @brief Handle an input event.
     /// @return True if the event was consumed.
     virtual bool onEvent(const Event &ev);
+
+    /// @brief Whether this widget can receive focus.
+    [[nodiscard]] virtual bool wantsFocus() const;
 
     /// @brief Retrieve widget rectangle.
     [[nodiscard]] Rect rect() const

--- a/tui/src/app.cpp
+++ b/tui/src/app.cpp
@@ -23,7 +23,24 @@ void App::tick()
 {
     for (const auto &ev : events_)
     {
-        if (root_)
+        if (ev.key.key == ui::Key::Tab)
+        {
+            if (ev.key.shift)
+            {
+                focus_.prev();
+            }
+            else
+            {
+                focus_.next();
+            }
+            continue;
+        }
+        bool consumed = false;
+        if (auto *f = focus_.focused())
+        {
+            consumed = f->onEvent(ev);
+        }
+        if (!consumed && root_)
         {
             root_->onEvent(ev);
         }

--- a/tui/src/ui/focus.cpp
+++ b/tui/src/ui/focus.cpp
@@ -1,0 +1,74 @@
+// tui/src/ui/focus.cpp
+// @brief FocusManager implementation cycling through registered widgets.
+// @invariant Ring contains widgets that want focus; current index is valid or -1.
+// @ownership FocusManager holds raw pointers without ownership.
+
+#include "tui/ui/focus.hpp"
+#include "tui/ui/widget.hpp"
+
+#include <algorithm>
+
+namespace viper::tui::ui
+{
+void FocusManager::registerWidget(Widget *w)
+{
+    if (!w || !w->wantsFocus())
+    {
+        return;
+    }
+    ring_.push_back(w);
+    if (current_ == -1)
+    {
+        current_ = 0;
+    }
+}
+
+void FocusManager::unregisterWidget(Widget *w)
+{
+    auto it = std::find(ring_.begin(), ring_.end(), w);
+    if (it == ring_.end())
+    {
+        return;
+    }
+    int idx = static_cast<int>(std::distance(ring_.begin(), it));
+    ring_.erase(it);
+    if (ring_.empty())
+    {
+        current_ = -1;
+    }
+    else if (idx <= current_)
+    {
+        current_ = current_ % static_cast<int>(ring_.size());
+    }
+}
+
+Widget *FocusManager::next()
+{
+    if (ring_.empty())
+    {
+        return nullptr;
+    }
+    current_ = (current_ + 1) % static_cast<int>(ring_.size());
+    return ring_[current_];
+}
+
+Widget *FocusManager::prev()
+{
+    if (ring_.empty())
+    {
+        return nullptr;
+    }
+    current_ = (current_ + static_cast<int>(ring_.size()) - 1) % static_cast<int>(ring_.size());
+    return ring_[current_];
+}
+
+Widget *FocusManager::focused() const
+{
+    if (current_ < 0 || current_ >= static_cast<int>(ring_.size()))
+    {
+        return nullptr;
+    }
+    return ring_[current_];
+}
+
+} // namespace viper::tui::ui

--- a/tui/src/ui/widget.cpp
+++ b/tui/src/ui/widget.cpp
@@ -19,4 +19,9 @@ bool Widget::onEvent(const Event &)
     return false;
 }
 
+bool Widget::wantsFocus() const
+{
+    return false;
+}
+
 } // namespace viper::tui::ui

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -37,3 +37,7 @@ add_test(NAME tui_test_unicode_width COMMAND tui_test_unicode_width)
 add_executable(tui_test_app_layout test_app_layout.cpp)
 target_link_libraries(tui_test_app_layout PRIVATE tui)
 add_test(NAME tui_test_app_layout COMMAND tui_test_app_layout)
+
+add_executable(tui_test_focus test_focus.cpp)
+target_link_libraries(tui_test_focus PRIVATE tui)
+add_test(NAME tui_test_focus COMMAND tui_test_focus)

--- a/tui/tests/test_focus.cpp
+++ b/tui/tests/test_focus.cpp
@@ -1,0 +1,71 @@
+// tui/tests/test_focus.cpp
+// @brief Verify key routing to focused widget and focus cycling with Tab.
+// @invariant Enter toggles only currently focused widget; Tab cycles focus order.
+// @ownership Test owns widgets, app, and TermIO.
+
+#include "tui/app.hpp"
+#include "tui/term/term_io.hpp"
+#include "tui/ui/container.hpp"
+#include "tui/ui/widget.hpp"
+
+#include <cassert>
+#include <memory>
+
+using tui::term::StringTermIO;
+using viper::tui::App;
+using viper::tui::ui::Event;
+using viper::tui::ui::Key;
+using viper::tui::ui::KeyEvent;
+using viper::tui::ui::VStack;
+using viper::tui::ui::Widget;
+
+struct ToggleWidget : Widget
+{
+    bool state{false};
+
+    bool wantsFocus() const override
+    {
+        return true;
+    }
+
+    bool onEvent(const Event &ev) override
+    {
+        if (ev.key.key == Key::Enter)
+        {
+            state = !state;
+            return true;
+        }
+        return false;
+    }
+};
+
+int main()
+{
+    auto root = std::make_unique<VStack>();
+    auto a = std::make_unique<ToggleWidget>();
+    auto b = std::make_unique<ToggleWidget>();
+    ToggleWidget *ap = a.get();
+    ToggleWidget *bp = b.get();
+    root->addChild(std::move(a));
+    root->addChild(std::move(b));
+
+    StringTermIO tio;
+    App app(std::move(root), tio, 2, 2);
+    app.focus().registerWidget(ap);
+    app.focus().registerWidget(bp);
+
+    // Initial focus on first widget
+    app.pushEvent(Event{KeyEvent{Key::Enter, false}});
+    app.tick();
+    assert(ap->state);
+    assert(!bp->state);
+
+    // Tab moves focus to second widget, Enter toggles second
+    app.pushEvent(Event{KeyEvent{Key::Tab, false}});
+    app.pushEvent(Event{KeyEvent{Key::Enter, false}});
+    app.tick();
+    assert(bp->state);
+    assert(ap->state);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add FocusManager to track focusable widgets in a ring
- route key events in App to focused widget and cycle focus on Tab
- exercise focus routing with toggle widgets test

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c51e4cc3008324b816f686f32391a3