### PR TITLE
refactor(il/io): split parser helpers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,9 +16,7 @@ add_library(il_build STATIC il/build/IRBuilder.cpp)
 target_link_libraries(il_build PUBLIC il_core support)
 target_include_directories(il_build PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_library(il_io STATIC il/io/Serializer.cpp il/io/Parser.cpp)
-target_link_libraries(il_io PUBLIC il_core)
-target_include_directories(il_io PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+add_subdirectory(il/io)
 
 add_library(il_verify STATIC il/verify/Verifier.cpp)
 target_link_libraries(il_verify PUBLIC il_core)

--- a/src/il/io/CMakeLists.txt
+++ b/src/il/io/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(il_io STATIC
+  Parser.cpp
+  ParserUtil.cpp
+  Serializer.cpp
+  TypeParser.cpp
+)
+
+target_link_libraries(il_io PUBLIC il_core)
+
+target_include_directories(il_io PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../..)

--- a/src/il/io/ParserUtil.cpp
+++ b/src/il/io/ParserUtil.cpp
@@ -1,0 +1,69 @@
+// File: src/il/io/ParserUtil.cpp
+// Purpose: Implements lexical helpers used by the IL parser.
+// Key invariants: None.
+// Ownership/Lifetime: Stateless functions operate on caller-provided buffers.
+// Links: docs/il-spec.md
+
+#include "il/io/ParserUtil.hpp"
+
+#include <cctype>
+#include <exception>
+
+namespace il::io
+{
+
+std::string trim(const std::string &text)
+{
+    size_t begin = 0;
+    while (begin < text.size() && std::isspace(static_cast<unsigned char>(text[begin])))
+        ++begin;
+    size_t end = text.size();
+    while (end > begin && std::isspace(static_cast<unsigned char>(text[end - 1])))
+        --end;
+    return text.substr(begin, end - begin);
+}
+
+std::string readToken(std::istringstream &stream)
+{
+    std::string token;
+    stream >> token;
+    if (!token.empty() && token.back() == ',')
+        token.pop_back();
+    return token;
+}
+
+bool parseIntegerLiteral(const std::string &token, long long &value)
+{
+    try
+    {
+        size_t idx = 0;
+        long long parsed = std::stoll(token, &idx);
+        if (idx != token.size())
+            return false;
+        value = parsed;
+        return true;
+    }
+    catch (const std::exception &)
+    {
+        return false;
+    }
+}
+
+bool parseFloatLiteral(const std::string &token, double &value)
+{
+    try
+    {
+        size_t idx = 0;
+        double parsed = std::stod(token, &idx);
+        if (idx != token.size())
+            return false;
+        value = parsed;
+        return true;
+    }
+    catch (const std::exception &)
+    {
+        return false;
+    }
+}
+
+} // namespace il::io

--- a/src/il/io/ParserUtil.hpp
+++ b/src/il/io/ParserUtil.hpp
@@ -1,0 +1,36 @@
+// File: src/il/io/ParserUtil.hpp
+// Purpose: Declares lexical helpers shared by IL parser components.
+// Key invariants: None.
+// Ownership/Lifetime: Stateless utility routines operate on caller-provided data.
+// Links: docs/il-spec.md
+#pragma once
+
+#include <sstream>
+#include <string>
+
+namespace il::io
+{
+
+/// @brief Remove leading and trailing whitespace from the supplied text.
+/// @param text Input string that may contain surrounding whitespace.
+/// @return Substring view with surrounding whitespace stripped.
+std::string trim(const std::string &text);
+
+/// @brief Extract the next comma or whitespace delimited token from a stream.
+/// @param stream Source stream backed by an instruction tail segment.
+/// @return Token without any trailing comma delimiter.
+std::string readToken(std::istringstream &stream);
+
+/// @brief Attempt to parse an integer literal token.
+/// @param token Textual representation of a signed integer.
+/// @param value Destination receiving the parsed value on success.
+/// @return True if the entire token was consumed as an integer.
+bool parseIntegerLiteral(const std::string &token, long long &value);
+
+/// @brief Attempt to parse a floating-point literal token.
+/// @param token Textual representation of a floating value.
+/// @param value Destination receiving the parsed value on success.
+/// @return True if the entire token was consumed as a floating literal.
+bool parseFloatLiteral(const std::string &token, double &value);
+
+} // namespace il::io

--- a/src/il/io/TypeParser.cpp
+++ b/src/il/io/TypeParser.cpp
@@ -1,0 +1,38 @@
+// File: src/il/io/TypeParser.cpp
+// Purpose: Implements parsing for IL textual type specifiers.
+// Key invariants: Supported types mirror docs/il-spec.md definitions.
+// Ownership/Lifetime: Stateless utilities returning value objects.
+// Links: docs/il-spec.md
+
+#include "il/io/TypeParser.hpp"
+
+namespace il::io
+{
+
+il::core::Type parseType(const std::string &token, bool *ok)
+{
+    auto makeType = [ok](il::core::Type::Kind kind) {
+        if (ok)
+            *ok = true;
+        return il::core::Type(kind);
+    };
+
+    if (token == "i64")
+        return makeType(il::core::Type::Kind::I64);
+    if (token == "i1")
+        return makeType(il::core::Type::Kind::I1);
+    if (token == "f64")
+        return makeType(il::core::Type::Kind::F64);
+    if (token == "ptr")
+        return makeType(il::core::Type::Kind::Ptr);
+    if (token == "str")
+        return makeType(il::core::Type::Kind::Str);
+    if (token == "void")
+        return makeType(il::core::Type::Kind::Void);
+
+    if (ok)
+        *ok = false;
+    return il::core::Type();
+}
+
+} // namespace il::io

--- a/src/il/io/TypeParser.hpp
+++ b/src/il/io/TypeParser.hpp
@@ -1,0 +1,21 @@
+// File: src/il/io/TypeParser.hpp
+// Purpose: Declares helpers for parsing textual IL type specifiers.
+// Key invariants: Type identifiers adhere to docs/il-spec.md definitions.
+// Ownership/Lifetime: Returned Type objects belong to callers.
+// Links: docs/il-spec.md
+#pragma once
+
+#include "il/core/Type.hpp"
+
+#include <string>
+
+namespace il::io
+{
+
+/// @brief Parse a textual type token into its IL representation.
+/// @param token Lowercase token naming a primitive IL type.
+/// @param ok Optional flag receiving true on success and false on failure.
+/// @return Parsed il::core::Type value or default constructed on failure.
+il::core::Type parseType(const std::string &token, bool *ok = nullptr);
+
+} // namespace il::io


### PR DESCRIPTION
## Summary
- extract reusable lexical helpers into ParserUtil and move type parsing into TypeParser
- update the IL parser to consume the new helpers without altering high-level logic
- adjust the il_io build configuration to compile the new translation units

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68c88e0356588324a29265651212d12c