### PR TITLE
Add Label and Button widgets with theme roles

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -17,6 +17,9 @@ add_library(tui STATIC
   src/ui/widget.cpp
   src/ui/container.cpp
   src/ui/focus.cpp
+  src/style/theme.cpp
+  src/widgets/label.cpp
+  src/widgets/button.cpp
   src/app.cpp
 )
 

--- a/tui/include/tui/style/theme.hpp
+++ b/tui/include/tui/style/theme.hpp
@@ -1,0 +1,38 @@
+// tui/include/tui/style/theme.hpp
+// @brief Simple color theme with role-based styles.
+// @invariant Provides fixed styles per role.
+// @ownership Theme does not own external resources.
+#pragma once
+
+#include "tui/render/screen.hpp"
+
+namespace viper::tui::style
+{
+
+/// @brief Roles used by widgets to query theme colors.
+enum class Role
+{
+    Normal,
+    Accent,
+    Disabled,
+    Selection
+};
+
+/// @brief Theme mapping roles to render styles.
+class Theme
+{
+  public:
+    /// @brief Construct theme with default color palette.
+    Theme();
+
+    /// @brief Retrieve style for a given role.
+    [[nodiscard]] const render::Style &style(Role r) const;
+
+  private:
+    render::Style normal_{};
+    render::Style accent_{};
+    render::Style disabled_{};
+    render::Style selection_{};
+};
+
+} // namespace viper::tui::style

--- a/tui/include/tui/widgets/button.hpp
+++ b/tui/include/tui/widgets/button.hpp
@@ -1,0 +1,47 @@
+// tui/include/tui/widgets/button.hpp
+// @brief Clickable button widget with text.
+// @invariant Callback executed on activation keys.
+// @ownership Button borrows Theme and stores callback.
+#pragma once
+
+#include <functional>
+#include <string>
+
+#include "tui/style/theme.hpp"
+#include "tui/ui/widget.hpp"
+
+namespace viper::tui::widgets
+{
+
+/// @brief Simple button with border and onClick handler.
+class Button : public ui::Widget
+{
+  public:
+    using OnClick = std::function<void()>;
+
+    /// @brief Construct button.
+    /// @param text Button label text.
+    /// @param onClick Callback invoked on activation.
+    /// @param theme Theme providing styles.
+    Button(std::string text, OnClick onClick, const style::Theme &theme);
+
+    /// @brief Paint button with border and label.
+    void paint(render::ScreenBuffer &sb) override;
+
+    /// @brief Handle key events for activation.
+    /// @return True if event consumed.
+    bool onEvent(const ui::Event &ev) override;
+
+    /// @brief Buttons want focus to receive input.
+    [[nodiscard]] bool wantsFocus() const override
+    {
+        return true;
+    }
+
+  private:
+    std::string text_{};
+    OnClick onClick_{};
+    const style::Theme &theme_;
+};
+
+} // namespace viper::tui::widgets

--- a/tui/include/tui/widgets/label.hpp
+++ b/tui/include/tui/widgets/label.hpp
@@ -1,0 +1,32 @@
+// tui/include/tui/widgets/label.hpp
+// @brief Simple text label widget.
+// @invariant Stores immutable text and theme reference.
+// @ownership Label does not own the Theme.
+#pragma once
+
+#include <string>
+
+#include "tui/style/theme.hpp"
+#include "tui/ui/widget.hpp"
+
+namespace viper::tui::widgets
+{
+
+/// @brief Displays read-only text.
+class Label : public ui::Widget
+{
+  public:
+    /// @brief Construct label with text and theme.
+    /// @param text Text to display.
+    /// @param theme Theme providing colors.
+    explicit Label(std::string text, const style::Theme &theme);
+
+    /// @brief Paint text into the screen buffer.
+    void paint(render::ScreenBuffer &sb) override;
+
+  private:
+    std::string text_{};
+    const style::Theme &theme_;
+};
+
+} // namespace viper::tui::widgets

