### PR TITLE
refactor(il/verify): introduce rule-based instruction checker

### DIFF
--- a/src/il/verify/InstructionChecker.cpp
+++ b/src/il/verify/InstructionChecker.cpp
@@ -6,6 +6,13 @@
 
 #include "il/verify/InstructionChecker.hpp"
 #include "il/core/Opcode.hpp"
+#include "il/verify/Rule.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
 
 using namespace il::core;
 
@@ -15,308 +22,417 @@ namespace il::verify
 namespace
 {
 
-bool expectOperandCount(const Function &fn,
-                        const BasicBlock &bb,
-                        const Instr &instr,
-                        size_t expected,
-                        std::ostream &err)
+struct Context
+{
+    const Function &fn;
+    const BasicBlock &bb;
+    const std::unordered_map<std::string, const Extern *> &externs;
+    const std::unordered_map<std::string, const Function *> &funcs;
+    TypeInference &types;
+    std::ostream &err;
+};
+
+bool expectOperandCount(const Context &ctx, const Instr &instr, size_t expected)
 {
     if (instr.operands.size() != expected)
     {
-        err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": expected " << expected
-            << " operand" << (expected == 1 ? "" : "s") << "\n";
+        ctx.err << ctx.fn.name << ":" << ctx.bb.label << ": " << makeSnippet(instr) << ": expected "
+                << expected << " operand" << (expected == 1 ? "" : "s") << "\n";
         return false;
     }
     return true;
 }
 
-bool expectAllOperandType(const Function &fn,
-                          const BasicBlock &bb,
-                          const Instr &instr,
-                          TypeInference &types,
-                          Type::Kind kind,
-                          std::ostream &err)
+bool expectAllOperandType(const Context &ctx, const Instr &instr, Type::Kind kind)
 {
     bool ok = true;
     for (const auto &op : instr.operands)
-        if (types.valueType(op).kind != kind)
+        if (ctx.types.valueType(op).kind != kind)
         {
-            err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": operand type mismatch\n";
+            ctx.err << ctx.fn.name << ":" << ctx.bb.label << ": " << makeSnippet(instr)
+                    << ": operand type mismatch\n";
             ok = false;
         }
     return ok;
 }
 
-bool verifyAlloca(const Function &fn,
-                  const BasicBlock &bb,
-                  const Instr &instr,
-                  TypeInference &types,
-                  std::ostream &err)
+class AllocaRule final : public Rule
 {
-    bool ok = expectOperandCount(fn, bb, instr, 1, err);
-    if (instr.operands.size() < 1)
-        return false;
-    if (types.valueType(instr.operands[0]).kind != Type::Kind::I64)
+public:
+    explicit AllocaRule(const Context &ctx) : ctx_(ctx) {}
+
+    bool check(const Instr &instr) override
     {
-        err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": size must be i64\n";
-        ok = false;
-    }
-    if (instr.operands[0].kind == Value::Kind::ConstInt)
-    {
-        long long sz = instr.operands[0].i64;
-        if (sz < 0)
+        bool ok = expectOperandCount(ctx_, instr, 1);
+        if (instr.operands.size() < 1)
+            return false;
+        if (ctx_.types.valueType(instr.operands[0]).kind != Type::Kind::I64)
         {
-            err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": negative alloca size\n";
+            ctx_.err << ctx_.fn.name << ":" << ctx_.bb.label << ": " << makeSnippet(instr)
+                     << ": size must be i64\n";
             ok = false;
         }
-        else if (sz > (1LL << 20))
+        if (instr.operands[0].kind == Value::Kind::ConstInt)
         {
-            err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": warning: huge alloca\n";
+            long long sz = instr.operands[0].i64;
+            if (sz < 0)
+            {
+                ctx_.err << ctx_.fn.name << ":" << ctx_.bb.label << ": " << makeSnippet(instr)
+                         << ": negative alloca size\n";
+                ok = false;
+            }
+            else if (sz > (1LL << 20))
+            {
+                ctx_.err << ctx_.fn.name << ":" << ctx_.bb.label << ": " << makeSnippet(instr)
+                         << ": warning: huge alloca\n";
+            }
         }
+        ctx_.types.recordResult(instr, Type(Type::Kind::Ptr));
+        return ok;
     }
-    types.recordResult(instr, Type(Type::Kind::Ptr));
-    return ok;
-}
 
-bool verifyIntBinary(const Function &fn,
-                     const BasicBlock &bb,
-                     const Instr &instr,
-                     TypeInference &types,
-                     std::ostream &err)
-{
-    bool ok = expectOperandCount(fn, bb, instr, 2, err);
-    if (instr.operands.size() < 2)
-        return false;
-    ok &= expectAllOperandType(fn, bb, instr, types, Type::Kind::I64, err);
-    types.recordResult(instr, Type(Type::Kind::I64));
-    return ok;
-}
+private:
+    Context ctx_;
+};
 
