### PR TITLE
Introduce command system and keybindings with a simple command palette

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(tui STATIC
   src/term/term_io.cpp
   src/term/session.cpp
   src/term/input.cpp
+  src/input/keymap.cpp
   src/util/unicode.cpp
   src/render/screen.cpp
   src/render/renderer.cpp
@@ -23,6 +24,7 @@ add_library(tui STATIC
   src/widgets/splitter.cpp
   src/widgets/status_bar.cpp
   src/widgets/search_bar.cpp
+  src/widgets/command_palette.cpp
   src/syntax/rules.cpp
   src/text/text_buffer.cpp
   src/text/search.cpp

--- a/tui/include/tui/app.hpp
+++ b/tui/include/tui/app.hpp
@@ -4,6 +4,7 @@
 // @ownership App owns root widget and screen buffer, borrows TermIO via Renderer.
 #pragma once
 
+#include "tui/input/keymap.hpp"
 #include "tui/render/renderer.hpp"
 #include "tui/ui/container.hpp"
 #include "tui/ui/focus.hpp"
@@ -34,6 +35,9 @@ class App
     /// @brief Access the focus manager.
     [[nodiscard]] ui::FocusManager &focus();
 
+    /// @brief Set global keymap for command dispatch.
+    void setKeymap(input::Keymap *km);
+
   private:
     std::unique_ptr<ui::Widget> root_{};
     render::ScreenBuffer screen_{};
@@ -42,6 +46,7 @@ class App
     int rows_{0};
     int cols_{0};
     ui::FocusManager focus_{};
+    input::Keymap *keymap_{nullptr};
 };
 
 } // namespace viper::tui

--- a/tui/include/tui/input/keymap.hpp
+++ b/tui/include/tui/input/keymap.hpp
@@ -1,0 +1,86 @@
+// tui/include/tui/input/keymap.hpp
+// @brief Map key chords to command callbacks with global and widget scopes.
+// @invariant Key chords uniquely identify commands; widget overrides global.
+// @ownership Keymap owns command list but not widget pointers.
+#pragma once
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "tui/term/input.hpp"
+#include "tui/ui/widget.hpp"
+
+namespace viper::tui::input
+{
+
+using CommandId = std::string;
+
+/// @brief Key plus modifiers defining a command trigger.
+struct KeyChord
+{
+    term::KeyEvent::Code code{term::KeyEvent::Code::Unknown};
+    unsigned mods{0};
+    uint32_t codepoint{0};
+
+    bool operator==(const KeyChord &other) const
+    {
+        return code == other.code && mods == other.mods && codepoint == other.codepoint;
+    }
+};
+
+struct KeyChordHash
+{
+    std::size_t operator()(const KeyChord &kc) const
+    {
+        return static_cast<std::size_t>(kc.code) ^ (kc.mods << 8) ^ (kc.codepoint << 16);
+    }
+};
+
+/// @brief Command entry with display name and callback.
+struct Command
+{
+    CommandId id{};
+    std::string name{};
+    std::function<void()> action{};
+};
+
+/// @brief Keymap supporting global and widget scoped bindings.
+class Keymap
+{
+  public:
+    /// @brief Register a command with identifier, name, and callback.
+    void registerCommand(CommandId id, std::string name, std::function<void()> action);
+
+    /// @brief Bind a key chord to a command globally.
+    void bindGlobal(const KeyChord &kc, const CommandId &id);
+
+    /// @brief Bind a key chord to a command for specific widget.
+    void bindWidget(ui::Widget *w, const KeyChord &kc, const CommandId &id);
+
+    /// @brief Handle a key for a widget, executing mapped command.
+    /// @return True if a command executed.
+    bool handle(ui::Widget *w, const term::KeyEvent &key) const;
+
+    /// @brief Execute command by identifier.
+    bool execute(const CommandId &id) const;
+
+    /// @brief Access registered commands.
+    [[nodiscard]] const std::vector<Command> &commands() const
+    {
+        return commands_;
+    }
+
+    /// @brief Find command by id.
+    [[nodiscard]] const Command *find(const CommandId &id) const;
+
+  private:
+    std::vector<Command> commands_{};
+    std::unordered_map<CommandId, std::size_t> index_{};
+    std::unordered_map<KeyChord, CommandId, KeyChordHash> global_{};
+    std::unordered_map<ui::Widget *, std::unordered_map<KeyChord, CommandId, KeyChordHash>>
+        widget_{};
+};
+
+} // namespace viper::tui::input

