### PR TITLE
tui(views): add TextView with cursor/selection and rendering

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(tui STATIC
   src/widgets/splitter.cpp
   src/widgets/status_bar.cpp
   src/text/text_buffer.cpp
+  src/views/text_view.cpp
   src/app.cpp
 )
 

--- a/tui/include/tui/views/text_view.hpp
+++ b/tui/include/tui/views/text_view.hpp
@@ -1,0 +1,76 @@
+// tui/include/tui/views/text_view.hpp
+// @brief Scrollable text view with cursor and selection.
+// @invariant Cursor stays within buffer bounds; selection uses byte offsets.
+// @ownership TextView borrows TextBuffer and Theme.
+#pragma once
+
+#include <cstddef>
+
+#include "tui/render/screen.hpp"
+#include "tui/style/theme.hpp"
+#include "tui/text/text_buffer.hpp"
+#include "tui/ui/widget.hpp"
+#include "tui/util/unicode.hpp"
+
+namespace viper::tui::views
+{
+
+/// @brief View for editing a TextBuffer with cursor and optional selection.
+class TextView : public ui::Widget
+{
+  public:
+    /// @brief Construct a TextView bound to a buffer.
+    /// @param buf Text buffer to view/edit.
+    /// @param theme Theme providing styles.
+    /// @param showLineNumbers Whether to render line numbers.
+    TextView(text::TextBuffer &buf, const style::Theme &theme, bool showLineNumbers = false);
+
+    /// @brief Paint visible lines into the screen buffer.
+    void paint(render::ScreenBuffer &sb) override;
+
+    /// @brief Handle navigation keys for cursor and selection.
+    /// @return True if the event was consumed.
+    bool onEvent(const ui::Event &ev) override;
+
+    /// @brief TextView wants focus for editing.
+    [[nodiscard]] bool wantsFocus() const override
+    {
+        return true;
+    }
+
+    /// @brief Current cursor row (0-based).
+    [[nodiscard]] std::size_t cursorRow() const
+    {
+        return cursor_row_;
+    }
+
+    /// @brief Current cursor column in display cells (0-based).
+    [[nodiscard]] std::size_t cursorCol() const
+    {
+        return cursor_col_;
+    }
+
+  private:
+    text::TextBuffer &buf_;
+    const style::Theme &theme_;
+    bool show_line_numbers_{};
+
+    std::size_t cursor_row_{0};
+    std::size_t cursor_col_{0};
+    std::size_t target_col_{0};
+    std::size_t top_row_{0};
+
+    std::size_t sel_start_{0};
+    std::size_t sel_end_{0};
+    std::size_t cursor_offset_{0};
+
+    // helpers
+    static std::pair<char32_t, std::size_t> decodeChar(const std::string &s, std::size_t off);
+    static std::size_t lineWidth(const std::string &line);
+    static std::size_t columnToOffset(const std::string &line, std::size_t col);
+    std::size_t offsetFromRowCol(std::size_t row, std::size_t col) const;
+    std::size_t totalLines() const;
+    void setCursor(std::size_t row, std::size_t col, bool shift, bool updateTarget);
+};
+
+} // namespace viper::tui::views