-bool verifyFloatBinary(const Function &fn,
-                       const BasicBlock &bb,
-                       const Instr &instr,
-                       TypeInference &types,
-                       std::ostream &err)
+class BinaryRule final : public Rule
 {
-    bool ok = expectOperandCount(fn, bb, instr, 2, err);
-    if (instr.operands.size() < 2)
-        return false;
-    ok &= expectAllOperandType(fn, bb, instr, types, Type::Kind::F64, err);
-    types.recordResult(instr, Type(Type::Kind::F64));
-    return ok;
-}
+public:
+    BinaryRule(const Context &ctx, Type::Kind operandKind, Type resultType)
+        : ctx_(ctx), operandKind_(operandKind), resultType_(resultType)
+    {
+    }
 
-bool verifyICmp(const Function &fn,
-                const BasicBlock &bb,
-                const Instr &instr,
-                TypeInference &types,
-                std::ostream &err)
-{
-    bool ok = expectOperandCount(fn, bb, instr, 2, err);
-    if (instr.operands.size() < 2)
-        return false;
-    ok &= expectAllOperandType(fn, bb, instr, types, Type::Kind::I64, err);
-    types.recordResult(instr, Type(Type::Kind::I1));
-    return ok;
-}
+    bool check(const Instr &instr) override
+    {
+        bool ok = expectOperandCount(ctx_, instr, 2);
+        if (instr.operands.size() < 2)
+            return false;
+        ok &= expectAllOperandType(ctx_, instr, operandKind_);
+        ctx_.types.recordResult(instr, resultType_);
+        return ok;
+    }
 
-bool verifyFCmp(const Function &fn,
-                const BasicBlock &bb,
-                const Instr &instr,
-                TypeInference &types,
-                std::ostream &err)
-{
-    bool ok = expectOperandCount(fn, bb, instr, 2, err);
-    if (instr.operands.size() < 2)
-        return false;
-    ok &= expectAllOperandType(fn, bb, instr, types, Type::Kind::F64, err);
-    types.recordResult(instr, Type(Type::Kind::I1));
-    return ok;
-}
+private:
+    Context ctx_;
+    Type::Kind operandKind_;
+    Type resultType_;
+};
 
-bool verifyUnaryExpected(const Function &fn,
-                         const BasicBlock &bb,
-                         const Instr &instr,
-                         TypeInference &types,
-                         Type::Kind operandKind,
-                         Type resultType,
-                         std::ostream &err)
+class UnaryRule final : public Rule
 {
-    bool ok = expectOperandCount(fn, bb, instr, 1, err);
-    if (instr.operands.size() < 1)
-        return false;
-    if (types.valueType(instr.operands[0]).kind != operandKind)
+public:
+    UnaryRule(const Context &ctx, Type::Kind operandKind, Type resultType)
+        : ctx_(ctx), operandKind_(operandKind), resultType_(resultType)
     {
-        err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": operand type mismatch\n";
-        ok = false;
     }
-    types.recordResult(instr, resultType);
-    return ok;
-}
 
