### PR TITLE
Refactor runtime signature metadata into shared registry

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,10 @@ add_library(il_core STATIC
 )
 target_include_directories(il_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_library(il_runtime STATIC il/runtime/RuntimeSignatures.cpp)
+target_link_libraries(il_runtime PUBLIC il_core)
+target_include_directories(il_runtime PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_library(il_build STATIC il/build/IRBuilder.cpp)
 target_link_libraries(il_build PUBLIC il_core support)
 target_include_directories(il_build PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
@@ -23,7 +27,7 @@ add_library(il_verify STATIC
   il/verify/InstructionChecker.cpp
   il/verify/ControlFlowChecker.cpp
   il/verify/TypeInference.cpp)
-target_link_libraries(il_verify PUBLIC il_core)
+target_link_libraries(il_verify PUBLIC il_core il_runtime)
 target_include_directories(il_verify PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(il_transform STATIC

--- a/src/frontends/basic/CMakeLists.txt
+++ b/src/frontends/basic/CMakeLists.txt
@@ -22,5 +22,5 @@ add_library(fe_basic STATIC
   DiagnosticEmitter.cpp
 )
 
-target_link_libraries(fe_basic PUBLIC support il_build il_core)
+target_link_libraries(fe_basic PUBLIC support il_build il_core il_runtime)
 target_include_directories(fe_basic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../..)

--- a/src/frontends/basic/LowerRuntime.cpp
+++ b/src/frontends/basic/LowerRuntime.cpp
@@ -5,11 +5,25 @@
 // Links: docs/class-catalog.md
 
 #include "frontends/basic/Lowerer.hpp"
+#include "il/runtime/RuntimeSignatures.hpp"
+#include <cassert>
+#include <string>
+#include <string_view>
 
 using namespace il::core;
 
 namespace il::frontends::basic
 {
+
+namespace
+{
+void declareRuntimeExtern(build::IRBuilder &b, std::string_view name)
+{
+    const auto *sig = il::runtime::findRuntimeSignature(name);
+    assert(sig && "runtime signature missing from registry");
+    b.addExtern(std::string(name), sig->retType, sig->paramTypes);
+}
+} // namespace
 
 // Purpose: declare required runtime.
 // Parameters: build::IRBuilder &b.
@@ -17,106 +31,91 @@ namespace il::frontends::basic
 // Side effects: may modify lowering state or emit IL.
 void Lowerer::declareRequiredRuntime(build::IRBuilder &b)
 {
-    using Type = il::core::Type;
-    b.addExtern("rt_print_str", Type(Type::Kind::Void), {Type(Type::Kind::Str)});
-    b.addExtern("rt_print_i64", Type(Type::Kind::Void), {Type(Type::Kind::I64)});
-    b.addExtern("rt_print_f64", Type(Type::Kind::Void), {Type(Type::Kind::F64)});
-    b.addExtern("rt_len", Type(Type::Kind::I64), {Type(Type::Kind::Str)});
-    b.addExtern("rt_substr",
-                Type(Type::Kind::Str),
-                {Type(Type::Kind::Str), Type(Type::Kind::I64), Type(Type::Kind::I64)});
+    declareRuntimeExtern(b, "rt_print_str");
+    declareRuntimeExtern(b, "rt_print_i64");
+    declareRuntimeExtern(b, "rt_print_f64");
+    declareRuntimeExtern(b, "rt_len");
+    declareRuntimeExtern(b, "rt_substr");
     if (needRtConcat)
-        b.addExtern(
-            "rt_concat", Type(Type::Kind::Str), {Type(Type::Kind::Str), Type(Type::Kind::Str)});
+        declareRuntimeExtern(b, "rt_concat");
     if (boundsChecks)
-        b.addExtern("rt_trap", Type(Type::Kind::Void), {Type(Type::Kind::Str)});
+        declareRuntimeExtern(b, "rt_trap");
     if (needInputLine)
-        b.addExtern("rt_input_line", Type(Type::Kind::Str), {});
+        declareRuntimeExtern(b, "rt_input_line");
     if (needRtToInt)
-        b.addExtern("rt_to_int", Type(Type::Kind::I64), {Type(Type::Kind::Str)});
+        declareRuntimeExtern(b, "rt_to_int");
     if (needRtIntToStr)
-        b.addExtern("rt_int_to_str", Type(Type::Kind::Str), {Type(Type::Kind::I64)});
+        declareRuntimeExtern(b, "rt_int_to_str");
     if (needRtF64ToStr)
-        b.addExtern("rt_f64_to_str", Type(Type::Kind::Str), {Type(Type::Kind::F64)});
+        declareRuntimeExtern(b, "rt_f64_to_str");
     if (needAlloc)
-        b.addExtern("rt_alloc", Type(Type::Kind::Ptr), {Type(Type::Kind::I64)});
+        declareRuntimeExtern(b, "rt_alloc");
     if (needRtLeft)
-        b.addExtern(
-            "rt_left", Type(Type::Kind::Str), {Type(Type::Kind::Str), Type(Type::Kind::I64)});
+        declareRuntimeExtern(b, "rt_left");
     if (needRtRight)
-        b.addExtern(
-            "rt_right", Type(Type::Kind::Str), {Type(Type::Kind::Str), Type(Type::Kind::I64)});
+        declareRuntimeExtern(b, "rt_right");
     if (needRtMid2)
-        b.addExtern(
-            "rt_mid2", Type(Type::Kind::Str), {Type(Type::Kind::Str), Type(Type::Kind::I64)});
+        declareRuntimeExtern(b, "rt_mid2");
     if (needRtMid3)
-        b.addExtern("rt_mid3",
-                    Type(Type::Kind::Str),
-                    {Type(Type::Kind::Str), Type(Type::Kind::I64), Type(Type::Kind::I64)});
+        declareRuntimeExtern(b, "rt_mid3");
     if (needRtInstr2)
-        b.addExtern(
-            "rt_instr2", Type(Type::Kind::I64), {Type(Type::Kind::Str), Type(Type::Kind::Str)});
+        declareRuntimeExtern(b, "rt_instr2");
     if (needRtInstr3)
-        b.addExtern("rt_instr3",
-                    Type(Type::Kind::I64),
-                    {Type(Type::Kind::I64), Type(Type::Kind::Str), Type(Type::Kind::Str)});
+        declareRuntimeExtern(b, "rt_instr3");
     if (needRtLtrim)
-        b.addExtern("rt_ltrim", Type(Type::Kind::Str), {Type(Type::Kind::Str)});
+        declareRuntimeExtern(b, "rt_ltrim");
     if (needRtRtrim)
-        b.addExtern("rt_rtrim", Type(Type::Kind::Str), {Type(Type::Kind::Str)});
+        declareRuntimeExtern(b, "rt_rtrim");
     if (needRtTrim)
-        b.addExtern("rt_trim", Type(Type::Kind::Str), {Type(Type::Kind::Str)});
+        declareRuntimeExtern(b, "rt_trim");
     if (needRtUcase)
-        b.addExtern("rt_ucase", Type(Type::Kind::Str), {Type(Type::Kind::Str)});
+        declareRuntimeExtern(b, "rt_ucase");
     if (needRtLcase)
-        b.addExtern("rt_lcase", Type(Type::Kind::Str), {Type(Type::Kind::Str)});
+        declareRuntimeExtern(b, "rt_lcase");
     if (needRtChr)
-        b.addExtern("rt_chr", Type(Type::Kind::Str), {Type(Type::Kind::I64)});
+        declareRuntimeExtern(b, "rt_chr");
     if (needRtAsc)
-        b.addExtern("rt_asc", Type(Type::Kind::I64), {Type(Type::Kind::Str)});
+        declareRuntimeExtern(b, "rt_asc");
 
     for (RuntimeFn fn : runtimeOrder)
     {
         switch (fn)
         {
             case RuntimeFn::Sqrt:
-                b.addExtern("rt_sqrt", Type(Type::Kind::F64), {Type(Type::Kind::F64)});
+                declareRuntimeExtern(b, "rt_sqrt");
                 break;
             case RuntimeFn::AbsI64:
-                b.addExtern("rt_abs_i64", Type(Type::Kind::I64), {Type(Type::Kind::I64)});
+                declareRuntimeExtern(b, "rt_abs_i64");
                 break;
             case RuntimeFn::AbsF64:
-                b.addExtern("rt_abs_f64", Type(Type::Kind::F64), {Type(Type::Kind::F64)});
+                declareRuntimeExtern(b, "rt_abs_f64");
                 break;
             case RuntimeFn::Floor:
-                b.addExtern("rt_floor", Type(Type::Kind::F64), {Type(Type::Kind::F64)});
+                declareRuntimeExtern(b, "rt_floor");
                 break;
             case RuntimeFn::Ceil:
-                b.addExtern("rt_ceil", Type(Type::Kind::F64), {Type(Type::Kind::F64)});
+                declareRuntimeExtern(b, "rt_ceil");
                 break;
             case RuntimeFn::Sin:
-                b.addExtern("rt_sin", Type(Type::Kind::F64), {Type(Type::Kind::F64)});
+                declareRuntimeExtern(b, "rt_sin");
                 break;
             case RuntimeFn::Cos:
-                b.addExtern("rt_cos", Type(Type::Kind::F64), {Type(Type::Kind::F64)});
+                declareRuntimeExtern(b, "rt_cos");
                 break;
             case RuntimeFn::Pow:
-                b.addExtern("rt_pow",
-                            Type(Type::Kind::F64),
-                            {Type(Type::Kind::F64), Type(Type::Kind::F64)});
+                declareRuntimeExtern(b, "rt_pow");
                 break;
             case RuntimeFn::RandomizeI64:
-                b.addExtern("rt_randomize_i64", Type(Type::Kind::Void), {Type(Type::Kind::I64)});
+                declareRuntimeExtern(b, "rt_randomize_i64");
                 break;
             case RuntimeFn::Rnd:
-                b.addExtern("rt_rnd", Type(Type::Kind::F64), {});
+                declareRuntimeExtern(b, "rt_rnd");
                 break;
         }
     }
 
     if (needRtStrEq)
-        b.addExtern(
-            "rt_str_eq", Type(Type::Kind::I1), {Type(Type::Kind::Str), Type(Type::Kind::Str)});
+        declareRuntimeExtern(b, "rt_str_eq");
 }
 
 // Purpose: track runtime.

--- a/src/il/runtime/RuntimeSignatures.cpp
+++ b/src/il/runtime/RuntimeSignatures.cpp
@@ -1,0 +1,97 @@
+// File: src/il/runtime/RuntimeSignatures.cpp
+// Purpose: Defines the shared runtime signature registry for IL producers and consumers.
+// Key invariants: Registry contents reflect the runtime C ABI signatures.
+// Ownership/Lifetime: Uses static storage duration; entries are immutable after construction.
+// Links: docs/il-spec.md
+
+#include "il/runtime/RuntimeSignatures.hpp"
+#include <initializer_list>
+
+namespace il::runtime
+{
+namespace
+{
+using Kind = il::core::Type::Kind;
+using SignatureMap = std::unordered_map<std::string_view, RuntimeSignature>;
+
+RuntimeSignature makeSignature(Kind ret, std::initializer_list<Kind> params)
+{
+    RuntimeSignature sig;
+    sig.retType = il::core::Type(ret);
+    sig.paramTypes.reserve(params.size());
+    for (Kind p : params)
+        sig.paramTypes.emplace_back(p);
+    return sig;
+}
+
+SignatureMap buildRegistry()
+{
+    SignatureMap map;
+    map.reserve(40);
+    auto add = [&](std::string_view name, Kind ret, std::initializer_list<Kind> params)
+    {
+        map.emplace(name, makeSignature(ret, params));
+    };
+
+    add("rt_abort", Kind::Void, {Kind::Ptr});
+    add("rt_trap", Kind::Void, {Kind::Str});
+    add("rt_print_str", Kind::Void, {Kind::Str});
+    add("rt_print_i64", Kind::Void, {Kind::I64});
+    add("rt_print_f64", Kind::Void, {Kind::F64});
+    add("rt_input_line", Kind::Str, {});
+    add("rt_len", Kind::I64, {Kind::Str});
+    add("rt_concat", Kind::Str, {Kind::Str, Kind::Str});
+    add("rt_substr", Kind::Str, {Kind::Str, Kind::I64, Kind::I64});
+    add("rt_left", Kind::Str, {Kind::Str, Kind::I64});
+    add("rt_right", Kind::Str, {Kind::Str, Kind::I64});
+    add("rt_mid2", Kind::Str, {Kind::Str, Kind::I64});
+    add("rt_mid3", Kind::Str, {Kind::Str, Kind::I64, Kind::I64});
+    add("rt_instr3", Kind::I64, {Kind::I64, Kind::Str, Kind::Str});
+    add("rt_instr2", Kind::I64, {Kind::Str, Kind::Str});
+    add("rt_ltrim", Kind::Str, {Kind::Str});
+    add("rt_rtrim", Kind::Str, {Kind::Str});
+    add("rt_trim", Kind::Str, {Kind::Str});
+    add("rt_ucase", Kind::Str, {Kind::Str});
+    add("rt_lcase", Kind::Str, {Kind::Str});
+    add("rt_chr", Kind::Str, {Kind::I64});
+    add("rt_asc", Kind::I64, {Kind::Str});
+    add("rt_str_eq", Kind::I1, {Kind::Str, Kind::Str});
+    add("rt_to_int", Kind::I64, {Kind::Str});
+    add("rt_int_to_str", Kind::Str, {Kind::I64});
+    add("rt_f64_to_str", Kind::Str, {Kind::F64});
+    add("rt_val", Kind::F64, {Kind::Str});
+    add("rt_str", Kind::Str, {Kind::F64});
+    add("rt_sqrt", Kind::F64, {Kind::F64});
+    add("rt_floor", Kind::F64, {Kind::F64});
+    add("rt_ceil", Kind::F64, {Kind::F64});
+    add("rt_sin", Kind::F64, {Kind::F64});
+    add("rt_cos", Kind::F64, {Kind::F64});
+    add("rt_pow", Kind::F64, {Kind::F64, Kind::F64});
+    add("rt_abs_i64", Kind::I64, {Kind::I64});
+    add("rt_abs_f64", Kind::F64, {Kind::F64});
+    add("rt_randomize_i64", Kind::Void, {Kind::I64});
+    add("rt_rnd", Kind::F64, {});
+    add("rt_alloc", Kind::Ptr, {Kind::I64});
+    add("rt_const_cstr", Kind::Str, {Kind::Ptr});
+
+    return map;
+}
+
+} // namespace
+
+const std::unordered_map<std::string_view, RuntimeSignature> &runtimeSignatures()
+{
+    static const SignatureMap table = buildRegistry();
+    return table;
+}
+
+const RuntimeSignature *findRuntimeSignature(std::string_view name)
+{
+    const auto &table = runtimeSignatures();
+    const auto it = table.find(name);
+    if (it == table.end())
+        return nullptr;
+    return &it->second;
+}
+
+} // namespace il::runtime

--- a/src/il/runtime/RuntimeSignatures.hpp
+++ b/src/il/runtime/RuntimeSignatures.hpp
@@ -1,0 +1,33 @@
+// File: src/il/runtime/RuntimeSignatures.hpp
+// Purpose: Declares the shared registry of runtime helper signatures.
+// Key invariants: Entries mirror the runtime C ABI and remain stable for consumers.
+// Ownership/Lifetime: Registry data lives for the duration of the process.
+// Links: docs/il-spec.md
+#pragma once
+
+#include "il/core/Type.hpp"
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace il::runtime
+{
+
+/// @brief Describes the IL signature for a runtime helper function.
+/// @notes Parameter order matches the runtime C ABI.
+struct RuntimeSignature
+{
+    il::core::Type retType;                  ///< Return type of the helper.
+    std::vector<il::core::Type> paramTypes;  ///< Parameter types in declaration order.
+};
+
+/// @brief Access the registry of runtime signatures keyed by symbol name.
+/// @return Mapping from runtime symbol to its IL signature metadata.
+const std::unordered_map<std::string_view, RuntimeSignature> &runtimeSignatures();
+
+/// @brief Look up the signature for a runtime helper if it exists.
+/// @param name Runtime symbol name, e.g., "rt_print_str".
+/// @return Pointer to the signature when registered; nullptr otherwise.
+const RuntimeSignature *findRuntimeSignature(std::string_view name);
+
+} // namespace il::runtime

--- a/src/il/verify/Verifier.cpp
+++ b/src/il/verify/Verifier.cpp
@@ -8,6 +8,7 @@
 #include "il/verify/ControlFlowChecker.hpp"
 #include "il/verify/InstructionChecker.hpp"
 #include "il/verify/TypeInference.hpp"
+#include "il/runtime/RuntimeSignatures.hpp"
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -16,65 +17,6 @@ using namespace il::core;
 
 namespace il::verify
 {
-
-namespace
-{
-struct ExternSig
-{
-    Type ret;
-    std::vector<Type> params;
-};
-
-const std::unordered_map<std::string, ExternSig> kExternSigs = {
-    {"rt_trap", {Type(Type::Kind::Void), {Type(Type::Kind::Ptr)}}},
-    {"rt_abort", {Type(Type::Kind::Void), {Type(Type::Kind::Ptr)}}},
-    {"rt_print_str", {Type(Type::Kind::Void), {Type(Type::Kind::Str)}}},
-    {"rt_print_i64", {Type(Type::Kind::Void), {Type(Type::Kind::I64)}}},
-    {"rt_print_f64", {Type(Type::Kind::Void), {Type(Type::Kind::F64)}}},
-    {"rt_input_line", {Type(Type::Kind::Str), {}}},
-    {"rt_len", {Type(Type::Kind::I64), {Type(Type::Kind::Str)}}},
-    {"rt_concat", {Type(Type::Kind::Str), {Type(Type::Kind::Str), Type(Type::Kind::Str)}}},
-    {"rt_substr",
-     {Type(Type::Kind::Str),
-      {Type(Type::Kind::Str), Type(Type::Kind::I64), Type(Type::Kind::I64)}}},
-    {"rt_left", {Type(Type::Kind::Str), {Type(Type::Kind::Str), Type(Type::Kind::I64)}}},
-    {"rt_right", {Type(Type::Kind::Str), {Type(Type::Kind::Str), Type(Type::Kind::I64)}}},
-    {"rt_mid2", {Type(Type::Kind::Str), {Type(Type::Kind::Str), Type(Type::Kind::I64)}}},
-    {"rt_mid3",
-     {Type(Type::Kind::Str),
-      {Type(Type::Kind::Str), Type(Type::Kind::I64), Type(Type::Kind::I64)}}},
-    {"rt_instr3",
-     {Type(Type::Kind::I64),
-      {Type(Type::Kind::I64), Type(Type::Kind::Str), Type(Type::Kind::Str)}}},
-    {"rt_instr2", {Type(Type::Kind::I64), {Type(Type::Kind::Str), Type(Type::Kind::Str)}}},
-    {"rt_ltrim", {Type(Type::Kind::Str), {Type(Type::Kind::Str)}}},
-    {"rt_rtrim", {Type(Type::Kind::Str), {Type(Type::Kind::Str)}}},
-    {"rt_trim", {Type(Type::Kind::Str), {Type(Type::Kind::Str)}}},
-    {"rt_ucase", {Type(Type::Kind::Str), {Type(Type::Kind::Str)}}},
-    {"rt_lcase", {Type(Type::Kind::Str), {Type(Type::Kind::Str)}}},
-    {"rt_chr", {Type(Type::Kind::Str), {Type(Type::Kind::I64)}}},
-    {"rt_asc", {Type(Type::Kind::I64), {Type(Type::Kind::Str)}}},
-    {"rt_str_eq", {Type(Type::Kind::I1), {Type(Type::Kind::Str), Type(Type::Kind::Str)}}},
-    {"rt_to_int", {Type(Type::Kind::I64), {Type(Type::Kind::Str)}}},
-    {"rt_int_to_str", {Type(Type::Kind::Str), {Type(Type::Kind::I64)}}},
-    {"rt_f64_to_str", {Type(Type::Kind::Str), {Type(Type::Kind::F64)}}},
-    {"rt_val", {Type(Type::Kind::F64), {Type(Type::Kind::Str)}}},
-    {"rt_str", {Type(Type::Kind::Str), {Type(Type::Kind::F64)}}},
-    {"rt_sqrt", {Type(Type::Kind::F64), {Type(Type::Kind::F64)}}},
-    {"rt_floor", {Type(Type::Kind::F64), {Type(Type::Kind::F64)}}},
-    {"rt_ceil", {Type(Type::Kind::F64), {Type(Type::Kind::F64)}}},
-    {"rt_sin", {Type(Type::Kind::F64), {Type(Type::Kind::F64)}}},
-    {"rt_cos", {Type(Type::Kind::F64), {Type(Type::Kind::F64)}}},
-    {"rt_pow", {Type(Type::Kind::F64), {Type(Type::Kind::F64), Type(Type::Kind::F64)}}},
-    {"rt_abs_i64", {Type(Type::Kind::I64), {Type(Type::Kind::I64)}}},
-    {"rt_abs_f64", {Type(Type::Kind::F64), {Type(Type::Kind::F64)}}},
-    {"rt_randomize_i64", {Type(Type::Kind::Void), {Type(Type::Kind::I64)}}},
-    {"rt_rnd", {Type(Type::Kind::F64), {}}},
-    {"rt_alloc", {Type(Type::Kind::Ptr), {Type(Type::Kind::I64)}}},
-    {"rt_const_cstr", {Type(Type::Kind::Str), {Type(Type::Kind::Ptr)}}},
-};
-
-} // namespace
 
 bool Verifier::verify(const Module &m, std::ostream &err)
 {
@@ -124,14 +66,13 @@ bool Verifier::verifyExterns(const Module &m,
             continue;
         }
 
-        auto itKnown = kExternSigs.find(e.name);
-        if (itKnown != kExternSigs.end())
+        const auto *sig = il::runtime::findRuntimeSignature(e.name);
+        if (sig)
         {
-            const ExternSig &sig = itKnown->second;
-            bool sigOk = e.retType.kind == sig.ret.kind && e.params.size() == sig.params.size();
+            bool sigOk = e.retType.kind == sig->retType.kind && e.params.size() == sig->paramTypes.size();
             if (sigOk)
-                for (size_t i = 0; i < sig.params.size(); ++i)
-                    if (e.params[i].kind != sig.params[i].kind)
+                for (size_t i = 0; i < sig->paramTypes.size(); ++i)
+                    if (e.params[i].kind != sig->paramTypes[i].kind)
                         sigOk = false;
             if (!sigOk)
             {


### PR DESCRIPTION
## Summary
- add a shared `il_runtime` library that owns the runtime helper signature table
- refactor the BASIC lowerer and verifier to consult the shared registry instead of bespoke literals
- hook the new component into the build so both the front end and verifier link against it

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cc12b34d9c83248375c6442d551fc9