### PR TITLE
Add HSplitter/VSplitter and a simple StatusBar

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -20,6 +20,8 @@ add_library(tui STATIC
   src/style/theme.cpp
   src/widgets/label.cpp
   src/widgets/button.cpp
+  src/widgets/splitter.cpp
+  src/widgets/status_bar.cpp
   src/app.cpp
 )
 

--- a/tui/include/tui/widgets/splitter.hpp
+++ b/tui/include/tui/widgets/splitter.hpp
@@ -1,0 +1,57 @@
+// tui/include/tui/widgets/splitter.hpp
+// @brief Widgets dividing space between two children horizontally or vertically.
+// @invariant Child rectangles computed from split ratio and parent rect.
+// @ownership Splitter owns child widgets via unique_ptr.
+#pragma once
+
+#include <memory>
+
+#include "tui/ui/widget.hpp"
+
+namespace viper::tui::widgets
+{
+/// @brief Split container dividing area into left and right parts.
+class HSplitter : public ui::Widget
+{
+  public:
+    /// @brief Construct horizontal splitter.
+    /// @param left Widget placed on the left side.
+    /// @param right Widget placed on the right side.
+    /// @param ratio Fraction [0,1] of width for the left widget.
+    HSplitter(std::unique_ptr<ui::Widget> left, std::unique_ptr<ui::Widget> right, float ratio);
+
+    /// @brief Layout children within given rectangle using ratio.
+    void layout(const ui::Rect &r) override;
+
+    /// @brief Paint both child widgets.
+    void paint(render::ScreenBuffer &sb) override;
+
+  private:
+    std::unique_ptr<ui::Widget> left_{};
+    std::unique_ptr<ui::Widget> right_{};
+    float ratio_{0.5F};
+};
+
+/// @brief Split container dividing area into top and bottom parts.
+class VSplitter : public ui::Widget
+{
+  public:
+    /// @brief Construct vertical splitter.
+    /// @param top Widget placed at the top.
+    /// @param bottom Widget placed at the bottom.
+    /// @param ratio Fraction [0,1] of height for the top widget.
+    VSplitter(std::unique_ptr<ui::Widget> top, std::unique_ptr<ui::Widget> bottom, float ratio);
+
+    /// @brief Layout children within given rectangle using ratio.
+    void layout(const ui::Rect &r) override;
+
+    /// @brief Paint both child widgets.
+    void paint(render::ScreenBuffer &sb) override;
+
+  private:
+    std::unique_ptr<ui::Widget> top_{};
+    std::unique_ptr<ui::Widget> bottom_{};
+    float ratio_{0.5F};
+};
+
+} // namespace viper::tui::widgets

--- a/tui/include/tui/widgets/status_bar.hpp
+++ b/tui/include/tui/widgets/status_bar.hpp
@@ -1,0 +1,38 @@
+// tui/include/tui/widgets/status_bar.hpp
+// @brief Single-line status bar showing left and right segments at bottom.
+// @invariant Renders within last row of assigned rectangle.
+// @ownership StatusBar borrows Theme, owns segment strings.
+#pragma once
+
+#include <string>
+
+#include "tui/style/theme.hpp"
+#include "tui/ui/widget.hpp"
+
+namespace viper::tui::widgets
+{
+/// @brief Displays status information at the bottom line.
+class StatusBar : public ui::Widget
+{
+  public:
+    /// @brief Construct status bar with initial texts.
+    /// @param left Text shown on the left side.
+    /// @param right Text shown on the right side.
+    /// @param theme Theme providing colors.
+    StatusBar(std::string left, std::string right, const style::Theme &theme);
+
+    /// @brief Set text on the left segment.
+    void setLeft(std::string left);
+    /// @brief Set text on the right segment.
+    void setRight(std::string right);
+
+    /// @brief Paint status bar into screen buffer.
+    void paint(render::ScreenBuffer &sb) override;
+
+  private:
+    std::string left_{};
+    std::string right_{};
+    const style::Theme &theme_;
+};
+
+} // namespace viper::tui::widgets