-bool verifyGEP(const Function &fn,
-               const BasicBlock &bb,
-               const Instr &instr,
-               TypeInference &types,
-               std::ostream &err)
-{
-    bool ok = expectOperandCount(fn, bb, instr, 2, err);
-    if (instr.operands.size() < 2)
-        return false;
-    if (types.valueType(instr.operands[0]).kind != Type::Kind::Ptr ||
-        types.valueType(instr.operands[1]).kind != Type::Kind::I64)
+    bool check(const Instr &instr) override
     {
-        err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": operand type mismatch\n";
-        ok = false;
-    }
-    types.recordResult(instr, Type(Type::Kind::Ptr));
-    return ok;
-}
-
-bool verifyLoad(const Function &fn,
-                const BasicBlock &bb,
-                const Instr &instr,
-                TypeInference &types,
-                std::ostream &err)
-{
-    bool ok = expectOperandCount(fn, bb, instr, 1, err);
-    if (instr.operands.size() < 1)
-        return false;
-    if (instr.type.kind == Type::Kind::Void)
-    {
-        err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": void load type\n";
-        ok = false;
-    }
-    if (types.valueType(instr.operands[0]).kind != Type::Kind::Ptr)
-    {
-        err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": pointer type mismatch\n";
-        ok = false;
-    }
-    [[maybe_unused]] size_t sz = TypeInference::typeSize(instr.type.kind);
-    types.recordResult(instr, instr.type);
-    return ok;
-}
-
-bool verifyStore(const Function &fn,
-                 const BasicBlock &bb,
-                 const Instr &instr,
-                 TypeInference &types,
-                 std::ostream &err)
-{
-    bool ok = expectOperandCount(fn, bb, instr, 2, err);
-    if (instr.operands.size() < 2)
-        return false;
-    if (instr.type.kind == Type::Kind::Void)
-    {
-        err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": void store type\n";
-        ok = false;
-    }
-    if (types.valueType(instr.operands[0]).kind != Type::Kind::Ptr)
-    {
-        err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": pointer type mismatch\n";
-        ok = false;
-    }
-    if (types.valueType(instr.operands[1]).kind != instr.type.kind)
-    {
-        err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": value type mismatch\n";
-        ok = false;
-    }
-    [[maybe_unused]] size_t sz = TypeInference::typeSize(instr.type.kind);
-    return ok;
-}
-
-bool verifyAddrOf(const Function &fn,
-                  const BasicBlock &bb,
-                  const Instr &instr,
-                  TypeInference &types,
-                  std::ostream &err)
-{
-    bool ok = true;
-    if (instr.operands.size() != 1 || instr.operands[0].kind != Value::Kind::GlobalAddr)
-    {
-        err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": operand must be global\n";
-        ok = false;
-    }
-    types.recordResult(instr, Type(Type::Kind::Ptr));
-    return ok;
-}
-
-bool verifyConstStr(const Function &fn,
-                    const BasicBlock &bb,
-                    const Instr &instr,
-                    TypeInference &types,
-                    std::ostream &err)
-{
-    bool ok = true;
-    if (instr.operands.size() != 1 || instr.operands[0].kind != Value::Kind::GlobalAddr)
-    {
-        err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": unknown string global\n";
-        ok = false;
-    }
-    types.recordResult(instr, Type(Type::Kind::Str));
-    return ok;
-}
-
-bool verifyConstNull(const Instr &instr, TypeInference &types)
-{
-    types.recordResult(instr, Type(Type::Kind::Ptr));
-    return true;
-}
-
-bool verifyCall(const Function &fn,
-                const BasicBlock &bb,
-                const Instr &instr,
-                const std::unordered_map<std::string, const Extern *> &externs,
-                const std::unordered_map<std::string, const Function *> &funcs,
-                TypeInference &types,
-                std::ostream &err)
-{
-    bool ok = true;
-    const Extern *sig = nullptr;
-    const Function *fnSig = nullptr;
-    auto itE = externs.find(instr.callee);
-    if (itE != externs.end())
-        sig = itE->second;
-    else
-    {
-        auto itF = funcs.find(instr.callee);
-        if (itF != funcs.end())
-            fnSig = itF->second;
-    }
-    if (!sig && !fnSig)
-    {
-        err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": unknown callee @" << instr.callee
-            << "\n";
-        return false;
-    }
-    size_t paramCount = sig ? sig->params.size() : fnSig->params.size();
-    if (instr.operands.size() != paramCount)
-    {
-        err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": call arg count mismatch\n";
-        ok = false;
-    }
-    size_t checked = std::min(instr.operands.size(), paramCount);
-    for (size_t i = 0; i < checked; ++i)
-    {
-        Type expected = sig ? sig->params[i] : fnSig->params[i].type;
-        if (types.valueType(instr.operands[i]).kind != expected.kind)
+        bool ok = expectOperandCount(ctx_, instr, 1);
+        if (instr.operands.size() < 1)
+            return false;
+        if (ctx_.types.valueType(instr.operands[0]).kind != operandKind_)
         {
-            err << fn.name << ":" << bb.label << ": " << makeSnippet(instr) << ": call arg type mismatch\n";
+            ctx_.err << ctx_.fn.name << ":" << ctx_.bb.label << ": " << makeSnippet(instr)
+                     << ": operand type mismatch\n";
             ok = false;
         }
+        ctx_.types.recordResult(instr, resultType_);
+        return ok;
     }
-    if (instr.result)
+
+private:
+    Context ctx_;
+    Type::Kind operandKind_;
+    Type resultType_;
+};
+
+class GEPRule final : public Rule
+{
+public:
+    explicit GEPRule(const Context &ctx) : ctx_(ctx) {}
+
+    bool check(const Instr &instr) override
     {
-        Type ret = sig ? sig->retType : fnSig->retType;
-        types.recordResult(instr, ret);
+        bool ok = expectOperandCount(ctx_, instr, 2);
+        if (instr.operands.size() < 2)
+            return false;
+        if (ctx_.types.valueType(instr.operands[0]).kind != Type::Kind::Ptr ||
+            ctx_.types.valueType(instr.operands[1]).kind != Type::Kind::I64)
+        {
+            ctx_.err << ctx_.fn.name << ":" << ctx_.bb.label << ": " << makeSnippet(instr)
+                     << ": operand type mismatch\n";
+            ok = false;
+        }
+        ctx_.types.recordResult(instr, Type(Type::Kind::Ptr));
+        return ok;
     }
-    return ok;
+
+private:
+    Context ctx_;
+};
+
+class LoadRule final : public Rule
+{
+public:
+    explicit LoadRule(const Context &ctx) : ctx_(ctx) {}
+
+    bool check(const Instr &instr) override
+    {
+        bool ok = expectOperandCount(ctx_, instr, 1);
+        if (instr.operands.size() < 1)
+            return false;
+        if (instr.type.kind == Type::Kind::Void)
+        {
+            ctx_.err << ctx_.fn.name << ":" << ctx_.bb.label << ": " << makeSnippet(instr)
+                     << ": void load type\n";
+            ok = false;
+        }
+        if (ctx_.types.valueType(instr.operands[0]).kind != Type::Kind::Ptr)
+        {
+            ctx_.err << ctx_.fn.name << ":" << ctx_.bb.label << ": " << makeSnippet(instr)
+                     << ": pointer type mismatch\n";
+            ok = false;
+        }
+        [[maybe_unused]] size_t sz = TypeInference::typeSize(instr.type.kind);
+        ctx_.types.recordResult(instr, instr.type);
+        return ok;
+    }
+
+private:
+    Context ctx_;
+};
+
+class StoreRule final : public Rule
+{
+public:
+    explicit StoreRule(const Context &ctx) : ctx_(ctx) {}
+
+    bool check(const Instr &instr) override
+    {
+        bool ok = expectOperandCount(ctx_, instr, 2);
+        if (instr.operands.size() < 2)
+            return false;
+        if (instr.type.kind == Type::Kind::Void)
+        {
+            ctx_.err << ctx_.fn.name << ":" << ctx_.bb.label << ": " << makeSnippet(instr)
+                     << ": void store type\n";
+            ok = false;
+        }
+        if (ctx_.types.valueType(instr.operands[0]).kind != Type::Kind::Ptr)
+        {
+            ctx_.err << ctx_.fn.name << ":" << ctx_.bb.label << ": " << makeSnippet(instr)
+                     << ": pointer type mismatch\n";
+            ok = false;
+        }
+        if (ctx_.types.valueType(instr.operands[1]).kind != instr.type.kind)
+        {
+            ctx_.err << ctx_.fn.name << ":" << ctx_.bb.label << ": " << makeSnippet(instr)
+                     << ": value type mismatch\n";
+            ok = false;
+        }
+        [[maybe_unused]] size_t sz = TypeInference::typeSize(instr.type.kind);
+        return ok;
+    }
+
+private:
+    Context ctx_;
+};
+
+class AddrOfRule final : public Rule
+{
+public:
+    explicit AddrOfRule(const Context &ctx) : ctx_(ctx) {}
+
+    bool check(const Instr &instr) override
+    {
+        bool ok = true;
+        if (instr.operands.size() != 1 || instr.operands[0].kind != Value::Kind::GlobalAddr)
+        {
+            ctx_.err << ctx_.fn.name << ":" << ctx_.bb.label << ": " << makeSnippet(instr)
+                     << ": operand must be global\n";
+            ok = false;
+        }
+        ctx_.types.recordResult(instr, Type(Type::Kind::Ptr));
+        return ok;
+    }
+
+private:
+    Context ctx_;
+};
+
+class ConstStrRule final : public Rule
+{
+public:
+    explicit ConstStrRule(const Context &ctx) : ctx_(ctx) {}
+
+    bool check(const Instr &instr) override
+    {
+        bool ok = true;
+        if (instr.operands.size() != 1 || instr.operands[0].kind != Value::Kind::GlobalAddr)
+        {
+            ctx_.err << ctx_.fn.name << ":" << ctx_.bb.label << ": " << makeSnippet(instr)
+                     << ": unknown string global\n";
+            ok = false;
+        }
+        ctx_.types.recordResult(instr, Type(Type::Kind::Str));
+        return ok;
+    }
+
+private:
+    Context ctx_;
+};
+
+class ConstNullRule final : public Rule
+{
+public:
+    explicit ConstNullRule(const Context &ctx) : ctx_(ctx) {}
+
+    bool check(const Instr &instr) override
+    {
+        ctx_.types.recordResult(instr, Type(Type::Kind::Ptr));
+        return true;
+    }
+
+private:
+    Context ctx_;
+};
+
+class CallRule final : public Rule
+{
+public:
+    explicit CallRule(const Context &ctx) : ctx_(ctx) {}
+
+    bool check(const Instr &instr) override
+    {
+        bool ok = true;
+        const Extern *sig = nullptr;
+        const Function *fnSig = nullptr;
+        auto itE = ctx_.externs.find(instr.callee);
+        if (itE != ctx_.externs.end())
+            sig = itE->second;
+        else
+        {
+            auto itF = ctx_.funcs.find(instr.callee);
+            if (itF != ctx_.funcs.end())
+                fnSig = itF->second;
+        }
+        if (!sig && !fnSig)
+        {
+            ctx_.err << ctx_.fn.name << ":" << ctx_.bb.label << ": " << makeSnippet(instr)
+                     << ": unknown callee @" << instr.callee << "\n";
+            return false;
+        }
+        size_t paramCount = sig ? sig->params.size() : fnSig->params.size();
+        if (instr.operands.size() != paramCount)
+        {
+            ctx_.err << ctx_.fn.name << ":" << ctx_.bb.label << ": " << makeSnippet(instr)
+                     << ": call arg count mismatch\n";
+            ok = false;
+        }
+        size_t checked = std::min(instr.operands.size(), paramCount);
+        for (size_t i = 0; i < checked; ++i)
+        {
+            Type expected = sig ? sig->params[i] : fnSig->params[i].type;
+            if (ctx_.types.valueType(instr.operands[i]).kind != expected.kind)
+            {
+                ctx_.err << ctx_.fn.name << ":" << ctx_.bb.label << ": " << makeSnippet(instr)
+                         << ": call arg type mismatch\n";
+                ok = false;
+            }
+        }
+        if (instr.result)
+        {
+            Type ret = sig ? sig->retType : fnSig->retType;
+            ctx_.types.recordResult(instr, ret);
+        }
+        return ok;
+    }
+
+private:
+    Context ctx_;
+};
+
+class DefaultRule final : public Rule
+{
+public:
+    explicit DefaultRule(const Context &ctx) : ctx_(ctx) {}
+
+    bool check(const Instr &instr) override
+    {
+        ctx_.types.recordResult(instr, instr.type);
+        return true;
+    }
+
+private:
+    Context ctx_;
+};
+
+using RuleFactory = std::function<std::unique_ptr<Rule>(const Context &)>;
+
+RuleFactory makeBinaryRule(Type::Kind operandKind, Type resultType)
+{
+    return [operandKind, resultType](const Context &ctx)
+    { return std::make_unique<BinaryRule>(ctx, operandKind, resultType); };
 }
 
