### PR TITLE
fix(runtime): clamp rt_instr3 start before decrement

### DIFF
--- a/runtime/rt.c
+++ b/runtime/rt.c
@@ -539,14 +539,12 @@ int64_t rt_instr3(int64_t start, rt_string hay, rt_string needle)
     if (!hay || !needle)
         return 0;
     int64_t len = hay->size;
-    start -= 1;
-    if (start < 0)
-        start = 0;
-    if (start > len)
-        start = len;
+    int64_t pos = start <= 1 ? 0 : start - 1;
+    if (pos > len)
+        pos = len;
     if (needle->size == 0)
-        return start + 1;
-    return rt_find(hay, start, needle);
+        return pos + 1;
+    return rt_find(hay, pos, needle);
 }
 
 /**

--- a/tests/runtime/RTInstrTests.cpp
+++ b/tests/runtime/RTInstrTests.cpp
@@ -1,10 +1,12 @@
 // File: tests/runtime/RTInstrTests.cpp
 // Purpose: Validate runtime INSTR search functions.
-// Key invariants: 1-based indexing semantics; empty needle returns clamped start.
+// Key invariants: 1-based indexing semantics; empty needle returns clamped
+// start; extreme start values clamp to 1.
 // Ownership: Uses runtime library.
 // Links: docs/runtime-abi.md
 #include "rt.hpp"
 #include <cassert>
+#include <limits.h>
 
 int main()
 {
@@ -16,6 +18,7 @@ int main()
     rt_string s4 = rt_const_cstr("AB");
     assert(rt_instr3(3, s3, s4) == 3);
     assert(rt_instr3(1, s3, s4) == 1);
+    assert(rt_instr3(LLONG_MIN, s3, s4) == rt_instr3(1, s3, s4));
 
     rt_string empty = rt_const_cstr("");
     assert(rt_instr3(3, s3, empty) == 3);


### PR DESCRIPTION
## Summary
- clamp `rt_instr3` start argument before decrement to handle extreme negatives
- add regression test for `rt_instr3(LLONG_MIN, ...)`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c646ba4c148324bcd82cd97dce4a90