### PR TITLE
refactor(il/transform): table-driven peephole rules

### DIFF
--- a/src/il/transform/Peephole.cpp
+++ b/src/il/transform/Peephole.cpp
@@ -147,86 +147,15 @@ void peephole(Module &m)
                     continue;
                 Value repl{};
                 bool match = false;
-                switch (in.op)
+                for (const auto &r : kRules)
                 {
-                    case Opcode::Add:
-                        if (isConstEq(in.operands[0], 0))
-                        {
-                            repl = in.operands[1];
-                            match = true;
-                        }
-                        else if (isConstEq(in.operands[1], 0))
-                        {
-                            repl = in.operands[0];
-                            match = true;
-                        }
+                    if (in.op == r.match.op &&
+                        isConstEq(in.operands[r.match.constIdx], r.match.value))
+                    {
+                        repl = in.operands[r.repl.operandIdx];
+                        match = true;
                         break;
-                    case Opcode::Sub:
-                        if (isConstEq(in.operands[1], 0))
-                        {
-                            repl = in.operands[0];
-                            match = true;
-                        }
-                        break;
-                    case Opcode::Mul:
-                        if (isConstEq(in.operands[0], 1))
-                        {
-                            repl = in.operands[1];
-                            match = true;
-                        }
-                        else if (isConstEq(in.operands[1], 1))
-                        {
-                            repl = in.operands[0];
-                            match = true;
-                        }
-                        break;
-                    case Opcode::And:
-                        if (isConstEq(in.operands[0], -1))
-                        {
-                            repl = in.operands[1];
-                            match = true;
-                        }
-                        else if (isConstEq(in.operands[1], -1))
-                        {
-                            repl = in.operands[0];
-                            match = true;
-                        }
-                        break;
-                    case Opcode::Or:
-                        if (isConstEq(in.operands[0], 0))
-                        {
-                            repl = in.operands[1];
-                            match = true;
-                        }
-                        else if (isConstEq(in.operands[1], 0))
-                        {
-                            repl = in.operands[0];
-                            match = true;
-                        }
-                        break;
-                    case Opcode::Xor:
-                        if (isConstEq(in.operands[0], 0))
-                        {
-                            repl = in.operands[1];
-                            match = true;
-                        }
-                        else if (isConstEq(in.operands[1], 0))
-                        {
-                            repl = in.operands[0];
-                            match = true;
-                        }
-                        break;
-                    case Opcode::Shl:
-                    case Opcode::LShr:
-                    case Opcode::AShr:
-                        if (isConstEq(in.operands[1], 0))
-                        {
-                            repl = in.operands[0];
-                            match = true;
-                        }
-                        break;
-                    default:
-                        break;
+                    }
                 }
                 if (match)
                 {

--- a/src/il/transform/Peephole.hpp
+++ b/src/il/transform/Peephole.hpp
@@ -5,12 +5,57 @@
 // Links: docs/class-catalog.md
 #pragma once
 
+#include <array>
+
 #include "il/core/Module.hpp"
 
 namespace il::transform
 {
 
-/// \brief Run peephole simplifications over @p m.
+/// \brief Pattern describing an instruction with a constant operand.
+struct Match
+{
+    /// Opcode to match.
+    core::Opcode op;
+    /// Operand index holding the constant.
+    unsigned constIdx;
+    /// Required constant value.
+    long long value;
+};
+
+/// \brief Replacement describing which operand to forward.
+struct Replace
+{
+    /// Index of the operand to use as the replacement value.
+    unsigned operandIdx;
+};
+
+/// \brief A peephole rule mapping a match to its replacement.
+struct Rule
+{
+    Match match;  ///< Match pattern.
+    Replace repl; ///< Replacement action.
+};
+
+/// \brief Registry of peephole rules.
+inline constexpr std::array<Rule, 14> kRules{{
+    {{core::Opcode::Add, 0, 0}, {1}},
+    {{core::Opcode::Add, 1, 0}, {0}},
+    {{core::Opcode::Sub, 1, 0}, {0}},
+    {{core::Opcode::Mul, 0, 1}, {1}},
+    {{core::Opcode::Mul, 1, 1}, {0}},
+    {{core::Opcode::And, 0, -1}, {1}},
+    {{core::Opcode::And, 1, -1}, {0}},
+    {{core::Opcode::Or, 0, 0}, {1}},
+    {{core::Opcode::Or, 1, 0}, {0}},
+    {{core::Opcode::Xor, 0, 0}, {1}},
+    {{core::Opcode::Xor, 1, 0}, {0}},
+    {{core::Opcode::Shl, 1, 0}, {0}},
+    {{core::Opcode::LShr, 1, 0}, {0}},
+    {{core::Opcode::AShr, 1, 0}, {0}},
+}};
+
+/// \brief Run peephole simplifications over @p m using registered rules.
 void peephole(core::Module &m);
 
 } // namespace il::transform


### PR DESCRIPTION
## Summary
- add Match/Replace pattern structs and registry for peephole rules
- drive peephole optimizer from registry rather than switch logic

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c82f7339ac8324b1256397c2538461