### PR TITLE
fix(il/io): handle malformed function headers

### DIFF
--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -739,6 +739,12 @@ bool parseFunctionHeader(const std::string &header, ParserState &st, std::ostrea
     size_t rp = header.find(')', lp);
     size_t arr = header.find("->", rp);
     size_t lb = header.find('{', arr);
+    if (arr == std::string::npos || lb == std::string::npos)
+    {
+        err << "line " << st.lineNo << ": malformed function header\n";
+        st.hasError = true;
+        return false;
+    }
     std::string name = header.substr(at + 1, lp - at - 1);
     std::string paramsStr = header.substr(lp + 1, rp - lp - 1);
     std::vector<Param> params;
@@ -773,7 +779,6 @@ bool parseFunctionHeader(const std::string &header, ParserState &st, std::ostrea
         st.curFn->valueNames[param.id] = param.name;
     st.blockParamCount.clear();
     st.pendingBrs.clear();
-    (void)err; // err currently unused
     return true;
 }
 

--- a/tests/unit/test_il_parse_malformed_func_header.cpp
+++ b/tests/unit/test_il_parse_malformed_func_header.cpp
@@ -1,0 +1,24 @@
+// File: tests/unit/test_il_parse_malformed_func_header.cpp
+// Purpose: Ensure parser rejects function headers missing delimiters.
+// Key invariants: Parser sets hasError and returns false for malformed headers.
+// Ownership/Lifetime: Test constructs modules and streams locally.
+// Links: docs/il-spec.md
+
+#include "il/io/Parser.hpp"
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    const char *src = R"(il 0.1.2
+func @main() -> i32
+)";
+    std::istringstream in(src);
+    il::core::Module m;
+    std::ostringstream err;
+    bool ok = il::io::Parser::parse(in, m, err);
+    assert(!ok);
+    std::string msg = err.str();
+    assert(msg.find("malformed function header") != std::string::npos);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- validate function headers for "->" and "{" delimiters
- add regression test for malformed function headers

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c650da42d4832498518ee3c5baf3f1