### PR TITLE
fix: align widget button test formatting

### DIFF
--- a/tui/tests/test_widgets_basic.cpp
+++ b/tui/tests/test_widgets_basic.cpp
@@ -43,7 +43,8 @@ int main()
 
     // Button paint and onClick
     bool clicked = false;
-    Button btn("Go", [&] { clicked = true; }, theme);
+    Button btn(
+        "Go", [&] { clicked = true; }, theme);
     btn.layout({0, 0, 4, 3});
     sb.resize(3, 4);
     sb.clear(theme.style(Role::Normal));


### PR DESCRIPTION
## Summary
- reformat the Button construction in the widget smoke test to satisfy clang-format-14

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68c84d1bbec48324a6db8eff8298d352