--- a/tui/src/views/text_view.cpp
+++ b/tui/src/views/text_view.cpp
@@ -1,0 +1,289 @@
+// tui/src/views/text_view.cpp
+// @brief Implementation of TextView widget for editing buffers.
+// @invariant Maintains cursor within line widths and buffer size.
+// @ownership TextView borrows TextBuffer and Theme.
+
+#include "tui/views/text_view.hpp"
+
+#include <algorithm>
+#include <string>
+
+using viper::tui::util::char_width;
+
+namespace viper::tui::views
+{
+namespace
+{
+std::pair<char32_t, std::size_t> decodeChar(const std::string &s, std::size_t off)
+{
+    unsigned char c = static_cast<unsigned char>(s[off]);
+    if (c < 0x80)
+        return {c, 1};
+    if ((c >> 5) == 0x6 && off + 1 < s.size())
+        return {static_cast<char32_t>(((c & 0x1F) << 6) |
+                                      (static_cast<unsigned char>(s[off + 1]) & 0x3F)),
+                2};
+    if ((c >> 4) == 0xE && off + 2 < s.size())
+        return {static_cast<char32_t>(((c & 0x0F) << 12) |
+                                      ((static_cast<unsigned char>(s[off + 1]) & 0x3F) << 6) |
+                                      (static_cast<unsigned char>(s[off + 2]) & 0x3F)),
+                3};
+    if ((c >> 3) == 0x1E && off + 3 < s.size())
+        return {static_cast<char32_t>(((c & 0x07) << 18) |
+                                      ((static_cast<unsigned char>(s[off + 1]) & 0x3F) << 12) |
+                                      ((static_cast<unsigned char>(s[off + 2]) & 0x3F) << 6) |
+                                      (static_cast<unsigned char>(s[off + 3]) & 0x3F)),
+                4};
+    return {U'\uFFFD', 1};
+}
+} // namespace
+
+TextView::TextView(text::TextBuffer &buf, const style::Theme &theme, bool showLineNumbers)
+    : buf_(buf), theme_(theme), show_line_numbers_(showLineNumbers)
+{
+}
+
+std::pair<char32_t, std::size_t> TextView::decodeChar(const std::string &s, std::size_t off)
+{
+    return ::viper::tui::views::decodeChar(s, off);
+}
+
+std::size_t TextView::lineWidth(const std::string &line)
+{
+    std::size_t i = 0;
+    std::size_t c = 0;
+    while (i < line.size())
+    {
+        auto [cp, len] = decodeChar(line, i);
+        c += char_width(cp);
+        i += len;
+    }
+    return c;
+}
+
+std::size_t TextView::columnToOffset(const std::string &line, std::size_t col)
+{
+    std::size_t i = 0;
+    std::size_t c = 0;
+    while (i < line.size())
+    {
+        auto [cp, len] = decodeChar(line, i);
+        std::size_t w = static_cast<std::size_t>(char_width(cp));
+        if (c + w > col)
+            break;
+        i += len;
+        c += w;
+    }
+    return i;
+}
+
+std::size_t TextView::offsetFromRowCol(std::size_t row, std::size_t col) const
+{
+    std::string text = buf_.str();
+    std::size_t off = 0;
+    std::size_t r = 0;
+    while (r < row)
+    {
+        std::size_t pos = text.find('\n', off);
+        if (pos == std::string::npos)
+            return text.size();
+        off = pos + 1;
+        ++r;
+    }
+    std::size_t lineEnd = text.find('\n', off);
+    std::string line =
+        lineEnd == std::string::npos ? text.substr(off) : text.substr(off, lineEnd - off);
+    return off + columnToOffset(line, col);
+}
+
+std::size_t TextView::totalLines() const
+{
+    std::string text = buf_.str();
+    return std::count(text.begin(), text.end(), '\n') + 1;
+}
+
+void TextView::setCursor(std::size_t row, std::size_t col, bool shift, bool updateTarget)
+{
+    cursor_row_ = row;
+    cursor_col_ = col;
+    if (updateTarget)
+        target_col_ = col;
+    cursor_offset_ = offsetFromRowCol(row, col);
+    if (shift)
+        sel_end_ = cursor_offset_;
+    else
+        sel_start_ = sel_end_ = cursor_offset_;
+}
+
+void TextView::paint(render::ScreenBuffer &sb)
+{
+    const auto &normal = theme_.style(style::Role::Normal);
+    const auto &sel = theme_.style(style::Role::Selection);
+    const auto &accent = theme_.style(style::Role::Accent);
+    std::size_t gutter = show_line_numbers_ ? 4 : 0;
+
+    for (int row = 0; row < rect_.h; ++row)
+    {
+        std::size_t lineNo = top_row_ + static_cast<std::size_t>(row);
+        std::string line = buf_.getLine(lineNo);
+        std::size_t lineStart = offsetFromRowCol(lineNo, 0);
+
+        if (show_line_numbers_)
+        {
+            std::string num = std::to_string(lineNo + 1);
+            if (num.size() < gutter - 1)
+                num = std::string(gutter - 1 - num.size(), ' ') + num;
+            num.push_back(' ');
+            for (std::size_t i = 0; i < gutter && i < num.size(); ++i)
+            {
+                auto &cell = sb.at(rect_.y + row, rect_.x + static_cast<int>(i));
+                cell.ch = static_cast<char32_t>(num[i]);
+                cell.style = normal;
+            }
+        }
+
+        std::size_t byte = 0;
+        std::size_t col = 0;
+        while (byte < line.size() &&
+               col < static_cast<std::size_t>(rect_.w - static_cast<int>(gutter)))
+        {
+            auto [cp, len] = decodeChar(line, byte);
+            std::size_t w = static_cast<std::size_t>(char_width(cp));
+            if (col + w > static_cast<std::size_t>(rect_.w - static_cast<int>(gutter)))
+                break;
+            std::size_t global = lineStart + byte;
+            bool selected = sel_start_ != sel_end_ && global >= std::min(sel_start_, sel_end_) &&
+                            global < std::max(sel_start_, sel_end_);
+            auto &cell = sb.at(rect_.y + row, rect_.x + static_cast<int>(gutter + col));
+            cell.ch = cp;
+            cell.width = static_cast<uint8_t>(w);
+            cell.style = selected ? sel : normal;
+            byte += len;
+            col += w;
+        }
+    }
+
+    if (cursor_row_ >= top_row_ && cursor_row_ < top_row_ + static_cast<std::size_t>(rect_.h))
+    {
+        std::size_t gutter = show_line_numbers_ ? 4 : 0;
+        if (cursor_col_ < static_cast<std::size_t>(rect_.w - static_cast<int>(gutter)))
+        {
+            auto &cell = sb.at(rect_.y + static_cast<int>(cursor_row_ - top_row_),
+                               rect_.x + static_cast<int>(gutter + cursor_col_));
+            cell.style = accent;
+        }
+    }
+}
+
+bool TextView::onEvent(const ui::Event &ev)
+{
+    using Code = term::KeyEvent::Code;
+    using Mods = term::KeyEvent::Mods;
+    bool shift = (ev.key.mods & Mods::Shift) != 0;
+    switch (ev.key.code)
+    {
+        case Code::Left:
+        {
+            if (cursor_col_ == 0)
+                return true;
+            std::string line = buf_.getLine(cursor_row_);
+            std::size_t curByte = columnToOffset(line, cursor_col_);
+            std::size_t i = 0;
+            std::size_t c = 0;
+            std::size_t prevCol = 0;
+            while (i < curByte)
+            {
+                auto [cp, len] = decodeChar(line, i);
+                prevCol = c;
+                c += static_cast<std::size_t>(char_width(cp));
+                i += len;
+            }
+            setCursor(cursor_row_, prevCol, shift, true);
+            if (cursor_row_ < top_row_)
+                top_row_ = cursor_row_;
+            return true;
+        }
+        case Code::Right:
+        {
+            std::string line = buf_.getLine(cursor_row_);
+            std::size_t lineW = lineWidth(line);
+            if (cursor_col_ >= lineW)
+                return true;
+            std::size_t curByte = columnToOffset(line, cursor_col_);
+            auto [cp, len] = decodeChar(line, curByte);
+            std::size_t newCol = cursor_col_ + static_cast<std::size_t>(char_width(cp));
+            setCursor(cursor_row_, newCol, shift, true);
+            return true;
+        }
+        case Code::Home:
+        {
+            setCursor(cursor_row_, 0, shift, true);
+            if (cursor_row_ < top_row_)
+                top_row_ = cursor_row_;
+            return true;
+        }
+        case Code::End:
+        {
+            std::string line = buf_.getLine(cursor_row_);
+            setCursor(cursor_row_, lineWidth(line), shift, true);
+            return true;
+        }
+        case Code::Up:
+        {
+            if (cursor_row_ == 0)
+                return true;
+            std::size_t newRow = cursor_row_ - 1;
+            std::string line = buf_.getLine(newRow);
+            std::size_t lineW = lineWidth(line);
+            std::size_t newCol = std::min(target_col_, lineW);
+            setCursor(newRow, newCol, shift, false);
+            if (cursor_row_ < top_row_)
+                top_row_ = cursor_row_;
+            return true;
+        }
+        case Code::Down:
+        {
+            std::size_t total = totalLines();
+            if (cursor_row_ + 1 >= total)
+                return true;
+            std::size_t newRow = cursor_row_ + 1;
+            std::string line = buf_.getLine(newRow);
+            std::size_t lineW = lineWidth(line);
+            std::size_t newCol = std::min(target_col_, lineW);
+            setCursor(newRow, newCol, shift, false);
+            if (cursor_row_ >= top_row_ + static_cast<std::size_t>(rect_.h))
+                top_row_ = cursor_row_ - static_cast<std::size_t>(rect_.h) + 1;
+            return true;
+        }
+        case Code::PageUp:
+        {
+            std::size_t page = rect_.h > 0 ? static_cast<std::size_t>(rect_.h) : 1;
+            std::size_t newRow = cursor_row_ > page ? cursor_row_ - page : 0;
+            std::string line = buf_.getLine(newRow);
+            std::size_t lineW = lineWidth(line);
+            std::size_t newCol = std::min(target_col_, lineW);
+            setCursor(newRow, newCol, shift, false);
+            top_row_ = newRow;
+            return true;
+        }
+        case Code::PageDown:
+        {
+            std::size_t page = rect_.h > 0 ? static_cast<std::size_t>(rect_.h) : 1;
+            std::size_t total = totalLines();
+            std::size_t newRow = std::min(cursor_row_ + page, total > 0 ? total - 1 : 0);
+            std::string line = buf_.getLine(newRow);
+            std::size_t lineW = lineWidth(line);
+            std::size_t newCol = std::min(target_col_, lineW);
+            setCursor(newRow, newCol, shift, false);
+            if (total > static_cast<std::size_t>(rect_.h))
+                top_row_ = std::min(newRow, total - static_cast<std::size_t>(rect_.h));
+            else
+                top_row_ = 0;
+            return true;
+        }
+        default:
+            return false;
+    }
+}
+
+} // namespace viper::tui::views

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -53,3 +53,7 @@ add_test(NAME tui_test_split_status COMMAND tui_test_split_status)
 add_executable(tui_test_text_buffer test_text_buffer.cpp)
 target_link_libraries(tui_test_text_buffer PRIVATE tui)
 add_test(NAME tui_test_text_buffer COMMAND tui_test_text_buffer)
