### PR TITLE
fix(runtime): trap on rt_abs_i64 overflow

### DIFF
--- a/archive/docs/runtime-abi.md
+++ b/archive/docs/runtime-abi.md
@@ -12,7 +12,7 @@ This document describes the stable C ABI provided by the runtime library.
 | `@rt_sin` | `f64 -> f64` | sine |
 | `@rt_cos` | `f64 -> f64` | cosine |
 | `@rt_pow` | `f64, f64 -> f64` | power |
-| `@rt_abs_i64` | `i64 -> i64` | absolute value (integer) |
+| `@rt_abs_i64` | `i64 -> i64` | absolute value (integer, traps on overflow) |
 | `@rt_abs_f64` | `f64 -> f64` | absolute value (float) |
 
 ## Random

--- a/runtime/rt_math.c
+++ b/runtime/rt_math.c
@@ -5,6 +5,8 @@
 // Links: docs/runtime-abi.md
 
 #include "rt_math.h"
+#include "rt.hpp"
+#include <limits.h>
 #include <math.h>
 
 // Ensure functions are visible with C linkage when included in C++ builds
@@ -104,11 +106,12 @@ extern "C"
      * Computes the absolute value of a signed 64-bit integer.
      *
      * @param v Input value.
-     * @return Absolute value of @p v. If @p v is `LLONG_MIN`, the result is
-     * implementation-defined due to two's-complement overflow.
+     * @return Absolute value of @p v. Traps if @p v is `LLONG_MIN`.
      */
     long long rt_abs_i64(long long v)
     {
+        if (v == LLONG_MIN)
+            return rt_trap("rt_abs_i64: overflow"), 0;
         return v < 0 ? -v : v;
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -145,6 +145,10 @@ add_executable(test_rt_math_core runtime/RTMathCoreTests.cpp)
 target_link_libraries(test_rt_math_core PRIVATE rt)
 add_test(NAME test_rt_math_core COMMAND test_rt_math_core)
 
+add_executable(test_rt_abs_i64_overflow runtime/RTAbsI64OverflowTests.cpp)
+target_link_libraries(test_rt_abs_i64_overflow PRIVATE rt)
+add_test(NAME test_rt_abs_i64_overflow COMMAND test_rt_abs_i64_overflow)
+
 add_executable(test_rt_random runtime/RTRandomTests.cpp)
 target_link_libraries(test_rt_random PRIVATE rt)
 add_test(NAME test_rt_random COMMAND test_rt_random)

--- a/tests/runtime/RTAbsI64OverflowTests.cpp
+++ b/tests/runtime/RTAbsI64OverflowTests.cpp
@@ -1,0 +1,23 @@
+// File: tests/runtime/RTAbsI64OverflowTests.cpp
+// Purpose: Verify rt_abs_i64 traps on overflow input.
+// Key invariants: Overflowing inputs trigger runtime trap.
+// Ownership: Uses runtime library; stubs vm_trap to capture message.
+// Links: docs/runtime-abi.md
+#include "rt_math.h"
+#include <cassert>
+#include <climits>
+#include <cstring>
+
+static const char *g_msg = nullptr;
+
+extern "C" void vm_trap(const char *msg)
+{
+    g_msg = msg;
+}
+
+int main()
+{
+    (void)rt_abs_i64(LLONG_MIN);
+    assert(g_msg && std::strcmp(g_msg, "rt_abs_i64: overflow") == 0);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- handle `LLONG_MIN` overflow in `rt_abs_i64` by trapping
- document `rt_abs_i64` overflow trap in runtime ABI
- test `rt_abs_i64(LLONG_MIN)` triggers trap

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c62f32c9d0832493a15a4957c1e777