### PR TITLE
Refactor IL parser to use lexer helper and modular handlers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,11 @@ add_library(il_build STATIC il/build/IRBuilder.cpp)
 target_link_libraries(il_build PUBLIC il_core support)
 target_include_directories(il_build PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_library(il_io STATIC il/io/Serializer.cpp il/io/Parser.cpp)
+add_library(il_io STATIC
+  il/io/Serializer.cpp
+  il/io/Parser.cpp
+  il/io/Lexer.cpp
+  il/io/detail/InstructionHandlers.cpp)
 target_link_libraries(il_io PUBLIC il_core)
 target_include_directories(il_io PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/il/io/Lexer.cpp
+++ b/src/il/io/Lexer.cpp
@@ -1,0 +1,46 @@
+// File: src/il/io/Lexer.cpp
+// Purpose: Implements lexical helper utilities for IL text parsing.
+// Key invariants: Operates on UTF-8/ASCII compatible strings.
+// Ownership/Lifetime: Functions allocate new std::string instances as needed.
+// Links: docs/il-spec.md
+
+#include "il/io/Lexer.hpp"
+
+#include <cctype>
+
+namespace il::io
+{
+
+std::string Lexer::trim(std::string_view text)
+{
+    size_t begin = 0;
+    size_t end = text.size();
+    while (begin < end && std::isspace(static_cast<unsigned char>(text[begin])))
+        ++begin;
+    while (end > begin && std::isspace(static_cast<unsigned char>(text[end - 1])))
+        --end;
+    return std::string{text.substr(begin, end - begin)};
+}
+
+std::string Lexer::nextToken(std::istringstream &stream)
+{
+    std::string token;
+    stream >> token;
+    if (!token.empty() && token.back() == ',')
+        token.pop_back();
+    return token;
+}
+
+std::vector<std::string> Lexer::splitCommaSeparated(std::string_view text)
+{
+    std::vector<std::string> tokens;
+    std::stringstream ss(std::string{text});
+    std::string piece;
+    while (std::getline(ss, piece, ','))
+    {
+        tokens.push_back(trim(piece));
+    }
+    return tokens;
+}
+
+} // namespace il::io

--- a/src/il/io/Lexer.hpp
+++ b/src/il/io/Lexer.hpp
@@ -1,0 +1,36 @@
+// File: src/il/io/Lexer.hpp
+// Purpose: Declares lexical helper utilities for IL text parsing.
+// Key invariants: Functions operate on ASCII-compatible strings.
+// Ownership/Lifetime: Returns new strings; does not own provided streams.
+// Links: docs/il-spec.md
+#pragma once
+
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace il::io
+{
+
+/// @brief Helper providing string tokenisation utilities for the IL parser.
+class Lexer
+{
+  public:
+    /// @brief Remove leading and trailing whitespace from @p text.
+    /// @param text Input text possibly containing whitespace padding.
+    /// @return A trimmed copy of the input string.
+    [[nodiscard]] static std::string trim(std::string_view text);
+
+    /// @brief Extract the next token from a comma-delimited stream.
+    /// @param stream Source stream advanced past the returned token.
+    /// @return Token with trailing comma stripped if present.
+    [[nodiscard]] static std::string nextToken(std::istringstream &stream);
+
+    /// @brief Split comma-separated text into trimmed tokens.
+    /// @param text Sequence containing comma delimiters.
+    /// @return Vector of tokens in textual order with whitespace removed.
+    [[nodiscard]] static std::vector<std::string> splitCommaSeparated(std::string_view text);
+};
+
+} // namespace il::io

--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -5,16 +5,20 @@
 // Links: docs/il-spec.md
 
 #include "il/io/Parser.hpp"
-#include "il/core/Opcode.hpp"
-#include "il/core/Value.hpp"
-#include "support/source_manager.hpp"
-#include <cctype>
-#include <functional>
-#include <sstream>
-#include <unordered_map>
-#include <unordered_set>
 
-using namespace il::core;
+#include "il/io/Lexer.hpp"
+#include "il/io/detail/InstructionHandlers.hpp"
+#include "il/io/detail/ParserState.hpp"
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using il::core::BasicBlock;
+using il::core::Function;
+using il::core::Module;
+using il::core::Param;
+using il::core::Type;
 
 namespace il::io
 {
@@ -22,894 +26,259 @@ namespace il::io
 namespace
 {
 
-/// @brief Strip leading and trailing whitespace from a string.
-/// @param s Input string that may contain surrounding spaces.
-/// @return Substring with external whitespace removed.
-/// @note Used throughout parsing to normalize tokens before inspection.
-std::string trim(const std::string &s)
+using detail::ParserState;
+
+bool parseInstruction(const std::string &line, ParserState &state, std::ostream &err);
+bool parseFunctionHeader(const std::string &header, ParserState &state, std::ostream &err);
+bool parseBlockHeader(const std::string &header, ParserState &state, std::ostream &err);
+bool parseFunction(std::istream &is, std::string &header, ParserState &state, std::ostream &err);
+bool parseModuleHeader(std::istream &is, std::string &line, ParserState &state, std::ostream &err);
+
+/// @brief Parse a single instruction line after optional result assignment.
+/// @param line Full textual instruction.
+/// @param state Current parser state providing context.
+/// @param err Stream receiving diagnostics from opcode handlers.
+/// @return True when parsing succeeds; false when errors occur.
+bool parseInstruction(const std::string &line, ParserState &state, std::ostream &err)
 {
-    size_t b = 0;
-    while (b < s.size() && std::isspace(static_cast<unsigned char>(s[b])))
-        ++b;
-    size_t e = s.size();
-    while (e > b && std::isspace(static_cast<unsigned char>(s[e - 1])))
-        --e;
-    return s.substr(b, e - b);
-}
-
-/// @brief Parse a textual type specifier.
-/// @param t Lowercase token such as "i64" or "ptr".
-/// @param ok Optional flag set true on success and false on unknown types.
-/// @return Matching Type or a default-constructed Type on failure.
-/// @details On error, @p ok is set to false and callers can treat the returned
-/// value as an invalid type indicator.
-Type parseType(const std::string &t, bool *ok = nullptr)
-{
-    if (t == "i64")
+    Function *fn = state.curFn;
+    BasicBlock *bb = state.curBB;
+    if (!fn || !bb)
     {
-        if (ok)
-            *ok = true;
-        return Type(Type::Kind::I64);
-    }
-    if (t == "i1")
-    {
-        if (ok)
-            *ok = true;
-        return Type(Type::Kind::I1);
-    }
-    if (t == "f64")
-    {
-        if (ok)
-            *ok = true;
-        return Type(Type::Kind::F64);
-    }
-    if (t == "ptr")
-    {
-        if (ok)
-            *ok = true;
-        return Type(Type::Kind::Ptr);
-    }
-    if (t == "str")
-    {
-        if (ok)
-            *ok = true;
-        return Type(Type::Kind::Str);
-    }
-    if (t == "void")
-    {
-        if (ok)
-            *ok = true;
-        return Type(Type::Kind::Void);
-    }
-    if (ok)
-        *ok = false;
-    return Type(); // error indicator
-}
-
-/// @brief Fetch the next token from a stream.
-/// @param ss Stream containing whitespace and comma separated tokens.
-/// @return Token with any trailing comma removed.
-/// @note Used for parsing instruction operand lists where commas delimit
-/// individual operands.
-std::string readToken(std::istringstream &ss)
-{
-    std::string t;
-    ss >> t;
-    if (!t.empty() && t.back() == ',')
-        t.pop_back();
-    return t;
-}
-
-struct ParserState
-{
-    /// @brief Module being populated while parsing proceeds.
-    Module &m;
-
-    /// @brief Function currently being assembled, or nullptr outside a function.
-    Function *curFn = nullptr;
-
-    /// @brief Active basic block receiving parsed instructions.
-    BasicBlock *curBB = nullptr;
-
-    /// @brief Mapping from SSA value names to their numeric ids.
-    std::unordered_map<std::string, unsigned> tempIds;
-
-    /// @brief Next available temporary id to assign to a newly seen name.
-    unsigned nextTemp = 0;
-
-    /// @brief Current source line number for diagnostics.
-    unsigned lineNo = 0;
-
-    /// @brief Source location last set via a ".loc" directive.
-    il::support::SourceLoc curLoc{};
-
-    /// @brief Expected parameter count for each basic block label.
-    std::unordered_map<std::string, size_t> blockParamCount;
-
-    /// @brief Flag tracking whether any fatal parse error has occurred.
-    bool hasError = false;
-
-    struct PendingBr
-    {
-        /// @brief Target label referenced before its definition.
-        std::string label;
-        /// @brief Number of arguments supplied with the branch.
-        size_t args;
-        /// @brief Line where the unresolved branch appeared.
-        unsigned line;
-    };
-
-    /// @brief Collection of branches awaiting verification of their targets.
-    std::vector<PendingBr> pendingBrs;
-
-    /// @brief Construct parser state for the given module.
-    explicit ParserState(Module &mod) : m(mod) {}
-};
-
-/// @brief Convert a token into a typed IL value.
-/// @param tok Token representing a value (temporary, literal, etc.).
-/// @param st Current parser state for symbol lookup and diagnostics.
-/// @param err Stream receiving diagnostic messages on failure.
-/// @return Parsed Value or a placeholder when parsing fails.
-/// @details Supports temps prefixed with '%', globals with '@', string,
-/// integer and floating literals. Invalid tokens set ParserState::hasError
-/// and emit an error with the current line number.
-Value parseValue(const std::string &tok, ParserState &st, std::ostream &err)
-{
-    if (tok.empty())
-        return Value::constInt(0);
-    if (tok[0] == '%')
-    {
-        std::string name = tok.substr(1);
-        auto it = st.tempIds.find(name);
-        if (it != st.tempIds.end())
-            return Value::temp(it->second);
-        if (name.size() > 1 && name[0] == 't')
-        {
-            bool digits = true;
-            for (size_t i = 1; i < name.size(); ++i)
-                if (!std::isdigit(static_cast<unsigned char>(name[i])))
-                    digits = false;
-            if (digits)
-            {
-                try
-                {
-                    return Value::temp(std::stoul(name.substr(1)));
-                }
-                catch (const std::exception &)
-                {
-                    st.hasError = true;
-                    err << "Line " << st.lineNo << ": invalid temp id '" << tok << "'\n";
-                    return Value::temp(0);
-                }
-            }
-        }
-        return Value::temp(0); // undefined temp will be diagnosed later
-    }
-    if (tok[0] == '@')
-        return Value::global(tok.substr(1));
-    if (tok == "null")
-        return Value::null();
-    if (tok.size() >= 2 && tok.front() == '"' && tok.back() == '"')
-        return Value::constStr(tok.substr(1, tok.size() - 2));
-    if (tok.find('.') != std::string::npos || tok.find('e') != std::string::npos ||
-        tok.find('E') != std::string::npos)
-    {
-        try
-        {
-            size_t idx = 0;
-            double val = std::stod(tok, &idx);
-            if (idx != tok.size())
-                throw std::invalid_argument("trailing characters");
-            return Value::constFloat(val);
-        }
-        catch (const std::exception &)
-        {
-            st.hasError = true;
-            err << "Line " << st.lineNo << ": invalid floating literal '" << tok << "'\n";
-            return Value::constFloat(0.0);
-        }
-    }
-    try
-    {
-        size_t idx = 0;
-        long long val = std::stoll(tok, &idx);
-        if (idx != tok.size())
-            throw std::invalid_argument("trailing characters");
-        return Value::constInt(val);
-    }
-    catch (const std::exception &)
-    {
-        st.hasError = true;
-        err << "Line " << st.lineNo << ": invalid integer literal '" << tok << "'\n";
-        return Value::constInt(0);
-    }
-}
-
-using InstrHandler =
-    std::function<bool(const std::string &, Instr &, ParserState &, std::ostream &)>;
-
-/// @brief Build a handler for binary arithmetic or logical instructions.
-/// @param op Opcode to assign to the instruction.
-/// @param ty Result type produced by the operation.
-/// @return Callable that parses two operand tokens and populates an Instr.
-/// @note Operand parsing delegates to parseValue(), which reports errors.
-InstrHandler makeBinaryHandler(Opcode op, Type ty)
-{
-    return [op, ty](const std::string &rest, Instr &in, ParserState &st, std::ostream &err)
-    {
-        std::istringstream ss(rest);
-        std::string a = readToken(ss);
-        std::string b = readToken(ss);
-        in.op = op;
-        if (!a.empty())
-            in.operands.push_back(parseValue(a, st, err));
-        if (!b.empty())
-            in.operands.push_back(parseValue(b, st, err));
-        in.type = ty;
-        return true;
-    };
-}
-
-/// @brief Build a handler for unary operations.
-/// @param op Opcode to assign.
-/// @param ty Result type for the instruction.
-/// @return Callable that parses a single operand using parseValue().
-InstrHandler makeUnaryHandler(Opcode op, Type ty)
-{
-    return [op, ty](const std::string &rest, Instr &in, ParserState &st, std::ostream &err)
-    {
-        std::istringstream ss(rest);
-        std::string a = readToken(ss);
-        in.op = op;
-        if (!a.empty())
-            in.operands.push_back(parseValue(a, st, err));
-        in.type = ty;
-        return true;
-    };
-}
-
-/// @brief Build a comparison instruction handler.
-/// @param op Comparison opcode.
-/// @return Binary handler preconfigured to produce an i1 result.
-InstrHandler makeCmpHandler(Opcode op)
-{
-    return makeBinaryHandler(op, Type(Type::Kind::I1));
-}
-
-bool parseAllocaInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
-bool parseGEPInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
-bool parseLoadInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
-bool parseStoreInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
-bool parseAddrOfInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
-bool parseConstStrInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
-bool parseConstNullInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
-bool parseCallInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err);
-bool parseBrInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err);
-bool parseCBrInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err);
-bool parseRetInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &);
-bool parseTrapInstr(const std::string &rest, Instr &in, ParserState &, std::ostream &);
-
-static const std::unordered_map<std::string, InstrHandler> kInstrHandlers = {
-    {"add", makeBinaryHandler(Opcode::Add, Type(Type::Kind::I64))},
-    {"sub", makeBinaryHandler(Opcode::Sub, Type(Type::Kind::I64))},
-    {"mul", makeBinaryHandler(Opcode::Mul, Type(Type::Kind::I64))},
-    {"sdiv", makeBinaryHandler(Opcode::SDiv, Type(Type::Kind::I64))},
-    {"udiv", makeBinaryHandler(Opcode::UDiv, Type(Type::Kind::I64))},
-    {"srem", makeBinaryHandler(Opcode::SRem, Type(Type::Kind::I64))},
-    {"urem", makeBinaryHandler(Opcode::URem, Type(Type::Kind::I64))},
-    {"and", makeBinaryHandler(Opcode::And, Type(Type::Kind::I64))},
-    {"or", makeBinaryHandler(Opcode::Or, Type(Type::Kind::I64))},
-    {"xor", makeBinaryHandler(Opcode::Xor, Type(Type::Kind::I64))},
-    {"shl", makeBinaryHandler(Opcode::Shl, Type(Type::Kind::I64))},
-    {"lshr", makeBinaryHandler(Opcode::LShr, Type(Type::Kind::I64))},
-    {"ashr", makeBinaryHandler(Opcode::AShr, Type(Type::Kind::I64))},
-    {"fadd", makeBinaryHandler(Opcode::FAdd, Type(Type::Kind::F64))},
-    {"fsub", makeBinaryHandler(Opcode::FSub, Type(Type::Kind::F64))},
-    {"fmul", makeBinaryHandler(Opcode::FMul, Type(Type::Kind::F64))},
-    {"fdiv", makeBinaryHandler(Opcode::FDiv, Type(Type::Kind::F64))},
-    {"icmp_eq", makeCmpHandler(Opcode::ICmpEq)},
-    {"icmp_ne", makeCmpHandler(Opcode::ICmpNe)},
-    {"scmp_lt", makeCmpHandler(Opcode::SCmpLT)},
-    {"scmp_le", makeCmpHandler(Opcode::SCmpLE)},
-    {"scmp_gt", makeCmpHandler(Opcode::SCmpGT)},
-    {"scmp_ge", makeCmpHandler(Opcode::SCmpGE)},
-    {"ucmp_lt", makeCmpHandler(Opcode::UCmpLT)},
-    {"ucmp_le", makeCmpHandler(Opcode::UCmpLE)},
-    {"ucmp_gt", makeCmpHandler(Opcode::UCmpGT)},
-    {"ucmp_ge", makeCmpHandler(Opcode::UCmpGE)},
-    {"fcmp_lt", makeCmpHandler(Opcode::FCmpLT)},
-    {"fcmp_le", makeCmpHandler(Opcode::FCmpLE)},
-    {"fcmp_gt", makeCmpHandler(Opcode::FCmpGT)},
-    {"fcmp_ge", makeCmpHandler(Opcode::FCmpGE)},
-    {"fcmp_eq", makeCmpHandler(Opcode::FCmpEQ)},
-    {"fcmp_ne", makeCmpHandler(Opcode::FCmpNE)},
-    {"sitofp", makeUnaryHandler(Opcode::Sitofp, Type(Type::Kind::F64))},
-    {"fptosi", makeUnaryHandler(Opcode::Fptosi, Type(Type::Kind::I64))},
-    {"zext1", makeUnaryHandler(Opcode::Zext1, Type(Type::Kind::I64))},
-    {"trunc1", makeUnaryHandler(Opcode::Trunc1, Type(Type::Kind::I1))},
-    {"alloca", parseAllocaInstr},
-    {"gep", parseGEPInstr},
-    {"load", parseLoadInstr},
-    {"store", parseStoreInstr},
-    {"addr_of", parseAddrOfInstr},
-    {"const_str", parseConstStrInstr},
-    {"const_null", parseConstNullInstr},
-    {"call", parseCallInstr},
-    {"br", parseBrInstr},
-    {"cbr", parseCBrInstr},
-    {"ret", parseRetInstr},
-    {"trap", parseTrapInstr}};
-
-/// @brief Parse the "alloca" instruction.
-/// @param rest Remaining text after the opcode, expecting an optional size operand.
-/// @param in Instruction to populate.
-/// @param st Parser state for diagnostics.
-/// @param err Error stream updated on malformed size tokens.
-/// @return True on successful parse.
-bool parseAllocaInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err)
-{
-    std::istringstream ss(rest);
-    std::string sz = readToken(ss);
-    in.op = Opcode::Alloca;
-    if (sz.empty())
-    {
-        err << "line " << st.lineNo << ": missing size for alloca\n";
-        st.hasError = true;
-    }
-    else
-    {
-        in.operands.push_back(parseValue(sz, st, err));
-    }
-    in.type = Type(Type::Kind::Ptr);
-    return true;
-}
-
-/// @brief Parse the "gep" instruction in the form "base, offset".
-/// @param rest Text following the opcode containing two operands.
-/// @param in Instruction to fill in.
-/// @param st Parser state for value lookups.
-/// @param err Stream receiving error diagnostics.
-/// @return True when both operands are parsed successfully.
-bool parseGEPInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err)
-{
-    std::istringstream ss(rest);
-    std::string base = readToken(ss);
-    std::string off = readToken(ss);
-    in.op = Opcode::GEP;
-    in.operands.push_back(parseValue(base, st, err));
-    in.operands.push_back(parseValue(off, st, err));
-    in.type = Type(Type::Kind::Ptr);
-    return true;
-}
-
-/// @brief Parse a "load" instruction of the form "<type> <ptr>".
-/// @param rest Remaining text containing the result type and pointer operand.
-/// @param in Instruction to populate.
-/// @param st Parser state used for operand resolution.
-/// @param err Error stream updated on malformed tokens.
-/// @return True on success.
-bool parseLoadInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err)
-{
-    std::istringstream ss(rest);
-    std::string ty = readToken(ss);
-    std::string ptr = readToken(ss);
-    in.op = Opcode::Load;
-    in.type = parseType(ty);
-    in.operands.push_back(parseValue(ptr, st, err));
-    return true;
-}
-
-/// @brief Parse a "store" instruction of the form "<type> <ptr> <val>".
-/// @param rest Remaining text containing value type, destination pointer and value.
-/// @param in Instruction to populate.
-/// @param st Parser state for value resolution.
-/// @param err Stream receiving error details.
-/// @return True when all operands are parsed.
-bool parseStoreInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err)
-{
-    std::istringstream ss(rest);
-    std::string ty = readToken(ss);
-    std::string ptr = readToken(ss);
-    std::string val = readToken(ss);
-    in.op = Opcode::Store;
-    in.type = parseType(ty);
-    in.operands.push_back(parseValue(ptr, st, err));
-    in.operands.push_back(parseValue(val, st, err));
-    return true;
-}
-
-/// @brief Parse the "addr_of" instruction expecting a global symbol.
-/// @param rest Text following opcode containing global identifier.
-/// @param in Instruction to populate.
-/// @param st Parser state for lookups.
-/// @param err Diagnostic output for invalid tokens.
-/// @return True if the global symbol is parsed.
-bool parseAddrOfInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err)
-{
-    std::istringstream ss(rest);
-    std::string g = readToken(ss);
-    in.op = Opcode::AddrOf;
-    if (!g.empty())
-        in.operands.push_back(parseValue(g, st, err));
-    in.type = Type(Type::Kind::Ptr);
-    return true;
-}
-
-/// @brief Parse the "const_str" instruction containing a quoted string literal.
-/// @param rest Text containing the literal to embed.
-/// @param in Instruction to populate.
-/// @param st Parser state for diagnostics.
-/// @param err Stream receiving error messages.
-/// @return True when parsing succeeds.
-bool parseConstStrInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err)
-{
-    std::istringstream ss(rest);
-    std::string g = readToken(ss);
-    in.op = Opcode::ConstStr;
-    if (!g.empty())
-        in.operands.push_back(parseValue(g, st, err));
-    in.type = Type(Type::Kind::Str);
-    return true;
-}
-
-/// @brief Parse the "const_null" instruction which yields a null pointer.
-/// @param rest Unused text following the opcode.
-/// @param in Instruction to populate.
-/// @param st Parser state (unused).
-/// @param err Error stream (unused).
-/// @return Always true as no operands are required.
-bool parseConstNullInstr(const std::string &rest, Instr &in, ParserState &, std::ostream &)
-{
-    (void)rest;
-    in.op = Opcode::ConstNull;
-    in.type = Type(Type::Kind::Ptr);
-    return true;
-}
-
-/// @brief Parse a "call" instruction of the form "@name(arg1, arg2)".
-/// @param rest Text containing the callee and argument list.
-/// @param in Instruction to populate.
-/// @param st Parser state for value lookups.
-/// @param err Stream receiving diagnostics on malformed syntax.
-/// @return True if the call is well-formed.
-/// @details Emits an error when the call syntax is malformed.
-bool parseCallInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err)
-{
-    in.op = Opcode::Call;
-    size_t at = rest.find('@');
-    size_t lp = rest.find('(', at);
-    size_t rp = rest.find(')', lp);
-    if (at == std::string::npos || lp == std::string::npos || rp == std::string::npos)
-    {
-        err << "line " << st.lineNo << ": malformed call\n";
+        err << "line " << state.lineNo << ": instruction outside block\n";
         return false;
     }
-    in.callee = rest.substr(at + 1, lp - at - 1);
-    std::string args = rest.substr(lp + 1, rp - lp - 1);
-    std::stringstream as(args);
-    std::string a;
-    while (std::getline(as, a, ','))
-    {
-        a = trim(a);
-        if (!a.empty())
-            in.operands.push_back(parseValue(a, st, err));
-    }
-    in.type = Type(Type::Kind::Void);
-    return true;
-}
 
