### PR TITLE
tui(term): add OSC52 clipboard support with headless tests

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(tui STATIC
   src/term/term_io.cpp
   src/term/session.cpp
   src/term/input.cpp
+  src/term/clipboard.cpp
   src/input/keymap.cpp
   src/util/unicode.cpp
   src/render/screen.cpp

--- a/tui/include/tui/term/clipboard.hpp
+++ b/tui/include/tui/term/clipboard.hpp
@@ -1,0 +1,53 @@
+// tui/include/tui/term/clipboard.hpp
+// @brief Terminal clipboard abstraction using OSC 52 sequences.
+// @invariant Copy emits OSC 52 unless disabled via VIPERTUI_DISABLE_OSC52.
+// @ownership Osc52Clipboard borrows TermIO; MockClipboard owns its buffer.
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace tui::term
+{
+class TermIO;
+
+class Clipboard
+{
+  public:
+    virtual ~Clipboard() = default;
+    virtual bool copy(std::string_view text) = 0;
+    virtual std::string paste() = 0;
+};
+
+class Osc52Clipboard : public Clipboard
+{
+  public:
+    explicit Osc52Clipboard(TermIO &io);
+    bool copy(std::string_view text) override;
+    std::string paste() override;
+
+  private:
+    TermIO &io_;
+};
+
+class MockClipboard : public Clipboard
+{
+  public:
+    bool copy(std::string_view text) override;
+    std::string paste() override;
+
+    const std::string &last() const
+    {
+        return last_;
+    }
+
+    void clear()
+    {
+        last_.clear();
+    }
+
+  private:
+    std::string last_{};
+};
+
+} // namespace tui::term

--- a/tui/src/term/clipboard.cpp
+++ b/tui/src/term/clipboard.cpp
@@ -1,0 +1,110 @@
+// tui/src/term/clipboard.cpp
+// @brief Implements OSC 52 clipboard operations.
+// @invariant Respects VIPERTUI_DISABLE_OSC52 environment guard.
+// @ownership Osc52Clipboard borrows TermIO; MockClipboard stores sequence.
+
+#include "tui/term/clipboard.hpp"
+#include "tui/term/term_io.hpp"
+
+#include <cstdlib>
+#include <string>
+#include <string_view>
+
+namespace tui::term
+{
+namespace
+{
+static const char kB64Table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+std::string base64_encode(std::string_view in)
+{
+    std::string out;
+    out.reserve(((in.size() + 2) / 3) * 4);
+    std::size_t i = 0;
+    while (i + 3 <= in.size())
+    {
+        unsigned triple = (static_cast<unsigned char>(in[i]) << 16) |
+                          (static_cast<unsigned char>(in[i + 1]) << 8) |
+                          (static_cast<unsigned char>(in[i + 2]));
+        out.push_back(kB64Table[(triple >> 18) & 0x3F]);
+        out.push_back(kB64Table[(triple >> 12) & 0x3F]);
+        out.push_back(kB64Table[(triple >> 6) & 0x3F]);
+        out.push_back(kB64Table[triple & 0x3F]);
+        i += 3;
+    }
+    if (i < in.size())
+    {
+        unsigned triple = static_cast<unsigned char>(in[i]) << 16;
+        bool two = false;
+        if (i + 1 < in.size())
+        {
+            triple |= static_cast<unsigned char>(in[i + 1]) << 8;
+            two = true;
+        }
+        out.push_back(kB64Table[(triple >> 18) & 0x3F]);
+        out.push_back(kB64Table[(triple >> 12) & 0x3F]);
+        if (two)
+        {
+            out.push_back(kB64Table[(triple >> 6) & 0x3F]);
+            out.push_back('=');
+        }
+        else
+        {
+            out.push_back('=');
+            out.push_back('=');
+        }
+    }
+    return out;
+}
+
+std::string build_seq(std::string_view text)
+{
+    std::string seq("\x1b]52;c;");
+    seq += base64_encode(text);
+    seq.push_back('\x07');
+    return seq;
+}
+
+bool osc52_disabled()
+{
+    const char *v = std::getenv("VIPERTUI_DISABLE_OSC52");
+    return v && v[0] == '1';
+}
+
+} // namespace
+
+Osc52Clipboard::Osc52Clipboard(TermIO &io) : io_(io) {}
+
+bool Osc52Clipboard::copy(std::string_view text)
+{
+    if (osc52_disabled())
+    {
+        return false;
+    }
+    io_.write(build_seq(text));
+    io_.flush();
+    return true;
+}
+
+std::string Osc52Clipboard::paste()
+{
+    return {};
+}
+
+bool MockClipboard::copy(std::string_view text)
+{
+    if (osc52_disabled())
+    {
+        last_.clear();
+        return false;
+    }
+    last_ = build_seq(text);
+    return true;
+}
+
+std::string MockClipboard::paste()
+{
+    return {};
+}
+
+} // namespace tui::term

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -10,6 +10,10 @@ add_executable(tui_test_term_io test_term_io.cpp)
 target_link_libraries(tui_test_term_io PRIVATE tui)
 add_test(NAME tui_test_term_io COMMAND tui_test_term_io)
 
+add_executable(tui_test_clipboard test_clipboard.cpp)
+target_link_libraries(tui_test_clipboard PRIVATE tui)
+add_test(NAME tui_test_clipboard COMMAND tui_test_clipboard)
+
 add_executable(tui_test_session test_session.cpp)
 target_link_libraries(tui_test_session PRIVATE tui)
 add_test(NAME tui_test_session COMMAND tui_test_session)

--- a/tui/tests/test_clipboard.cpp
+++ b/tui/tests/test_clipboard.cpp
@@ -1,0 +1,55 @@
+// tui/tests/test_clipboard.cpp
+// @brief Tests for OSC 52 clipboard sequences and env guard.
+// @invariant MockClipboard captures last sequence; StringTermIO captures writes.
+// @ownership MockClipboard owns its buffer.
+
+#include "tui/term/clipboard.hpp"
+#include "tui/term/term_io.hpp"
+
+#include <cassert>
+#include <cstdlib>
+
+static void clear_disable()
+{
+#if defined(_WIN32)
+    _putenv_s("VIPERTUI_DISABLE_OSC52", "");
+#else
+    unsetenv("VIPERTUI_DISABLE_OSC52");
+#endif
+}
+
+static void set_disable()
+{
+#if defined(_WIN32)
+    _putenv_s("VIPERTUI_DISABLE_OSC52", "1");
+#else
+    setenv("VIPERTUI_DISABLE_OSC52", "1", 1);
+#endif
+}
+
+int main()
+{
+    clear_disable();
+    tui::term::StringTermIO tio;
+    tui::term::Osc52Clipboard cb(tio);
+    bool ok = cb.copy("hello");
+    assert(ok);
+    assert(tio.buffer() == "\x1b]52;c;aGVsbG8=\x07");
+
+    set_disable();
+    ok = cb.copy("world");
+    assert(!ok);
+    assert(tio.buffer() == "\x1b]52;c;aGVsbG8=\x07");
+
+    clear_disable();
+    tui::term::MockClipboard mock;
+    ok = mock.copy("test");
+    assert(ok);
+    assert(mock.last() == "\x1b]52;c;dGVzdA==\x07");
+
+    set_disable();
+    ok = mock.copy("again");
+    assert(!ok);
+    assert(mock.last().empty());
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add OSC52 clipboard that writes sequences via TermIO
- provide mock clipboard for tests and document interface
- validate sequence generation and environment guard in unit test

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c5e69fea588324b42817ee618133b5