### PR TITLE
Refactor BASIC constant folder dispatch

### DIFF
--- a/src/frontends/basic/ConstFolder.hpp
+++ b/src/frontends/basic/ConstFolder.hpp
@@ -36,8 +36,6 @@ Numeric promote(const Numeric &a, const Numeric &b);
 /// @return Folded expression or nullptr on mismatch.
 template <typename F> ExprPtr foldNumericBinary(const Expr &l, const Expr &r, F op);
 
-/// @brief Fold string binary operation (e.g., concatenation).
-ExprPtr foldStringBinary(const StringExpr &l, TokenKind op, const StringExpr &r);
 } // namespace detail
 
 } // namespace il::frontends::basic

--- a/tests/unit/test_basic_constfold.cpp
+++ b/tests/unit/test_basic_constfold.cpp
@@ -9,6 +9,7 @@
 #include "frontends/basic/SemanticAnalyzer.hpp"
 #include "support/source_manager.hpp"
 #include <cassert>
+#include <cmath>
 #include <sstream>
 #include <string>
 
@@ -17,9 +18,22 @@ using namespace il::support;
 
 int main()
 {
-    // int + float promotes to float
+    auto expectInt = [](const std::string &expr, long long expected)
     {
-        std::string src = "10 LET X = 1 + 2.5\n20 END\n";
+        std::string src = "10 LET X = " + expr + "\n20 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("test.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        foldConstants(*prog);
+        auto *let = dynamic_cast<LetStmt *>(prog->main[0].get());
+        auto *ie = dynamic_cast<IntExpr *>(let->expr.get());
+        assert(ie && ie->value == expected);
+    };
+
+    auto expectFloat = [](const std::string &expr, double expected)
+    {
+        std::string src = "10 LET X = " + expr + "\n20 END\n";
         SourceManager sm;
         uint32_t fid = sm.addFile("test.bas");
         Parser p(src, fid);
@@ -27,23 +41,51 @@ int main()
         foldConstants(*prog);
         auto *let = dynamic_cast<LetStmt *>(prog->main[0].get());
         auto *flt = dynamic_cast<FloatExpr *>(let->expr.get());
-        assert(flt && flt->value == 3.5);
-    }
+        assert(flt && std::fabs(flt->value - expected) < 1e-9);
+    };
 
-    // string concatenation
+    auto expectString = [](const std::string &expr, const std::string &expected)
     {
-        std::string src = "10 PRINT \"foo\" + \"bar\"\n20 END\n";
+        std::string src = "10 LET A$ = " + expr + "\n20 END\n";
         SourceManager sm;
         uint32_t fid = sm.addFile("test.bas");
         Parser p(src, fid);
         auto prog = p.parseProgram();
         foldConstants(*prog);
-        auto *pr = dynamic_cast<PrintStmt *>(prog->main[0].get());
-        auto *se = dynamic_cast<StringExpr *>(pr->items[0].expr.get());
-        assert(se && se->value == "foobar");
-    }
+        auto *let = dynamic_cast<LetStmt *>(prog->main[0].get());
+        auto *se = dynamic_cast<StringExpr *>(let->expr.get());
+        assert(se && se->value == expected);
+    };
 
-    // rejected string arithmetic retains diagnostic code
+    // Arithmetic
+    expectFloat("1 + 2.5", 3.5);
+    expectInt("10 - 3", 7);
+    expectInt("6 * 7", 42);
+    expectFloat("5 / 2", 2.5);
+    expectInt("7 \\ 3", 2);
+    expectInt("10 MOD 3", 1);
+
+    // Comparisons
+    expectInt("5 = 5", 1);
+    expectInt("5 <> 3", 1);
+    expectInt("2 < 1", 0);
+    expectInt("2 <= 2", 1);
+    expectInt("5 > 2", 1);
+    expectInt("7 >= 8", 0);
+
+    // Logical operations and unary NOT
+    expectInt("0 AND 5", 0);
+    expectInt("0 OR 1", 1);
+    expectInt("NOT 0", 1);
+    expectInt("NOT 4", 0);
+
+    // String operations
+    expectString("\"foo\" + \"bar\"", "foobar");
+    expectInt("\"foo\" = \"foo\"", 1);
+    expectInt("\"foo\" = \"bar\"", 0);
+    expectInt("\"a\" <> \"b\"", 1);
+
+    // Rejected string arithmetic retains diagnostic code
     {
         std::string src = "10 PRINT \"a\" * \"b\"\n20 END\n";
         SourceManager sm;
@@ -60,45 +102,6 @@ int main()
         em.printAll(oss);
         assert(em.errorCount() == 1);
         assert(oss.str().find("B2001") != std::string::npos);
-    }
-
-    // numeric comparison
-    {
-        std::string src = "10 LET X = 5 > 2\n20 END\n";
-        SourceManager sm;
-        uint32_t fid = sm.addFile("test.bas");
-        Parser p(src, fid);
-        auto prog = p.parseProgram();
-        foldConstants(*prog);
-        auto *let = dynamic_cast<LetStmt *>(prog->main[0].get());
-        auto *ie = dynamic_cast<IntExpr *>(let->expr.get());
-        assert(ie && ie->value == 1);
-    }
-
-    // string comparison
-    {
-        std::string src = "10 PRINT \"foo\" = \"bar\"\n20 END\n";
-        SourceManager sm;
-        uint32_t fid = sm.addFile("test.bas");
-        Parser p(src, fid);
-        auto prog = p.parseProgram();
-        foldConstants(*prog);
-        auto *pr = dynamic_cast<PrintStmt *>(prog->main[0].get());
-        auto *ie = dynamic_cast<IntExpr *>(pr->items[0].expr.get());
-        assert(ie && ie->value == 0);
-    }
-
-    // logical OR
-    {
-        std::string src = "10 LET X = 0 OR 1\n20 END\n";
-        SourceManager sm;
-        uint32_t fid = sm.addFile("test.bas");
-        Parser p(src, fid);
-        auto prog = p.parseProgram();
-        foldConstants(*prog);
-        auto *let = dynamic_cast<LetStmt *>(prog->main[0].get());
-        auto *ie = dynamic_cast<IntExpr *>(let->expr.get());
-        assert(ie && ie->value == 1);
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- add a reusable NumericVisitor helper for folding arithmetic and logical operations
- refactor the BASIC constant folder to use a single operator table and visitor-based dispatch
- expand constant folding tests to cover every arithmetic, comparison, logical, and string case

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68c8c5ce05d0832482f31ab90c5c02fa