-/// @brief Parse an unconditional branch instruction.
-/// @param rest Text describing the branch target and optional arguments.
-/// @param in Instruction to populate.
-/// @param st Parser state used for target resolution.
-/// @param err Stream for reporting bad argument counts or syntax.
-/// @return True if the branch is well-formed.
-/// @details Accepts either "label" or "label(arg1, arg2)" forms and validates
-/// argument counts against the target block's parameters.
-bool parseBrInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err)
-{
-    in.op = Opcode::Br;
-    std::string t = rest;
-    if (t.rfind("label ", 0) == 0)
-        t = trim(t.substr(6));
-    size_t lp = t.find('(');
-    std::vector<Value> args;
-    std::string lbl;
-    if (lp == std::string::npos)
-    {
-        lbl = t;
-    }
-    else
-    {
-        size_t rp = t.find(')', lp);
-        if (rp == std::string::npos)
-        {
-            err << "line " << st.lineNo << ": mismatched ')\n";
-            return false;
-        }
-        lbl = trim(t.substr(0, lp));
-        std::string argsStr = t.substr(lp + 1, rp - lp - 1);
-        std::stringstream as(argsStr);
-        std::string a;
-        while (std::getline(as, a, ','))
-        {
-            a = trim(a);
-            if (!a.empty())
-                args.push_back(parseValue(a, st, err));
-        }
-    }
-    in.labels.push_back(lbl);
-    in.brArgs.push_back(args);
-    size_t argCount = args.size();
-    auto it = st.blockParamCount.find(lbl);
-    if (it != st.blockParamCount.end())
-    {
-        if (it->second != argCount)
-        {
-            err << "line " << st.lineNo << ": bad arg count\n";
-            return false;
-        }
-    }
-    else
-        st.pendingBrs.push_back({lbl, argCount, st.lineNo});
-    in.type = Type(Type::Kind::Void);
-    return true;
-}
-
-/// @brief Parse a conditional branch of the form
-/// "<cond>, label %a(...), label %b(...)".
-/// @param rest Text containing the condition and two labeled targets.
-/// @param in Instruction to populate.
-/// @param st Parser state for validation.
-/// @param err Stream receiving error diagnostics.
-/// @return True when both targets and the condition are well-formed.
-bool parseCBrInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err)
-{
-    in.op = Opcode::CBr;
-    std::istringstream ss(rest);
-    std::string c = readToken(ss);
-    std::string rem;
-    std::getline(ss, rem);
-    rem = trim(rem);
-    size_t comma = rem.find(',');
-    if (comma == std::string::npos)
-    {
-        err << "line " << st.lineNo << ": malformed cbr\n";
-        return false;
-    }
-    std::string first = trim(rem.substr(0, comma));
-    std::string second = trim(rem.substr(comma + 1));
-    auto parseTarget =
-        [&](const std::string &part, std::string &lbl, std::vector<Value> &args) -> bool
-    {
-        std::string t = part;
-        if (t.rfind("label ", 0) == 0)
-            t = trim(t.substr(6));
-        size_t lp = t.find('(');
-        if (lp == std::string::npos)
-        {
-            lbl = trim(t);
-        }
-        else
-        {
-            size_t rp = t.find(')', lp);
-            if (rp == std::string::npos)
-                return false;
-            lbl = trim(t.substr(0, lp));
-            std::string argsStr = t.substr(lp + 1, rp - lp - 1);
-            std::stringstream as(argsStr);
-            std::string a;
-            while (std::getline(as, a, ','))
-            {
-                a = trim(a);
-                if (!a.empty())
-                    args.push_back(parseValue(a, st, err));
-            }
-        }
-        return true;
-    };
-    std::vector<Value> a1, a2;
-    std::string l1, l2;
-    if (!parseTarget(first, l1, a1) || !parseTarget(second, l2, a2))
-    {
-        err << "line " << st.lineNo << ": mismatched ')\n";
-        return false;
-    }
-    in.operands.push_back(parseValue(c, st, err));
-    in.labels.push_back(l1);
-    in.labels.push_back(l2);
-    in.brArgs.push_back(a1);
-    in.brArgs.push_back(a2);
-    size_t n1 = a1.size();
-    auto it1 = st.blockParamCount.find(l1);
-    if (it1 != st.blockParamCount.end())
-    {
-        if (it1->second != n1)
-        {
-            err << "line " << st.lineNo << ": bad arg count\n";
-            return false;
-        }
-    }
-    else
-        st.pendingBrs.push_back({l1, n1, st.lineNo});
-    size_t n2 = a2.size();
-    auto it2 = st.blockParamCount.find(l2);
-    if (it2 != st.blockParamCount.end())
-    {
-        if (it2->second != n2)
-        {
-            err << "line " << st.lineNo << ": bad arg count\n";
-            return false;
-        }
-    }
-    else
-        st.pendingBrs.push_back({l2, n2, st.lineNo});
-    in.type = Type(Type::Kind::Void);
-    return true;
-}
-
-/// @brief Parse a "ret" instruction with an optional return value.
-/// @param rest Remaining text potentially containing a return operand.
-/// @param in Instruction to populate.
-/// @param st Parser state for value resolution.
-/// @param err Stream receiving diagnostics.
-/// @return True always; malformed values are reported by parseValue().
-bool parseRetInstr(const std::string &rest, Instr &in, ParserState &st, std::ostream &err)
-{
-    in.op = Opcode::Ret;
-    std::string v = trim(rest);
-    if (!v.empty())
-        in.operands.push_back(parseValue(v, st, err));
-    in.type = Type(Type::Kind::Void);
-    return true;
-}
-
-/// @brief Parse the "trap" instruction which halts execution.
-/// @param rest Unused text after the opcode.
-/// @param in Instruction to populate.
-/// @param st Parser state (unused).
-/// @param err Error stream (unused).
-/// @return Always true.
-bool parseTrapInstr(const std::string &, Instr &in, ParserState &, std::ostream &)
-{
-    in.op = Opcode::Trap;
-    in.type = Type(Type::Kind::Void);
-    return true;
-}
-
-/// @brief Parse a single instruction line after removing result assignment.
-/// @param line Full instruction text.
-/// @param st Current parser state for context and diagnostics.
-/// @param err Stream receiving error messages when opcode handlers fail.
-/// @return True if parsing succeeded and the instruction was appended.
-bool parseInstruction(const std::string &line, ParserState &st, std::ostream &err)
-{
-    Instr in;
-    in.loc = st.curLoc;
+    core::Instr instr;
+    instr.loc = state.curLoc;
     std::string work = line;
-    if (work[0] == '%')
+    if (!work.empty() && work[0] == '%')
     {
         size_t eq = work.find('=');
         if (eq == std::string::npos)
         {
-            err << "line " << st.lineNo << ": missing '='\n";
-            st.hasError = true;
+            err << "line " << state.lineNo << ": missing '='\n";
+            state.hasError = true;
             return false;
         }
-        std::string res = trim(work.substr(1, eq - 1));
-        auto [it, inserted] = st.tempIds.emplace(res, st.nextTemp);
+        std::string resultName = Lexer::trim(work.substr(1, eq - 1));
+        auto [it, inserted] = state.tempIds.emplace(resultName, state.nextTemp);
         if (inserted)
         {
-            if (st.curFn->valueNames.size() <= st.nextTemp)
-                st.curFn->valueNames.resize(st.nextTemp + 1);
-            st.curFn->valueNames[st.nextTemp] = res;
-            st.nextTemp++;
+            if (fn->valueNames.size() <= state.nextTemp)
+                fn->valueNames.resize(state.nextTemp + 1);
+            fn->valueNames[state.nextTemp] = resultName;
+            state.nextTemp++;
         }
-        in.result = it->second;
-        work = trim(work.substr(eq + 1));
+        instr.result = it->second;
+        work = Lexer::trim(work.substr(eq + 1));
     }
+
     std::istringstream ss(work);
-    std::string op;
-    ss >> op;
+    std::string opcode;
+    ss >> opcode;
     std::string rest;
     std::getline(ss, rest);
-    rest = trim(rest);
-    auto it = kInstrHandlers.find(op);
-    if (it == kInstrHandlers.end())
+    rest = Lexer::trim(rest);
+
+    const auto &handlers = detail::instructionHandlers();
+    auto it = handlers.find(opcode);
+    if (it == handlers.end())
     {
-        err << "line " << st.lineNo << ": unknown opcode " << op << "\n";
+        err << "line " << state.lineNo << ": unknown opcode " << opcode << "\n";
         return false;
     }
-    if (!it->second(rest, in, st, err))
+    if (!it->second(rest, instr, state, err))
         return false;
-    st.curBB->instructions.push_back(std::move(in));
+
+    bb->instructions.push_back(std::move(instr));
     return true;
 }
 
