### PR TITLE
tui(ui): add ModalHost and Popup with focus capture

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(tui STATIC
   src/ui/widget.cpp
   src/ui/container.cpp
   src/ui/focus.cpp
+  src/ui/modal.cpp
   src/style/theme.cpp
   src/widgets/label.cpp
   src/widgets/button.cpp

--- a/tui/include/tui/ui/modal.hpp
+++ b/tui/include/tui/ui/modal.hpp
@@ -1,0 +1,74 @@
+// tui/include/tui/ui/modal.hpp
+// @brief Modal host and popup widgets handling layered dialogs.
+// @invariant ModalHost routes events to top modal; Popup centers within host.
+// @ownership ModalHost owns root and modals; Popup borrows dismiss callback.
+#pragma once
+
+#include "tui/ui/widget.hpp"
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace viper::tui::ui
+{
+class Popup;
+
+/// @brief Hosts a root widget and manages a stack of modal widgets.
+class ModalHost : public Widget
+{
+  public:
+    /// @brief Construct host with root widget.
+    explicit ModalHost(std::unique_ptr<Widget> root);
+
+    /// @brief Push a modal widget on top.
+    void pushModal(std::unique_ptr<Widget> modal);
+
+    /// @brief Pop the topmost modal.
+    void popModal();
+
+    void layout(const Rect &r) override;
+    void paint(render::ScreenBuffer &sb) override;
+    bool onEvent(const Event &ev) override;
+
+    /// @brief Always focusable to intercept events.
+    [[nodiscard]] bool wantsFocus() const override
+    {
+        return true;
+    }
+
+    /// @brief Access underlying root widget.
+    [[nodiscard]] Widget *root();
+
+  private:
+    std::unique_ptr<Widget> root_{};
+    std::vector<std::unique_ptr<Widget>> modals_{};
+};
+
+/// @brief Simple popup widget with border and dismiss callback.
+class Popup : public Widget
+{
+  public:
+    /// @brief Construct popup with dimensions.
+    Popup(int w, int h);
+
+    /// @brief Set callback invoked on dismiss.
+    void setOnClose(std::function<void()> cb);
+
+    void layout(const Rect &r) override;
+    void paint(render::ScreenBuffer &sb) override;
+    bool onEvent(const Event &ev) override;
+
+    [[nodiscard]] bool wantsFocus() const override
+    {
+        return true;
+    }
+
+  private:
+    int width_{0};
+    int height_{0};
+    Rect box_{};
+    std::function<void()> onClose_{};
+};
+
+} // namespace viper::tui::ui

--- a/tui/src/ui/modal.cpp
+++ b/tui/src/ui/modal.cpp
@@ -1,0 +1,143 @@
+// tui/src/ui/modal.cpp
+// @brief Modal host and popup widget implementations with backdrop.
+// @invariant ModalHost paints root then modals with full-screen backdrop.
+// @ownership ModalHost owns root and modals; Popup borrows dismiss callback.
+
+#include "tui/ui/modal.hpp"
+
+#include <algorithm>
+
+namespace viper::tui::ui
+{
+ModalHost::ModalHost(std::unique_ptr<Widget> root) : root_(std::move(root)) {}
+
+Widget *ModalHost::root()
+{
+    return root_.get();
+}
+
+void ModalHost::pushModal(std::unique_ptr<Widget> modal)
+{
+    if (auto *p = dynamic_cast<Popup *>(modal.get()))
+    {
+        p->setOnClose([this] { popModal(); });
+    }
+    modals_.push_back(std::move(modal));
+}
+
+void ModalHost::popModal()
+{
+    if (!modals_.empty())
+    {
+        modals_.pop_back();
+    }
+}
+
+void ModalHost::layout(const Rect &r)
+{
+    Widget::layout(r);
+    if (root_)
+    {
+        root_->layout(r);
+    }
+    for (auto &m : modals_)
+    {
+        m->layout(r);
+    }
+}
+
+void ModalHost::paint(render::ScreenBuffer &sb)
+{
+    if (root_)
+    {
+        root_->paint(sb);
+    }
+    if (!modals_.empty())
+    {
+        for (int y = rect_.y; y < rect_.y + rect_.h; ++y)
+        {
+            for (int x = rect_.x; x < rect_.x + rect_.w; ++x)
+            {
+                sb.at(y, x).ch = U' ';
+            }
+        }
+        for (auto &m : modals_)
+        {
+            m->paint(sb);
+        }
+    }
+}
+
+bool ModalHost::onEvent(const Event &ev)
+{
+    if (!modals_.empty())
+    {
+        (void)modals_.back()->onEvent(ev);
+        return true;
+    }
+    if (root_)
+    {
+        return root_->onEvent(ev);
+    }
+    return false;
+}
+
+Popup::Popup(int w, int h) : width_(w), height_(h) {}
+
+void Popup::setOnClose(std::function<void()> cb)
+{
+    onClose_ = std::move(cb);
+}
+
+void Popup::layout(const Rect &r)
+{
+    Widget::layout(r);
+    int w = std::min(width_, r.w);
+    int h = std::min(height_, r.h);
+    int x = r.x + (r.w - w) / 2;
+    int y = r.y + (r.h - h) / 2;
+    box_ = {x, y, w, h};
+}
+
+void Popup::paint(render::ScreenBuffer &sb)
+{
+    int x0 = box_.x;
+    int y0 = box_.y;
+    int w = box_.w;
+    int h = box_.h;
+
+    for (int x = 0; x < w; ++x)
+    {
+        auto &top = sb.at(y0, x0 + x);
+        top.ch = (x == 0 || x == w - 1) ? U'+' : U'-';
+        auto &bot = sb.at(y0 + h - 1, x0 + x);
+        bot.ch = (x == 0 || x == w - 1) ? U'+' : U'-';
+    }
+    for (int y = 1; y < h - 1; ++y)
+    {
+        auto &left = sb.at(y0 + y, x0);
+        left.ch = U'|';
+        auto &right = sb.at(y0 + y, x0 + w - 1);
+        right.ch = U'|';
+        for (int x = 1; x < w - 1; ++x)
+        {
+            sb.at(y0 + y, x0 + x).ch = U' ';
+        }
+    }
+}
+
+bool Popup::onEvent(const Event &ev)
+{
+    const auto &k = ev.key;
+    if (k.code == term::KeyEvent::Code::Esc || k.code == term::KeyEvent::Code::Enter)
+    {
+        if (onClose_)
+        {
+            onClose_();
+        }
+        return true;
+    }
+    return false;
+}
+
+} // namespace viper::tui::ui

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -50,6 +50,10 @@ add_executable(tui_test_widgets_basic test_widgets_basic.cpp)
 target_link_libraries(tui_test_widgets_basic PRIVATE tui)
 add_test(NAME tui_test_widgets_basic COMMAND tui_test_widgets_basic)
 
+add_executable(tui_test_modal test_modal.cpp)
+target_link_libraries(tui_test_modal PRIVATE tui)
+add_test(NAME tui_test_modal COMMAND tui_test_modal)
+
 add_executable(tui_test_split_status test_split_status.cpp)
 target_link_libraries(tui_test_split_status PRIVATE tui)
 add_test(NAME tui_test_split_status COMMAND tui_test_split_status)

--- a/tui/tests/test_modal.cpp
+++ b/tui/tests/test_modal.cpp
@@ -1,0 +1,81 @@
+// tui/tests/test_modal.cpp
+// @brief Verify popup blocks events and dismisses on keys.
+// @invariant Underlying widget ignores keys while popup active.
+// @ownership Test owns widgets, modal host, app, and TermIO.
+
+#include "tui/app.hpp"
+#include "tui/term/term_io.hpp"
+#include "tui/ui/modal.hpp"
+
+#include <cassert>
+#include <memory>
+
+using tui::term::StringTermIO;
+using viper::tui::App;
+using viper::tui::term::KeyEvent;
+using viper::tui::ui::Event;
+using viper::tui::ui::ModalHost;
+using viper::tui::ui::Popup;
+using viper::tui::ui::Widget;
+
+struct FlagWidget : Widget
+{
+    bool flag{false};
+
+    bool onEvent(const Event &ev) override
+    {
+        if (ev.key.code == KeyEvent::Code::Enter)
+        {
+            flag = true;
+            return true;
+        }
+        return false;
+    }
+
+    bool wantsFocus() const override
+    {
+        return true;
+    }
+};
+
+int main()
+{
+    auto base = std::make_unique<FlagWidget>();
+    FlagWidget *ptr = base.get();
+    auto host = std::make_unique<ModalHost>(std::move(base));
+    ModalHost *hptr = host.get();
+    StringTermIO tio;
+    App app(std::move(host), tio, 10, 10);
+    app.focus().registerWidget(hptr);
+
+    // Ensure base widget receives keys without popup
+    Event ev{};
+    ev.key.code = KeyEvent::Code::Enter;
+    app.pushEvent(ev);
+    app.tick();
+    assert(ptr->flag);
+
+    // Popup intercepts and dismisses on Enter
+    ptr->flag = false;
+    hptr->pushModal(std::make_unique<Popup>(4, 3));
+    app.pushEvent(ev);
+    app.tick();
+    assert(!ptr->flag);
+    app.pushEvent(ev);
+    app.tick();
+    assert(ptr->flag);
+
+    // Popup intercepts and dismisses on Esc
+    ptr->flag = false;
+    hptr->pushModal(std::make_unique<Popup>(4, 3));
+    ev.key.code = KeyEvent::Code::Esc;
+    app.pushEvent(ev);
+    app.tick();
+    assert(!ptr->flag);
+    ev.key.code = KeyEvent::Code::Enter;
+    app.pushEvent(ev);
+    app.tick();
+    assert(ptr->flag);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add ModalHost widget to manage stacked modal dialogs with backdrop
- introduce Popup widget that centers a bordered box and dismisses on Esc/Enter
- verify modal focus capture with unit test

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c5ea2d8c2c83248d7ebcbcb196d600