### PR TITLE
Add negative diagnostics for non-boolean BASIC conditions

### DIFF
--- a/src/frontends/basic/SemanticDiagnostics.hpp
+++ b/src/frontends/basic/SemanticDiagnostics.hpp
@@ -19,7 +19,7 @@ class SemanticDiagnostics
 
     /// @brief Message template for non-boolean conditions.
     static constexpr std::string_view NonBooleanConditionMessage =
-        "Expected BOOLEAN condition, got {type}. Consider '{expr} <> 0'.";
+        "Expected BOOLEAN condition, got {type}. Suggestion: use {expr} <> 0.";
 
     void emit(il::support::Severity sev,
               std::string code,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -829,6 +829,22 @@ add_test(NAME basic_semantics_condition_nonboolean_errors COMMAND ${CMAKE_COMMAN
   -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
   -P ${CMAKE_CURRENT_SOURCE_DIR}/basic/semantics/check_diag.cmake)
 
+add_test(NAME basic_negatives_if_int_condition COMMAND ${CMAKE_COMMAND}
+  -DILC=${BASIC_ILC}
+  -DBAS_FILE=${CMAKE_CURRENT_SOURCE_DIR}/basic/negatives/test_if_int_condition.bas
+  -DDIAG_FILE=${CMAKE_CURRENT_SOURCE_DIR}/basic/negatives/test_if_int_condition.diag
+  -DEXPECT_STATUS=1
+  -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/basic/semantics/check_diag.cmake)
+
+add_test(NAME basic_negatives_while_float_condition COMMAND ${CMAKE_COMMAND}
+  -DILC=${BASIC_ILC}
+  -DBAS_FILE=${CMAKE_CURRENT_SOURCE_DIR}/basic/negatives/test_while_float_condition.bas
+  -DDIAG_FILE=${CMAKE_CURRENT_SOURCE_DIR}/basic/negatives/test_while_float_condition.diag
+  -DEXPECT_STATUS=1
+  -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/basic/semantics/check_diag.cmake)
+
 add_test(NAME basic_semantics_boolean_constfold COMMAND ${CMAKE_COMMAND}
   -DILC=${BASIC_ILC}
   -DBAS_FILE=${CMAKE_CURRENT_SOURCE_DIR}/basic/semantics/test_boolean_constfold.bas

--- a/tests/basic/negatives/test_if_int_condition.bas
+++ b/tests/basic/negatives/test_if_int_condition.bas
@@ -1,0 +1,2 @@
+IF 2 THEN PRINT 1
+END

--- a/tests/basic/negatives/test_if_int_condition.diag
+++ b/tests/basic/negatives/test_if_int_condition.diag
@@ -1,0 +1,3 @@
+tests/basic/negatives/test_if_int_condition.bas:1:4: error[E1001]: Expected BOOLEAN condition, got INT. Suggestion: use 2 <> 0.
+IF 2 THEN PRINT 1
+   ^

--- a/tests/basic/negatives/test_while_float_condition.bas
+++ b/tests/basic/negatives/test_while_float_condition.bas
@@ -1,0 +1,4 @@
+WHILE 3.14
+  PRINT 1
+WEND
+END

--- a/tests/basic/negatives/test_while_float_condition.diag
+++ b/tests/basic/negatives/test_while_float_condition.diag
@@ -1,0 +1,3 @@
+tests/basic/negatives/test_while_float_condition.bas:1:7: error[E1001]: Expected BOOLEAN condition, got FLOAT. Suggestion: use 3.14 <> 0.
+WHILE 3.14
+      ^

--- a/tests/basic/semantics/test_condition_nonboolean_errors.diag
+++ b/tests/basic/semantics/test_condition_nonboolean_errors.diag
@@ -1,6 +1,6 @@
-tests/basic/semantics/test_condition_nonboolean_errors.bas:3:4: error[E1001]: Expected BOOLEAN condition, got INT. Consider '2 <> 0'.
+tests/basic/semantics/test_condition_nonboolean_errors.bas:3:4: error[E1001]: Expected BOOLEAN condition, got INT. Suggestion: use 2 <> 0.
 IF 2 THEN PRINT 1
    ^
-tests/basic/semantics/test_condition_nonboolean_errors.bas:5:7: error[E1001]: Expected BOOLEAN condition, got FLOAT. Consider '3.14 <> 0'.
+tests/basic/semantics/test_condition_nonboolean_errors.bas:5:7: error[E1001]: Expected BOOLEAN condition, got FLOAT. Suggestion: use 3.14 <> 0.
 WHILE 3.14
       ^


### PR DESCRIPTION
## Summary
- update the non-boolean condition diagnostic to surface a `use <expr> <> 0` fix-it
- add BASIC negative tests covering IF and WHILE non-boolean condition errors
- register the new tests so they run under ctest

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cb8050be5c8324b60d97a1317db7a7