--- a/tui/src/widgets/splitter.cpp
+++ b/tui/src/widgets/splitter.cpp
@@ -1,0 +1,86 @@
+// tui/src/widgets/splitter.cpp
+// @brief Splitter widgets dividing area between two children.
+// @invariant Child layouts recomputed from stored ratio on resize.
+// @ownership Splitters own child widgets and delegate painting.
+
+#include "tui/widgets/splitter.hpp"
+
+#include <algorithm>
+
+namespace viper::tui::widgets
+{
+HSplitter::HSplitter(std::unique_ptr<ui::Widget> left,
+                     std::unique_ptr<ui::Widget> right,
+                     float ratio)
+    : left_(std::move(left)), right_(std::move(right)), ratio_(ratio)
+{
+}
+
+void HSplitter::layout(const ui::Rect &r)
+{
+    Widget::layout(r);
+    int leftW = static_cast<int>(static_cast<float>(r.w) * ratio_);
+    leftW = std::clamp(leftW, 0, r.w);
+    int rightW = r.w - leftW;
+    ui::Rect lr{r.x, r.y, leftW, r.h};
+    ui::Rect rr{r.x + leftW, r.y, rightW, r.h};
+    if (left_)
+    {
+        left_->layout(lr);
+    }
+    if (right_)
+    {
+        right_->layout(rr);
+    }
+}
+
+void HSplitter::paint(render::ScreenBuffer &sb)
+{
+    if (left_)
+    {
+        left_->paint(sb);
+    }
+    if (right_)
+    {
+        right_->paint(sb);
+    }
+}
+
+VSplitter::VSplitter(std::unique_ptr<ui::Widget> top,
+                     std::unique_ptr<ui::Widget> bottom,
+                     float ratio)
+    : top_(std::move(top)), bottom_(std::move(bottom)), ratio_(ratio)
+{
+}
+
+void VSplitter::layout(const ui::Rect &r)
+{
+    Widget::layout(r);
+    int topH = static_cast<int>(static_cast<float>(r.h) * ratio_);
+    topH = std::clamp(topH, 0, r.h);
+    int bottomH = r.h - topH;
+    ui::Rect tr{r.x, r.y, r.w, topH};
+    ui::Rect br{r.x, r.y + topH, r.w, bottomH};
+    if (top_)
+    {
+        top_->layout(tr);
+    }
+    if (bottom_)
+    {
+        bottom_->layout(br);
+    }
+}
+
+void VSplitter::paint(render::ScreenBuffer &sb)
+{
+    if (top_)
+    {
+        top_->paint(sb);
+    }
+    if (bottom_)
+    {
+        bottom_->paint(sb);
+    }
+}
+
+} // namespace viper::tui::widgets

--- a/tui/src/widgets/status_bar.cpp
+++ b/tui/src/widgets/status_bar.cpp
@@ -1,0 +1,54 @@
+// tui/src/widgets/status_bar.cpp
+// @brief StatusBar widget painting text on bottom line.
+// @invariant Left and right segments remain within widget width.
+// @ownership StatusBar borrows Theme for styling.
+
+#include "tui/widgets/status_bar.hpp"
+
+#include <algorithm>
+
+namespace viper::tui::widgets
+{
+StatusBar::StatusBar(std::string left, std::string right, const style::Theme &theme)
+    : left_(std::move(left)), right_(std::move(right)), theme_(theme)
+{
+}
+
+void StatusBar::setLeft(std::string left)
+{
+    left_ = std::move(left);
+}
+
+void StatusBar::setRight(std::string right)
+{
+    right_ = std::move(right);
+}
+
+void StatusBar::paint(render::ScreenBuffer &sb)
+{
+    const auto &st = theme_.style(style::Role::Normal);
+    int y = rect_.y + rect_.h - 1;
+    for (int x = 0; x < rect_.w; ++x)
+    {
+        auto &cell = sb.at(y, rect_.x + x);
+        cell.ch = U' ';
+        cell.style = st;
+    }
+    for (std::size_t i = 0; i < left_.size() && static_cast<int>(i) < rect_.w; ++i)
+    {
+        auto &cell = sb.at(y, rect_.x + static_cast<int>(i));
+        cell.ch = static_cast<char32_t>(left_[i]);
+        cell.style = st;
+    }
+    int start = rect_.x + rect_.w - static_cast<int>(right_.size());
+    start = std::max(start, rect_.x);
+    for (std::size_t i = 0; i < right_.size() && start + static_cast<int>(i) < rect_.x + rect_.w;
+         ++i)
+    {
+        auto &cell = sb.at(y, start + static_cast<int>(i));
+        cell.ch = static_cast<char32_t>(right_[i]);
+        cell.style = st;
+    }
+}
+
+} // namespace viper::tui::widgets

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -45,3 +45,7 @@ add_test(NAME tui_test_focus COMMAND tui_test_focus)
 add_executable(tui_test_widgets_basic test_widgets_basic.cpp)
 target_link_libraries(tui_test_widgets_basic PRIVATE tui)
 add_test(NAME tui_test_widgets_basic COMMAND tui_test_widgets_basic)