-bool verifyDefault(const Instr &instr, TypeInference &types)
+RuleFactory makeUnaryRule(Type::Kind operandKind, Type resultType)
 {
-    types.recordResult(instr, instr.type);
-    return true;
+    return [operandKind, resultType](const Context &ctx)
+    { return std::make_unique<UnaryRule>(ctx, operandKind, resultType); };
+}
+
+const std::unordered_map<Opcode, RuleFactory> &ruleTable()
+{
+    static const std::unordered_map<Opcode, RuleFactory> table = {
+        {Opcode::Alloca, [](const Context &ctx) { return std::make_unique<AllocaRule>(ctx); }},
+        {Opcode::Add, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I64))},
+        {Opcode::Sub, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I64))},
+        {Opcode::Mul, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I64))},
+        {Opcode::SDiv, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I64))},
+        {Opcode::UDiv, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I64))},
+        {Opcode::SRem, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I64))},
+        {Opcode::URem, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I64))},
+        {Opcode::And, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I64))},
+        {Opcode::Or, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I64))},
+        {Opcode::Xor, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I64))},
+        {Opcode::Shl, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I64))},
+        {Opcode::LShr, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I64))},
+        {Opcode::AShr, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I64))},
+        {Opcode::FAdd, makeBinaryRule(Type::Kind::F64, Type(Type::Kind::F64))},
+        {Opcode::FSub, makeBinaryRule(Type::Kind::F64, Type(Type::Kind::F64))},
+        {Opcode::FMul, makeBinaryRule(Type::Kind::F64, Type(Type::Kind::F64))},
+        {Opcode::FDiv, makeBinaryRule(Type::Kind::F64, Type(Type::Kind::F64))},
+        {Opcode::ICmpEq, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I1))},
+        {Opcode::ICmpNe, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I1))},
+        {Opcode::SCmpLT, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I1))},
+        {Opcode::SCmpLE, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I1))},
+        {Opcode::SCmpGT, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I1))},
+        {Opcode::SCmpGE, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I1))},
+        {Opcode::UCmpLT, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I1))},
+        {Opcode::UCmpLE, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I1))},
+        {Opcode::UCmpGT, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I1))},
+        {Opcode::UCmpGE, makeBinaryRule(Type::Kind::I64, Type(Type::Kind::I1))},
+        {Opcode::FCmpEQ, makeBinaryRule(Type::Kind::F64, Type(Type::Kind::I1))},
+        {Opcode::FCmpNE, makeBinaryRule(Type::Kind::F64, Type(Type::Kind::I1))},
+        {Opcode::FCmpLT, makeBinaryRule(Type::Kind::F64, Type(Type::Kind::I1))},
+        {Opcode::FCmpLE, makeBinaryRule(Type::Kind::F64, Type(Type::Kind::I1))},
+        {Opcode::FCmpGT, makeBinaryRule(Type::Kind::F64, Type(Type::Kind::I1))},
+        {Opcode::FCmpGE, makeBinaryRule(Type::Kind::F64, Type(Type::Kind::I1))},
+        {Opcode::Sitofp, makeUnaryRule(Type::Kind::I64, Type(Type::Kind::F64))},
+        {Opcode::Fptosi, makeUnaryRule(Type::Kind::F64, Type(Type::Kind::I64))},
+        {Opcode::Zext1, makeUnaryRule(Type::Kind::I1, Type(Type::Kind::I64))},
+        {Opcode::Trunc1, makeUnaryRule(Type::Kind::I64, Type(Type::Kind::I1))},
+        {Opcode::GEP, [](const Context &ctx) { return std::make_unique<GEPRule>(ctx); }},
+        {Opcode::Load, [](const Context &ctx) { return std::make_unique<LoadRule>(ctx); }},
+        {Opcode::Store, [](const Context &ctx) { return std::make_unique<StoreRule>(ctx); }},
+        {Opcode::AddrOf, [](const Context &ctx) { return std::make_unique<AddrOfRule>(ctx); }},
+        {Opcode::ConstStr, [](const Context &ctx) { return std::make_unique<ConstStrRule>(ctx); }},
+        {Opcode::ConstNull, [](const Context &ctx) { return std::make_unique<ConstNullRule>(ctx); }},
+        {Opcode::Call, [](const Context &ctx) { return std::make_unique<CallRule>(ctx); }},
+    };
+    return table;
 }
 
 } // namespace
