### PR TITLE
refactor(runtime): split runtime into memory, string, and IO modules

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(rt STATIC rt.c rt_math.c rt_random.c)
+add_library(rt STATIC rt_memory.c rt_string.c rt_io.c rt_math.c rt_random.c)
 target_include_directories(rt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(rt PUBLIC m)

--- a/runtime/rt.hpp
+++ b/runtime/rt.hpp
@@ -1,5 +1,5 @@
 // File: runtime/rt.hpp
-// Purpose: Declares C runtime utilities for strings and I/O.
+// Purpose: Declares C runtime utilities for memory, strings, and I/O.
 // Key invariants: Reference counts remain non-negative.
 // Ownership/Lifetime: Caller manages returned strings.
 // Links: docs/class-catalog.md
@@ -12,13 +12,8 @@ extern "C"
 {
 #endif
 
-    typedef struct rt_string_impl
-    {
-        int64_t refcnt;
-        int64_t size;
-        int64_t capacity;
-        const char *data;
-    } *rt_string;
+    struct rt_string_impl;
+    typedef struct rt_string_impl *rt_string;
 
     /// @brief Abort execution with message @p msg.
     /// @param msg Null-terminated message string.

--- a/runtime/rt_internal.h
+++ b/runtime/rt_internal.h
@@ -1,0 +1,17 @@
+// File: runtime/rt_internal.h
+// Purpose: Defines internal runtime structures shared across implementation files.
+// Key invariants: Strings use reference counts; structure layout is stable.
+// Ownership/Lifetime: Caller manages lifetime of rt_string instances.
+// Links: docs/class-catalog.md
+
+#pragma once
+
+#include "rt.hpp"
+
+struct rt_string_impl
+{
+    int64_t refcnt;
+    int64_t size;
+    int64_t capacity;
+    const char *data;
+};

--- a/runtime/rt_io.c
+++ b/runtime/rt_io.c
@@ -1,0 +1,130 @@
+// File: runtime/rt_io.c
+// Purpose: Implements I/O utilities and trap handling for the BASIC runtime.
+// Key invariants: Output routines do not append newlines unless specified.
+// Ownership/Lifetime: Caller manages strings passed to printing routines.
+// Links: docs/class-catalog.md
+
+#include "rt_internal.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * Terminate the program immediately due to a fatal runtime error.
+ *
+ * @param msg Optional message describing the reason for the abort.
+ * @return Never returns.
+ */
+void rt_abort(const char *msg)
+{
+    if (msg)
+        fprintf(stderr, "runtime trap: %s\n", msg);
+    else
+        fprintf(stderr, "runtime trap\n");
+    exit(1);
+}
+
+/**
+ * Trap handler used by the VM layer. Can be overridden by hosts.
+ *
+ * @param msg Optional message describing the trap condition.
+ * @return Never returns.
+ */
+__attribute__((weak)) void vm_trap(const char *msg)
+{
+    rt_abort(msg);
+}
+
+/**
+ * Entry point for raising runtime traps from helper routines.
+ *
+ * @param msg Message describing the trap condition.
+ * @return Never returns.
+ */
+void rt_trap(const char *msg)
+{
+    vm_trap(msg);
+}
+
+/**
+ * Write a runtime string to standard output without a trailing newline.
+ *
+ * @param s String to print; NULL strings are ignored.
+ */
+void rt_print_str(rt_string s)
+{
+    if (s && s->data)
+        fwrite(s->data, 1, (size_t)s->size, stdout);
+}
+
+/**
+ * Print a 64-bit integer in decimal form to stdout.
+ *
+ * @param v Value to print.
+ */
+void rt_print_i64(int64_t v)
+{
+    printf("%lld", (long long)v);
+}
+
+/**
+ * Print a double-precision floating-point number to stdout.
+ *
+ * @param v Value to print.
+ */
+void rt_print_f64(double v)
+{
+    printf("%g", v);
+}
+
+/**
+ * Read a single line of input from stdin into a runtime string.
+ *
+ * @return Newly allocated runtime string containing the line without the
+ * trailing newline, or NULL on EOF before any characters are read.
+ */
+rt_string rt_input_line(void)
+{
+    size_t cap = 1024;
+    size_t len = 0;
+    char *buf = (char *)rt_alloc(cap);
+    for (;;)
+    {
+        int ch = fgetc(stdin);
+        if (ch == EOF)
+        {
+            if (len == 0)
+            {
+                free(buf);
+                return NULL;
+            }
+            break;
+        }
+        if (ch == '\n')
+            break;
+        if (len + 1 >= cap)
+        {
+            size_t new_cap = cap * 2;
+            char *nbuf = (char *)realloc(buf, new_cap);
+            if (!nbuf)
+            {
+                free(buf);
+                rt_trap("out of memory");
+                return NULL;
+            }
+            buf = nbuf;
+            cap = new_cap;
+        }
+        buf[len++] = (char)ch;
+    }
+    buf[len] = '\0';
+    rt_string s = (rt_string)rt_alloc(sizeof(*s));
+    s->refcnt = 1;
+    s->size = (int64_t)len;
+    s->capacity = s->size;
+    char *data = (char *)rt_alloc(len + 1);
+    memcpy(data, buf, len + 1);
+    s->data = data;
+    free(buf);
+    return s;
+}

--- a/runtime/rt_memory.c
+++ b/runtime/rt_memory.c
@@ -1,0 +1,29 @@
+// File: runtime/rt_memory.c
+// Purpose: Implements memory allocation helpers for the BASIC runtime.
+// Key invariants: Allocation sizes must be non-negative and fit in size_t.
+// Ownership/Lifetime: Caller owns and must free returned memory blocks.
+// Links: docs/class-catalog.md
+
+#include "rt_internal.h"
+#include <stdlib.h>
+
+/**
+ * Allocate a block of memory for runtime usage.
+ *
+ * @param bytes Number of bytes to allocate. Must be non-negative.
+ * @return Pointer to allocated memory, or traps on invalid input or failure.
+ */
+void *rt_alloc(int64_t bytes)
+{
+    if (bytes < 0)
+        return rt_trap("negative allocation"), NULL;
+    if ((uint64_t)bytes > SIZE_MAX)
+    {
+        rt_trap("allocation too large");
+        return NULL;
+    }
+    void *p = malloc((size_t)bytes);
+    if (!p)
+        rt_trap("out of memory");
+    return p;
+}

--- a/tests/runtime/RTInputLineTests.cpp
+++ b/tests/runtime/RTInputLineTests.cpp
@@ -2,7 +2,7 @@
 // Purpose: Ensure rt_input_line handles lines longer than the initial buffer and EOF-terminated
 // lines. Key invariants: rt_input_line returns full line content for >1023 chars, with or without
 // trailing newline. Ownership: Uses runtime library. Links: docs/runtime-abi.md
-#include "rt.hpp"
+#include "rt_internal.h"
 #include <cassert>
 #include <cstring>
 #include <string>

--- a/tests/runtime/RTValStrTests.cpp
+++ b/tests/runtime/RTValStrTests.cpp
@@ -3,7 +3,7 @@
 // Key invariants: Parsing stops at non-numeric; round-trip within tolerance.
 // Ownership: Uses runtime library.
 // Links: docs/class-catalog.md
-#include "rt.hpp"
+#include "rt_internal.h"
 #include <cassert>
 #include <cmath>
 #include <cstdio>

--- a/tests/unit/test_rt_conv.cpp
+++ b/tests/unit/test_rt_conv.cpp
@@ -3,7 +3,7 @@
 // Key invariants: Returned strings match decimal formatting used by PRINT.
 // Ownership: Uses runtime library.
 // Links: docs/class-catalog.md
-#include "rt.hpp"
+#include "rt_internal.h"
 #include <cassert>
 #include <string>
 

--- a/tests/unit/test_rt_int_to_str_big.cpp
+++ b/tests/unit/test_rt_int_to_str_big.cpp
@@ -4,7 +4,7 @@
 //                 output longer than the initial stack buffer.
 // Ownership: Uses runtime library.
 // Links: docs/class-catalog.md
-#include "rt.hpp"
+#include "rt_internal.h"
 #include <cassert>
 #include <cstdarg>
 #include <cstdio>

--- a/tests/unit/test_vm_addr_of.cpp
+++ b/tests/unit/test_vm_addr_of.cpp
@@ -5,7 +5,7 @@
 // Links: docs/il-reference.md
 
 #include "il/io/Parser.hpp"
-#include "rt.hpp"
+#include "rt_internal.h"
 #include "vm/VM.hpp"
 #include <cassert>
 #include <sstream>


### PR DESCRIPTION
## Summary
- split runtime helpers into rt_memory.c, rt_string.c, and rt_io.c
- expose shared rt_string_impl via new rt_internal.h and forward declare in rt.hpp
- adjust tests and build configuration for new module layout

## Testing
- `cmake -S . -B build`
- `cmake --build build -j4`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c825e54a0083248ea3fa2e9f8fb830