### PR TITLE
refactor(frontends/basic): centralize procedure analysis setup

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -220,6 +220,10 @@ class SemanticAnalyzer
     /// @brief Determine if single statement @p s guarantees a return value.
     bool mustReturn(const Stmt &s) const;
 
+    /// @brief Shared setup/teardown for analyzing procedures.
+    template <typename Proc, typename BodyCallback>
+    void analyzeProcedureCommon(const Proc &proc, BodyCallback &&bodyCheck);
+
     /// @brief Analyze body of FUNCTION @p f.
     void analyzeProc(const FunctionDecl &f);
     /// @brief Analyze body of SUB @p s.


### PR DESCRIPTION
## Summary
- extract the common scope setup/teardown for procedure analysis into `analyzeProcedureCommon`
- reuse the helper for both FUNCTION and SUB analyzers while keeping the FUNCTION return diagnostics

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68cc1a82d00c832480232ef704e93422