### PR TITLE
feat(frontends/basic): validate IF conditions

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -124,6 +124,10 @@ class SemanticAnalyzer
     /// @return Inferred type of the expression.
     Type visitExpr(const Expr &e);
 
+    /// @brief Ensure a conditional expression yields a BOOLEAN result.
+    /// @param expr Condition expression to analyze.
+    void checkConditionExpr(const Expr &expr);
+
     /// @brief Analyze variable reference.
     Type analyzeVar(VarExpr &v);
     /// @brief Analyze unary expression.


### PR DESCRIPTION
## Summary
- add a helper to classify IF conditions and format diagnostics
- invoke the helper when analyzing IF and ELSEIF branches, while skipping constant boolean literals

## Testing
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68caddfc65ec8324afd6a9fa4e1d787a