--- a/tui/src/style/theme.cpp
+++ b/tui/src/style/theme.cpp
@@ -1,0 +1,42 @@
+// tui/src/style/theme.cpp
+// @brief Default theme color mappings.
+// @invariant Color values remain constant after construction.
+// @ownership Theme owns no external resources.
+
+#include "tui/style/theme.hpp"
+
+namespace viper::tui::style
+{
+
+Theme::Theme()
+{
+    normal_.fg = {255, 255, 255, 255};
+    normal_.bg = {0, 0, 0, 255};
+
+    accent_.fg = {0, 0, 0, 255};
+    accent_.bg = {200, 200, 200, 255};
+
+    disabled_.fg = {128, 128, 128, 255};
+    disabled_.bg = normal_.bg;
+
+    selection_.fg = {0, 0, 0, 255};
+    selection_.bg = {0, 128, 255, 255};
+}
+
+const render::Style &Theme::style(Role r) const
+{
+    switch (r)
+    {
+        case Role::Accent:
+            return accent_;
+        case Role::Disabled:
+            return disabled_;
+        case Role::Selection:
+            return selection_;
+        case Role::Normal:
+        default:
+            return normal_;
+    }
+}
+
+} // namespace viper::tui::style

--- a/tui/src/widgets/button.cpp
+++ b/tui/src/widgets/button.cpp
@@ -1,0 +1,79 @@
+// tui/src/widgets/button.cpp
+// @brief Button widget with ASCII border and activation keys.
+// @invariant Border size matches layout rectangle.
+// @ownership Button borrows Theme and callback.
+
+#include "tui/widgets/button.hpp"
+
+namespace viper::tui::widgets
+{
+
+Button::Button(std::string text, OnClick onClick, const style::Theme &theme)
+    : text_(std::move(text)), onClick_(std::move(onClick)), theme_(theme)
+{
+}
+
+void Button::paint(render::ScreenBuffer &sb)
+{
+    const auto &border = theme_.style(style::Role::Accent);
+    const auto &txt = theme_.style(style::Role::Normal);
+
+    int x0 = rect_.x;
+    int y0 = rect_.y;
+    int w = rect_.w;
+    int h = rect_.h;
+
+    // Top and bottom borders
+    for (int x = 0; x < w; ++x)
+    {
+        auto &top = sb.at(y0, x0 + x);
+        top.ch = (x == 0 || x == w - 1) ? U'+' : U'-';
+        top.style = border;
+        auto &bot = sb.at(y0 + h - 1, x0 + x);
+        bot.ch = (x == 0 || x == w - 1) ? U'+' : U'-';
+        bot.style = border;
+    }
+
+    // Sides and fill
+    for (int y = 1; y < h - 1; ++y)
+    {
+        auto &left = sb.at(y0 + y, x0);
+        left.ch = U'|';
+        left.style = border;
+        auto &right = sb.at(y0 + y, x0 + w - 1);
+        right.ch = U'|';
+        right.style = border;
+        for (int x = 1; x < w - 1; ++x)
+        {
+            auto &cell = sb.at(y0 + y, x0 + x);
+            cell.ch = U' ';
+            cell.style = txt;
+        }
+    }
+
+    // Text centered vertically on second row
+    int row = y0 + h / 2;
+    int start = x0 + 1;
+    for (std::size_t i = 0; i < text_.size() && start + static_cast<int>(i) < x0 + w - 1; ++i)
+    {
+        auto &cell = sb.at(row, start + static_cast<int>(i));
+        cell.ch = static_cast<char32_t>(text_[i]);
+        cell.style = txt;
+    }
+}
+
+bool Button::onEvent(const ui::Event &ev)
+{
+    const auto &k = ev.key;
+    if (k.code == term::KeyEvent::Code::Enter || k.codepoint == U' ')
+    {
+        if (onClick_)
+        {
+            onClick_();
+        }
+        return true;
+    }
+    return false;
+}
+
+} // namespace viper::tui::widgets