-/// @brief Parse a function's header and initialize parser state.
-/// @param header Full header line beginning with "func".
-/// @param st Parser state to update with new function information.
-/// @param err Stream for diagnostics (currently unused).
-/// @return True on successful parse of the function signature.
-bool parseFunctionHeader(const std::string &header, ParserState &st, std::ostream &err)
+/// @brief Parse a function header and initialize function state.
+/// @param header Complete header line beginning with "func".
+/// @param state Parser state updated with function metadata.
+/// @param err Diagnostic output stream.
+/// @return True when the signature is well-formed.
+bool parseFunctionHeader(const std::string &header, ParserState &state, std::ostream &err)
 {
     size_t at = header.find('@');
     size_t lp = header.find('(', at);
     size_t rp = header.find(')', lp);
-    size_t arr = header.find("->", rp);
-    size_t lb = header.find('{', arr);
-    if (arr == std::string::npos || lb == std::string::npos)
+    size_t arrow = header.find("->", rp);
+    size_t brace = header.find('{', arrow);
+    if (arrow == std::string::npos || brace == std::string::npos)
     {
-        err << "line " << st.lineNo << ": malformed function header\n";
-        st.hasError = true;
+        err << "line " << state.lineNo << ": malformed function header\n";
+        state.hasError = true;
         return false;
     }
+
     std::string name = header.substr(at + 1, lp - at - 1);
     std::string paramsStr = header.substr(lp + 1, rp - lp - 1);
     std::vector<Param> params;
     std::stringstream pss(paramsStr);
-    std::string p;
-    while (std::getline(pss, p, ','))
+    std::string paramToken;
+    while (std::getline(pss, paramToken, ','))
     {
-        p = trim(p);
-        if (p.empty())
+        paramToken = Lexer::trim(paramToken);
+        if (paramToken.empty())
             continue;
-        std::stringstream ps(p);
+        std::stringstream ps(paramToken);
         std::string ty, nm;
         ps >> ty >> nm;
         if (!ty.empty() && !nm.empty() && nm[0] == '%')
-            params.push_back({nm.substr(1), parseType(ty)});
+            params.push_back({nm.substr(1), detail::parseType(ty)});
     }
-    std::string retStr = trim(header.substr(arr + 2, lb - arr - 2));
-    st.tempIds.clear();
+
+    std::string retStr = Lexer::trim(header.substr(arrow + 2, brace - arrow - 2));
+    state.tempIds.clear();
     unsigned idx = 0;
     for (auto &param : params)
     {
         param.id = idx;
-        st.tempIds[param.name] = idx;
+        state.tempIds[param.name] = idx;
         ++idx;
     }
-    st.m.functions.push_back({name, parseType(retStr), params, {}, {}});
-    st.curFn = &st.m.functions.back();
-    st.curBB = nullptr;
-    st.nextTemp = idx;
-    st.curFn->valueNames.resize(st.nextTemp);
+
+    state.m.functions.push_back({name, detail::parseType(retStr), params, {}, {}});
+    state.curFn = &state.m.functions.back();
+    state.curBB = nullptr;
+    state.nextTemp = idx;
+    state.curFn->valueNames.resize(state.nextTemp);
     for (auto &param : params)
-        st.curFn->valueNames[param.id] = param.name;
-    st.blockParamCount.clear();
-    st.pendingBrs.clear();
+        state.curFn->valueNames[param.id] = param.name;
+    state.blockParamCount.clear();
+    state.pendingBrs.clear();
     return true;
 }
 
