### PR TITLE
Refactor BASIC loop parsing to share helper

### DIFF
--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -67,6 +67,12 @@ class Parser
     /// @return IF statement node.
     StmtPtr parseIf(int line);
 
+    /// @brief Parse the body of a loop terminated by @p terminator.
+    /// @param terminator Token that ends the loop (e.g., WEND or NEXT).
+    /// @param lineOut Optional pointer receiving the terminator's line number.
+    /// @param dst Destination vector populated with parsed statements.
+    void parseLoopBody(TokenKind terminator, int *lineOut, std::vector<StmtPtr> &dst);
+
     /// @brief Parse a WHILE loop.
     /// @return WHILE statement node.
     StmtPtr parseWhile();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -455,6 +455,10 @@ add_executable(test_basic_parse_array_var unit/test_basic_parse_array_var.cpp)
 target_link_libraries(test_basic_parse_array_var PRIVATE fe_basic support)
 add_test(NAME test_basic_parse_array_var COMMAND test_basic_parse_array_var)
 
+add_executable(test_basic_parse_loops unit/test_basic_parse_loops.cpp)
+target_link_libraries(test_basic_parse_loops PRIVATE fe_basic support)
+add_test(NAME test_basic_parse_loops COMMAND test_basic_parse_loops)
+
 add_executable(test_basic_intrinsics unit/test_basic_intrinsics.cpp)
 target_link_libraries(test_basic_intrinsics PRIVATE fe_basic support)
 add_test(NAME test_basic_intrinsics COMMAND test_basic_intrinsics)

--- a/tests/unit/test_basic_parse_loops.cpp
+++ b/tests/unit/test_basic_parse_loops.cpp
@@ -1,0 +1,54 @@
+// File: tests/unit/test_basic_parse_loops.cpp
+// Purpose: Verify loop parsing shares body handling without regressing NEXT/WEND semantics.
+// Key invariants: Loop bodies exclude terminators and preserve nested statement line numbers.
+// Ownership/Lifetime: Test owns parser, AST, and source manager instances.
+// Links: docs/class-catalog.md
+
+#include "frontends/basic/Parser.hpp"
+#include "support/source_manager.hpp"
+#include <cassert>
+#include <string>
+
+using namespace il::frontends::basic;
+using namespace il::support;
+
+int main()
+{
+    {
+        std::string src = "10 FOR I = 1 TO 3\n20 PRINT I\n30 NEXT I\n40 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("loops.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        assert(prog);
+        assert(prog->main.size() == 2);
+        auto *forStmt = dynamic_cast<ForStmt *>(prog->main[0].get());
+        assert(forStmt);
+        assert(forStmt->body.size() == 1);
+        auto *print = dynamic_cast<PrintStmt *>(forStmt->body[0].get());
+        assert(print);
+        assert(print->line == 20);
+        auto *endStmt = dynamic_cast<EndStmt *>(prog->main[1].get());
+        assert(endStmt);
+    }
+
+    {
+        std::string src = "10 WHILE X\n20 PRINT X\n30 WEND\n40 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("loops.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        assert(prog);
+        assert(prog->main.size() == 2);
+        auto *whileStmt = dynamic_cast<WhileStmt *>(prog->main[0].get());
+        assert(whileStmt);
+        assert(whileStmt->body.size() == 1);
+        auto *print = dynamic_cast<PrintStmt *>(whileStmt->body[0].get());
+        assert(print);
+        assert(print->line == 20);
+        auto *endStmt = dynamic_cast<EndStmt *>(prog->main[1].get());
+        assert(endStmt);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extract the shared loop body handling into a reusable parseLoopBody helper and wire parseWhile/parseFor through it
- add a unit test covering FOR/NEXT and WHILE/WEND parsing to ensure terminators no longer materialize as AST nodes

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cc2183156c83248b1a4a9e5c7a8e03