### PR TITLE
tui(ui): implement focus management and key routing with tests

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(tui STATIC
   src/render/renderer.cpp
   src/ui/widget.cpp
   src/ui/container.cpp
+  src/ui/focus.cpp
   src/app.cpp
 )
 

--- a/tui/include/tui/app.hpp
+++ b/tui/include/tui/app.hpp
@@ -6,6 +6,7 @@
 
 #include "tui/render/renderer.hpp"
 #include "tui/ui/container.hpp"
+#include "tui/ui/focus.hpp"
 #include "tui/ui/widget.hpp"
 
 #include <memory>
@@ -30,6 +31,9 @@ class App
     /// @brief Process pending events and render one frame.
     void tick();
 
+    /// @brief Access the focus manager.
+    [[nodiscard]] ui::FocusManager &focus();
+
   private:
     std::unique_ptr<ui::Widget> root_{};
     render::ScreenBuffer screen_{};
@@ -37,6 +41,7 @@ class App
     std::vector<ui::Event> events_{};
     int rows_{0};
     int cols_{0};
+    ui::FocusManager focus_{};
 };
 
 } // namespace viper::tui

--- a/tui/include/tui/ui/focus.hpp
+++ b/tui/include/tui/ui/focus.hpp
@@ -1,0 +1,38 @@
+// tui/include/tui/ui/focus.hpp
+// @brief Manage focusable widgets and current focus.
+// @invariant Holds pointers to widgets that remain valid while registered.
+// @ownership FocusManager does not own widgets; widgets must unregister before destruction.
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace viper::tui::ui
+{
+class Widget;
+
+/// @brief Tracks focusable widgets in registration order.
+class FocusManager
+{
+  public:
+    /// @brief Register a widget if it wants focus.
+    void registerWidget(Widget *w);
+
+    /// @brief Remove a widget from the focus ring.
+    void unregisterWidget(Widget *w);
+
+    /// @brief Advance to the next focusable widget.
+    [[nodiscard]] Widget *next();
+
+    /// @brief Move to the previous focusable widget.
+    [[nodiscard]] Widget *prev();
+
+    /// @brief Return currently focused widget, if any.
+    [[nodiscard]] Widget *current() const;
+
+  private:
+    std::vector<Widget *> ring_{};
+    std::size_t index_{0};
+};
+
+} // namespace viper::tui::ui

--- a/tui/include/tui/ui/widget.hpp
+++ b/tui/include/tui/ui/widget.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "tui/render/screen.hpp"
+#include "tui/term/input.hpp"
 
 namespace viper::tui::ui
 {
@@ -18,6 +19,7 @@ struct Rect
 
 struct Event
 {
+    term::KeyEvent key{};
 };
 
 /// @brief Abstract base for all widgets.
@@ -35,6 +37,12 @@ class Widget
     /// @brief Handle an input event.
     /// @return True if the event was consumed.
     virtual bool onEvent(const Event &ev);
+
+    /// @brief Whether this widget can receive focus.
+    [[nodiscard]] virtual bool wantsFocus() const
+    {
+        return false;
+    }
 
     /// @brief Retrieve widget rectangle.
     [[nodiscard]] Rect rect() const

--- a/tui/src/app.cpp
+++ b/tui/src/app.cpp
@@ -19,13 +19,30 @@ void App::pushEvent(const ui::Event &ev)
     events_.push_back(ev);
 }
 
