### PR TITLE
fix(vm): size register file to SSA value count

### DIFF
--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -145,7 +145,11 @@ Frame VM::setupFrame(const Function &fn,
 {
     Frame fr;
     fr.func = &fn;
-    fr.regs.resize(64);
+    // Pre-size register file to the function's SSA value count. This mirrors
+    // the number of temporaries and parameters required by @p fn and avoids
+    // incremental growth during execution.
+    fr.regs.resize(fn.valueNames.size());
+    assert(fr.regs.size() == fn.valueNames.size());
     for (const auto &b : fn.blocks)
         blocks[b.label] = &b;
     bb = fn.blocks.empty() ? nullptr : &fn.blocks.front();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -467,6 +467,10 @@ add_executable(test_vm_unknown_global unit/test_vm_unknown_global.cpp)
 target_link_libraries(test_vm_unknown_global PRIVATE il_build il_vm support)
 add_test(NAME test_vm_unknown_global COMMAND test_vm_unknown_global)
 
+add_executable(test_vm_many_temps unit/test_vm_many_temps.cpp)
+target_link_libraries(test_vm_many_temps PRIVATE il_vm support)
+add_test(NAME test_vm_many_temps COMMAND test_vm_many_temps)
+
 add_executable(test_vm_addr_of unit/test_vm_addr_of.cpp)
 target_link_libraries(test_vm_addr_of PRIVATE il_io il_vm support)
 add_test(NAME test_vm_addr_of COMMAND test_vm_addr_of)

--- a/tests/unit/test_vm_many_temps.cpp
+++ b/tests/unit/test_vm_many_temps.cpp
@@ -1,0 +1,57 @@
+// File: tests/unit/test_vm_many_temps.cpp
+// Purpose: Ensure VM handles functions with more than 64 SSA temporaries.
+// Key invariants: Function with 70 temporaries executes and returns expected value.
+// Ownership: Test constructs IL module and executes VM.
+// Links: docs/il-reference.md
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Module.hpp"
+#include "il/core/Opcode.hpp"
+#include "il/core/Type.hpp"
+#include "il/core/Value.hpp"
+#include "vm/VM.hpp"
+#include <cassert>
+
+int main()
+{
+    using namespace il::core;
+
+    Module m;
+    Function fn;
+    fn.name = "main";
+    fn.retType = Type(Type::Kind::I64);
+
+    BasicBlock bb;
+    bb.label = "entry";
+
+    for (unsigned i = 0; i < 70; ++i)
+    {
+        bb.instructions.emplace_back();
+        Instr &in = bb.instructions.back();
+        in.result = i;
+        in.op = Opcode::Add;
+        in.type = Type(Type::Kind::I64);
+        if (i == 0)
+            in.operands = {Value::constInt(0), Value::constInt(0)};
+        else
+            in.operands = {Value::temp(i - 1), Value::constInt(1)};
+    }
+
+    bb.instructions.emplace_back();
+    Instr &ret = bb.instructions.back();
+    ret.op = Opcode::Ret;
+    ret.type = Type(Type::Kind::Void);
+    ret.operands = {Value::temp(69)};
+    bb.terminated = true;
+
+    fn.blocks.push_back(std::move(bb));
+    fn.valueNames.resize(70);
+    m.functions.push_back(std::move(fn));
+
+    il::vm::VM vm(m);
+    int64_t res = vm.run();
+    assert(res == 69);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- size VM frame registers based on function SSA value count
- add unit test for executing function with 70 temporaries

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c634963274832488c39f0efc76fcc9