@@ -329,72 +445,16 @@ bool verifyInstruction(const Function &fn,
                        TypeInference &types,
                        std::ostream &err)
 {
-    switch (instr.op)
+    Context ctx{fn, bb, externs, funcs, types, err};
+    const auto &table = ruleTable();
+    auto it = table.find(instr.op);
+    if (it == table.end())
     {
-        case Opcode::Alloca:
-            return verifyAlloca(fn, bb, instr, types, err);
-        case Opcode::Add:
-        case Opcode::Sub:
-        case Opcode::Mul:
-        case Opcode::SDiv:
-        case Opcode::UDiv:
-        case Opcode::SRem:
-        case Opcode::URem:
-        case Opcode::And:
-        case Opcode::Or:
-        case Opcode::Xor:
-        case Opcode::Shl:
-        case Opcode::LShr:
-        case Opcode::AShr:
-            return verifyIntBinary(fn, bb, instr, types, err);
-        case Opcode::FAdd:
-        case Opcode::FSub:
-        case Opcode::FMul:
-        case Opcode::FDiv:
-            return verifyFloatBinary(fn, bb, instr, types, err);
-        case Opcode::ICmpEq:
-        case Opcode::ICmpNe:
-        case Opcode::SCmpLT:
-        case Opcode::SCmpLE:
-        case Opcode::SCmpGT:
-        case Opcode::SCmpGE:
-        case Opcode::UCmpLT:
-        case Opcode::UCmpLE:
-        case Opcode::UCmpGT:
-        case Opcode::UCmpGE:
-            return verifyICmp(fn, bb, instr, types, err);
-        case Opcode::FCmpEQ:
-        case Opcode::FCmpNE:
-        case Opcode::FCmpLT:
-        case Opcode::FCmpLE:
-        case Opcode::FCmpGT:
-        case Opcode::FCmpGE:
-            return verifyFCmp(fn, bb, instr, types, err);
-        case Opcode::Sitofp:
-            return verifyUnaryExpected(fn, bb, instr, types, Type::Kind::I64, Type(Type::Kind::F64), err);
-        case Opcode::Fptosi:
-            return verifyUnaryExpected(fn, bb, instr, types, Type::Kind::F64, Type(Type::Kind::I64), err);
-        case Opcode::Zext1:
-            return verifyUnaryExpected(fn, bb, instr, types, Type::Kind::I1, Type(Type::Kind::I64), err);
-        case Opcode::Trunc1:
-            return verifyUnaryExpected(fn, bb, instr, types, Type::Kind::I64, Type(Type::Kind::I1), err);
-        case Opcode::GEP:
-            return verifyGEP(fn, bb, instr, types, err);
-        case Opcode::Load:
-            return verifyLoad(fn, bb, instr, types, err);
-        case Opcode::Store:
-            return verifyStore(fn, bb, instr, types, err);
-        case Opcode::AddrOf:
-            return verifyAddrOf(fn, bb, instr, types, err);
-        case Opcode::ConstStr:
-            return verifyConstStr(fn, bb, instr, types, err);
-        case Opcode::ConstNull:
-            return verifyConstNull(instr, types);
-        case Opcode::Call:
-            return verifyCall(fn, bb, instr, externs, funcs, types, err);
-        default:
-            return verifyDefault(instr, types);
+        DefaultRule rule(ctx);
+        return rule.check(instr);
     }
+    std::unique_ptr<Rule> rule = it->second(ctx);
+    return rule->check(instr);
 }
 
 } // namespace il::verify

