### PR TITLE
tui(app): add tui_demo with headless mode for CI

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -39,5 +39,7 @@ add_library(tui STATIC
 
 target_include_directories(tui PUBLIC include)
 
+add_subdirectory(apps)
+
 enable_testing()
 add_subdirectory(tests)

--- a/tui/apps/CMakeLists.txt
+++ b/tui/apps/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(tui_demo tui_demo.cpp)
+
+target_link_libraries(tui_demo PRIVATE tui)

--- a/tui/apps/tui_demo.cpp
+++ b/tui/apps/tui_demo.cpp
@@ -1,0 +1,111 @@
+// tui/apps/tui_demo.cpp
+// @brief Small demo app wiring TerminalSession + App + a couple widgets.
+// @invariant Exits on Ctrl+Q in interactive mode; headless renders once.
+// @ownership App owns widget tree; TermIO and environment are borrowed.
+
+#include "tui/app.hpp"
+#include "tui/style/theme.hpp"
+#include "tui/term/input.hpp"
+#include "tui/term/session.hpp"
+#include "tui/term/term_io.hpp"
+#include "tui/text/text_buffer.hpp"
+#include "tui/views/text_view.hpp"
+#include "tui/widgets/list_view.hpp"
+#include "tui/widgets/splitter.hpp"
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+#if defined(_WIN32)
+#include <conio.h>
+#else
+#include <unistd.h>
+#endif
+
+int main()
+{
+    bool headless = false;
+    if (const char *v = std::getenv("VIPERTUI_NO_TTY"))
+    {
+        headless = (v[0] == '1');
+    }
+
+    tui::TerminalSession session;
+    tui::term::RealTermIO tio;
+
+    viper::tui::style::Theme theme;
+    viper::tui::text::TextBuffer buf;
+    buf.load("Hello from ViperTUI demo\nPress Ctrl+Q to quit.");
+    auto tv = std::make_unique<viper::tui::views::TextView>(buf, theme, false);
+    auto *tv_ptr = tv.get();
+    std::vector<std::string> items{"Item 1", "Item 2", "Item 3"};
+    auto lv = std::make_unique<viper::tui::widgets::ListView>(items, theme);
+    auto *lv_ptr = lv.get();
+    auto root =
+        std::make_unique<viper::tui::widgets::HSplitter>(std::move(tv), std::move(lv), 0.5F);
+
+    viper::tui::App app(std::move(root), tio, 24, 80);
+    app.focus().registerWidget(tv_ptr);
+    app.focus().registerWidget(lv_ptr);
+
+    app.tick();
+    if (headless)
+    {
+        return 0;
+    }
+
+    viper::tui::term::InputDecoder decoder;
+#if defined(_WIN32)
+    while (true)
+    {
+        int c = _getch();
+        if (c == 17)
+        {
+            break; // Ctrl+Q
+        }
+        char ch = static_cast<char>(c);
+        decoder.feed(std::string_view(&ch, 1));
+        for (auto &ev : decoder.drain())
+        {
+            viper::tui::ui::Event e{};
+            e.key = ev;
+            app.pushEvent(e);
+        }
+        app.tick();
+    }
+#else
+    char in[64];
+    while (true)
+    {
+        ssize_t n = ::read(STDIN_FILENO, in, sizeof(in));
+        if (n <= 0)
+        {
+            break;
+        }
+        bool quit = false;
+        for (ssize_t i = 0; i < n; ++i)
+        {
+            if (in[i] == 17)
+            {
+                quit = true; // Ctrl+Q
+            }
+        }
+        decoder.feed(std::string_view(in, static_cast<size_t>(n)));
+        for (auto &ev : decoder.drain())
+        {
+            viper::tui::ui::Event e{};
+            e.key = ev;
+            app.pushEvent(e);
+        }
+        app.tick();
+        if (quit)
+        {
+            break;
+        }
+    }
+#endif
+
+    return 0;
+}

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -87,3 +87,7 @@ add_executable(tui_test_config test_config.cpp)
 target_link_libraries(tui_test_config PRIVATE tui)
 target_compile_definitions(tui_test_config PRIVATE CONFIG_INI="${CMAKE_CURRENT_SOURCE_DIR}/data/config.ini")
 add_test(NAME tui_test_config COMMAND tui_test_config)
+
+add_executable(tui_test_demo_headless test_demo_headless.cpp)
+target_link_libraries(tui_test_demo_headless PRIVATE tui)
+add_test(NAME tui_test_demo_headless COMMAND tui_test_demo_headless)

--- a/tui/tests/test_demo_headless.cpp
+++ b/tui/tests/test_demo_headless.cpp
@@ -1,0 +1,30 @@
+// tui/tests/test_demo_headless.cpp
+// @brief Run tui_demo in headless mode; expect clean exit.
+// @invariant VIPERTUI_NO_TTY=1 triggers one-frame render and exit.
+// @ownership None.
+
+#include <cassert>
+#include <cstdlib>
+#include <string>
+
+static void set_no_tty_env()
+{
+#if defined(_WIN32)
+    _putenv_s("VIPERTUI_NO_TTY", "1");
+#else
+    setenv("VIPERTUI_NO_TTY", "1", 1);
+#endif
+}
+
+int main()
+{
+    set_no_tty_env();
+#if defined(_WIN32)
+    const std::string cmd = "..\\apps\\tui_demo.exe";
+#else
+    const std::string cmd = "../apps/tui_demo";
+#endif
+    int rc = std::system(cmd.c_str());
+    assert(rc == 0);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add tui_demo example wiring TerminalSession and widgets
- Support headless single-frame run via VIPERTUI_NO_TTY
- Test demo headless exit in CI

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c5f6a9baf88324b85aa2c9d9b9d87b