+
+add_executable(tui_test_text_view test_text_view.cpp)
+target_link_libraries(tui_test_text_view PRIVATE tui)
+add_test(NAME tui_test_text_view COMMAND tui_test_text_view)

--- a/tui/tests/test_text_view.cpp
+++ b/tui/tests/test_text_view.cpp
@@ -1,0 +1,70 @@
+// tui/tests/test_text_view.cpp
+// @brief Navigation and rendering tests for TextView.
+// @invariant Cursor stays within lines and selection paints correctly.
+// @ownership Test owns buffer, theme, and view instances.
+
+#include "tui/render/screen.hpp"
+#include "tui/style/theme.hpp"
+#include "tui/views/text_view.hpp"
+
+#include <cassert>
+
+using viper::tui::render::ScreenBuffer;
+using viper::tui::style::Role;
+using viper::tui::style::Theme;
+using viper::tui::term::KeyEvent;
+using viper::tui::text::TextBuffer;
+using viper::tui::ui::Event;
+using viper::tui::views::TextView;
+
+int main()
+{
+    Theme theme;
+    TextBuffer buf;
+    buf.load("alpha\nbeta\ngamma\ndelta");
+
+    TextView view(buf, theme, false);
+    view.layout({0, 0, 10, 2});
+
+    // Move to second line and end
+    Event ev{};
+    ev.key.code = KeyEvent::Code::Down;
+    view.onEvent(ev);
+    ev.key.code = KeyEvent::Code::End;
+    view.onEvent(ev);
+    assert(view.cursorRow() == 1);
+    assert(view.cursorCol() == 4);
+
+    // Page down to last line (height=2)
+    ev.key.code = KeyEvent::Code::PageDown;
+    view.onEvent(ev);
+    assert(view.cursorRow() == 3);
+
+    // Home and select first char with shift+right
+    ev.key.code = KeyEvent::Code::Home;
+    ev.key.mods = 0;
+    view.onEvent(ev);
+    ev.key.code = KeyEvent::Code::Right;
+    ev.key.mods = KeyEvent::Mods::Shift;
+    view.onEvent(ev);
+    assert(view.cursorCol() == 1);
+
+    // Paint and verify selection
+    ScreenBuffer sb;
+    sb.resize(2, 10);
+    sb.clear(theme.style(Role::Normal));
+    view.paint(sb);
+    const auto &selStyle = theme.style(Role::Selection);
+    assert(sb.at(1, 0).ch == U'd');
+    assert(sb.at(1, 0).style == selStyle);
+    assert(sb.at(0, 0).ch == U'g');
+    assert(sb.at(0, 0).style == theme.style(Role::Normal));
+
+    // Page up back to second line
+    ev.key.code = KeyEvent::Code::PageUp;
+    ev.key.mods = 0;
+    view.onEvent(ev);
+    assert(view.cursorRow() == 1);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add TextView widget backed by TextBuffer with optional line numbers and selection support
- Implement cursor movement for navigation keys and painting of selected text
- Test TextView navigation, paging, and selection rendering

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c5d6bcc0748324acbe12697ac42122