--- a/src/il/verify/Rule.hpp
+++ b/src/il/verify/Rule.hpp
@@ -1,0 +1,25 @@
+// File: src/il/verify/Rule.hpp
+// Purpose: Declares the instruction verification rule interface.
+// Key invariants: Rules operate with verifier-provided context and do not own data.
+// Ownership/Lifetime: Implementations hold references managed by the verifier.
+// Links: docs/il-spec.md
+#pragma once
+
+#include "il/core/Instr.hpp"
+
+namespace il::verify
+{
+
+/// @brief Interface implemented by verification rules for specific opcodes.
+class Rule
+{
+public:
+    virtual ~Rule() = default;
+
+    /// @brief Validate the given instruction using the rule context.
+    /// @param instr Instruction to be validated.
+    /// @return True when the instruction satisfies the rule.
+    virtual bool check(const il::core::Instr &instr) = 0;
+};
+
+} // namespace il::verify

--- a/tests/unit/test_il_instruction_checker.cpp
+++ b/tests/unit/test_il_instruction_checker.cpp
@@ -44,6 +44,16 @@ int main()
     assert(temps.at(3).kind == Type::Kind::I64);
     assert(types.isDefined(3));
 
+    Instr cn;
+    cn.result = 5u;
+    cn.op = Opcode::ConstNull;
+
+    ok = verifyInstruction(fn, bb, cn, externs, funcs, types, err);
+    assert(ok);
+    assert(err.str().empty());
+    assert(temps.at(5).kind == Type::Kind::Ptr);
+    assert(types.isDefined(5));
+
     std::unordered_map<unsigned, Type> tempsBad;
     tempsBad[1] = Type(Type::Kind::I64);
     tempsBad[2] = Type(Type::Kind::I64);


### PR DESCRIPTION
## Summary
- add a reusable il::verify::Rule interface for opcode checks
- refactor InstructionChecker to dispatch through rule objects instead of a switch
- extend the instruction checker unit test to cover const null handling

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68c8d78e0a7c8324902f034627e88214