### PR TITLE
feat(runtime): centralize string reference counting

### DIFF
--- a/runtime/rt.hpp
+++ b/runtime/rt.hpp
@@ -39,6 +39,15 @@ extern "C"
     /// @return Newly allocated string without trailing newline.
     rt_string rt_input_line(void);
 
+    /// @brief Increment reference count of @p s.
+    /// @param s String to reference; null allowed.
+    /// @return Input string pointer.
+    rt_string rt_string_ref(rt_string s);
+
+    /// @brief Decrement reference count of @p s and free on zero.
+    /// @param s String to release; null allowed.
+    void rt_string_unref(rt_string s);
+
     /// @brief Get length of string @p s in bytes.
     /// @param s String to measure.
     /// @return Number of bytes excluding terminator.


### PR DESCRIPTION
## Summary
- add rt_string_ref and rt_string_unref for consistent runtime string lifetime handling
- use rt_string_ref instead of direct refcnt increments across string helpers
- document new reference helpers in rt.hpp

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`
- `valgrind --leak-check=full /tmp/refcheck`


------
https://chatgpt.com/codex/tasks/task_e_68c828fad6c4832482bdc95e4836d0ae