### PR TITLE
refactor(frontends/basic): centralize const fold helpers

### DIFF
--- a/src/frontends/basic/ConstFoldHelpers.hpp
+++ b/src/frontends/basic/ConstFoldHelpers.hpp
@@ -1,0 +1,75 @@
+// File: src/frontends/basic/ConstFoldHelpers.hpp
+// Purpose: Generic helpers for ConstFolder numeric, comparison, and string operations.
+// Key invariants: Helpers rely on Numeric promotion semantics and preserve 64-bit wrap-around for
+// integers. Ownership/Lifetime: Returned ExprPtr objects are heap-allocated and owned by the
+// caller. Links: docs/class-catalog.md
+#pragma once
+
+#include "frontends/basic/ConstFolder.hpp"
+#include <optional>
+#include <utility>
+
+namespace il::frontends::basic::detail
+{
+/// @brief Apply arithmetic operation on two literals with promotion.
+/// @param l Left operand expression.
+/// @param r Right operand expression.
+/// @param fop Operation to apply when either operand is float.
+/// @param iop Operation to apply when both operands are integers.
+/// @return Folded literal or nullptr on mismatch.
+/// @invariant Integer operation must model 64-bit wrap-around semantics when needed.
+template <typename FloatOp, typename IntOp>
+ExprPtr foldArithmetic(const Expr &l, const Expr &r, FloatOp fop, IntOp iop)
+{
+    return foldNumericBinary(
+        l,
+        r,
+        [fop, iop](const Numeric &a, const Numeric &b) -> std::optional<Numeric>
+        {
+            if (a.isFloat)
+            {
+                double v = fop(a.f, b.f);
+                return Numeric{true, v, static_cast<long long>(v)};
+            }
+            long long v = iop(a.i, b.i);
+            return Numeric{false, static_cast<double>(v), v};
+        });
+}
+
+/// @brief Apply comparison or logical operation on two literals with promotion.
+/// @param l Left operand expression.
+/// @param r Right operand expression.
+/// @param fcmp Comparator when either operand is float.
+/// @param icmp Comparator when both operands are integers.
+/// @param allowFloat Whether float operands are permitted (false causes failure if any is float).
+/// @return Integer literal 0/1 or nullptr on mismatch.
+/// @invariant Result is always integer; 1 for true, 0 for false.
+template <typename FloatCmp, typename IntCmp>
+ExprPtr foldCompare(
+    const Expr &l, const Expr &r, FloatCmp fcmp, IntCmp icmp, bool allowFloat = true)
+{
+    return foldNumericBinary(
+        l,
+        r,
+        [fcmp, icmp, allowFloat](const Numeric &a, const Numeric &b) -> std::optional<Numeric>
+        {
+            if (!allowFloat && (a.isFloat || b.isFloat))
+                return std::nullopt;
+            bool res = a.isFloat ? fcmp(a.f, b.f) : icmp(a.i, b.i);
+            long long v = res ? 1 : 0;
+            return Numeric{false, static_cast<double>(v), v};
+        });
+}
+
+/// @brief Apply binary string operation using callback @p op.
+/// @param l Left string operand.
+/// @param r Right string operand.
+/// @param op Callback operating on string values and returning ExprPtr.
+/// @return Folded literal produced by @p op.
+/// @invariant Caller ensures @p op models BASIC semantics.
+template <typename Op> ExprPtr foldString(const StringExpr &l, const StringExpr &r, Op op)
+{
+    return op(l.value, r.value);
+}
+
+} // namespace il::frontends::basic::detail

--- a/tests/unit/test_basic_constfold.cpp
+++ b/tests/unit/test_basic_constfold.cpp
@@ -62,5 +62,44 @@ int main()
         assert(oss.str().find("B2001") != std::string::npos);
     }
 
+    // numeric comparison
+    {
+        std::string src = "10 LET X = 5 > 2\n20 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("test.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        foldConstants(*prog);
+        auto *let = dynamic_cast<LetStmt *>(prog->main[0].get());
+        auto *ie = dynamic_cast<IntExpr *>(let->expr.get());
+        assert(ie && ie->value == 1);
+    }
+
+    // string comparison
+    {
+        std::string src = "10 PRINT \"foo\" = \"bar\"\n20 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("test.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        foldConstants(*prog);
+        auto *pr = dynamic_cast<PrintStmt *>(prog->main[0].get());
+        auto *ie = dynamic_cast<IntExpr *>(pr->items[0].expr.get());
+        assert(ie && ie->value == 0);
+    }
+
+    // logical OR
+    {
+        std::string src = "10 LET X = 0 OR 1\n20 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("test.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        foldConstants(*prog);
+        auto *let = dynamic_cast<LetStmt *>(prog->main[0].get());
+        auto *ie = dynamic_cast<IntExpr *>(let->expr.get());
+        assert(ie && ie->value == 1);
+    }
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- introduce template helpers for arithmetic, comparison, and string folding
- reuse helpers inside ConstFolder to cut duplicated logic
- add unit tests for comparisons, string equality, and logical OR

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c820cf3330832482b0b0c61749beae