### PR TITLE
Refactor BASIC boolean lowering to use shared helper

### DIFF
--- a/src/frontends/basic/LowerEmit.hpp
+++ b/src/frontends/basic/LowerEmit.hpp
@@ -33,6 +33,22 @@ RVal lowerUnaryExpr(const UnaryExpr &expr);
 /// @param expr Binary expression node.
 /// @return Resulting value and type.
 RVal lowerBinaryExpr(const BinaryExpr &expr);
+/// @brief Lower a boolean expression using explicit branch bodies.
+/// @param cond Boolean condition selecting THEN branch.
+/// @param loc Source location to attribute to control flow.
+/// @param emitThen Lambda emitting THEN branch body, storing into result slot.
+/// @param emitElse Lambda emitting ELSE branch body, storing into result slot.
+/// @param thenLabelBase Optional label base for THEN block naming.
+/// @param elseLabelBase Optional label base for ELSE block naming.
+/// @param joinLabelBase Optional label base for join block naming.
+/// @return Resulting value and type.
+RVal lowerBoolBranchExpr(Value cond,
+                         il::support::SourceLoc loc,
+                         const std::function<void(Value)> &emitThen,
+                         const std::function<void(Value)> &emitElse,
+                         std::string_view thenLabelBase = {},
+                         std::string_view elseLabelBase = {},
+                         std::string_view joinLabelBase = {});
 /// @brief Lower logical (`AND`/`OR`) expressions with short-circuiting.
 /// @param expr Binary expression node.
 /// @return Resulting value and type.
@@ -125,8 +141,11 @@ void lowerRandomize(const RandomizeStmt &stmt);
 // helpers
 IlType ilBoolTy();
 IlValue emitBoolConst(bool v);
-IlValue emitBoolFromBranches(std::function<void()> emitThen,
-                             std::function<void()> emitElse);
+IlValue emitBoolFromBranches(const std::function<void(Value)> &emitThen,
+                             const std::function<void(Value)> &emitElse,
+                             std::string_view thenLabelBase = "bool_then",
+                             std::string_view elseLabelBase = "bool_else",
+                             std::string_view joinLabelBase = "bool_join");
 Value emitAlloca(int bytes);
 Value emitLoad(Type ty, Value addr);
 void emitStore(Type ty, Value addr, Value val);

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -13,6 +13,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -220,8 +221,6 @@ class Lowerer
     il::support::SourceLoc curLoc{}; ///< current source location for emitted IR
     bool boundsChecks{false};
     unsigned boundsCheckId{0};
-
-    Value *boolBranchSlotPtr{nullptr};
 
     // runtime requirement tracking
     bool needInputLine{false};


### PR DESCRIPTION
## Summary
- add a `lowerBoolBranchExpr` helper that builds the boolean branch/join structure once
- refactor unary `NOT` and logical `AND`/`OR` lowering to delegate to the helper with lambdas
- extend `emitBoolFromBranches` to accept slot-aware lambdas and configurable block label bases

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cba9a74ba083249d281e51514c2126