### PR TITLE
fix(runtime): handle long integers in rt_int_to_str

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -793,13 +793,33 @@ rt_string rt_int_to_str(int64_t v)
     int n = snprintf(buf, sizeof(buf), "%lld", (long long)v);
     if (n < 0)
         rt_trap("rt_int_to_str: format");
+
+    const char *src = buf;
+    char *tmp = NULL;
+    if (n >= (int)sizeof(buf))
+    {
+        tmp = (char *)malloc((size_t)n + 1);
+        if (!tmp)
+            rt_trap("rt_int_to_str: alloc");
+        int n2 = snprintf(tmp, (size_t)n + 1, "%lld", (long long)v);
+        if (n2 < 0 || n2 > n)
+        {
+            free(tmp);
+            rt_trap("rt_int_to_str: format");
+        }
+        src = tmp;
+    }
+
     rt_string s = (rt_string)rt_alloc(sizeof(*s));
     s->refcnt = 1;
     s->size = n;
     s->capacity = n;
-    char *data = (char *)rt_alloc(n + 1);
-    memcpy(data, buf, (size_t)n + 1);
+    char *data = (char *)rt_alloc((size_t)n + 1);
+    memcpy(data, src, (size_t)n + 1);
     s->data = data;
+
+    if (tmp)
+        free(tmp);
     return s;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,10 @@ add_executable(test_rt_conv unit/test_rt_conv.cpp)
 target_link_libraries(test_rt_conv PRIVATE rt)
 add_test(NAME test_rt_conv COMMAND test_rt_conv)
 
+add_executable(test_rt_int_to_str_big unit/test_rt_int_to_str_big.cpp)
+target_link_libraries(test_rt_int_to_str_big PRIVATE rt)
+add_test(NAME test_rt_int_to_str_big COMMAND test_rt_int_to_str_big)
+
 add_executable(test_rt_val_str runtime/RTValStrTests.cpp)
 target_link_libraries(test_rt_val_str PRIVATE rt)
 add_test(NAME test_rt_val_str COMMAND test_rt_val_str)

--- a/tests/unit/test_rt_int_to_str_big.cpp
+++ b/tests/unit/test_rt_int_to_str_big.cpp
@@ -1,0 +1,38 @@
+// File: tests/unit/test_rt_int_to_str_big.cpp
+// Purpose: Ensure rt_int_to_str handles integers with more than 31 digits.
+// Key invariants: Dynamic buffer allocation is used when snprintf reports
+//                 output longer than the initial stack buffer.
+// Ownership: Uses runtime library.
+// Links: docs/class-catalog.md
+#include "rt.hpp"
+#include <cassert>
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+extern "C" int snprintf(char *str, size_t size, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    long long v = va_arg(ap, long long);
+    va_end(ap);
+    char buf[128];
+    int n = std::sprintf(buf, "%040lld", v); // 40 digits
+    if (str && size > 0)
+    {
+        size_t copy = (n < (int)size) ? (size_t)n : size - 1;
+        std::memcpy(str, buf, copy);
+        str[copy] = '\0';
+    }
+    return n;
+}
+
+int main()
+{
+    rt_string s = rt_int_to_str(1234567890LL);
+    std::string expected(40, '0');
+    expected.replace(expected.size() - 10, 10, "1234567890");
+    assert(s && std::string(s->data, (size_t)s->size) == expected);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- allow rt_int_to_str to grow beyond 32 bytes using a temporary buffer
- cover oversized integer formatting with a regression test

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c628f1bde883248351ebdf2375776b