-/// @brief Parse a block label and parameters, creating the basic block.
-/// @param header Text of the block label possibly followed by parameters.
-/// @param st Parser state to update with the new block.
-/// @param err Diagnostic output stream.
-/// @return True on success, false when parameters are malformed.
-bool parseBlockHeader(const std::string &header, ParserState &st, std::ostream &err)
+/// @brief Parse a block label with optional parameter list.
+/// @param header Label text, potentially including parameters.
+/// @param state Parser state tracking SSA numbering.
+/// @param err Diagnostics stream for reporting malformations.
+/// @return True if the header is valid.
+bool parseBlockHeader(const std::string &header, ParserState &state, std::ostream &err)
 {
     size_t lp = header.find('(');
-    std::vector<Param> bparams;
-    std::string label = trim(header);
+    std::vector<Param> blockParams;
+    std::string label = Lexer::trim(header);
     if (lp != std::string::npos)
     {
         size_t rp = header.find(')', lp);
         if (rp == std::string::npos)
         {
-            err << "line " << st.lineNo << ": mismatched ')\n";
+            err << "line " << state.lineNo << ": mismatched ')\n";
             return false;
         }
-        label = trim(header.substr(0, lp));
+        label = Lexer::trim(header.substr(0, lp));
         std::string paramsStr = header.substr(lp + 1, rp - lp - 1);
         std::stringstream pss(paramsStr);
-        std::string q;
-        while (std::getline(pss, q, ','))
+        std::string token;
+        while (std::getline(pss, token, ','))
         {
-            q = trim(q);
-            if (q.empty())
+            token = Lexer::trim(token);
+            if (token.empty())
                 continue;
-            size_t col = q.find(':');
-            if (col == std::string::npos)
+            size_t colon = token.find(':');
+            if (colon == std::string::npos)
             {
-                err << "line " << st.lineNo << ": bad param\n";
+                err << "line " << state.lineNo << ": bad param\n";
                 return false;
             }
-            std::string nm = trim(q.substr(0, col));
+            std::string nm = Lexer::trim(token.substr(0, colon));
             if (!nm.empty() && nm[0] == '%')
                 nm = nm.substr(1);
-            std::string tyStr = trim(q.substr(col + 1));
+            std::string tyStr = Lexer::trim(token.substr(colon + 1));
             bool ok = true;
-            Type ty = parseType(tyStr, &ok);
+            Type ty = detail::parseType(tyStr, &ok);
             if (!ok || ty.kind == Type::Kind::Void)
             {
-                err << "line " << st.lineNo << ": unknown param type\n";
+                err << "line " << state.lineNo << ": unknown param type\n";
                 return false;
             }
-            bparams.push_back({nm, ty, st.nextTemp});
-            st.tempIds[nm] = st.nextTemp;
-            if (st.curFn->valueNames.size() <= st.nextTemp)
-                st.curFn->valueNames.resize(st.nextTemp + 1);
-            st.curFn->valueNames[st.nextTemp] = nm;
-            ++st.nextTemp;
+            blockParams.push_back({nm, ty, state.nextTemp});
+            state.tempIds[nm] = state.nextTemp;
+            if (state.curFn->valueNames.size() <= state.nextTemp)
+                state.curFn->valueNames.resize(state.nextTemp + 1);
+            state.curFn->valueNames[state.nextTemp] = nm;
+            ++state.nextTemp;
         }
     }
-    st.curFn->blocks.push_back({label, bparams, {}, false});
-    st.curBB = &st.curFn->blocks.back();
-    st.blockParamCount[label] = bparams.size();
-    for (auto it = st.pendingBrs.begin(); it != st.pendingBrs.end();)
+
+    state.curFn->blocks.push_back({label, blockParams, {}, false});
+    state.curBB = &state.curFn->blocks.back();
+    state.blockParamCount[label] = blockParams.size();
+    for (auto it = state.pendingBrs.begin(); it != state.pendingBrs.end();)
     {
         if (it->label == label)
         {
-            if (it->args != bparams.size())
+            if (it->args != blockParams.size())
             {
                 err << "line " << it->line << ": bad arg count\n";
                 return false;
             }
-            it = st.pendingBrs.erase(it);
+            it = state.pendingBrs.erase(it);
         }
         else
+        {
             ++it;
+        }
     }
     return true;
 }
 
