### PR TITLE
front/basic/lex: add boolean keyword tokens

### DIFF
--- a/src/frontends/basic/Lexer.cpp
+++ b/src/frontends/basic/Lexer.cpp
@@ -209,12 +209,22 @@ Token Lexer::lexIdentifierOrKeyword()
         return {TokenKind::KeywordSub, s, loc};
     if (s == "RETURN")
         return {TokenKind::KeywordReturn, s, loc};
+    if (s == "BOOLEAN")
+        return {TokenKind::KeywordBoolean, s, loc};
+    if (s == "TRUE")
+        return {TokenKind::KeywordTrue, s, loc};
+    if (s == "FALSE")
+        return {TokenKind::KeywordFalse, s, loc};
     if (s == "INPUT")
         return {TokenKind::KeywordInput, s, loc};
     if (s == "DIM")
         return {TokenKind::KeywordDim, s, loc};
     if (s == "RANDOMIZE")
         return {TokenKind::KeywordRandomize, s, loc};
+    if (s == "ANDALSO")
+        return {TokenKind::KeywordAndAlso, s, loc};
+    if (s == "ORELSE")
+        return {TokenKind::KeywordOrElse, s, loc};
     if (s == "AND")
         return {TokenKind::KeywordAnd, s, loc};
     if (s == "OR")

--- a/src/frontends/basic/Token.cpp
+++ b/src/frontends/basic/Token.cpp
@@ -99,6 +99,16 @@ const char *tokenKindToString(TokenKind k)
             return "SUB";
         case TokenKind::KeywordReturn:
             return "RETURN";
+        case TokenKind::KeywordBoolean:
+            return "BOOLEAN";
+        case TokenKind::KeywordTrue:
+            return "TRUE";
+        case TokenKind::KeywordFalse:
+            return "FALSE";
+        case TokenKind::KeywordAndAlso:
+            return "ANDALSO";
+        case TokenKind::KeywordOrElse:
+            return "ORELSE";
         case TokenKind::Plus:
             return "+";
         case TokenKind::Minus:

--- a/src/frontends/basic/Token.hpp
+++ b/src/frontends/basic/Token.hpp
@@ -80,6 +80,13 @@ enum class TokenKind
     Comma,     ///< ','.
     Semicolon, ///< ';'.
     Colon,     ///< ':'.
+
+    // Additional keywords and literals (appended to preserve existing values).
+    KeywordBoolean, ///< 'BOOLEAN'.
+    KeywordTrue,    ///< 'TRUE'.
+    KeywordFalse,   ///< 'FALSE'.
+    KeywordAndAlso, ///< 'ANDALSO'.
+    KeywordOrElse,  ///< 'ORELSE'.
 };
 
 /// @brief A lexical token produced by the BASIC lexer.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -548,6 +548,11 @@ add_test(NAME basic_lex_comments COMMAND ${CMAKE_COMMAND}
   -DBAS_FILE=${CMAKE_SOURCE_DIR}/tests/basic/lex/Comments.bas
   -DGOLDEN=${CMAKE_SOURCE_DIR}/tests/basic/lex/Comments.tokens
   -P ${CMAKE_SOURCE_DIR}/tests/basic/lex/check_tokens.cmake)
+add_test(NAME basic_lex_boolean_tokens COMMAND ${CMAKE_COMMAND}
+  -DBASIC_LEX_DUMP=${BASIC_LEX_DUMP}
+  -DBAS_FILE=${CMAKE_SOURCE_DIR}/tests/basic/lex/test_boolean_tokens.bas
+  -DGOLDEN=${CMAKE_SOURCE_DIR}/tests/basic/lex/test_boolean_tokens.expect
+  -P ${CMAKE_SOURCE_DIR}/tests/basic/lex/check_tokens.cmake)
 
 set(BASIC_ILC $<TARGET_FILE:ilc>)
 add_test(NAME basic_to_il_ex1 COMMAND ${CMAKE_COMMAND}

--- a/tests/basic/lex/test_boolean_tokens.bas
+++ b/tests/basic/lex/test_boolean_tokens.bas
@@ -1,0 +1,7 @@
+' File: tests/basic/lex/test_boolean_tokens.bas
+' Purpose: Verify BOOLEAN keywords, literals, and logical operators.
+
+10 boolean TRUE false
+20 AndAlso orelse
+30 AND Or not
+40 true andalso FALSE

--- a/tests/basic/lex/test_boolean_tokens.expect
+++ b/tests/basic/lex/test_boolean_tokens.expect
@@ -1,0 +1,23 @@
+1:48 eol
+2:69 eol
+3:1 eol
+4:1 number 10
+4:4 BOOLEAN
+4:12 TRUE
+4:17 FALSE
+4:22 eol
+5:1 number 20
+5:4 ANDALSO
+5:12 ORELSE
+5:18 eol
+6:1 number 30
+6:4 AND
+6:8 OR
+6:11 NOT
+6:14 eol
+7:1 number 40
+7:4 TRUE
+7:9 ANDALSO
+7:17 FALSE
+7:22 eol
+8:1 eof


### PR DESCRIPTION
## Summary
- add lexer support for BOOLEAN, TRUE/FALSE, ANDALSO and ORELSE keywords
- expose new token kinds in the token to-string helper
- cover the new keywords with a golden lexer test

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68c8d84982a083248f901b170284e144