### PR TITLE
feat(tui/term): implement MockClipboard::paste() by decoding OSC52

### DIFF
--- a/tui/src/term/clipboard.cpp
+++ b/tui/src/term/clipboard.cpp
@@ -104,7 +104,66 @@ bool MockClipboard::copy(std::string_view text)
 
 std::string MockClipboard::paste()
 {
-    return {};
+    // Expect: ESC ] 52 ; c ; <base64> BEL   (or ST terminator)
+    auto find_last_semicolon = last_.rfind(';');
+    if (find_last_semicolon == std::string::npos)
+        return {};
+
+    // Find terminator: BEL (\x07) or ST (\x1b\\)
+    std::size_t end = last_.find('\x07', find_last_semicolon + 1);
+    if (end == std::string::npos)
+    {
+        // Look for ST: ESC \\ terminator
+        std::size_t esc = last_.find('\x1b', find_last_semicolon + 1);
+        if (esc != std::string::npos && esc + 1 < last_.size() && last_[esc + 1] == '\\')
+        {
+            end = esc;
+        }
+    }
+    if (end == std::string::npos)
+        return {};
+
+    std::string_view b64 =
+        std::string_view(last_).substr(find_last_semicolon + 1, end - (find_last_semicolon + 1));
+
+    auto dec = [](char c) -> int
+    {
+        if (c >= 'A' && c <= 'Z')
+            return c - 'A';
+        if (c >= 'a' && c <= 'z')
+            return c - 'a' + 26;
+        if (c >= '0' && c <= '9')
+            return c - '0' + 52;
+        if (c == '+')
+            return 62;
+        if (c == '/')
+            return 63;
+        if (c == '=')
+            return -2; // padding
+        return -1;     // invalid
+    };
+
+    std::string out;
+    int val = 0;
+    int valb = -8;
+    for (char c : b64)
+    {
+        int d = dec(c);
+        if (d < 0)
+        {
+            if (d == -2)
+                break; // stop at padding
+            continue;  // skip invalid
+        }
+        val = (val << 6) | d;
+        valb += 6;
+        if (valb >= 0)
+        {
+            out.push_back(char((val >> valb) & 0xFF));
+            valb -= 8;
+        }
+    }
+    return out;
 }
 
 } // namespace tui::term

--- a/tui/tests/test_clipboard.cpp
+++ b/tui/tests/test_clipboard.cpp
@@ -46,10 +46,12 @@ int main()
     ok = mock.copy("test");
     assert(ok);
     assert(mock.last() == "\x1b]52;c;dGVzdA==\x07");
+    assert(mock.paste() == "test");
 
     set_disable();
     ok = mock.copy("again");
     assert(!ok);
     assert(mock.last().empty());
+    assert(mock.paste().empty());
     return 0;
 }


### PR DESCRIPTION
## Summary
- decode last OSC 52 sequence in MockClipboard::paste() using a small Base64 decoder
- test that paste round-trips text stored by copy

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c665f5058c8324b9cc4634d9c4749d