+ui::FocusManager &App::focus()
+{
+    return focus_;
+}
+
 void App::tick()
 {
     for (const auto &ev : events_)
     {
-        if (root_)
+        if (ev.key.code == term::KeyEvent::Code::Tab)
         {
-            root_->onEvent(ev);
+            if (ev.key.mods & term::KeyEvent::Shift)
+            {
+                (void)focus_.prev();
+            }
+            else
+            {
+                (void)focus_.next();
+            }
+            continue;
+        }
+        if (auto *w = focus_.current())
+        {
+            w->onEvent(ev);
         }
     }
     events_.clear();

--- a/tui/src/ui/focus.cpp
+++ b/tui/src/ui/focus.cpp
@@ -1,0 +1,78 @@
+// tui/src/ui/focus.cpp
+// @brief FocusManager implementation.
+// @invariant Registered widgets remain valid until unregistered.
+// @ownership FocusManager borrows widgets only.
+
+#include "tui/ui/focus.hpp"
+#include "tui/ui/widget.hpp"
+
+#include <algorithm>
+
+namespace viper::tui::ui
+{
+void FocusManager::registerWidget(Widget *w)
+{
+    if (!w || !w->wantsFocus())
+    {
+        return;
+    }
+    ring_.push_back(w);
+    if (ring_.size() == 1)
+    {
+        index_ = 0;
+    }
+}
+
+void FocusManager::unregisterWidget(Widget *w)
+{
+    auto it = std::find(ring_.begin(), ring_.end(), w);
+    if (it == ring_.end())
+    {
+        return;
+    }
+    std::size_t removed = static_cast<std::size_t>(std::distance(ring_.begin(), it));
+    ring_.erase(it);
+    if (ring_.empty())
+    {
+        index_ = 0;
+    }
+    else if (index_ >= ring_.size())
+    {
+        index_ = 0;
+    }
+    else if (index_ > removed)
+    {
+        --index_;
+    }
+}
+
+Widget *FocusManager::next()
+{
+    if (ring_.empty())
+    {
+        return nullptr;
+    }
+    index_ = (index_ + 1) % ring_.size();
+    return ring_[index_];
+}
+
+Widget *FocusManager::prev()
+{
+    if (ring_.empty())
+    {
+        return nullptr;
+    }
+    index_ = (index_ + ring_.size() - 1) % ring_.size();
+    return ring_[index_];
+}
+
+Widget *FocusManager::current() const
+{
+    if (ring_.empty())
+    {
+        return nullptr;
+    }
+    return ring_[index_];
+}
+
+} // namespace viper::tui::ui

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -37,3 +37,7 @@ add_test(NAME tui_test_unicode_width COMMAND tui_test_unicode_width)
 add_executable(tui_test_app_layout test_app_layout.cpp)
 target_link_libraries(tui_test_app_layout PRIVATE tui)
 add_test(NAME tui_test_app_layout COMMAND tui_test_app_layout)
+
+add_executable(tui_test_focus test_focus.cpp)
+target_link_libraries(tui_test_focus PRIVATE tui)
+add_test(NAME tui_test_focus COMMAND tui_test_focus)

--- a/tui/tests/test_focus.cpp
+++ b/tui/tests/test_focus.cpp
@@ -1,0 +1,81 @@
+// tui/tests/test_focus.cpp
+// @brief Verify focus cycling and key routing between widgets.
+// @invariant Tab and Shift-Tab change focused widget; Enter dispatches to current.
+// @ownership Test owns widgets, app, and TermIO.
+
+#include "tui/app.hpp"
+#include "tui/term/input.hpp"
+#include "tui/term/term_io.hpp"
+#include "tui/ui/container.hpp"
+
+#include <cassert>
+#include <memory>
+
+using tui::term::StringTermIO;
+using viper::tui::App;
+using viper::tui::term::KeyEvent;
+using viper::tui::ui::Event;
+using viper::tui::ui::VStack;
+using viper::tui::ui::Widget;
+
+struct FocusWidget : Widget
+{
+    bool flag{false};
+
+    bool wantsFocus() const override
+    {
+        return true;
+    }
+
+    bool onEvent(const Event &ev) override
+    {
+        if (ev.key.code == KeyEvent::Code::Enter)
+        {
+            flag = !flag;
+            return true;
+        }
+        return false;
+    }
+};
+
+int main()
+{
+    auto root = std::make_unique<VStack>();
+    auto w1 = std::make_unique<FocusWidget>();
+    auto w2 = std::make_unique<FocusWidget>();
+    FocusWidget *p1 = w1.get();
+    FocusWidget *p2 = w2.get();
+    root->addChild(std::move(w1));
+    root->addChild(std::move(w2));
+    StringTermIO tio;
+    App app(std::move(root), tio, 1, 1);
+    app.focus().registerWidget(p1);
+    app.focus().registerWidget(p2);
+
+    KeyEvent enter{};
+    enter.code = KeyEvent::Code::Enter;
+    app.pushEvent({enter});
+    app.tick();
+    assert(p1->flag);
+    assert(!p2->flag);
+
+    KeyEvent tab{};
+    tab.code = KeyEvent::Code::Tab;
+    app.pushEvent({tab});
+    app.tick();
+
+    app.pushEvent({enter});
+    app.tick();
+    assert(p2->flag);
+
+    KeyEvent shiftTab{};
+    shiftTab.code = KeyEvent::Code::Tab;
+    shiftTab.mods = KeyEvent::Shift;
+    app.pushEvent({shiftTab});
+    app.tick();
+
+    app.pushEvent({enter});
+    app.tick();
+    assert(!p1->flag);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add FocusManager and `wantsFocus` API for widgets
- cycle focus with Tab/Shift-Tab and dispatch keys to current widget
- cover focus routing with unit test

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c51e4cc3008324b816f686f32391a3