### PR TITLE
Refactor Lowerer to use shared LoweringContext state

### DIFF
--- a/src/frontends/basic/LowerExpr.cpp
+++ b/src/frontends/basic/LowerExpr.cpp
@@ -28,15 +28,14 @@ namespace il::frontends::basic
 Lowerer::RVal Lowerer::lowerVarExpr(const VarExpr &v)
 {
     curLoc = v.loc;
-    auto it = varSlots.find(v.name);
-    assert(it != varSlots.end());
-    Value ptr = Value::temp(it->second);
-    bool isArray = arrays.count(v.name);
+    auto slotId = ctx.lookupVarSlot(v.name);
+    assert(slotId && "variable slot missing");
+    Value ptr = Value::temp(*slotId);
+    bool isArray = ctx.arrays().count(v.name);
     bool isStr = !v.name.empty() && v.name.back() == '$';
     bool isF64 = !v.name.empty() && v.name.back() == '#';
     bool isBoolVar = false;
-    auto typeIt = varTypes.find(v.name);
-    if (typeIt != varTypes.end() && typeIt->second == AstType::Bool)
+    if (auto ty = ctx.lookupVarType(v.name); ty && *ty == AstType::Bool)
         isBoolVar = true;
     Type ty = isArray ? Type(Type::Kind::Ptr)
                       : (isStr ? Type(Type::Kind::Str)

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "frontends/basic/AST.hpp"
+#include "frontends/basic/LoweringContext.hpp"
 #include "frontends/basic/NameMangler.hpp"
 #include "il/build/IRBuilder.hpp"
 #include "il/core/Module.hpp"
@@ -211,13 +212,7 @@ class Lowerer
     BasicBlock *cur{nullptr};
     size_t fnExit{0};
     NameMangler mangler;
-    std::unordered_map<int, size_t> lineBlocks;
-    std::unordered_map<std::string, unsigned> varSlots;
-    std::unordered_map<std::string, unsigned> arrayLenSlots;
-    std::unordered_map<std::string, AstType> varTypes;
-    std::unordered_map<std::string, std::string> strings;
-    std::unordered_set<std::string> vars;
-    std::unordered_set<std::string> arrays;
+    LoweringContext ctx;
     il::support::SourceLoc curLoc{}; ///< current source location for emitted IR
     bool boundsChecks{false};
     unsigned boundsCheckId{0};


### PR DESCRIPTION
## Summary
- extend `LoweringContext` to manage variable slots, array length slots, line block indices, and interned string globals
- update the BASIC lowerer helpers to (re)initialize the context per procedure and for the top-level program while querying it for slots and blocks
- route array lowering, string emission, and bounds checks through the context-owned state instead of Lowerer-local maps

## Testing
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68cc498217008324909d0a8df3ed4281