-/// @brief Parse a function body after its header has been read.
-/// @param is Input stream positioned after the function header.
+/// @brief Parse a function body after reading its header.
+/// @param is Input stream delivering subsequent lines.
 /// @param header Previously read function header line.
-/// @param st Parser state to populate.
-/// @param err Diagnostic output stream.
-/// @return True when the function and all contained blocks are parsed.
-bool parseFunction(std::istream &is, std::string &header, ParserState &st, std::ostream &err)
+/// @param state Parser state owning the active function.
+/// @param err Stream for diagnostic output.
+/// @return True when the function parses without fatal errors.
+bool parseFunction(std::istream &is, std::string &header, ParserState &state, std::ostream &err)
 {
-    if (!parseFunctionHeader(header, st, err))
+    if (!parseFunctionHeader(header, state, err))
         return false;
 
     std::string line;
     while (std::getline(is, line))
     {
-        ++st.lineNo;
-        line = trim(line);
+        ++state.lineNo;
+        line = Lexer::trim(line);
         if (line.empty() || line.rfind("//", 0) == 0)
             continue;
         if (line[0] == '}')
         {
-            st.curFn = nullptr;
-            st.curBB = nullptr;
+            state.curFn = nullptr;
+            state.curBB = nullptr;
             return true;
         }
         if (line.back() == ':')
         {
-            if (!parseBlockHeader(line.substr(0, line.size() - 1), st, err))
+            if (!parseBlockHeader(line.substr(0, line.size() - 1), state, err))
                 return false;
             continue;
-        }
-        if (!st.curBB)
-        {
-            err << "line " << st.lineNo << ": instruction outside block\n";
-            return false;
         }
         if (line.rfind(".loc", 0) == 0)
         {
             std::istringstream ls(line.substr(4));
             uint32_t fid = 0, ln = 0, col = 0;
             ls >> fid >> ln >> col;
-            st.curLoc = {fid, ln, col};
+            state.curLoc = {fid, ln, col};
             continue;
         }
-        if (!parseInstruction(line, st, err))
+        if (!parseInstruction(line, state, err))
             return false;
     }
     return true;
 }
 
