### PR TITLE
Add simple config loader for keymaps/theme/settings

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(tui STATIC
   src/text/search.cpp
   src/views/text_view.cpp
   src/app.cpp
+  src/config/config.cpp
 )
 
 target_include_directories(tui PUBLIC include)

--- a/tui/include/tui/config/config.hpp
+++ b/tui/include/tui/config/config.hpp
@@ -1,0 +1,53 @@
+// tui/include/tui/config/config.hpp
+// @brief Load INI-like configuration for theme, keymap, and editor settings.
+// @invariant Parsed values remain valid after load.
+// @ownership Config owns parsed data only.
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "tui/input/keymap.hpp"
+#include "tui/render/screen.hpp"
+
+namespace viper::tui::config
+{
+
+/// @brief Theme colors for roles.
+struct Theme
+{
+    render::Style normal{};
+    render::Style accent{};
+    render::Style disabled{};
+    render::Style selection{};
+};
+
+/// @brief Editor-specific settings.
+struct Editor
+{
+    unsigned tab_width{4};
+    bool soft_wrap{false};
+};
+
+/// @brief Key binding entry.
+struct Binding
+{
+    input::KeyChord chord{};
+    input::CommandId command{};
+};
+
+/// @brief Aggregated configuration.
+struct Config
+{
+    Theme theme{};
+    std::vector<Binding> keymap_global{};
+    Editor editor{};
+};
+
+/// @brief Load configuration from file path.
+/// @param path INI-like file to parse.
+/// @param out Filled with parsed configuration.
+/// @return True if file parsed successfully.
+bool loadFromFile(const std::string &path, Config &out);
+
+} // namespace viper::tui::config

