### PR TITLE
refactor: split semantic analyzer helpers

### DIFF
--- a/src/frontends/basic/ProcRegistry.hpp
+++ b/src/frontends/basic/ProcRegistry.hpp
@@ -1,0 +1,148 @@
+// File: src/frontends/basic/ProcRegistry.hpp
+// Purpose: Manages BASIC procedure signatures and registration diagnostics.
+// Key invariants: Each procedure name maps to a unique signature.
+// Ownership/Lifetime: Borrows SemanticDiagnostics; no AST ownership.
+// Links: docs/class-catalog.md
+#pragma once
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "frontends/basic/AST.hpp"
+#include "frontends/basic/SemanticDiagnostics.hpp"
+
+namespace il::frontends::basic
+{
+
+struct ProcSignature
+{
+    enum class Kind
+    {
+        Function,
+        Sub
+    } kind{Kind::Function};
+    std::optional<Type> retType;
+
+    struct Param
+    {
+        Type type{Type::I64};
+        bool is_array{false};
+    };
+
+    std::vector<Param> params;
+};
+
+using ProcTable = std::unordered_map<std::string, ProcSignature>;
+
+class ProcRegistry
+{
+  public:
+    explicit ProcRegistry(SemanticDiagnostics &d) : de(d) {}
+
+    void clear()
+    {
+        procs_.clear();
+    }
+
+    void registerProc(const FunctionDecl &f)
+    {
+        if (procs_.count(f.name))
+        {
+            std::string msg = "duplicate procedure '" + f.name + "'";
+            de.emit(il::support::Severity::Error,
+                    "B1004",
+                    f.loc,
+                    static_cast<uint32_t>(f.name.size()),
+                    std::move(msg));
+            return;
+        }
+        ProcSignature sig;
+        sig.kind = ProcSignature::Kind::Function;
+        sig.retType = f.ret;
+        std::unordered_set<std::string> paramNames;
+        for (const auto &p : f.params)
+        {
+            if (!paramNames.insert(p.name).second)
+            {
+                std::string msg = "duplicate parameter '" + p.name + "'";
+                de.emit(il::support::Severity::Error,
+                        "B1005",
+                        p.loc,
+                        static_cast<uint32_t>(p.name.size()),
+                        std::move(msg));
+            }
+            if (p.is_array && p.type != Type::I64 && p.type != Type::Str)
+            {
+                std::string msg = "array parameter must be i64 or str";
+                de.emit(il::support::Severity::Error,
+                        "B2004",
+                        p.loc,
+                        static_cast<uint32_t>(p.name.size()),
+                        std::move(msg));
+            }
+            sig.params.push_back({p.type, p.is_array});
+        }
+        procs_.emplace(f.name, std::move(sig));
+    }
+
+    void registerProc(const SubDecl &s)
+    {
+        if (procs_.count(s.name))
+        {
+            std::string msg = "duplicate procedure '" + s.name + "'";
+            de.emit(il::support::Severity::Error,
+                    "B1004",
+                    s.loc,
+                    static_cast<uint32_t>(s.name.size()),
+                    std::move(msg));
+            return;
+        }
+        ProcSignature sig;
+        sig.kind = ProcSignature::Kind::Sub;
+        sig.retType = std::nullopt;
+        std::unordered_set<std::string> paramNames;
+        for (const auto &p : s.params)
+        {
+            if (!paramNames.insert(p.name).second)
+            {
+                std::string msg = "duplicate parameter '" + p.name + "'";
+                de.emit(il::support::Severity::Error,
+                        "B1005",
+                        p.loc,
+                        static_cast<uint32_t>(p.name.size()),
+                        std::move(msg));
+            }
+            if (p.is_array && p.type != Type::I64 && p.type != Type::Str)
+            {
+                std::string msg = "array parameter must be i64 or str";
+                de.emit(il::support::Severity::Error,
+                        "B2004",
+                        p.loc,
+                        static_cast<uint32_t>(p.name.size()),
+                        std::move(msg));
+            }
+            sig.params.push_back({p.type, p.is_array});
+        }
+        procs_.emplace(s.name, std::move(sig));
+    }
+
+    const ProcTable &procs() const
+    {
+        return procs_;
+    }
+
+    const ProcSignature *lookup(const std::string &name) const
+    {
+        auto it = procs_.find(name);
+        return it == procs_.end() ? nullptr : &it->second;
+    }
+
+  private:
+    SemanticDiagnostics &de;
+    ProcTable procs_;
+};
+
+} // namespace il::frontends::basic