-/// @brief Parse top-level module declarations (il, extern, global, func).
-/// @param is Input stream for additional lines when encountering a function.
-/// @param line Current line to interpret.
-/// @param st Parser state updated with module metadata.
-/// @param err Output stream for error messages.
-/// @return True if the line was successfully processed.
-bool parseModuleHeader(std::istream &is, std::string &line, ParserState &st, std::ostream &err)
+/// @brief Parse top-level module declarations.
+/// @param is Input stream for additional lines (used when encountering a function).
+/// @param line Current source line to interpret.
+/// @param state Parser state capturing module construction.
+/// @param err Stream that collects diagnostics.
+/// @return True when the declaration is handled successfully.
+bool parseModuleHeader(std::istream &is, std::string &line, ParserState &state, std::ostream &err)
 {
     if (line.rfind("il", 0) == 0)
     {
@@ -918,9 +287,9 @@ bool parseModuleHeader(std::istream &is, std::string &line, ParserState &st, std
         ls >> kw;
         std::string ver;
         if (ls >> ver)
-            st.m.version = ver;
+            state.m.version = ver;
         else
-            st.m.version = "0.1.2";
+            state.m.version = "0.1.2";
         return true;
     }
     if (line.rfind("extern", 0) == 0)
@@ -928,47 +297,49 @@ bool parseModuleHeader(std::istream &is, std::string &line, ParserState &st, std
         size_t at = line.find('@');
         size_t lp = line.find('(', at);
         size_t rp = line.find(')', lp);
-        size_t arr = line.find("->", rp);
-        if (arr == std::string::npos)
+        size_t arrow = line.find("->", rp);
+        if (arrow == std::string::npos)
         {
-            err << "line " << st.lineNo << ": missing '->'\n";
-            st.hasError = true;
+            err << "line " << state.lineNo << ": missing '->'\n";
+            state.hasError = true;
             return false;
         }
         std::string name = line.substr(at + 1, lp - at - 1);
         std::string paramsStr = line.substr(lp + 1, rp - lp - 1);
         std::vector<Type> params;
         std::stringstream pss(paramsStr);
-        std::string p;
+        std::string token;
         bool typesOk = true;
-        while (std::getline(pss, p, ','))
+        while (std::getline(pss, token, ','))
         {
-            p = trim(p);
-            if (p.empty())
+            token = Lexer::trim(token);
+            if (token.empty())
                 continue;
             bool ok = true;
-            Type ty = parseType(p, &ok);
+            Type ty = detail::parseType(token, &ok);
             if (!ok)
             {
-                err << "line " << st.lineNo << ": unknown type '" << p << "'\n";
-                st.hasError = true;
+                err << "line " << state.lineNo << ": unknown type '" << token << "'\n";
+                state.hasError = true;
                 typesOk = false;
             }
             else
+            {
                 params.push_back(ty);
+            }
         }
-        std::string retStr = trim(line.substr(arr + 2));
+        std::string retStr = Lexer::trim(line.substr(arrow + 2));
         bool retOk = true;
-        Type retTy = parseType(retStr, &retOk);
+        Type retTy = detail::parseType(retStr, &retOk);
         if (!retOk)
         {
-            err << "line " << st.lineNo << ": unknown type '" << retStr << "'\n";
-            st.hasError = true;
+            err << "line " << state.lineNo << ": unknown type '" << retStr << "'\n";
+            state.hasError = true;
             typesOk = false;
         }
         if (!typesOk)
             return false;
-        st.m.externs.push_back({name, retTy, params});
+        state.m.externs.push_back({name, retTy, params});
         return true;
     }
     if (line.rfind("global", 0) == 0)
@@ -977,44 +348,40 @@ bool parseModuleHeader(std::istream &is, std::string &line, ParserState &st, std
         size_t eq = line.find('=', at);
         if (eq == std::string::npos)
         {
-            err << "line " << st.lineNo << ": missing '='\n";
-            st.hasError = true;
+            err << "line " << state.lineNo << ": missing '='\n";
+            state.hasError = true;
             return false;
         }
         size_t q1 = line.find('"', eq);
         size_t q2 = line.rfind('"');
-        std::string name = trim(line.substr(at + 1, eq - at - 1));
+        std::string name = Lexer::trim(line.substr(at + 1, eq - at - 1));
         std::string init = line.substr(q1 + 1, q2 - q1 - 1);
-        st.m.globals.push_back({name, Type(Type::Kind::Str), init});
+        state.m.globals.push_back({name, Type(Type::Kind::Str), init});
         return true;
     }
     if (line.rfind("func", 0) == 0)
-        return parseFunction(is, line, st, err);
-    err << "line " << st.lineNo << ": unexpected line: " << line << "\n";
+        return parseFunction(is, line, state, err);
+
+    err << "line " << state.lineNo << ": unexpected line: " << line << "\n";
     return false;
 }
 
 } // namespace
 
-/// @brief Entry point for parsing a textual IL module.
-/// @param is Input stream containing IL text.
-/// @param m Module to populate.
-/// @param err Stream for error diagnostics.
-/// @return True if no fatal parsing errors were encountered.
 bool Parser::parse(std::istream &is, Module &m, std::ostream &err)
 {
-    ParserState st{m};
+    ParserState state{m};
     std::string line;
     while (std::getline(is, line))
     {
-        ++st.lineNo;
-        line = trim(line);
+        ++state.lineNo;
+        line = Lexer::trim(line);
         if (line.empty() || line.rfind("//", 0) == 0)
             continue;
-        if (!parseModuleHeader(is, line, st, err))
+        if (!parseModuleHeader(is, line, state, err))
             return false;
     }
-    return !st.hasError;
+    return !state.hasError;
 }
 
 } // namespace il::io