+
+add_executable(tui_test_split_status test_split_status.cpp)
+target_link_libraries(tui_test_split_status PRIVATE tui)
+add_test(NAME tui_test_split_status COMMAND tui_test_split_status)

--- a/tui/tests/test_split_status.cpp
+++ b/tui/tests/test_split_status.cpp
@@ -1,0 +1,67 @@
+// tui/tests/test_split_status.cpp
+// @brief Verify Splitter layout and StatusBar paint behavior.
+// @invariant Splitter maintains ratios on resize and StatusBar renders bottom text.
+// @ownership Test owns widgets, theme and screen buffer.
+
+#include "tui/render/screen.hpp"
+#include "tui/style/theme.hpp"
+#include "tui/widgets/splitter.hpp"
+#include "tui/widgets/status_bar.hpp"
+
+#include <cassert>
+#include <memory>
+
+using viper::tui::render::ScreenBuffer;
+using viper::tui::style::Role;
+using viper::tui::style::Theme;
+using viper::tui::ui::Rect;
+using viper::tui::ui::Widget;
+using viper::tui::widgets::HSplitter;
+using viper::tui::widgets::StatusBar;
+using viper::tui::widgets::VSplitter;
+
+struct Dummy : Widget
+{
+    void paint(ScreenBuffer &) override {}
+};
+
+int main()
+{
+    Theme theme;
+
+    // HSplitter layout
+    auto left = std::make_unique<Dummy>();
+    auto right = std::make_unique<Dummy>();
+    Dummy *lp = left.get();
+    Dummy *rp = right.get();
+    HSplitter hs(std::move(left), std::move(right), 0.5F);
+    hs.layout({0, 0, 10, 4});
+    assert(lp->rect().w == 5);
+    assert(rp->rect().x == 5);
+    hs.layout({0, 0, 8, 4});
+    assert(lp->rect().w == 4);
+    assert(rp->rect().x == 4);
+
+    // VSplitter layout
+    auto top = std::make_unique<Dummy>();
+    auto bottom = std::make_unique<Dummy>();
+    Dummy *tp = top.get();
+    Dummy *bp = bottom.get();
+    VSplitter vs(std::move(top), std::move(bottom), 0.25F);
+    vs.layout({0, 0, 6, 8});
+    assert(tp->rect().h == 2);
+    assert(bp->rect().y == 2);
+
+    // StatusBar paint
+    StatusBar bar("LEFT", "RIGHT", theme);
+    bar.layout({0, 0, 10, 3});
+    ScreenBuffer sb;
+    sb.resize(3, 10);
+    sb.clear(theme.style(Role::Normal));
+    bar.paint(sb);
+    int y = 2; // bottom line
+    assert(sb.at(y, 0).ch == U'L');
+    assert(sb.at(y, 9).ch == U'T');
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add HSplitter and VSplitter widgets to divide space between two children
- implement StatusBar widget rendering left and right segments on bottom line
- test splitter layout logic and status bar paint output

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c52304ca2083248dd0e5beeb47cb6a