### PR TITLE
refactor(frontends/basic): table-driven const folding

### DIFF
--- a/src/frontends/basic/ConstFolder.hpp
+++ b/src/frontends/basic/ConstFolder.hpp
@@ -7,6 +7,7 @@
 
 #include "frontends/basic/AST.hpp"
 #include "frontends/basic/Token.hpp"
+#include <array>
 #include <optional>
 
 namespace il::frontends::basic
@@ -36,8 +37,65 @@ Numeric promote(const Numeric &a, const Numeric &b);
 /// @return Folded expression or nullptr on mismatch.
 template <typename F> ExprPtr foldNumericBinary(const Expr &l, const Expr &r, F op);
 
-/// @brief Fold string binary operation (e.g., concatenation).
-ExprPtr foldStringBinary(const StringExpr &l, TokenKind op, const StringExpr &r);
+/// @brief Function pointer type for numeric binary fold handlers.
+using BinaryNumericFn = ExprPtr (*)(const Expr &, const Expr &);
+
+/// @brief Function pointer type for string binary fold handlers.
+using BinaryStringFn = ExprPtr (*)(const StringExpr &, const StringExpr &);
+
+/// @brief Table entry describing how to fold a BASIC binary operator.
+struct BinaryFoldEntry
+{
+    BinaryExpr::Op op;      ///< AST opcode represented by the entry.
+    BinaryNumericFn numeric; ///< Numeric evaluator (nullptr when unsupported).
+    BinaryStringFn string;   ///< String evaluator (nullptr when unsupported).
+};
+
+ExprPtr foldNumericAdd(const Expr &l, const Expr &r);
+ExprPtr foldNumericSub(const Expr &l, const Expr &r);
+ExprPtr foldNumericMul(const Expr &l, const Expr &r);
+ExprPtr foldNumericDiv(const Expr &l, const Expr &r);
+ExprPtr foldNumericIDiv(const Expr &l, const Expr &r);
+ExprPtr foldNumericMod(const Expr &l, const Expr &r);
+ExprPtr foldNumericEq(const Expr &l, const Expr &r);
+ExprPtr foldNumericNe(const Expr &l, const Expr &r);
+ExprPtr foldNumericLt(const Expr &l, const Expr &r);
+ExprPtr foldNumericLe(const Expr &l, const Expr &r);
+ExprPtr foldNumericGt(const Expr &l, const Expr &r);
+ExprPtr foldNumericGe(const Expr &l, const Expr &r);
+ExprPtr foldNumericAnd(const Expr &l, const Expr &r);
+ExprPtr foldNumericOr(const Expr &l, const Expr &r);
+
+ExprPtr foldStringConcat(const StringExpr &l, const StringExpr &r);
+ExprPtr foldStringEq(const StringExpr &l, const StringExpr &r);
+ExprPtr foldStringNe(const StringExpr &l, const StringExpr &r);
+
+inline constexpr std::array<BinaryFoldEntry, 14> kBinaryFoldTable = {{
+    {BinaryExpr::Op::Add, &foldNumericAdd, &foldStringConcat},
+    {BinaryExpr::Op::Sub, &foldNumericSub, nullptr},
+    {BinaryExpr::Op::Mul, &foldNumericMul, nullptr},
+    {BinaryExpr::Op::Div, &foldNumericDiv, nullptr},
+    {BinaryExpr::Op::IDiv, &foldNumericIDiv, nullptr},
+    {BinaryExpr::Op::Mod, &foldNumericMod, nullptr},
+    {BinaryExpr::Op::Eq, &foldNumericEq, &foldStringEq},
+    {BinaryExpr::Op::Ne, &foldNumericNe, &foldStringNe},
+    {BinaryExpr::Op::Lt, &foldNumericLt, nullptr},
+    {BinaryExpr::Op::Le, &foldNumericLe, nullptr},
+    {BinaryExpr::Op::Gt, &foldNumericGt, nullptr},
+    {BinaryExpr::Op::Ge, &foldNumericGe, nullptr},
+    {BinaryExpr::Op::And, &foldNumericAnd, nullptr},
+    {BinaryExpr::Op::Or, &foldNumericOr, nullptr},
+}};
+
+inline const BinaryFoldEntry *findBinaryFold(BinaryExpr::Op op)
+{
+    for (const auto &entry : kBinaryFoldTable)
+    {
+        if (entry.op == op)
+            return &entry;
+    }
+    return nullptr;
+}
 } // namespace detail
 
 } // namespace il::frontends::basic

--- a/tests/unit/test_basic_constfold.cpp
+++ b/tests/unit/test_basic_constfold.cpp
@@ -101,5 +101,31 @@ int main()
         assert(ie && ie->value == 1);
     }
 
+    // numeric modulus
+    {
+        std::string src = "10 LET X = 7 MOD 3\n20 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("test.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        foldConstants(*prog);
+        auto *let = dynamic_cast<LetStmt *>(prog->main[0].get());
+        auto *ie = dynamic_cast<IntExpr *>(let->expr.get());
+        assert(ie && ie->value == 1);
+    }
+
+    // string inequality
+    {
+        std::string src = "10 PRINT \"foo\" <> \"bar\"\n20 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("test.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        foldConstants(*prog);
+        auto *pr = dynamic_cast<PrintStmt *>(prog->main[0].get());
+        auto *ie = dynamic_cast<IntExpr *>(pr->items[0].expr.get());
+        assert(ie && ie->value == 1);
+    }
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a table of binary fold handlers to drive constant folding dispatch
- implement reusable numeric and string fold helpers that use the table lookup
- extend BASIC constant folding unit tests to cover numeric modulus and string inequality cases

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68c8d32b8bb4832490f29ae62068b251