### PR TITLE
fix(runtime): guard oversized allocations

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -96,6 +96,11 @@ void *rt_alloc(int64_t bytes)
 {
     if (bytes < 0)
         return rt_trap("negative allocation"), NULL;
+    if ((uint64_t)bytes > SIZE_MAX)
+    {
+        rt_trap("allocation too large");
+        return NULL;
+    }
     void *p = malloc((size_t)bytes);
     if (!p)
         rt_trap("out of memory");

--- a/tests/runtime/RTAllocTooLargeTests.cpp
+++ b/tests/runtime/RTAllocTooLargeTests.cpp
@@ -1,0 +1,60 @@
+// File: tests/runtime/RTAllocTooLargeTests.cpp
+// Purpose: Verify rt_alloc traps when allocation exceeds size_t range.
+// Key invariants: rt_alloc reports "allocation too large" when bytes > SIZE_MAX.
+// Ownership: Uses runtime library.
+// Links: docs/runtime-abi.md
+#include "rt.hpp"
+#include <cassert>
+#include <stdint.h>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#if SIZE_MAX < INT64_MAX
+
+static std::string capture(void (*fn)())
+{
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        fn();
+        _exit(0);
+    }
+    close(fds[1]);
+    char buf[256];
+    ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
+    if (n > 0)
+        buf[n] = '\0';
+    else
+        buf[0] = '\0';
+    int status = 0;
+    waitpid(pid, &status, 0);
+    return std::string(buf);
+}
+
+static void call_alloc_too_large()
+{
+    rt_alloc((int64_t)SIZE_MAX + 1);
+}
+
+int main()
+{
+    std::string out = capture(call_alloc_too_large);
+    bool ok = out.find("allocation too large") != std::string::npos;
+    assert(ok);
+    return 0;
+}
+
+#else
+
+int main()
+{
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
## Summary
- trap allocations exceeding host size_t to prevent undefined behaviour
- add regression test for oversized allocation trap

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c628d3a5888324af044d4bffcf8cbd