### PR TITLE
Validate UTF-8 decoding and add malformed input tests

### DIFF
--- a/tui/src/util/unicode.cpp
+++ b/tui/src/util/unicode.cpp
@@ -100,6 +100,14 @@ std::u32string decode_utf8(std::string_view in)
             ++i;
             continue;
         }
+        bool overlong =
+            (len == 2 && cp < 0x80) || (len == 3 && cp < 0x800) || (len == 4 && cp < 0x10000);
+        if (overlong || cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF))
+        {
+            out.push_back(0xFFFD);
+            ++i;
+            continue;
+        }
         out.push_back(cp);
         i += len;
     }

--- a/tui/tests/test_unicode_width.cpp
+++ b/tui/tests/test_unicode_width.cpp
@@ -25,5 +25,23 @@ int main()
     assert(char_width(s[0]) == 1);
     assert(char_width(s[1]) == 0);
 
+    s = decode_utf8("\xC0\xAF"); // overlong '/'
+    assert(s.size() == 2);
+    assert(s[0] == 0xFFFD && s[1] == 0xFFFD);
+
+    s = decode_utf8("\xED\xA0\x80"); // surrogate U+D800
+    assert(s.size() == 3);
+    for (auto ch : s)
+    {
+        assert(ch == 0xFFFD);
+    }
+
+    s = decode_utf8("\xF4\x90\x80\x80"); // > U+10FFFF
+    assert(s.size() == 4);
+    for (auto ch : s)
+    {
+        assert(ch == 0xFFFD);
+    }
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- ensure `decode_utf8` rejects overlong, surrogate, and out-of-range code points
- expand Unicode unit test to cover malformed UTF-8 sequences

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c644ebc8a48324af88042a15f266e6