--- a/tui/include/tui/widgets/command_palette.hpp
+++ b/tui/include/tui/widgets/command_palette.hpp
@@ -1,0 +1,44 @@
+// tui/include/tui/widgets/command_palette.hpp
+// @brief Searchable palette listing commands and executing selection.
+// @invariant Filtered command list updates on query changes.
+// @ownership CommandPalette borrows Keymap and Theme.
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "tui/input/keymap.hpp"
+#include "tui/style/theme.hpp"
+#include "tui/ui/widget.hpp"
+
+namespace viper::tui::widgets
+{
+
+/// @brief Widget showing command palette with incremental search.
+class CommandPalette : public ui::Widget
+{
+  public:
+    CommandPalette(input::Keymap &km, const style::Theme &theme);
+
+    /// @brief Paint query and filtered commands.
+    void paint(render::ScreenBuffer &sb) override;
+
+    /// @brief Handle typing and Enter to execute command.
+    bool onEvent(const ui::Event &ev) override;
+
+    /// @brief Palette requires focus for typing.
+    [[nodiscard]] bool wantsFocus() const override
+    {
+        return true;
+    }
+
+  private:
+    input::Keymap &km_;
+    const style::Theme &theme_;
+    std::string query_{};
+    std::vector<input::CommandId> results_{};
+
+    void update();
+};
+
+} // namespace viper::tui::widgets

--- a/tui/src/app.cpp
+++ b/tui/src/app.cpp
@@ -24,6 +24,11 @@ ui::FocusManager &App::focus()
     return focus_;
 }
 
+void App::setKeymap(input::Keymap *km)
+{
+    keymap_ = km;
+}
+
 void App::tick()
 {
     for (const auto &ev : events_)
@@ -40,9 +45,17 @@ void App::tick()
             }
             continue;
         }
-        if (auto *w = focus_.current())
+        bool handled = false;
+        if (keymap_)
         {
-            w->onEvent(ev);
+            handled = keymap_->handle(focus_.current(), ev.key);
+        }
+        if (!handled)
+        {
+            if (auto *w = focus_.current())
+            {
+                w->onEvent(ev);
+            }
         }
     }
     events_.clear();

--- a/tui/src/widgets/command_palette.cpp
+++ b/tui/src/widgets/command_palette.cpp
@@ -1,0 +1,108 @@
+// tui/src/widgets/command_palette.cpp
+// @brief CommandPalette implementation filtering commands and executing.
+// @invariant Query changes recompute filtered list.
+// @ownership CommandPalette borrows Keymap and Theme.
+
+#include "tui/widgets/command_palette.hpp"
+
+namespace viper::tui::widgets
+{
+using viper::tui::term::KeyEvent;
+
+CommandPalette::CommandPalette(input::Keymap &km, const style::Theme &theme)
+    : km_(km), theme_(theme)
+{
+    update();
+}
+
+void CommandPalette::update()
+{
+    results_.clear();
+    auto q = query_;
+    for (auto &c : q)
+    {
+        c = static_cast<char>(std::tolower(c));
+    }
+    for (const auto &cmd : km_.commands())
+    {
+        std::string name = cmd.name;
+        for (auto &ch : name)
+        {
+            ch = static_cast<char>(std::tolower(ch));
+        }
+        if (q.empty() || name.find(q) != std::string::npos)
+        {
+            results_.push_back(cmd.id);
+        }
+    }
+}
+
+bool CommandPalette::onEvent(const ui::Event &ev)
+{
+    using Code = KeyEvent::Code;
+    if (ev.key.code == Code::Backspace)
+    {
+        if (!query_.empty())
+        {
+            query_.pop_back();
+            update();
+        }
+        return true;
+    }
+    if (ev.key.code == Code::Enter)
+    {
+        if (!results_.empty())
+        {
+            km_.execute(results_.front());
+        }
+        return true;
+    }
+    if (ev.key.code == Code::Unknown && ev.key.codepoint >= 32 && ev.key.codepoint <= 126)
+    {
+        query_.push_back(static_cast<char>(ev.key.codepoint));
+        update();
+        return true;
+    }
+    return false;
+}
+
+void CommandPalette::paint(render::ScreenBuffer &sb)
+{
+    const auto &st = theme_.style(style::Role::Normal);
+    for (int y = 0; y < rect_.h; ++y)
+    {
+        for (int x = 0; x < rect_.w; ++x)
+        {
+            auto &cell = sb.at(rect_.y + y, rect_.x + x);
+            cell.ch = U' ';
+            cell.style = st;
+        }
+    }
+    std::string header = ":" + query_;
+    for (int x = 0; x < rect_.w && x < static_cast<int>(header.size()); ++x)
+    {
+        auto &cell = sb.at(rect_.y, rect_.x + x);
+        cell.ch = static_cast<char32_t>(header[x]);
+        cell.style = st;
+    }
+    int row = 1;
+    for (const auto &id : results_)
+    {
+        if (row >= rect_.h)
+        {
+            break;
+        }
+        if (const auto *cmd = km_.find(id))
+        {
+            for (int x = 0; x < rect_.w && x < static_cast<int>(cmd->name.size()); ++x)
+            {
+                auto &cell = sb.at(rect_.y + row, rect_.x + x);
+                cell.ch = static_cast<char32_t>(cmd->name[x]);
+                cell.style = st;
+            }
+        }
+        ++row;
+    }
+}
+
+} // namespace viper::tui::widgets

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -62,6 +62,10 @@ add_executable(tui_test_search test_search.cpp)
 target_link_libraries(tui_test_search PRIVATE tui)
 add_test(NAME tui_test_search COMMAND tui_test_search)
 