--- a/tui/src/widgets/label.cpp
+++ b/tui/src/widgets/label.cpp
@@ -1,0 +1,24 @@
+// tui/src/widgets/label.cpp
+// @brief Label widget rendering plain text.
+// @invariant Text length does not exceed layout width.
+// @ownership Label borrows Theme reference.
+
+#include "tui/widgets/label.hpp"
+
+namespace viper::tui::widgets
+{
+
+Label::Label(std::string text, const style::Theme &theme) : text_(std::move(text)), theme_(theme) {}
+
+void Label::paint(render::ScreenBuffer &sb)
+{
+    const auto &st = theme_.style(style::Role::Normal);
+    for (std::size_t i = 0; i < text_.size() && static_cast<int>(i) < rect_.w; ++i)
+    {
+        auto &cell = sb.at(rect_.y, rect_.x + static_cast<int>(i));
+        cell.ch = static_cast<char32_t>(text_[i]);
+        cell.style = st;
+    }
+}
+
+} // namespace viper::tui::widgets

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -41,3 +41,7 @@ add_test(NAME tui_test_app_layout COMMAND tui_test_app_layout)
 add_executable(tui_test_focus test_focus.cpp)
 target_link_libraries(tui_test_focus PRIVATE tui)
 add_test(NAME tui_test_focus COMMAND tui_test_focus)
+
+add_executable(tui_test_widgets_basic test_widgets_basic.cpp)
+target_link_libraries(tui_test_widgets_basic PRIVATE tui)
+add_test(NAME tui_test_widgets_basic COMMAND tui_test_widgets_basic)

--- a/tui/tests/test_widgets_basic.cpp
+++ b/tui/tests/test_widgets_basic.cpp
@@ -1,0 +1,68 @@
+// tui/tests/test_widgets_basic.cpp
+// @brief Verify basic Label and Button behavior.
+// @invariant Painting writes expected glyphs and button handles keys.
+// @ownership Widgets and theme owned within test.
+
+#include "tui/render/renderer.hpp"
+#include "tui/render/screen.hpp"
+#include "tui/style/theme.hpp"
+#include "tui/term/term_io.hpp"
+#include "tui/widgets/button.hpp"
+#include "tui/widgets/label.hpp"
+
+#include <cassert>
+#include <string>
+
+using tui::term::StringTermIO;
+using viper::tui::render::Renderer;
+using viper::tui::render::ScreenBuffer;
+using viper::tui::style::Role;
+using viper::tui::style::Theme;
+using viper::tui::term::KeyEvent;
+using viper::tui::ui::Event;
+using viper::tui::widgets::Button;
+using viper::tui::widgets::Label;
+
+int main()
+{
+    Theme theme;
+
+    // Label paint
+    Label lbl("Hello", theme);
+    lbl.layout({0, 0, 5, 1});
+
+    ScreenBuffer sb;
+    sb.resize(1, 5);
+    sb.clear(theme.style(Role::Normal));
+    lbl.paint(sb);
+
+    StringTermIO tio;
+    Renderer r(tio, true);
+    r.draw(sb);
+    assert(tio.buffer().find("Hello") != std::string::npos);
+
+    // Button paint and onClick
+    bool clicked = false;
+    Button btn("Go", [&] { clicked = true; }, theme);
+    btn.layout({0, 0, 4, 3});
+    sb.resize(3, 4);
+    sb.clear(theme.style(Role::Normal));
+    btn.paint(sb);
+    tio.clear();
+    r.draw(sb);
+    assert(tio.buffer().find("Go") != std::string::npos);
+    assert(tio.buffer().find("+--+") != std::string::npos);
+
+    Event ev{};
+    ev.key.code = KeyEvent::Code::Enter;
+    assert(btn.onEvent(ev));
+    assert(clicked);
+
+    clicked = false;
+    ev.key.code = KeyEvent::Code::Unknown;
+    ev.key.codepoint = U' ';
+    assert(btn.onEvent(ev));
+    assert(clicked);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- introduce Theme with normal, accent, disabled and selection roles
- add Label and Button widgets using Theme
- test basic widget rendering and button activation

## Testing
- `cmake -S . -B build`
- `cmake --build build -- -j4`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c520a87c9c83249eaeef8125b1c727