### PR TITLE
fix(frontends/basic): cast chars before classification

### DIFF
--- a/src/frontends/basic/Lexer.cpp
+++ b/src/frontends/basic/Lexer.cpp
@@ -285,7 +285,7 @@ Token Lexer::next()
         (c == '.' && pos_ + 1 < src_.size() &&
          std::isdigit(static_cast<unsigned char>(src_[pos_ + 1]))))
         return lexNumber();
-    if (std::isalpha(c))
+    if (std::isalpha(static_cast<unsigned char>(c)))
         return lexIdentifierOrKeyword();
     if (c == '"')
         return lexString();

--- a/tests/unit/test_basic_lexer_high_bit.cpp
+++ b/tests/unit/test_basic_lexer_high_bit.cpp
@@ -41,6 +41,14 @@ int main()
         assert(lex.next().kind == TokenKind::EndOfFile);
     }
     {
+        std::string input(1, static_cast<char>(0xFF));
+        Lexer lex(input, 0);
+        Token t = lex.next();
+        assert(t.kind == TokenKind::Unknown);
+        assert(t.lexeme == std::string(1, static_cast<char>(0xFF)));
+        assert(lex.next().kind == TokenKind::EndOfFile);
+    }
+    {
         std::string input = std::string("REM") + static_cast<char>(0x80) + "\n1";
         Lexer lex(input, 0);
         Token t1 = lex.next();


### PR DESCRIPTION
## Summary
- cast characters to unsigned before using `std::isalpha` in the BASIC lexer to avoid UB
- extend high-bit lexer test to cover `0xFF`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c62f35e5488324b738f90b73033218