+add_executable(tui_test_keymap_palette test_keymap_palette.cpp)
+target_link_libraries(tui_test_keymap_palette PRIVATE tui)
+add_test(NAME tui_test_keymap_palette COMMAND tui_test_keymap_palette)
+
 add_executable(tui_test_syntax test_syntax.cpp)
 target_link_libraries(tui_test_syntax PRIVATE tui)
 target_compile_definitions(tui_test_syntax PRIVATE SYNTAX_JSON="${CMAKE_CURRENT_SOURCE_DIR}/../resources/syntax/json.json")

--- a/tui/tests/test_keymap_palette.cpp
+++ b/tui/tests/test_keymap_palette.cpp
@@ -1,0 +1,85 @@
+// tui/tests/test_keymap_palette.cpp
+// @brief Validate keymap scopes and CommandPalette filtering/execution.
+// @invariant Widget-specific bindings override global and palette runs callbacks.
+// @ownership Theme and widgets owned by test.
+
+#include "tui/input/keymap.hpp"
+#include "tui/render/renderer.hpp"
+#include "tui/render/screen.hpp"
+#include "tui/style/theme.hpp"
+#include "tui/term/term_io.hpp"
+#include "tui/widgets/command_palette.hpp"
+#include "tui/widgets/label.hpp"
+
+#include <cassert>
+
+using tui::term::StringTermIO;
+using viper::tui::input::KeyChord;
+using viper::tui::input::Keymap;
+using viper::tui::render::Renderer;
+using viper::tui::render::ScreenBuffer;
+using viper::tui::style::Role;
+using viper::tui::style::Theme;
+using viper::tui::term::KeyEvent;
+using viper::tui::ui::Event;
+using viper::tui::widgets::CommandPalette;
+using viper::tui::widgets::Label;
+
+int main()
+{
+    Theme theme;
+    Keymap km;
+
+    bool global_fired = false;
+    bool widget_fired = false;
+    bool save_fired = false;
+
+    km.registerCommand("global", "Global", [&] { global_fired = true; });
+    km.registerCommand("widget", "Widget", [&] { widget_fired = true; });
+    km.registerCommand("save", "Save", [&] { save_fired = true; });
+
+    KeyChord gkc{KeyEvent::Code::F1, 0, 0};
+    km.bindGlobal(gkc, "global");
+
+    Label lbl("L", theme);
+    KeyChord wkc{KeyEvent::Code::F2, 0, 0};
+    km.bindWidget(&lbl, wkc, "widget");
+
+    KeyEvent ev{};
+    ev.code = KeyEvent::Code::F1;
+    assert(km.handle(nullptr, ev));
+    assert(global_fired);
+
+    ev.code = KeyEvent::Code::F2;
+    assert(!km.handle(nullptr, ev));
+    assert(!widget_fired);
+    assert(km.handle(&lbl, ev));
+    assert(widget_fired);
+
+    CommandPalette cp(km, theme);
+    cp.layout({0, 0, 10, 3});
+
+    Event e{};
+    e.key.code = KeyEvent::Code::Unknown;
+    e.key.codepoint = U's';
+    cp.onEvent(e);
+    e.key.codepoint = U'a';
+    cp.onEvent(e);
+
+    ScreenBuffer sb;
+    sb.resize(3, 10);
+    sb.clear(theme.style(Role::Normal));
+    cp.paint(sb);
+
+    StringTermIO tio;
+    Renderer r(tio, true);
+    r.draw(sb);
+    assert(tio.buffer().find("Save") != std::string::npos);
+
+    e.key.code = KeyEvent::Code::Enter;
+    e.key.codepoint = 0;
+    cp.onEvent(e);
+    assert(save_fired);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add Keymap for mapping key chords to commands with global and widget scopes
- introduce CommandPalette widget for searching and running commands
- wire global keymap into App and test command palette

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c5e322ec7483248ec4e36ca3f6c0f0