### PR TITLE
tui(widgets): add ListView and TreeView with navigation tests

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -27,6 +27,8 @@ add_library(tui STATIC
   src/widgets/status_bar.cpp
   src/widgets/search_bar.cpp
   src/widgets/command_palette.cpp
+  src/widgets/list_view.cpp
+  src/widgets/tree_view.cpp
   src/syntax/rules.cpp
   src/text/text_buffer.cpp
   src/text/search.cpp

--- a/tui/include/tui/widgets/list_view.hpp
+++ b/tui/include/tui/widgets/list_view.hpp
@@ -1,0 +1,62 @@
+// tui/include/tui/widgets/list_view.hpp
+// @brief Selectable list widget with multi-selection and custom renderer.
+// @invariant Cursor and selection indices remain within item range.
+// @ownership ListView borrows Theme; caller owns item strings.
+#pragma once
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "tui/style/theme.hpp"
+#include "tui/ui/widget.hpp"
+
+namespace viper::tui::widgets
+{
+
+/// @brief Displays a vertical list of items with keyboard navigation.
+class ListView : public ui::Widget
+{
+  public:
+    using ItemRenderer = std::function<void(render::ScreenBuffer &,
+                                            int row,
+                                            const std::string &item,
+                                            bool selected,
+                                            const style::Theme &theme)>;
+
+    /// @brief Construct list view with items and theme.
+    ListView(std::vector<std::string> items, const style::Theme &theme);
+
+    /// @brief Set custom item renderer.
+    void setRenderer(ItemRenderer r);
+
+    /// @brief Paint list items.
+    void paint(render::ScreenBuffer &sb) override;
+
+    /// @brief Handle navigation and selection keys.
+    /// @return True if event consumed.
+    bool onEvent(const ui::Event &ev) override;
+
+    /// @brief List wants focus for keyboard navigation.
+    [[nodiscard]] bool wantsFocus() const override
+    {
+        return true;
+    }
+
+    /// @brief Retrieve selected item indices.
+    [[nodiscard]] std::vector<int> selection() const;
+
+  private:
+    std::vector<std::string> items_{};
+    std::vector<bool> selected_{};
+    ItemRenderer renderer_{};
+    const style::Theme &theme_;
+    int cursor_{0};
+    int anchor_{0};
+
+    void defaultRender(render::ScreenBuffer &sb, int row, const std::string &item, bool selected);
+    void clearSelection();
+    void selectRange(int a, int b);
+};
+
+} // namespace viper::tui::widgets

--- a/tui/include/tui/widgets/tree_view.hpp
+++ b/tui/include/tui/widgets/tree_view.hpp
@@ -1,0 +1,68 @@
+// tui/include/tui/widgets/tree_view.hpp
+// @brief Hierarchical tree widget with expandable nodes.
+// @invariant Visible list rebuilt after expansion changes.
+// @ownership TreeView owns nodes; Theme borrowed.
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "tui/style/theme.hpp"
+#include "tui/ui/widget.hpp"
+
+namespace viper::tui::widgets
+{
+
+/// @brief Node in TreeView hierarchy.
+struct TreeNode
+{
+    std::string label{};
+    std::vector<std::unique_ptr<TreeNode>> children{};
+    TreeNode *parent{nullptr};
+    bool expanded{false};
+
+    explicit TreeNode(std::string lbl) : label(std::move(lbl)) {}
+
+    TreeNode *add(std::unique_ptr<TreeNode> child)
+    {
+        child->parent = this;
+        children.push_back(std::move(child));
+        return children.back().get();
+    }
+};
+
+/// @brief Displays a tree of nodes with expand/collapse controls.
+class TreeView : public ui::Widget
+{
+  public:
+    /// @brief Construct with root nodes and theme.
+    TreeView(std::vector<std::unique_ptr<TreeNode>> roots, const style::Theme &theme);
+
+    /// @brief Paint visible nodes.
+    void paint(render::ScreenBuffer &sb) override;
+
+    /// @brief Handle navigation and expansion keys.
+    /// @return True if event consumed.
+    bool onEvent(const ui::Event &ev) override;
+
+    /// @brief Tree view wants focus for keyboard handling.
+    [[nodiscard]] bool wantsFocus() const override
+    {
+        return true;
+    }
+
+    /// @brief Current node under cursor.
+    [[nodiscard]] TreeNode *current() const;
+
+  private:
+    std::vector<std::unique_ptr<TreeNode>> roots_{};
+    const style::Theme &theme_;
+    std::vector<TreeNode *> visible_{};
+    int cursor_{0};
+
+    void rebuild();
+    static int depth(TreeNode *n);
+};
+
+} // namespace viper::tui::widgets

--- a/tui/src/widgets/list_view.cpp
+++ b/tui/src/widgets/list_view.cpp
@@ -1,0 +1,143 @@
+// tui/src/widgets/list_view.cpp
+// @brief Implementation of selectable ListView widget.
+// @invariant Selection flags align with items vector.
+// @ownership ListView borrows Theme; items owned by caller.
+
+#include "tui/widgets/list_view.hpp"
+
+#include <algorithm>
+
+namespace viper::tui::widgets
+{
+
+ListView::ListView(std::vector<std::string> items, const style::Theme &theme)
+    : items_(std::move(items)), theme_(theme)
+{
+    selected_.resize(items_.size(), false);
+    if (!items_.empty())
+    {
+        selected_[0] = true;
+    }
+    renderer_ = [this](render::ScreenBuffer &sb,
+                       int row,
+                       const std::string &item,
+                       bool selected,
+                       const style::Theme &) { defaultRender(sb, row, item, selected); };
+}
+
+void ListView::setRenderer(ItemRenderer r)
+{
+    renderer_ = std::move(r);
+}
+
+void ListView::paint(render::ScreenBuffer &sb)
+{
+    for (std::size_t i = 0; i < items_.size() && static_cast<int>(i) < rect_.h; ++i)
+    {
+        renderer_(sb, rect_.y + static_cast<int>(i), items_[i], selected_[i], theme_);
+    }
+}
+
+bool ListView::onEvent(const ui::Event &ev)
+{
+    if (items_.empty())
+    {
+        return false;
+    }
+    const auto &k = ev.key;
+    if (k.code == term::KeyEvent::Code::Up)
+    {
+        if (cursor_ > 0)
+        {
+            --cursor_;
+        }
+    }
+    else if (k.code == term::KeyEvent::Code::Down)
+    {
+        if (cursor_ + 1 < static_cast<int>(items_.size()))
+        {
+            ++cursor_;
+        }
+    }
+    else
+    {
+        return false;
+    }
+
+    if (k.mods & term::KeyEvent::Mods::Ctrl)
+    {
+        return true;
+    }
+    if (k.mods & term::KeyEvent::Mods::Shift)
+    {
+        clearSelection();
+        selectRange(anchor_, cursor_);
+        return true;
+    }
+    clearSelection();
+    anchor_ = cursor_;
+    selected_[cursor_] = true;
+    return true;
+}
+
+std::vector<int> ListView::selection() const
+{
+    std::vector<int> out;
+    for (std::size_t i = 0; i < selected_.size(); ++i)
+    {
+        if (selected_[i])
+        {
+            out.push_back(static_cast<int>(i));
+        }
+    }
+    return out;
+}
+
+void ListView::defaultRender(render::ScreenBuffer &sb,
+                             int row,
+                             const std::string &item,
+                             bool selected)
+{
+    const auto &sel = theme_.style(style::Role::Accent);
+    const auto &nor = theme_.style(style::Role::Normal);
+    int x = rect_.x;
+    auto &pref = sb.at(row, x);
+    pref.ch = selected ? U'>' : U' ';
+    pref.style = sel;
+    int maxw = rect_.w - 1;
+    for (int i = 0; i < maxw; ++i)
+    {
+        auto &c = sb.at(row, x + 1 + i);
+        if (i < static_cast<int>(item.size()))
+        {
+            c.ch = static_cast<char32_t>(item[i]);
+        }
+        else
+        {
+            c.ch = U' ';
+        }
+        c.style = nor;
+    }
+}
+
+void ListView::clearSelection()
+{
+    std::fill(selected_.begin(), selected_.end(), false);
+}
+
+void ListView::selectRange(int a, int b)
+{
+    if (a > b)
+    {
+        std::swap(a, b);
+    }
+    for (int i = a; i <= b && i < static_cast<int>(selected_.size()); ++i)
+    {
+        if (i >= 0)
+        {
+            selected_[i] = true;
+        }
+    }
+}
+
+} // namespace viper::tui::widgets

--- a/tui/src/widgets/tree_view.cpp
+++ b/tui/src/widgets/tree_view.cpp
@@ -1,0 +1,178 @@
+// tui/src/widgets/tree_view.cpp
+// @brief Implementation of TreeView widget with expand/collapse.
+// @invariant Visible nodes refreshed on state change.
+// @ownership TreeView owns nodes and borrows Theme.
+
+#include "tui/widgets/tree_view.hpp"
+
+#include <algorithm>
+
+namespace viper::tui::widgets
+{
+
+TreeView::TreeView(std::vector<std::unique_ptr<TreeNode>> roots, const style::Theme &theme)
+    : roots_(std::move(roots)), theme_(theme)
+{
+    rebuild();
+}
+
+void TreeView::paint(render::ScreenBuffer &sb)
+{
+    const auto &sel = theme_.style(style::Role::Accent);
+    const auto &nor = theme_.style(style::Role::Normal);
+    for (std::size_t i = 0; i < visible_.size() && static_cast<int>(i) < rect_.h; ++i)
+    {
+        auto *node = visible_[i];
+        int y = rect_.y + static_cast<int>(i);
+        int x = rect_.x;
+        auto &csel = sb.at(y, x);
+        csel.ch = (cursor_ == static_cast<int>(i)) ? U'>' : U' ';
+        csel.style = sel;
+        x += 1;
+        int d = depth(node);
+        for (int k = 0; k < d * 2 && k + x < rect_.x + rect_.w; ++k)
+        {
+            auto &cell = sb.at(y, x + k);
+            cell.ch = U' ';
+            cell.style = nor;
+        }
+        x += d * 2;
+        if (x < rect_.x + rect_.w)
+        {
+            auto &mark = sb.at(y, x);
+            mark.ch = node->children.empty() ? U' ' : (node->expanded ? U'-' : U'+');
+            mark.style = sel;
+            ++x;
+        }
+        int maxw = rect_.x + rect_.w - x;
+        for (int j = 0; j < maxw; ++j)
+        {
+            auto &cell = sb.at(y, x + j);
+            if (j < static_cast<int>(node->label.size()))
+            {
+                cell.ch = static_cast<char32_t>(node->label[j]);
+            }
+            else
+            {
+                cell.ch = U' ';
+            }
+            cell.style = nor;
+        }
+    }
+}
+
+bool TreeView::onEvent(const ui::Event &ev)
+{
+    if (visible_.empty())
+    {
+        return false;
+    }
+    const auto &k = ev.key;
+    if (k.code == term::KeyEvent::Code::Up)
+    {
+        if (cursor_ > 0)
+        {
+            --cursor_;
+        }
+        return true;
+    }
+    if (k.code == term::KeyEvent::Code::Down)
+    {
+        if (cursor_ + 1 < static_cast<int>(visible_.size()))
+        {
+            ++cursor_;
+        }
+        return true;
+    }
+    auto *node = visible_[cursor_];
+    if (k.code == term::KeyEvent::Code::Right)
+    {
+        if (!node->children.empty() && !node->expanded)
+        {
+            node->expanded = true;
+            rebuild();
+        }
+        return true;
+    }
+    if (k.code == term::KeyEvent::Code::Left)
+    {
+        if (node->expanded)
+        {
+            node->expanded = false;
+            rebuild();
+        }
+        else if (node->parent)
+        {
+            auto *p = node->parent;
+            auto it = std::find(visible_.begin(), visible_.end(), p);
+            if (it != visible_.end())
+            {
+                cursor_ = static_cast<int>(it - visible_.begin());
+            }
+        }
+        return true;
+    }
+    if (k.code == term::KeyEvent::Code::Enter)
+    {
+        if (!node->children.empty())
+        {
+            node->expanded = !node->expanded;
+            rebuild();
+        }
+        return true;
+    }
+    return false;
+}
+
+TreeNode *TreeView::current() const
+{
+    if (visible_.empty())
+    {
+        return nullptr;
+    }
+    return visible_[cursor_];
+}
+
+void TreeView::rebuild()
+{
+    visible_.clear();
+    std::vector<TreeNode *> stack;
+    for (auto &r : roots_)
+    {
+        stack.push_back(r.get());
+        while (!stack.empty())
+        {
+            TreeNode *n = stack.back();
+            stack.pop_back();
+            visible_.push_back(n);
+            if (n->expanded)
+            {
+                for (auto it = n->children.rbegin(); it != n->children.rend(); ++it)
+                {
+                    stack.push_back(it->get());
+                }
+            }
+        }
+    }
+    if (cursor_ >= static_cast<int>(visible_.size()))
+    {
+        cursor_ = static_cast<int>(visible_.size()) - 1;
+    }
+    if (cursor_ < 0)
+    {
+        cursor_ = 0;
+    }
+}
+
+int TreeView::depth(TreeNode *n)
+{
+    int d = 0;
+    while (n->parent)
+    {
+        n = n->parent;
+        ++d;
+    }
+    return d;
+}
+
+} // namespace viper::tui::widgets

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -78,3 +78,7 @@ add_executable(tui_test_syntax test_syntax.cpp)
 target_link_libraries(tui_test_syntax PRIVATE tui)
 target_compile_definitions(tui_test_syntax PRIVATE SYNTAX_JSON="${CMAKE_CURRENT_SOURCE_DIR}/../resources/syntax/json.json")
 add_test(NAME tui_test_syntax COMMAND tui_test_syntax)
+
+add_executable(tui_test_list_tree test_list_tree.cpp)
+target_link_libraries(tui_test_list_tree PRIVATE tui)
+add_test(NAME tui_test_list_tree COMMAND tui_test_list_tree)

--- a/tui/tests/test_list_tree.cpp
+++ b/tui/tests/test_list_tree.cpp
@@ -1,0 +1,122 @@
+// tui/tests/test_list_tree.cpp
+// @brief Test ListView and TreeView keyboard behavior and painting.
+// @invariant Selection and expansion reflect simulated key events.
+// @ownership Theme and widgets owned within test.
+
+#include "tui/render/renderer.hpp"
+#include "tui/render/screen.hpp"
+#include "tui/style/theme.hpp"
+#include "tui/term/term_io.hpp"
+#include "tui/widgets/list_view.hpp"
+#include "tui/widgets/tree_view.hpp"
+
+#include <cassert>
+#include <cctype>
+#include <memory>
+#include <string>
+#include <vector>
+
+using tui::term::StringTermIO;
+using viper::tui::render::Renderer;
+using viper::tui::render::ScreenBuffer;
+using viper::tui::style::Role;
+using viper::tui::style::Theme;
+using viper::tui::term::KeyEvent;
+using viper::tui::ui::Event;
+using viper::tui::widgets::ListView;
+using viper::tui::widgets::TreeNode;
+using viper::tui::widgets::TreeView;
+
+int main()
+{
+    Theme theme;
+    ScreenBuffer sb;
+    StringTermIO tio;
+    Renderer r(tio, true);
+
+    // ListView basic paint and selection
+    ListView lv({"one", "two", "three"}, theme);
+    lv.layout({0, 0, 8, 3});
+    sb.resize(3, 8);
+    sb.clear(theme.style(Role::Normal));
+    lv.paint(sb);
+    tio.clear();
+    r.draw(sb);
+    assert(tio.buffer().find('>') != std::string::npos);
+    assert(tio.buffer().find("one") != std::string::npos);
+
+    Event ev{};
+    ev.key.code = KeyEvent::Code::Down;
+    lv.onEvent(ev);
+    ev.key.mods = KeyEvent::Shift;
+    ev.key.code = KeyEvent::Code::Down;
+    lv.onEvent(ev);
+    auto sel = lv.selection();
+    assert(sel.size() == 2 && sel[0] == 1 && sel[1] == 2);
+
+    // Custom renderer outputs uppercase without prefix
+    lv.setRenderer(
+        [](ScreenBuffer &sb, int row, const std::string &it, bool, const Theme &theme)
+        {
+            for (int i = 0; i < static_cast<int>(it.size()); ++i)
+            {
+                auto &c = sb.at(row, i);
+                c.ch = static_cast<char32_t>(std::toupper(it[i]));
+                c.style = theme.style(Role::Normal);
+            }
+        });
+    sb.clear(theme.style(Role::Normal));
+    lv.paint(sb);
+    tio.clear();
+    r.draw(sb);
+    assert(tio.buffer().find("ONE") != std::string::npos);
+
+    // TreeView expand/collapse
+    auto root = std::make_unique<TreeNode>("root");
+    root->add(std::make_unique<TreeNode>("child1"));
+    auto c2 = root->add(std::make_unique<TreeNode>("child2"));
+    c2->add(std::make_unique<TreeNode>("grand"));
+    std::vector<std::unique_ptr<TreeNode>> roots;
+    roots.push_back(std::move(root));
+    TreeView tv(std::move(roots), theme);
+    tv.layout({0, 0, 12, 5});
+    sb.resize(5, 12);
+    sb.clear(theme.style(Role::Normal));
+    tv.paint(sb);
+    tio.clear();
+    r.draw(sb);
+    assert(tio.buffer().find('+') != std::string::npos);
+    assert(tio.buffer().find("root") != std::string::npos);
+
+    ev = {};
+    ev.key.code = KeyEvent::Code::Enter;
+    tv.onEvent(ev);
+    sb.clear(theme.style(Role::Normal));
+    tv.paint(sb);
+    tio.clear();
+    r.draw(sb);
+    assert(tio.buffer().find('-') != std::string::npos);
+    assert(tio.buffer().find("root") != std::string::npos);
+
+    ev.key.code = KeyEvent::Code::Down;
+    tv.onEvent(ev); // child1
+    ev.key.code = KeyEvent::Code::Down;
+    tv.onEvent(ev); // child2
+    ev.key.code = KeyEvent::Code::Enter;
+    tv.onEvent(ev); // expand child2
+    sb.clear(theme.style(Role::Normal));
+    tv.paint(sb);
+    tio.clear();
+    r.draw(sb);
+    assert(tio.buffer().find("grand") != std::string::npos);
+
+    ev.key.code = KeyEvent::Code::Left;
+    tv.onEvent(ev); // collapse child2
+    sb.clear(theme.style(Role::Normal));
+    tv.paint(sb);
+    tio.clear();
+    r.draw(sb);
+    assert(tio.buffer().find("grand") == std::string::npos);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement selectable ListView with multi-select and custom renderer
- add hierarchical TreeView with expand/collapse
- cover keyboard navigation and rendering with new tests

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c5ecd087288324b17bffacc3269626