--- a/src/il/io/detail/InstructionHandlers.cpp
+++ b/src/il/io/detail/InstructionHandlers.cpp
@@ -1,0 +1,485 @@
+// File: src/il/io/detail/InstructionHandlers.cpp
+// Purpose: Implements opcode-specific parsing helpers for the IL parser.
+// Key invariants: Maintains parser state consistency when constructing instructions.
+// Ownership/Lifetime: Functions mutate caller-provided ParserState and instruction objects.
+// Links: docs/il-spec.md
+
+#include "il/io/detail/InstructionHandlers.hpp"
+
+#include "il/io/Lexer.hpp"
+#include <cctype>
+#include <exception>
+#include <sstream>
+
+using il::core::Instr;
+using il::core::Opcode;
+using il::core::Type;
+using il::core::Value;
+
+namespace il::io::detail
+{
+
+Type parseType(const std::string &token, bool *ok)
+{
+    if (token == "i64")
+    {
+        if (ok)
+            *ok = true;
+        return Type(Type::Kind::I64);
+    }
+    if (token == "i1")
+    {
+        if (ok)
+            *ok = true;
+        return Type(Type::Kind::I1);
+    }
+    if (token == "f64")
+    {
+        if (ok)
+            *ok = true;
+        return Type(Type::Kind::F64);
+    }
+    if (token == "ptr")
+    {
+        if (ok)
+            *ok = true;
+        return Type(Type::Kind::Ptr);
+    }
+    if (token == "str")
+    {
+        if (ok)
+            *ok = true;
+        return Type(Type::Kind::Str);
+    }
+    if (token == "void")
+    {
+        if (ok)
+            *ok = true;
+        return Type(Type::Kind::Void);
+    }
+    if (ok)
+        *ok = false;
+    return Type();
+}
+
+Value parseValue(const std::string &token, ParserState &state, std::ostream &err)
+{
+    if (token.empty())
+        return Value::constInt(0);
+    if (token[0] == '%')
+    {
+        std::string name = token.substr(1);
+        auto it = state.tempIds.find(name);
+        if (it != state.tempIds.end())
+            return Value::temp(it->second);
+        if (name.size() > 1 && name[0] == 't')
+        {
+            bool digits = true;
+            for (size_t i = 1; i < name.size(); ++i)
+                if (!std::isdigit(static_cast<unsigned char>(name[i])))
+                    digits = false;
+            if (digits)
+            {
+                try
+                {
+                    return Value::temp(std::stoul(name.substr(1)));
+                }
+                catch (const std::exception &)
+                {
+                    state.hasError = true;
+                    err << "Line " << state.lineNo << ": invalid temp id '" << token << "'\n";
+                    return Value::temp(0);
+                }
+            }
+        }
+        return Value::temp(0);
+    }
+    if (token[0] == '@')
+        return Value::global(token.substr(1));
+    if (token == "null")
+        return Value::null();
+    if (token.size() >= 2 && token.front() == '"' && token.back() == '"')
+        return Value::constStr(token.substr(1, token.size() - 2));
+    if (token.find('.') != std::string::npos || token.find('e') != std::string::npos ||
+        token.find('E') != std::string::npos)
+    {
+        try
+        {
+            size_t idx = 0;
+            double val = std::stod(token, &idx);
+            if (idx != token.size())
+                throw std::invalid_argument("trailing characters");
+            return Value::constFloat(val);
+        }
+        catch (const std::exception &)
+        {
+            state.hasError = true;
+            err << "Line " << state.lineNo << ": invalid floating literal '" << token << "'\n";
+            return Value::constFloat(0.0);
+        }
+    }
+    try
+    {
+        size_t idx = 0;
+        long long val = std::stoll(token, &idx);
+        if (idx != token.size())
+            throw std::invalid_argument("trailing characters");
+        return Value::constInt(val);
+    }
+    catch (const std::exception &)
+    {
+        state.hasError = true;
+        err << "Line " << state.lineNo << ": invalid integer literal '" << token << "'\n";
+        return Value::constInt(0);
+    }
+}
+
+namespace
+{
+
+InstrHandler makeBinaryHandler(Opcode op, Type type)
+{
+    return [op, type](const std::string &rest, Instr &instr, ParserState &state, std::ostream &err)
+    {
+        std::istringstream ss(rest);
+        std::string a = Lexer::nextToken(ss);
+        std::string b = Lexer::nextToken(ss);
+        instr.op = op;
+        if (!a.empty())
+            instr.operands.push_back(parseValue(a, state, err));
+        if (!b.empty())
+            instr.operands.push_back(parseValue(b, state, err));
+        instr.type = type;
+        return true;
+    };
+}
+
+InstrHandler makeUnaryHandler(Opcode op, Type type)
+{
+    return [op, type](const std::string &rest, Instr &instr, ParserState &state, std::ostream &err)
+    {
+        std::istringstream ss(rest);
+        std::string a = Lexer::nextToken(ss);
+        instr.op = op;
+        if (!a.empty())
+            instr.operands.push_back(parseValue(a, state, err));
+        instr.type = type;
+        return true;
+    };
+}
+
+InstrHandler makeCmpHandler(Opcode op)
+{
+    return makeBinaryHandler(op, Type(Type::Kind::I1));
+}
+
+bool parseAllocaInstr(const std::string &rest, Instr &instr, ParserState &state, std::ostream &err)
+{
+    std::istringstream ss(rest);
+    std::string sizeTok = Lexer::nextToken(ss);
+    instr.op = Opcode::Alloca;
+    if (sizeTok.empty())
+    {
+        err << "line " << state.lineNo << ": missing size for alloca\n";
+        state.hasError = true;
+    }
+    else
+    {
+        instr.operands.push_back(parseValue(sizeTok, state, err));
+    }
+    instr.type = Type(Type::Kind::Ptr);
+    return true;
+}
+
+bool parseGEPInstr(const std::string &rest, Instr &instr, ParserState &state, std::ostream &err)
+{
+    std::istringstream ss(rest);
+    std::string base = Lexer::nextToken(ss);
+    std::string offset = Lexer::nextToken(ss);
+    instr.op = Opcode::GEP;
+    instr.operands.push_back(parseValue(base, state, err));
+    instr.operands.push_back(parseValue(offset, state, err));
+    instr.type = Type(Type::Kind::Ptr);
+    return true;
+}
+
+bool parseLoadInstr(const std::string &rest, Instr &instr, ParserState &state, std::ostream &err)
+{
+    std::istringstream ss(rest);
+    std::string typeTok = Lexer::nextToken(ss);
+    std::string ptr = Lexer::nextToken(ss);
+    instr.op = Opcode::Load;
+    instr.type = parseType(typeTok);
+    instr.operands.push_back(parseValue(ptr, state, err));
+    return true;
+}
+
+bool parseStoreInstr(const std::string &rest, Instr &instr, ParserState &state, std::ostream &err)
+{
+    std::istringstream ss(rest);
+    std::string typeTok = Lexer::nextToken(ss);
+    std::string ptr = Lexer::nextToken(ss);
+    std::string val = Lexer::nextToken(ss);
+    instr.op = Opcode::Store;
+    instr.type = parseType(typeTok);
+    instr.operands.push_back(parseValue(ptr, state, err));
+    instr.operands.push_back(parseValue(val, state, err));
+    return true;
+}
+
+bool parseAddrOfInstr(const std::string &rest, Instr &instr, ParserState &state, std::ostream &err)
+{
+    std::istringstream ss(rest);
+    std::string global = Lexer::nextToken(ss);
+    instr.op = Opcode::AddrOf;
+    if (!global.empty())
+        instr.operands.push_back(parseValue(global, state, err));
+    instr.type = Type(Type::Kind::Ptr);
+    return true;
+}
+
+bool parseConstStrInstr(const std::string &rest, Instr &instr, ParserState &state, std::ostream &err)
+{
+    std::istringstream ss(rest);
+    std::string literal = Lexer::nextToken(ss);
+    instr.op = Opcode::ConstStr;
+    if (!literal.empty())
+        instr.operands.push_back(parseValue(literal, state, err));
+    instr.type = Type(Type::Kind::Str);
+    return true;
+}
+
+bool parseConstNullInstr(const std::string &rest, Instr &instr, ParserState &, std::ostream &)
+{
+    (void)rest;
+    instr.op = Opcode::ConstNull;
+    instr.type = Type(Type::Kind::Ptr);
+    return true;
+}
+
+bool parseCallInstr(const std::string &rest, Instr &instr, ParserState &state, std::ostream &err)
+{
+    instr.op = Opcode::Call;
+    size_t at = rest.find('@');
+    size_t lp = rest.find('(', at);
+    size_t rp = rest.find(')', lp);
+    if (at == std::string::npos || lp == std::string::npos || rp == std::string::npos)
+    {
+        err << "line " << state.lineNo << ": malformed call\n";
+        return false;
+    }
+    instr.callee = rest.substr(at + 1, lp - at - 1);
+    std::string args = rest.substr(lp + 1, rp - lp - 1);
+    for (const auto &arg : Lexer::splitCommaSeparated(args))
+    {
+        if (!arg.empty())
+            instr.operands.push_back(parseValue(arg, state, err));
+    }
+    instr.type = Type(Type::Kind::Void);
+    return true;
+}
+
+bool parseBrInstr(const std::string &rest, Instr &instr, ParserState &state, std::ostream &err)
+{
+    instr.op = Opcode::Br;
+    std::string targetText = rest;
+    if (targetText.rfind("label ", 0) == 0)
+        targetText = Lexer::trim(targetText.substr(6));
+    size_t lp = targetText.find('(');
+    std::vector<Value> args;
+    std::string label;
+    if (lp == std::string::npos)
+    {
+        label = targetText;
+    }
+    else
+    {
+        size_t rp = targetText.find(')', lp);
+        if (rp == std::string::npos)
+        {
+            err << "line " << state.lineNo << ": mismatched ')\n";
+            return false;
+        }
+        label = Lexer::trim(targetText.substr(0, lp));
+        std::string argsStr = targetText.substr(lp + 1, rp - lp - 1);
+        for (const auto &arg : Lexer::splitCommaSeparated(argsStr))
+        {
+            if (!arg.empty())
+                args.push_back(parseValue(arg, state, err));
+        }
+    }
+    instr.labels.push_back(label);
+    instr.brArgs.push_back(args);
+    size_t argCount = args.size();
+    auto it = state.blockParamCount.find(label);
+    if (it != state.blockParamCount.end())
+    {
+        if (it->second != argCount)
+        {
+            err << "line " << state.lineNo << ": bad arg count\n";
+            return false;
+        }
+    }
+    else
+        state.pendingBrs.push_back({label, argCount, state.lineNo});
+    instr.type = Type(Type::Kind::Void);
+    return true;
+}
+
+bool parseCBrInstr(const std::string &rest, Instr &instr, ParserState &state, std::ostream &err)
+{
+    instr.op = Opcode::CBr;
+    std::istringstream ss(rest);
+    std::string condition = Lexer::nextToken(ss);
+    std::string remainder;
+    std::getline(ss, remainder);
+    remainder = Lexer::trim(remainder);
+    size_t comma = remainder.find(',');
+    if (comma == std::string::npos)
+    {
+        err << "line " << state.lineNo << ": malformed cbr\n";
+        return false;
+    }
+    std::string first = Lexer::trim(remainder.substr(0, comma));
+    std::string second = Lexer::trim(remainder.substr(comma + 1));
+    auto parseTarget = [&](const std::string &part, std::string &label, std::vector<Value> &args) -> bool
+    {
+        std::string text = part;
+        if (text.rfind("label ", 0) == 0)
+            text = Lexer::trim(text.substr(6));
+        size_t lp = text.find('(');
+        if (lp == std::string::npos)
+        {
+            label = Lexer::trim(text);
+        }
+        else
+        {
+            size_t rp = text.find(')', lp);
+            if (rp == std::string::npos)
+                return false;
+            label = Lexer::trim(text.substr(0, lp));
+            std::string argsStr = text.substr(lp + 1, rp - lp - 1);
+            for (const auto &arg : Lexer::splitCommaSeparated(argsStr))
+            {
+                if (!arg.empty())
+                    args.push_back(parseValue(arg, state, err));
+            }
+        }
+        return true;
+    };
+    std::vector<Value> args1, args2;
+    std::string label1, label2;
+    if (!parseTarget(first, label1, args1) || !parseTarget(second, label2, args2))
+    {
+        err << "line " << state.lineNo << ": mismatched ')\n";
+        return false;
+    }
+    instr.operands.push_back(parseValue(condition, state, err));
+    instr.labels.push_back(label1);
+    instr.labels.push_back(label2);
+    instr.brArgs.push_back(args1);
+    instr.brArgs.push_back(args2);
+    size_t n1 = args1.size();
+    auto it1 = state.blockParamCount.find(label1);
+    if (it1 != state.blockParamCount.end())
+    {
+        if (it1->second != n1)
+        {
+            err << "line " << state.lineNo << ": bad arg count\n";
+            return false;
+        }
+    }
+    else
+        state.pendingBrs.push_back({label1, n1, state.lineNo});
+    size_t n2 = args2.size();
+    auto it2 = state.blockParamCount.find(label2);
+    if (it2 != state.blockParamCount.end())
+    {
+        if (it2->second != n2)
+        {
+            err << "line " << state.lineNo << ": bad arg count\n";
+            return false;
+        }
+    }
+    else
+        state.pendingBrs.push_back({label2, n2, state.lineNo});
+    instr.type = Type(Type::Kind::Void);
+    return true;
+}
+
+bool parseRetInstr(const std::string &rest, Instr &instr, ParserState &state, std::ostream &err)
+{
+    instr.op = Opcode::Ret;
+    std::string value = Lexer::trim(rest);
+    if (!value.empty())
+        instr.operands.push_back(parseValue(value, state, err));
+    instr.type = Type(Type::Kind::Void);
+    return true;
+}
+
+bool parseTrapInstr(const std::string &, Instr &instr, ParserState &, std::ostream &)
+{
+    instr.op = Opcode::Trap;
+    instr.type = Type(Type::Kind::Void);
+    return true;
+}
+
+} // namespace
+
+const std::unordered_map<std::string, InstrHandler> &instructionHandlers()
+{
+    static const std::unordered_map<std::string, InstrHandler> handlers = {
+        {"add", makeBinaryHandler(Opcode::Add, Type(Type::Kind::I64))},
+        {"sub", makeBinaryHandler(Opcode::Sub, Type(Type::Kind::I64))},
+        {"mul", makeBinaryHandler(Opcode::Mul, Type(Type::Kind::I64))},
+        {"sdiv", makeBinaryHandler(Opcode::SDiv, Type(Type::Kind::I64))},
+        {"udiv", makeBinaryHandler(Opcode::UDiv, Type(Type::Kind::I64))},
+        {"srem", makeBinaryHandler(Opcode::SRem, Type(Type::Kind::I64))},
+        {"urem", makeBinaryHandler(Opcode::URem, Type(Type::Kind::I64))},
+        {"and", makeBinaryHandler(Opcode::And, Type(Type::Kind::I64))},
+        {"or", makeBinaryHandler(Opcode::Or, Type(Type::Kind::I64))},
+        {"xor", makeBinaryHandler(Opcode::Xor, Type(Type::Kind::I64))},
+        {"shl", makeBinaryHandler(Opcode::Shl, Type(Type::Kind::I64))},
+        {"lshr", makeBinaryHandler(Opcode::LShr, Type(Type::Kind::I64))},
+        {"ashr", makeBinaryHandler(Opcode::AShr, Type(Type::Kind::I64))},
+        {"fadd", makeBinaryHandler(Opcode::FAdd, Type(Type::Kind::F64))},
+        {"fsub", makeBinaryHandler(Opcode::FSub, Type(Type::Kind::F64))},
+        {"fmul", makeBinaryHandler(Opcode::FMul, Type(Type::Kind::F64))},
+        {"fdiv", makeBinaryHandler(Opcode::FDiv, Type(Type::Kind::F64))},
+        {"icmp_eq", makeCmpHandler(Opcode::ICmpEq)},
+        {"icmp_ne", makeCmpHandler(Opcode::ICmpNe)},
+        {"scmp_lt", makeCmpHandler(Opcode::SCmpLT)},
+        {"scmp_le", makeCmpHandler(Opcode::SCmpLE)},
+        {"scmp_gt", makeCmpHandler(Opcode::SCmpGT)},
+        {"scmp_ge", makeCmpHandler(Opcode::SCmpGE)},
+        {"ucmp_lt", makeCmpHandler(Opcode::UCmpLT)},
+        {"ucmp_le", makeCmpHandler(Opcode::UCmpLE)},
+        {"ucmp_gt", makeCmpHandler(Opcode::UCmpGT)},
+        {"ucmp_ge", makeCmpHandler(Opcode::UCmpGE)},
+        {"fcmp_lt", makeCmpHandler(Opcode::FCmpLT)},
+        {"fcmp_le", makeCmpHandler(Opcode::FCmpLE)},
+        {"fcmp_gt", makeCmpHandler(Opcode::FCmpGT)},
+        {"fcmp_ge", makeCmpHandler(Opcode::FCmpGE)},
+        {"fcmp_eq", makeCmpHandler(Opcode::FCmpEQ)},
+        {"fcmp_ne", makeCmpHandler(Opcode::FCmpNE)},
+        {"sitofp", makeUnaryHandler(Opcode::Sitofp, Type(Type::Kind::F64))},
+        {"fptosi", makeUnaryHandler(Opcode::Fptosi, Type(Type::Kind::I64))},
+        {"zext1", makeUnaryHandler(Opcode::Zext1, Type(Type::Kind::I64))},
+        {"trunc1", makeUnaryHandler(Opcode::Trunc1, Type(Type::Kind::I1))},
+        {"alloca", parseAllocaInstr},
+        {"gep", parseGEPInstr},
+        {"load", parseLoadInstr},
+        {"store", parseStoreInstr},
+        {"addr_of", parseAddrOfInstr},
+        {"const_str", parseConstStrInstr},
+        {"const_null", parseConstNullInstr},
+        {"call", parseCallInstr},
+        {"br", parseBrInstr},
+        {"cbr", parseCBrInstr},
+        {"ret", parseRetInstr},
+        {"trap", parseTrapInstr},
+    };
+    return handlers;
+}
+
+} // namespace il::io::detail

