### PR TITLE
refactor(frontends/basic): index statement handler table

### DIFF
--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -19,22 +19,24 @@ Parser::Parser(std::string_view src, uint32_t file_id, DiagnosticEmitter *emitte
     : lexer_(src, file_id), emitter_(emitter)
 {
     tokens_.push_back(lexer_.next());
-    stmtHandlers_ = {
-        {TokenKind::KeywordPrint, {&Parser::parsePrint, nullptr}},
-        {TokenKind::KeywordLet, {&Parser::parseLet, nullptr}},
-        {TokenKind::KeywordIf, {nullptr, &Parser::parseIf}},
-        {TokenKind::KeywordWhile, {&Parser::parseWhile, nullptr}},
-        {TokenKind::KeywordFor, {&Parser::parseFor, nullptr}},
-        {TokenKind::KeywordNext, {&Parser::parseNext, nullptr}},
-        {TokenKind::KeywordGoto, {&Parser::parseGoto, nullptr}},
-        {TokenKind::KeywordEnd, {&Parser::parseEnd, nullptr}},
-        {TokenKind::KeywordInput, {&Parser::parseInput, nullptr}},
-        {TokenKind::KeywordDim, {&Parser::parseDim, nullptr}},
-        {TokenKind::KeywordRandomize, {&Parser::parseRandomize, nullptr}},
-        {TokenKind::KeywordFunction, {&Parser::parseFunction, nullptr}},
-        {TokenKind::KeywordSub, {&Parser::parseSub, nullptr}},
-        {TokenKind::KeywordReturn, {&Parser::parseReturn, nullptr}},
+
+    auto setHandler = [this](TokenKind kind, StmtHandler handler) {
+        stmtHandlers_[static_cast<std::size_t>(kind)] = handler;
     };
+    setHandler(TokenKind::KeywordPrint, {&Parser::parsePrint, nullptr});
+    setHandler(TokenKind::KeywordLet, {&Parser::parseLet, nullptr});
+    setHandler(TokenKind::KeywordIf, {nullptr, &Parser::parseIf});
+    setHandler(TokenKind::KeywordWhile, {&Parser::parseWhile, nullptr});
+    setHandler(TokenKind::KeywordFor, {&Parser::parseFor, nullptr});
+    setHandler(TokenKind::KeywordNext, {&Parser::parseNext, nullptr});
+    setHandler(TokenKind::KeywordGoto, {&Parser::parseGoto, nullptr});
+    setHandler(TokenKind::KeywordEnd, {&Parser::parseEnd, nullptr});
+    setHandler(TokenKind::KeywordInput, {&Parser::parseInput, nullptr});
+    setHandler(TokenKind::KeywordDim, {&Parser::parseDim, nullptr});
+    setHandler(TokenKind::KeywordRandomize, {&Parser::parseRandomize, nullptr});
+    setHandler(TokenKind::KeywordFunction, {&Parser::parseFunction, nullptr});
+    setHandler(TokenKind::KeywordSub, {&Parser::parseSub, nullptr});
+    setHandler(TokenKind::KeywordReturn, {&Parser::parseReturn, nullptr});
 }
 
 /// @brief Parse the entire BASIC program.

--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -9,10 +9,10 @@
 #include "frontends/basic/AST.hpp"
 #include "frontends/basic/DiagnosticEmitter.hpp"
 #include "frontends/basic/Lexer.hpp"
+#include <array>
 #include <memory>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -45,7 +45,7 @@ class Parser
         StmtPtr (Parser::*with_line)(int) = nullptr; ///< Handler requiring line number.
     };
 
-    std::unordered_map<TokenKind, StmtHandler> stmtHandlers_; ///< Token to parser mapping.
+    std::array<StmtHandler, static_cast<std::size_t>(TokenKind::Count)> stmtHandlers_{}; ///< Token to parser mapping.
 
 #include "frontends/basic/Parser_Token.hpp"
 

--- a/src/frontends/basic/Parser_Stmt.cpp
+++ b/src/frontends/basic/Parser_Stmt.cpp
@@ -15,12 +15,15 @@ namespace il::frontends::basic
 /// @return Parsed statement node or EndStmt for unknown tokens.
 StmtPtr Parser::parseStatement(int line)
 {
-    auto it = stmtHandlers_.find(peek().kind);
-    if (it != stmtHandlers_.end())
+    const auto kind = peek().kind;
+    const auto index = static_cast<std::size_t>(kind);
+    if (index < stmtHandlers_.size())
     {
-        if (it->second.no_arg)
-            return (this->*(it->second.no_arg))();
-        return (this->*(it->second.with_line))(line);
+        const auto &handler = stmtHandlers_[index];
+        if (handler.no_arg)
+            return (this->*(handler.no_arg))();
+        if (handler.with_line)
+            return (this->*(handler.with_line))(line);
     }
     auto stmt = std::make_unique<EndStmt>();
     stmt->loc = peek().loc;

--- a/src/frontends/basic/Token.cpp
+++ b/src/frontends/basic/Token.cpp
@@ -143,6 +143,8 @@ const char *tokenKindToString(TokenKind k)
             return ";";
         case TokenKind::Colon:
             return ":";
+        case TokenKind::Count:
+            break;
     }
     return "?";
 }

--- a/src/frontends/basic/Token.hpp
+++ b/src/frontends/basic/Token.hpp
@@ -88,6 +88,8 @@ enum class TokenKind
     KeywordFalse,   ///< 'FALSE'.
     KeywordAndAlso, ///< 'ANDALSO'.
     KeywordOrElse,  ///< 'ORELSE'.
+
+    Count, ///< Total number of token kinds (sentinel, not a real token).
 };
 
 /// @brief A lexical token produced by the BASIC lexer.


### PR DESCRIPTION
## Summary
- replace the unordered_map-based statement dispatch table with a fixed-size array indexed by TokenKind
- add a TokenKind::Count sentinel and update parseStatement to use direct indexing while keeping the EndStmt fallback

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cc278439f48324a197564e0ece57a0