### PR TITLE
Refactor ConstFolder to use visitor-driven dispatch

### DIFF
--- a/src/frontends/basic/ConstFoldHelpers.hpp
+++ b/src/frontends/basic/ConstFoldHelpers.hpp
@@ -9,7 +9,7 @@
 #include <optional>
 #include <utility>
 
-namespace il::frontends::basic::detail
+namespace il::frontends::basic::detail::numeric
 {
 /// @brief Apply arithmetic operation on two literals with promotion.
 /// @param l Left operand expression.
@@ -61,15 +61,20 @@ ExprPtr foldCompare(
         });
 }
 
+} // namespace il::frontends::basic::detail::numeric
+
 /// @brief Apply binary string operation using callback @p op.
 /// @param l Left string operand.
 /// @param r Right string operand.
 /// @param op Callback operating on string values and returning ExprPtr.
 /// @return Folded literal produced by @p op.
 /// @invariant Caller ensures @p op models BASIC semantics.
+namespace il::frontends::basic::detail::strings
+{
+
 template <typename Op> ExprPtr foldString(const StringExpr &l, const StringExpr &r, Op op)
 {
     return op(l.value, r.value);
 }
 
-} // namespace il::frontends::basic::detail
+} // namespace il::frontends::basic::detail::strings

--- a/src/frontends/basic/ConstFolder.hpp
+++ b/src/frontends/basic/ConstFolder.hpp
@@ -16,7 +16,7 @@ namespace il::frontends::basic
 /// \param prog Program to transform in place.
 void foldConstants(Program &prog);
 
-namespace detail
+namespace detail::numeric
 {
 /// @brief Numeric literal wrapper used during folding.
 struct Numeric
@@ -35,9 +35,12 @@ Numeric promote(const Numeric &a, const Numeric &b);
 /// @brief Fold numeric binary operation using callback @p op.
 /// @return Folded expression or nullptr on mismatch.
 template <typename F> ExprPtr foldNumericBinary(const Expr &l, const Expr &r, F op);
+} // namespace detail::numeric
 
+namespace detail::strings
+{
 /// @brief Fold string binary operation (e.g., concatenation).
-ExprPtr foldStringBinary(const StringExpr &l, TokenKind op, const StringExpr &r);
-} // namespace detail
+ExprPtr foldBinary(const StringExpr &l, TokenKind op, const StringExpr &r);
+} // namespace detail::strings
 
 } // namespace il::frontends::basic


### PR DESCRIPTION
## Summary
- Introduced an ExprVisitor dispatch for constant folding and split numeric and string helpers into dedicated namespaces.
- Updated helper headers to reflect the numeric/string partitions and centralize literal extraction logic.
- Reworked builtin, binary, and recursive folding routines to rely on visitor utilities instead of scattered dynamic_cast checks.

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68c85f0593f48324895982cde9d26b35