--- a/src/frontends/basic/ScopeTracker.hpp
+++ b/src/frontends/basic/ScopeTracker.hpp
@@ -1,0 +1,93 @@
+// File: src/frontends/basic/ScopeTracker.hpp
+// Purpose: Provides lexical scope tracking with name mangling for the BASIC front end.
+// Key invariants: Scopes form a stack; resolving searches innermost to outermost.
+// Ownership/Lifetime: Owned by SemanticAnalyzer; no AST ownership.
+// Links: docs/class-catalog.md
+#pragma once
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace il::frontends::basic
+{
+
+class ScopeTracker
+{
+  public:
+    class ScopedScope
+    {
+      public:
+        explicit ScopedScope(ScopeTracker &st) : st_(st)
+        {
+            st_.pushScope();
+        }
+
+        ~ScopedScope()
+        {
+            st_.popScope();
+        }
+
+      private:
+        ScopeTracker &st_;
+    };
+
+    void reset()
+    {
+        stack_.clear();
+        nextId_ = 0;
+    }
+
+    void pushScope()
+    {
+        stack_.emplace_back();
+    }
+
+    void popScope()
+    {
+        if (!stack_.empty())
+            stack_.pop_back();
+    }
+
+    void bind(const std::string &name, const std::string &mapped)
+    {
+        if (!stack_.empty())
+            stack_.back()[name] = mapped;
+    }
+
+    bool isDeclaredInCurrentScope(const std::string &name) const
+    {
+        return !stack_.empty() && stack_.back().count(name);
+    }
+
+    std::string declareLocal(const std::string &name)
+    {
+        std::string unique = name + "_" + std::to_string(nextId_++);
+        if (!stack_.empty())
+            stack_.back()[name] = unique;
+        return unique;
+    }
+
+    std::optional<std::string> resolve(const std::string &name) const
+    {
+        for (auto it = stack_.rbegin(); it != stack_.rend(); ++it)
+        {
+            auto found = it->find(name);
+            if (found != it->end())
+                return found->second;
+        }
+        return std::nullopt;
+    }
+
+    bool hasScope() const
+    {
+        return !stack_.empty();
+    }
+
+  private:
+    std::vector<std::unordered_map<std::string, std::string>> stack_;
+    unsigned nextId_{0};
+};
+
+} // namespace il::frontends::basic

--- a/src/frontends/basic/SemanticDiagnostics.hpp
+++ b/src/frontends/basic/SemanticDiagnostics.hpp
@@ -1,0 +1,46 @@
+// File: src/frontends/basic/SemanticDiagnostics.hpp
+// Purpose: Wraps DiagnosticEmitter for semantic analysis utilities.
+// Key invariants: Forwards diagnostics without altering counts.
+// Ownership/Lifetime: Borrows DiagnosticEmitter; no ownership of sources.
+// Links: docs/class-catalog.md
+#pragma once
+
+#include "frontends/basic/DiagnosticEmitter.hpp"
+
+namespace il::frontends::basic
+{
+
+class SemanticDiagnostics
+{
+  public:
+    explicit SemanticDiagnostics(DiagnosticEmitter &emitter) : emitter_(emitter) {}
+
+    void emit(il::support::Severity sev,
+              std::string code,
+              il::support::SourceLoc loc,
+              uint32_t length,
+              std::string message)
+    {
+        emitter_.emit(sev, std::move(code), loc, length, std::move(message));
+    }
+
+    size_t errorCount() const
+    {
+        return emitter_.errorCount();
+    }
+
+    size_t warningCount() const
+    {
+        return emitter_.warningCount();
+    }
+
+    DiagnosticEmitter &emitter()
+    {
+        return emitter_;
+    }
+
+  private:
+    DiagnosticEmitter &emitter_;
+};
+
+} // namespace il::frontends::basic

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -419,6 +419,10 @@ add_executable(test_basic_semantic unit/test_basic_semantic.cpp)
 target_link_libraries(test_basic_semantic PRIVATE fe_basic support)
 add_test(NAME test_basic_semantic COMMAND test_basic_semantic)
 
+add_executable(test_basic_semantic_components unit/test_basic_semantic_components.cpp)
+target_link_libraries(test_basic_semantic_components PRIVATE fe_basic support)
+add_test(NAME test_basic_semantic_components COMMAND test_basic_semantic_components)
+
 add_executable(test_basic_intrinsic_semantics unit/test_basic_intrinsic_semantics.cpp)
 target_link_libraries(test_basic_intrinsic_semantics PRIVATE fe_basic support)
 add_test(NAME test_basic_intrinsic_semantics COMMAND test_basic_intrinsic_semantics)

--- a/tests/unit/test_basic_semantic_components.cpp
+++ b/tests/unit/test_basic_semantic_components.cpp
@@ -1,0 +1,51 @@
+// File: tests/unit/test_basic_semantic_components.cpp
+// Purpose: Unit tests for scope tracking, procedure registration, and diagnostics.
+// Key invariants: Components operate independently and report expected state.
+// Ownership/Lifetime: Test owns all objects locally.
+// Links: docs/class-catalog.md
+
+#include "frontends/basic/DiagnosticEmitter.hpp"
+#include "frontends/basic/ProcRegistry.hpp"
+#include "frontends/basic/ScopeTracker.hpp"
+#include "frontends/basic/SemanticDiagnostics.hpp"
+#include "support/source_manager.hpp"
+#include <cassert>
+
+using namespace il::frontends::basic;
+using namespace il::support;
+
+int main()
+{
+    // ScopeTracker behaviour
+    ScopeTracker st;
+    st.pushScope();
+    st.bind("A", "A");
+    auto unique = st.declareLocal("B");
+    assert(st.resolve("A") && *st.resolve("A") == "A");
+    assert(st.resolve("B") && *st.resolve("B") == unique);
+    st.popScope();
+    assert(!st.resolve("A"));
+
+    // Diagnostics forwarding
+    DiagnosticEngine eng;
+    SourceManager sm;
+    DiagnosticEmitter emitter(eng, sm);
+    SemanticDiagnostics diag(emitter);
+    diag.emit(Severity::Warning, "W0001", {}, 0, "warn");
+    assert(diag.warningCount() == 1);
+
+    // Procedure registration
+    ProcRegistry reg(diag);
+    FunctionDecl f;
+    f.name = "FOO";
+    Param p;
+    p.name = "X";
+    p.type = Type::I64;
+    f.params.push_back(p);
+    reg.registerProc(f);
+    assert(reg.procs().count("FOO") == 1);
+    reg.registerProc(f); // duplicate
+    assert(diag.errorCount() == 1);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extract ScopeTracker for lexical scope management
- add ProcRegistry and SemanticDiagnostics helpers
- cover helpers with a basic unit test

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c8378343688324a82ea163aca786ca