### PR TITLE
fix(runtime): clamp substring length to avoid overflow

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -303,8 +303,9 @@ rt_string rt_substr(rt_string s, int64_t start, int64_t len)
         len = 0;
     if (start > s->size)
         start = s->size;
-    if (start + len > s->size)
-        len = s->size - start;
+    int64_t avail = s->size - start;
+    if (len > avail)
+        len = avail;
     if (len == 0)
         return rt_empty_string();
     if (start == 0 && len == s->size)

--- a/tests/unit/test_rt_string.cpp
+++ b/tests/unit/test_rt_string.cpp
@@ -1,5 +1,11 @@
+// File: tests/unit/test_rt_string.cpp
+// Purpose: Verify runtime string helpers including substring operations clamp inputs.
+// Key invariants: Substring operations clamp start/length and avoid overflow.
+// Ownership: Uses runtime library.
+// Links: docs/class-catalog.md
 #include "rt.hpp"
 #include <cassert>
+#include <limits>
 
 int main()
 {
@@ -28,6 +34,13 @@ int main()
     assert(rt_str_eq(clamp2, hell));
     rt_string clamp3 = rt_substr(hw, 2, -5);
     assert(rt_len(clamp3) == 0);
+
+    int64_t huge = std::numeric_limits<int64_t>::max();
+    rt_string biglen = rt_substr(hw, 2, huge);
+    rt_string lloworld = rt_const_cstr("lloworld");
+    assert(rt_str_eq(biglen, lloworld));
+    rt_string bigstart = rt_substr(hw, huge, huge);
+    assert(rt_len(bigstart) == 0);
 
     assert(!rt_str_eq(hello, world));
 


### PR DESCRIPTION
## Summary
- prevent overflow in `rt_substr` by comparing length against available characters
- add regression tests exercising `rt_substr` with huge start/length inputs

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c644e3cb5c832499107bb8563cb743