### PR TITLE
feat(tui/app): add App::resize(rows, cols) and resize ScreenBuffer

### DIFF
--- a/tui/include/tui/app.hpp
+++ b/tui/include/tui/app.hpp
@@ -38,6 +38,11 @@ class App
     /// @brief Set global keymap for command dispatch.
     void setKeymap(input::Keymap *km);
 
+    /// @brief Resize the app's screen and request re-layout on next tick.
+    /// @param rows New number of rows (height).
+    /// @param cols New number of columns (width).
+    void resize(int rows, int cols);
+
   private:
     std::unique_ptr<ui::Widget> root_{};
     render::ScreenBuffer screen_{};

--- a/tui/src/app.cpp
+++ b/tui/src/app.cpp
@@ -70,4 +70,11 @@ void App::tick()
     screen_.snapshotPrev();
 }
 
+void App::resize(int rows, int cols)
+{
+    rows_ = rows;
+    cols_ = cols;
+    screen_.resize(rows_, cols_);
+}
+
 } // namespace viper::tui

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -42,6 +42,10 @@ add_executable(tui_test_app_layout test_app_layout.cpp)
 target_link_libraries(tui_test_app_layout PRIVATE tui)
 add_test(NAME tui_test_app_layout COMMAND tui_test_app_layout)
 
+add_executable(tui_test_app_resize test_app_resize.cpp)
+target_link_libraries(tui_test_app_resize PRIVATE tui)
+add_test(NAME tui_test_app_resize COMMAND tui_test_app_resize)
+
 add_executable(tui_test_focus test_focus.cpp)
 target_link_libraries(tui_test_focus PRIVATE tui)
 add_test(NAME tui_test_focus COMMAND tui_test_focus)

--- a/tui/tests/test_app_resize.cpp
+++ b/tui/tests/test_app_resize.cpp
@@ -1,0 +1,52 @@
+// tui/tests/test_app_resize.cpp
+// @brief Verify App::resize updates layout dimensions.
+// @invariant Root widget rect matches new size after resize.
+// @ownership Test owns widget, app, and TermIO.
+
+#include "tui/app.hpp"
+#include "tui/render/screen.hpp"
+#include "tui/term/term_io.hpp"
+#include "tui/ui/widget.hpp"
+
+#include <cassert>
+#include <memory>
+
+using tui::term::StringTermIO;
+using viper::tui::App;
+using viper::tui::render::ScreenBuffer;
+using viper::tui::ui::Widget;
+
+struct CharWidget : Widget
+{
+    char ch;
+
+    explicit CharWidget(char c) : ch(c) {}
+
+    void paint(ScreenBuffer &sb) override
+    {
+        auto r = rect();
+        for (int y = r.y; y < r.y + r.h; ++y)
+        {
+            for (int x = r.x; x < r.x + r.w; ++x)
+            {
+                sb.at(y, x).ch = ch;
+            }
+        }
+    }
+};
+
+int main()
+{
+    auto root = std::make_unique<CharWidget>('X');
+    CharWidget *wp = root.get();
+    StringTermIO tio;
+    App app(std::move(root), tio, 1, 1);
+    app.tick();
+    assert(wp->rect().h == 1);
+    assert(wp->rect().w == 1);
+    app.resize(2, 3);
+    app.tick();
+    assert(wp->rect().h == 2);
+    assert(wp->rect().w == 3);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `App::resize(rows, cols)` to update cached dimensions and resize the internal ScreenBuffer
- hook up minimal unit test covering resize behavior

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c65b00a0bc83248c1b27f101a90c25