--- a/src/il/io/detail/InstructionHandlers.hpp
+++ b/src/il/io/detail/InstructionHandlers.hpp
@@ -1,0 +1,41 @@
+// File: src/il/io/detail/InstructionHandlers.hpp
+// Purpose: Declares opcode-specific parsing helpers for the IL parser.
+// Key invariants: Handlers assume parser state invariants from ParserState.hpp.
+// Ownership/Lifetime: Operate on caller-provided state and instruction objects.
+// Links: docs/il-spec.md
+#pragma once
+
+#include "il/core/Instr.hpp"
+#include "il/core/Type.hpp"
+#include "il/core/Value.hpp"
+#include "il/io/detail/ParserState.hpp"
+#include <functional>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+
+namespace il::io::detail
+{
+
+/// @brief Signature for individual opcode parsing callbacks.
+using InstrHandler =
+    std::function<bool(const std::string &, core::Instr &, ParserState &, std::ostream &)>;
+
+/// @brief Parse a textual type token into an IL Type instance.
+/// @param token Lowercase token such as "i64", "ptr", or "void".
+/// @param ok Optional flag updated to reflect success.
+/// @return Parsed type or default Type on failure.
+core::Type parseType(const std::string &token, bool *ok = nullptr);
+
+/// @brief Parse a textual value token.
+/// @param token Token representing constants, temporaries, or globals.
+/// @param state Parser state containing symbol tables and diagnostics info.
+/// @param err Stream receiving diagnostic messages.
+/// @return Parsed Value object; errors are reported through @p err.
+core::Value parseValue(const std::string &token, ParserState &state, std::ostream &err);
+
+/// @brief Access the opcode dispatch table used by the parser.
+/// @return Mapping from opcode mnemonics to handler callbacks.
+const std::unordered_map<std::string, InstrHandler> &instructionHandlers();
+
+} // namespace il::io::detail

--- a/src/il/io/detail/ParserState.hpp
+++ b/src/il/io/detail/ParserState.hpp
@@ -1,0 +1,67 @@
+// File: src/il/io/detail/ParserState.hpp
+// Purpose: Declares shared parser state used by IL parsing helpers.
+// Key invariants: Tracks current function/block context consistently.
+// Ownership/Lifetime: Borrows module reference; does not own pointed-to data.
+// Links: docs/il-spec.md
+#pragma once
+
+#include "il/core/Function.hpp"
+#include "il/core/Module.hpp"
+#include "support/source_manager.hpp"
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace il::io::detail
+{
+
+using il::core::BasicBlock;
+using il::core::Function;
+using il::core::Module;
+
+/// @brief Aggregated state shared across parsing routines.
+struct ParserState
+{
+    /// @brief Module being populated by the parser.
+    Module &m;
+
+    /// @brief Function currently under construction, nullptr when outside.
+    Function *curFn = nullptr;
+
+    /// @brief Basic block currently accepting instructions, nullptr if none.
+    BasicBlock *curBB = nullptr;
+
+    /// @brief Mapping from SSA names to numeric identifiers.
+    std::unordered_map<std::string, unsigned> tempIds;
+
+    /// @brief Next unused SSA id for value assignment.
+    unsigned nextTemp = 0;
+
+    /// @brief Current source line for diagnostics.
+    unsigned lineNo = 0;
+
+    /// @brief Active source location recorded via .loc directives.
+    il::support::SourceLoc curLoc{};
+
+    /// @brief Expected parameter count for each known basic block label.
+    std::unordered_map<std::string, size_t> blockParamCount;
+
+    /// @brief Flag toggled when fatal parsing errors occur.
+    bool hasError = false;
+
+    /// @brief Deferred branch resolution metadata.
+    struct PendingBr
+    {
+        std::string label; ///< Referenced block label.
+        size_t args = 0;   ///< Number of provided arguments.
+        unsigned line = 0; ///< Source line where branch appeared.
+    };
+
+    /// @brief Branches that target labels not yet defined.
+    std::vector<PendingBr> pendingBrs;
+
+    /// @brief Construct state for the supplied module.
+    explicit ParserState(Module &mod) : m(mod) {}
+};
+
+} // namespace il::io::detail


### PR DESCRIPTION
## Summary
- extract common string tokenisation routines into a reusable il::io::Lexer helper
- move opcode-specific parsing logic into il/io/detail with a shared dispatch table
- update Parser implementation and build configuration to use the new helpers

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68c8403b3010832485081b7a7e1e6d8f