### PR TITLE
refactor(frontends/basic): table-driven statement dispatch

### DIFF
--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -19,6 +19,22 @@ Parser::Parser(std::string_view src, uint32_t file_id, DiagnosticEmitter *emitte
     : lexer_(src, file_id), emitter_(emitter)
 {
     tokens_.push_back(lexer_.next());
+    stmtHandlers_ = {
+        {TokenKind::KeywordPrint, {&Parser::parsePrint, nullptr}},
+        {TokenKind::KeywordLet, {&Parser::parseLet, nullptr}},
+        {TokenKind::KeywordIf, {nullptr, &Parser::parseIf}},
+        {TokenKind::KeywordWhile, {&Parser::parseWhile, nullptr}},
+        {TokenKind::KeywordFor, {&Parser::parseFor, nullptr}},
+        {TokenKind::KeywordNext, {&Parser::parseNext, nullptr}},
+        {TokenKind::KeywordGoto, {&Parser::parseGoto, nullptr}},
+        {TokenKind::KeywordEnd, {&Parser::parseEnd, nullptr}},
+        {TokenKind::KeywordInput, {&Parser::parseInput, nullptr}},
+        {TokenKind::KeywordDim, {&Parser::parseDim, nullptr}},
+        {TokenKind::KeywordRandomize, {&Parser::parseRandomize, nullptr}},
+        {TokenKind::KeywordFunction, {&Parser::parseFunction, nullptr}},
+        {TokenKind::KeywordSub, {&Parser::parseSub, nullptr}},
+        {TokenKind::KeywordReturn, {&Parser::parseReturn, nullptr}},
+    };
 }
 
 /// @brief Parse the entire BASIC program.

--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -36,6 +37,15 @@ class Parser
     mutable std::vector<Token> tokens_;      ///< Lookahead token buffer.
     DiagnosticEmitter *emitter_ = nullptr;   ///< Diagnostic sink; not owned.
     std::unordered_set<std::string> arrays_; ///< Names of arrays declared via DIM.
+
+    /// @brief Mapping entry for statement parsers.
+    struct StmtHandler
+    {
+        StmtPtr (Parser::*no_arg)() = nullptr;       ///< Handler without line parameter.
+        StmtPtr (Parser::*with_line)(int) = nullptr; ///< Handler requiring line number.
+    };
+
+    std::unordered_map<TokenKind, StmtHandler> stmtHandlers_; ///< Token to parser mapping.
 
 #include "frontends/basic/Parser_Token.hpp"
 

--- a/src/frontends/basic/Parser_Stmt.cpp
+++ b/src/frontends/basic/Parser_Stmt.cpp
@@ -15,34 +15,13 @@ namespace il::frontends::basic
 /// @return Parsed statement node or EndStmt for unknown tokens.
 StmtPtr Parser::parseStatement(int line)
 {
-    if (at(TokenKind::KeywordPrint))
-        return parsePrint();
-    if (at(TokenKind::KeywordLet))
-        return parseLet();
-    if (at(TokenKind::KeywordIf))
-        return parseIf(line);
-    if (at(TokenKind::KeywordWhile))
-        return parseWhile();
-    if (at(TokenKind::KeywordFor))
-        return parseFor();
-    if (at(TokenKind::KeywordNext))
-        return parseNext();
-    if (at(TokenKind::KeywordGoto))
-        return parseGoto();
-    if (at(TokenKind::KeywordEnd))
-        return parseEnd();
-    if (at(TokenKind::KeywordInput))
-        return parseInput();
-    if (at(TokenKind::KeywordDim))
-        return parseDim();
-    if (at(TokenKind::KeywordRandomize))
-        return parseRandomize();
-    if (at(TokenKind::KeywordFunction))
-        return parseFunction();
-    if (at(TokenKind::KeywordSub))
-        return parseSub();
-    if (at(TokenKind::KeywordReturn))
-        return parseReturn();
+    auto it = stmtHandlers_.find(peek().kind);
+    if (it != stmtHandlers_.end())
+    {
+        if (it->second.no_arg)
+            return (this->*(it->second.no_arg))();
+        return (this->*(it->second.with_line))(line);
+    }
     auto stmt = std::make_unique<EndStmt>();
     stmt->loc = peek().loc;
     return stmt;


### PR DESCRIPTION
## Summary
- map token kinds to parser handlers for BASIC statements
- route statement parsing through handler table instead of if-chain
- default to EndStmt when token unrecognized

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c81df83a6c832498842bf9e843d35f