--- a/tui/src/config/config.cpp
+++ b/tui/src/config/config.cpp
@@ -1,0 +1,261 @@
+// tui/src/config/config.cpp
+// @brief INI-like configuration loader implementation.
+// @invariant Reads sections [theme], [keymap.global], and [editor].
+// @ownership Loader does not own external resources beyond file path.
+
+#include "tui/config/config.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <sstream>
+#include <string_view>
+
+namespace viper::tui::config
+{
+
+namespace
+{
+std::string trim(std::string_view sv)
+{
+    while (!sv.empty() && std::isspace(static_cast<unsigned char>(sv.front())))
+    {
+        sv.remove_prefix(1);
+    }
+    while (!sv.empty() && std::isspace(static_cast<unsigned char>(sv.back())))
+    {
+        sv.remove_suffix(1);
+    }
+    return std::string(sv);
+}
+
+bool parse_color(const std::string &s, render::RGBA &out)
+{
+    std::string hex = s;
+    if (!hex.empty() && hex[0] == '#')
+    {
+        hex.erase(0, 1);
+    }
+    if (hex.size() != 6)
+    {
+        return false;
+    }
+    unsigned v = 0;
+    std::istringstream iss(hex);
+    iss >> std::hex >> v;
+    if (iss.fail())
+    {
+        return false;
+    }
+    out.r = static_cast<uint8_t>((v >> 16) & 0xFF);
+    out.g = static_cast<uint8_t>((v >> 8) & 0xFF);
+    out.b = static_cast<uint8_t>(v & 0xFF);
+    out.a = 255;
+    return true;
+}
+
+term::KeyEvent::Code parse_code(const std::string &name)
+{
+    using Code = term::KeyEvent::Code;
+    if (name == "enter")
+        return Code::Enter;
+    if (name == "esc")
+        return Code::Esc;
+    if (name == "tab")
+        return Code::Tab;
+    if (name == "backspace")
+        return Code::Backspace;
+    if (name == "up")
+        return Code::Up;
+    if (name == "down")
+        return Code::Down;
+    if (name == "left")
+        return Code::Left;
+    if (name == "right")
+        return Code::Right;
+    if (name == "home")
+        return Code::Home;
+    if (name == "end")
+        return Code::End;
+    if (name == "pageup")
+        return Code::PageUp;
+    if (name == "pagedown")
+        return Code::PageDown;
+    if (name == "insert")
+        return Code::Insert;
+    if (name == "delete")
+        return Code::Delete;
+    if (name.size() > 1 && name[0] == 'f')
+    {
+        int num = std::stoi(name.substr(1));
+        switch (num)
+        {
+            case 1:
+                return Code::F1;
+            case 2:
+                return Code::F2;
+            case 3:
+                return Code::F3;
+            case 4:
+                return Code::F4;
+            case 5:
+                return Code::F5;
+            case 6:
+                return Code::F6;
+            case 7:
+                return Code::F7;
+            case 8:
+                return Code::F8;
+            case 9:
+                return Code::F9;
+            case 10:
+                return Code::F10;
+            case 11:
+                return Code::F11;
+            case 12:
+                return Code::F12;
+            default:
+                break;
+        }
+    }
+    return Code::Unknown;
+}
+
+input::KeyChord parse_chord(const std::string &str)
+{
+    input::KeyChord kc{};
+    std::stringstream ss(str);
+    std::string token;
+    while (std::getline(ss, token, '+'))
+    {
+        token = trim(token);
+        std::string lower;
+        lower.resize(token.size());
+        std::transform(token.begin(),
+                       token.end(),
+                       lower.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        if (lower == "ctrl")
+        {
+            kc.mods |= term::KeyEvent::Ctrl;
+            continue;
+        }
+        if (lower == "alt")
+        {
+            kc.mods |= term::KeyEvent::Alt;
+            continue;
+        }
+        if (lower == "shift")
+        {
+            kc.mods |= term::KeyEvent::Shift;
+            continue;
+        }
+        if (token.size() == 1)
+        {
+            kc.codepoint = static_cast<uint32_t>(token[0]);
+        }
+        else
+        {
+            kc.code = parse_code(lower);
+        }
+    }
+    return kc;
+}
+
+bool parse_bool(const std::string &s)
+{
+    std::string lower;
+    lower.resize(s.size());
+    std::transform(
+        s.begin(), s.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
+    return lower == "1" || lower == "true" || lower == "yes";
+}
+
+} // namespace
+
+bool loadFromFile(const std::string &path, Config &out)
+{
+    std::ifstream in(path);
+    if (!in)
+    {
+        return false;
+    }
+    std::string line;
+    std::string section;
+    while (std::getline(in, line))
+    {
+        std::string trimmed = trim(line);
+        if (trimmed.empty() || trimmed[0] == '#' || trimmed[0] == ';')
+        {
+            continue;
+        }
+        if (trimmed.front() == '[' && trimmed.back() == ']')
+        {
+            section = trimmed.substr(1, trimmed.size() - 2);
+            std::transform(section.begin(),
+                           section.end(),
+                           section.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
+            continue;
+        }
+        auto eq = trimmed.find('=');
+        if (eq == std::string::npos)
+        {
+            continue;
+        }
+        std::string key = trim(trimmed.substr(0, eq));
+        std::string value = trim(trimmed.substr(eq + 1));
+        std::string lower_key;
+        lower_key.resize(key.size());
+        std::transform(key.begin(),
+                       key.end(),
+                       lower_key.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+
+        if (section == "theme")
+        {
+            render::RGBA col;
+            if (!parse_color(value, col))
+            {
+                continue;
+            }
+            if (lower_key == "normal_fg")
+                out.theme.normal.fg = col;
+            else if (lower_key == "normal_bg")
+                out.theme.normal.bg = col;
+            else if (lower_key == "accent_fg")
+                out.theme.accent.fg = col;
+            else if (lower_key == "accent_bg")
+                out.theme.accent.bg = col;
+            else if (lower_key == "disabled_fg")
+                out.theme.disabled.fg = col;
+            else if (lower_key == "disabled_bg")
+                out.theme.disabled.bg = col;
+            else if (lower_key == "selection_fg")
+                out.theme.selection.fg = col;
+            else if (lower_key == "selection_bg")
+                out.theme.selection.bg = col;
+        }
+        else if (section == "keymap.global")
+        {
+            Binding b{};
+            b.chord = parse_chord(key);
+            b.command = value;
+            out.keymap_global.push_back(b);
+        }
+        else if (section == "editor")
+        {
+            if (lower_key == "tab_width")
+            {
+                out.editor.tab_width = static_cast<unsigned>(std::stoul(value));
+            }
+            else if (lower_key == "soft_wrap")
+            {
+                out.editor.soft_wrap = parse_bool(value);
+            }
+        }
+    }
+    return true;
+}
+
+} // namespace viper::tui::config

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -82,3 +82,8 @@ add_test(NAME tui_test_syntax COMMAND tui_test_syntax)
 add_executable(tui_test_list_tree test_list_tree.cpp)
 target_link_libraries(tui_test_list_tree PRIVATE tui)
 add_test(NAME tui_test_list_tree COMMAND tui_test_list_tree)
+
+add_executable(tui_test_config test_config.cpp)
+target_link_libraries(tui_test_config PRIVATE tui)
+target_compile_definitions(tui_test_config PRIVATE CONFIG_INI="${CMAKE_CURRENT_SOURCE_DIR}/data/config.ini")
+add_test(NAME tui_test_config COMMAND tui_test_config)

--- a/tui/tests/data/config.ini
+++ b/tui/tests/data/config.ini
@@ -1,0 +1,17 @@
+[theme]
+normal_fg=#ffffff
+normal_bg=#000000
+accent_fg=#000000
+accent_bg=#c8c8c8
+disabled_fg=#808080
+disabled_bg=#000000
+selection_fg=#000000
+selection_bg=#0080ff
+
+[keymap.global]
+Ctrl+S=save
+F1=help
+
+[editor]
+tab_width=2
+soft_wrap=true

--- a/tui/tests/test_config.cpp
+++ b/tui/tests/test_config.cpp
@@ -1,0 +1,41 @@
+// tui/tests/test_config.cpp
+// @brief Verify configuration loader parses theme, keymap, and editor settings.
+// @invariant Parsed values match expected sample config.
+// @ownership Test owns configuration data only.
+
+#include "tui/config/config.hpp"
+
+#include <cassert>
+
+using viper::tui::config::Config;
+using viper::tui::config::loadFromFile;
+using viper::tui::render::RGBA;
+using viper::tui::term::KeyEvent;
+
+int main()
+{
+    Config cfg;
+    bool ok = loadFromFile(CONFIG_INI, cfg);
+    assert(ok);
+
+    // Theme color
+    assert((cfg.theme.accent.bg == RGBA{200, 200, 200, 255}));
+
+    // Editor settings
+    assert(cfg.editor.tab_width == 2);
+    assert(cfg.editor.soft_wrap);
+
+    // Keymap binding
+    bool found_save = false;
+    for (const auto &b : cfg.keymap_global)
+    {
+        if (b.command == "save")
+        {
+            found_save = true;
+            assert((b.chord.mods & KeyEvent::Ctrl) != 0);
+            assert(b.chord.codepoint == 'S' || b.chord.codepoint == 's');
+        }
+    }
+    assert(found_save);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- parse INI-like configuration files for theme colors, key bindings, and editor settings
- provide sample config and unit test verifying parsing

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c5f32aefcc8324a64a4b62e5cb287f