### PR TITLE
fix(il/io): report missing extern arrow

### DIFF
--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -924,6 +924,12 @@ bool parseModuleHeader(std::istream &is, std::string &line, ParserState &st, std
         size_t lp = line.find('(', at);
         size_t rp = line.find(')', lp);
         size_t arr = line.find("->", rp);
+        if (arr == std::string::npos)
+        {
+            err << "line " << st.lineNo << ": missing '->'\n";
+            st.hasError = true;
+            return false;
+        }
         std::string name = line.substr(at + 1, lp - at - 1);
         std::string paramsStr = line.substr(lp + 1, rp - lp - 1);
         std::vector<Type> params;

--- a/tests/unit/test_il_parse_extern_missing_arrow.cpp
+++ b/tests/unit/test_il_parse_extern_missing_arrow.cpp
@@ -1,0 +1,28 @@
+// File: tests/unit/test_il_parse_extern_missing_arrow.cpp
+// Purpose: Ensure IL parser reports error when extern declaration lacks '->'.
+// Key invariants: Parser sets hasError and returns false for malformed extern.
+// Ownership/Lifetime: Test constructs modules and buffers locally.
+// Links: docs/il-spec.md
+
+#include "il/io/Parser.hpp"
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    const char *src = R"(il 0.1.2
+extern @foo(i32)
+func @main() -> i32 {
+entry:
+  ret 0
+}
+)";
+    std::istringstream in(src);
+    il::core::Module m;
+    std::ostringstream err;
+    bool ok = il::io::Parser::parse(in, m, err);
+    assert(!ok);
+    std::string msg = err.str();
+    assert(msg.find("missing '->'") != std::string::npos);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- validate extern declarations contain `->` before parsing return type
- add unit test for extern without return arrow

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c650d280088324bbc4f02e78ee0c7e