### PR TITLE
feat(tui/widgets): keyboard-adjustable H/V splitters with Ctrl+Arrows

### DIFF
--- a/tui/include/tui/widgets/splitter.hpp
+++ b/tui/include/tui/widgets/splitter.hpp
@@ -26,6 +26,11 @@ class HSplitter : public ui::Widget
     /// @brief Paint both child widgets.
     void paint(render::ScreenBuffer &sb) override;
 
+    /// @brief Handle keyboard events for adjusting split ratio.
+    bool onEvent(const viper::tui::term::KeyEvent &ev);
+
+    bool onEvent(const ui::Event &ev) override;
+
   private:
     std::unique_ptr<ui::Widget> left_{};
     std::unique_ptr<ui::Widget> right_{};
@@ -47,6 +52,11 @@ class VSplitter : public ui::Widget
 
     /// @brief Paint both child widgets.
     void paint(render::ScreenBuffer &sb) override;
+
+    /// @brief Handle keyboard events for adjusting split ratio.
+    bool onEvent(const viper::tui::term::KeyEvent &ev);
+
+    bool onEvent(const ui::Event &ev) override;
 
   private:
     std::unique_ptr<ui::Widget> top_{};

--- a/tui/src/widgets/splitter.cpp
+++ b/tui/src/widgets/splitter.cpp
@@ -84,3 +84,75 @@ void VSplitter::paint(render::ScreenBuffer &sb)
 }
 
 } // namespace viper::tui::widgets
+
+namespace viper::tui::widgets
+{
+
+static inline float clamp_ratio(float r)
+{
+    if (r < 0.05F)
+        return 0.05F;
+    if (r > 0.95F)
+        return 0.95F;
+    return r;
+}
+
+bool HSplitter::onEvent(const viper::tui::term::KeyEvent &ev)
+{
+    using viper::tui::term::KeyEvent;
+    if ((ev.mods & KeyEvent::Ctrl) == 0)
+        return false;
+
+    bool changed = false;
+    if (ev.code == KeyEvent::Code::Left)
+    {
+        ratio_ = clamp_ratio(ratio_ - 0.05F);
+        changed = true;
+    }
+    if (ev.code == KeyEvent::Code::Right)
+    {
+        ratio_ = clamp_ratio(ratio_ + 0.05F);
+        changed = true;
+    }
+    if (!changed)
+        return false;
+
+    layout(rect_);
+    return true;
+}
+
+bool VSplitter::onEvent(const viper::tui::term::KeyEvent &ev)
+{
+    using viper::tui::term::KeyEvent;
+    if ((ev.mods & KeyEvent::Ctrl) == 0)
+        return false;
+
+    bool changed = false;
+    if (ev.code == KeyEvent::Code::Up)
+    {
+        ratio_ = clamp_ratio(ratio_ - 0.05F);
+        changed = true;
+    }
+    if (ev.code == KeyEvent::Code::Down)
+    {
+        ratio_ = clamp_ratio(ratio_ + 0.05F);
+        changed = true;
+    }
+    if (!changed)
+        return false;
+
+    layout(rect_);
+    return true;
+}
+
+bool HSplitter::onEvent(const ui::Event &ev)
+{
+    return onEvent(ev.key);
+}
+
+bool VSplitter::onEvent(const ui::Event &ev)
+{
+    return onEvent(ev.key);
+}
+
+} // namespace viper::tui::widgets

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -103,3 +103,7 @@ add_test(NAME tui_test_demo_headless COMMAND tui_test_demo_headless)
 add_executable(tui_test_win_vt test_win_vt.cpp)
 target_link_libraries(tui_test_win_vt PRIVATE tui)
 add_test(NAME tui_test_win_vt COMMAND tui_test_win_vt)
+
+add_executable(tui_test_splitter_keyboard test_splitter_keyboard.cpp)
+target_link_libraries(tui_test_splitter_keyboard PRIVATE tui)
+add_test(NAME tui_test_splitter_keyboard COMMAND tui_test_splitter_keyboard)

--- a/tui/tests/test_splitter_keyboard.cpp
+++ b/tui/tests/test_splitter_keyboard.cpp
@@ -1,0 +1,72 @@
+// tui/tests/test_splitter_keyboard.cpp
+// @brief Verify splitters adjust ratio via Ctrl+Arrow keys.
+// @invariant Ratios clamp to bounds and trigger layout updates.
+// @ownership Splitters own stub child widgets used for measurement.
+
+#include "tui/widgets/splitter.hpp"
+
+#include <cassert>
+#include <memory>
+
+using viper::tui::term::KeyEvent;
+using viper::tui::widgets::HSplitter;
+using viper::tui::widgets::VSplitter;
+
+struct StubWidget : viper::tui::ui::Widget
+{
+    void layout(const viper::tui::ui::Rect &r) override
+    {
+        viper::tui::ui::Widget::layout(r);
+        last = r;
+    }
+
+    void paint(viper::tui::render::ScreenBuffer &) override {}
+
+    viper::tui::ui::Rect last{};
+};
+
+int main()
+{
+    // Horizontal splitter ratio adjustments
+    auto left = std::make_unique<StubWidget>();
+    auto right = std::make_unique<StubWidget>();
+    auto *lp = left.get();
+    auto *rp = right.get();
+    HSplitter hs(std::move(left), std::move(right), 0.5F);
+    hs.layout({0, 0, 100, 10});
+
+    KeyEvent k{};
+    k.mods = KeyEvent::Ctrl;
+    k.code = KeyEvent::Code::Left;
+    assert(hs.onEvent(k));
+    assert(lp->last.w == 45);
+    assert(rp->last.w == 55);
+
+    for (int i = 0; i < 20; ++i)
+        hs.onEvent(k);
+    assert(lp->last.w == 5);
+
+    k.code = KeyEvent::Code::Right;
+    assert(hs.onEvent(k));
+    assert(lp->last.w == 10);
+
+    // Vertical splitter ratio adjustments
+    auto top = std::make_unique<StubWidget>();
+    auto bottom = std::make_unique<StubWidget>();
+    auto *tp = top.get();
+    auto *bp = bottom.get();
+    VSplitter vs(std::move(top), std::move(bottom), 0.5F);
+    vs.layout({0, 0, 10, 100});
+
+    k.code = KeyEvent::Code::Up;
+    assert(vs.onEvent(k));
+    assert(tp->last.h == 45);
+    assert(bp->last.h == 55);
+
+    k.code = KeyEvent::Code::Down;
+    for (int i = 0; i < 20; ++i)
+        vs.onEvent(k);
+    assert(tp->last.h == 95);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- allow HSplitter and VSplitter ratios adjusted via Ctrl+Arrow keys
- clamp splitter ratios between 5% and 95% and relayout
- add regression test for keyboard splitter adjustments

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c662a65a5c8324a5fba4f7c5aa9f2e