### PR TITLE
Refactor BASIC builtin semantics to use registry metadata

### DIFF
--- a/src/frontends/basic/BuiltinRegistry.cpp
+++ b/src/frontends/basic/BuiltinRegistry.cpp
@@ -8,7 +8,6 @@
 
 #include "frontends/basic/BuiltinRegistry.hpp"
 #include "frontends/basic/Lowerer.hpp"
-#include "frontends/basic/SemanticAnalyzer.hpp"
 #include <array>
 #include <unordered_map>
 
@@ -17,31 +16,84 @@ namespace il::frontends::basic
 namespace
 {
 using B = BuiltinCallExpr::Builtin;
+using Mask = BuiltinTypeMask;
+
+static constexpr std::array<BuiltinArgSpec, 1> kStringArg = {{{Mask::String}}};
+static constexpr std::array<BuiltinArgSpec, 1> kNumberArg = {{{Mask::Int | Mask::Float}}};
+static constexpr std::array<BuiltinArgSpec, 1> kFloatArg = {{{Mask::Float}}};
+static constexpr std::array<BuiltinArgSpec, 2> kStringNumberArgs = {{{Mask::String}, {Mask::Int | Mask::Float}}};
+static constexpr std::array<BuiltinArgSpec, 2> kTwoNumberArgs = {{{Mask::Int | Mask::Float}, {Mask::Int | Mask::Float}}};
+static constexpr std::array<BuiltinArgSpec, 2> kStringStringArgs = {{{Mask::String}, {Mask::String}}};
+static constexpr std::array<BuiltinArgSpec, 3> kStringNumberNumberArgs = {
+    {{Mask::String}, {Mask::Int | Mask::Float}, {Mask::Int | Mask::Float}}};
+static constexpr std::array<BuiltinArgSpec, 3> kNumberStringStringArgs = {
+    {{Mask::Int | Mask::Float}, {Mask::String}, {Mask::String}}};
+
+static constexpr std::array<BuiltinSignature, 1> kStringSignatures = {{{kStringArg.data(), kStringArg.size()}}};
+static constexpr std::array<BuiltinSignature, 1> kNumberSignatures = {{{kNumberArg.data(), kNumberArg.size()}}};
+static constexpr std::array<BuiltinSignature, 1> kFloatSignatures = {{{kFloatArg.data(), kFloatArg.size()}}};
+static constexpr std::array<BuiltinSignature, 1> kStringNumberSignatures = {
+    {{kStringNumberArgs.data(), kStringNumberArgs.size()}}};
+static constexpr std::array<BuiltinSignature, 1> kTwoNumberSignatures = {{{kTwoNumberArgs.data(), kTwoNumberArgs.size()}}};
+static constexpr std::array<BuiltinSignature, 1> kStringStringSignatures = {
+    {{kStringStringArgs.data(), kStringStringArgs.size()}}};
+static constexpr std::array<BuiltinSignature, 1> kNumberStringStringSignatures = {
+    {{kNumberStringStringArgs.data(), kNumberStringStringArgs.size()}}};
+static constexpr std::array<BuiltinSignature, 2> kMidSignatures = {{
+    {kStringNumberArgs.data(), kStringNumberArgs.size()},
+    {kStringNumberNumberArgs.data(), kStringNumberNumberArgs.size()},
+}};
+static constexpr std::array<BuiltinSignature, 2> kInstrSignatures = {{
+    {kStringStringArgs.data(), kStringStringArgs.size()},
+    {kNumberStringStringArgs.data(), kNumberStringStringArgs.size()},
+}};
 
 static const std::array<BuiltinInfo, 23> kBuiltins = {{
-    {"LEN", 1, 1, &SemanticAnalyzer::analyzeLen, &Lowerer::lowerLen, &Lowerer::scanLen},
-    {"MID$", 2, 3, &SemanticAnalyzer::analyzeMid, &Lowerer::lowerMid, &Lowerer::scanMid},
-    {"LEFT$", 2, 2, &SemanticAnalyzer::analyzeLeft, &Lowerer::lowerLeft, &Lowerer::scanLeft},
-    {"RIGHT$", 2, 2, &SemanticAnalyzer::analyzeRight, &Lowerer::lowerRight, &Lowerer::scanRight},
-    {"STR$", 1, 1, &SemanticAnalyzer::analyzeStr, &Lowerer::lowerStr, &Lowerer::scanStr},
-    {"VAL", 1, 1, &SemanticAnalyzer::analyzeVal, &Lowerer::lowerVal, &Lowerer::scanVal},
-    {"INT", 1, 1, &SemanticAnalyzer::analyzeInt, &Lowerer::lowerInt, &Lowerer::scanInt},
-    {"SQR", 1, 1, &SemanticAnalyzer::analyzeSqr, &Lowerer::lowerSqr, &Lowerer::scanSqr},
-    {"ABS", 1, 1, &SemanticAnalyzer::analyzeAbs, &Lowerer::lowerAbs, &Lowerer::scanAbs},
-    {"FLOOR", 1, 1, &SemanticAnalyzer::analyzeFloor, &Lowerer::lowerFloor, &Lowerer::scanFloor},
-    {"CEIL", 1, 1, &SemanticAnalyzer::analyzeCeil, &Lowerer::lowerCeil, &Lowerer::scanCeil},
-    {"SIN", 1, 1, &SemanticAnalyzer::analyzeSin, &Lowerer::lowerSin, &Lowerer::scanSin},
-    {"COS", 1, 1, &SemanticAnalyzer::analyzeCos, &Lowerer::lowerCos, &Lowerer::scanCos},
-    {"POW", 2, 2, &SemanticAnalyzer::analyzePow, &Lowerer::lowerPow, &Lowerer::scanPow},
-    {"RND", 0, 0, &SemanticAnalyzer::analyzeRnd, &Lowerer::lowerRnd, &Lowerer::scanRnd},
-    {"INSTR", 2, 3, &SemanticAnalyzer::analyzeInstr, &Lowerer::lowerInstr, &Lowerer::scanInstr},
-    {"LTRIM$", 1, 1, &SemanticAnalyzer::analyzeLtrim, &Lowerer::lowerLtrim, &Lowerer::scanLtrim},
-    {"RTRIM$", 1, 1, &SemanticAnalyzer::analyzeRtrim, &Lowerer::lowerRtrim, &Lowerer::scanRtrim},
-    {"TRIM$", 1, 1, &SemanticAnalyzer::analyzeTrim, &Lowerer::lowerTrim, &Lowerer::scanTrim},
-    {"UCASE$", 1, 1, &SemanticAnalyzer::analyzeUcase, &Lowerer::lowerUcase, &Lowerer::scanUcase},
-    {"LCASE$", 1, 1, &SemanticAnalyzer::analyzeLcase, &Lowerer::lowerLcase, &Lowerer::scanLcase},
-    {"CHR$", 1, 1, &SemanticAnalyzer::analyzeChr, &Lowerer::lowerChr, &Lowerer::scanChr},
-    {"ASC", 1, 1, &SemanticAnalyzer::analyzeAsc, &Lowerer::lowerAsc, &Lowerer::scanAsc},
+    {"LEN", 1, 1, kStringSignatures.data(), kStringSignatures.size(), BuiltinResultKind::Int,
+     &Lowerer::lowerLen, &Lowerer::scanLen},
+    {"MID$", 2, 3, kMidSignatures.data(), kMidSignatures.size(), BuiltinResultKind::String,
+     &Lowerer::lowerMid, &Lowerer::scanMid},
+    {"LEFT$", 2, 2, kStringNumberSignatures.data(), kStringNumberSignatures.size(), BuiltinResultKind::String,
+     &Lowerer::lowerLeft, &Lowerer::scanLeft},
+    {"RIGHT$", 2, 2, kStringNumberSignatures.data(), kStringNumberSignatures.size(), BuiltinResultKind::String,
+     &Lowerer::lowerRight, &Lowerer::scanRight},
+    {"STR$", 1, 1, kNumberSignatures.data(), kNumberSignatures.size(), BuiltinResultKind::String,
+     &Lowerer::lowerStr, &Lowerer::scanStr},
+    {"VAL", 1, 1, kStringSignatures.data(), kStringSignatures.size(), BuiltinResultKind::Int,
+     &Lowerer::lowerVal, &Lowerer::scanVal},
+    {"INT", 1, 1, kFloatSignatures.data(), kFloatSignatures.size(), BuiltinResultKind::Int,
+     &Lowerer::lowerInt, &Lowerer::scanInt},
+    {"SQR", 1, 1, kNumberSignatures.data(), kNumberSignatures.size(), BuiltinResultKind::Float,
+     &Lowerer::lowerSqr, &Lowerer::scanSqr},
+    {"ABS", 1, 1, kNumberSignatures.data(), kNumberSignatures.size(), BuiltinResultKind::NumericLikeFirstArg,
+     &Lowerer::lowerAbs, &Lowerer::scanAbs},
+    {"FLOOR", 1, 1, kNumberSignatures.data(), kNumberSignatures.size(), BuiltinResultKind::Float,
+     &Lowerer::lowerFloor, &Lowerer::scanFloor},
+    {"CEIL", 1, 1, kNumberSignatures.data(), kNumberSignatures.size(), BuiltinResultKind::Float,
+     &Lowerer::lowerCeil, &Lowerer::scanCeil},
+    {"SIN", 1, 1, kNumberSignatures.data(), kNumberSignatures.size(), BuiltinResultKind::Float,
+     &Lowerer::lowerSin, &Lowerer::scanSin},
+    {"COS", 1, 1, kNumberSignatures.data(), kNumberSignatures.size(), BuiltinResultKind::Float,
+     &Lowerer::lowerCos, &Lowerer::scanCos},
+    {"POW", 2, 2, kTwoNumberSignatures.data(), kTwoNumberSignatures.size(), BuiltinResultKind::Float,
+     &Lowerer::lowerPow, &Lowerer::scanPow},
+    {"RND", 0, 0, nullptr, 0, BuiltinResultKind::Float, &Lowerer::lowerRnd, &Lowerer::scanRnd},
+    {"INSTR", 2, 3, kInstrSignatures.data(), kInstrSignatures.size(), BuiltinResultKind::Int,
+     &Lowerer::lowerInstr, &Lowerer::scanInstr},
+    {"LTRIM$", 1, 1, kStringSignatures.data(), kStringSignatures.size(), BuiltinResultKind::String,
+     &Lowerer::lowerLtrim, &Lowerer::scanLtrim},
+    {"RTRIM$", 1, 1, kStringSignatures.data(), kStringSignatures.size(), BuiltinResultKind::String,
+     &Lowerer::lowerRtrim, &Lowerer::scanRtrim},
+    {"TRIM$", 1, 1, kStringSignatures.data(), kStringSignatures.size(), BuiltinResultKind::String,
+     &Lowerer::lowerTrim, &Lowerer::scanTrim},
+    {"UCASE$", 1, 1, kStringSignatures.data(), kStringSignatures.size(), BuiltinResultKind::String,
+     &Lowerer::lowerUcase, &Lowerer::scanUcase},
+    {"LCASE$", 1, 1, kStringSignatures.data(), kStringSignatures.size(), BuiltinResultKind::String,
+     &Lowerer::lowerLcase, &Lowerer::scanLcase},
+    {"CHR$", 1, 1, kNumberSignatures.data(), kNumberSignatures.size(), BuiltinResultKind::String,
+     &Lowerer::lowerChr, &Lowerer::scanChr},
+    {"ASC", 1, 1, kStringSignatures.data(), kStringSignatures.size(), BuiltinResultKind::Int,
+     &Lowerer::lowerAsc, &Lowerer::scanAsc},
 }};
 
 static const std::unordered_map<std::string_view, B> kByName = {

--- a/src/frontends/basic/BuiltinRegistry.hpp
+++ b/src/frontends/basic/BuiltinRegistry.hpp
@@ -8,24 +8,73 @@
 
 #include "frontends/basic/AST.hpp"
 #include "frontends/basic/Lowerer.hpp"
-#include "frontends/basic/SemanticAnalyzer.hpp"
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <string_view>
-#include <vector>
 
 namespace il::frontends::basic
 {
+/// @brief Bitmask describing allowable BASIC value categories for builtin arguments.
+enum class BuiltinTypeMask : std::uint8_t
+{
+    None = 0,
+    Int = 1u << 0,
+    Float = 1u << 1,
+    String = 1u << 2,
+    Bool = 1u << 3,
+};
+
+constexpr BuiltinTypeMask operator|(BuiltinTypeMask lhs, BuiltinTypeMask rhs)
+{
+    return static_cast<BuiltinTypeMask>(static_cast<std::uint8_t>(lhs) |
+                                        static_cast<std::uint8_t>(rhs));
+}
+
+constexpr BuiltinTypeMask operator&(BuiltinTypeMask lhs, BuiltinTypeMask rhs)
+{
+    return static_cast<BuiltinTypeMask>(static_cast<std::uint8_t>(lhs) &
+                                        static_cast<std::uint8_t>(rhs));
+}
+
+constexpr bool any(BuiltinTypeMask mask)
+{
+    return mask != BuiltinTypeMask::None;
+}
+
+/// @brief Per-argument type constraints for a builtin signature.
+struct BuiltinArgSpec
+{
+    BuiltinTypeMask allowed;
+};
+
+/// @brief Single callable signature for a builtin (fixed arity/argument types).
+struct BuiltinSignature
+{
+    const BuiltinArgSpec *args;
+    std::size_t argCount;
+};
+
+/// @brief Result inference strategy for a builtin call.
+enum class BuiltinResultKind
+{
+    Int,
+    Float,
+    String,
+    Bool,
+    NumericLikeFirstArg,
+    Unknown,
+};
+
 /// @brief Metadata for a BASIC built-in function.
 struct BuiltinInfo
 {
     const char *name;    ///< BASIC source spelling.
     std::size_t minArgs; ///< Minimum accepted arguments.
     std::size_t maxArgs; ///< Maximum accepted arguments.
-
-    using AnalyzeFn = SemanticAnalyzer::Type (SemanticAnalyzer::*)(
-        const BuiltinCallExpr &, const std::vector<SemanticAnalyzer::Type> &);
-    AnalyzeFn analyze; ///< Semantic analysis hook.
+    const BuiltinSignature *signatures; ///< Supported signatures for type checking.
+    std::size_t signatureCount;         ///< Number of signatures.
+    BuiltinResultKind result;           ///< Result inference rule.
 
     using LowerFn = typename Lowerer::RVal (Lowerer::*)(const BuiltinCallExpr &);
     LowerFn lower; ///< Lowering hook.

--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -11,7 +11,6 @@
 #include "frontends/basic/ProcRegistry.hpp"
 #include "frontends/basic/ScopeTracker.hpp"
 #include "frontends/basic/SemanticDiagnostics.hpp"
-#include <initializer_list>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -22,6 +21,9 @@
 
 namespace il::frontends::basic
 {
+
+struct BuiltinInfo;
+struct BuiltinSignature;
 
 /// @brief Traverses BASIC AST to collect symbols and labels, validate variable
 ///        references, and verify FOR/NEXT nesting.
@@ -185,65 +187,21 @@ class SemanticAnalyzer
     /// @brief Analyze built-in function call.
     Type analyzeBuiltinCall(const BuiltinCallExpr &c);
 
-  public:
-    /// @brief Analyze RND builtin.
-    Type analyzeRnd(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze LEN builtin.
-    Type analyzeLen(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze MID$ builtin.
-    Type analyzeMid(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze LEFT$ builtin.
-    Type analyzeLeft(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze RIGHT$ builtin.
-    Type analyzeRight(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze STR$ builtin.
-    Type analyzeStr(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze VAL builtin.
-    Type analyzeVal(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze INT builtin.
-    Type analyzeInt(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze INSTR builtin.
-    Type analyzeInstr(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze LTRIM$ builtin.
-    Type analyzeLtrim(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze RTRIM$ builtin.
-    Type analyzeRtrim(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze TRIM$ builtin.
-    Type analyzeTrim(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze UCASE$ builtin.
-    Type analyzeUcase(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze LCASE$ builtin.
-    Type analyzeLcase(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze CHR$ builtin.
-    Type analyzeChr(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze ASC builtin.
-    Type analyzeAsc(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze SQR builtin.
-    Type analyzeSqr(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze ABS builtin.
-    Type analyzeAbs(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze FLOOR builtin.
-    Type analyzeFloor(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze CEIL builtin.
-    Type analyzeCeil(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze SIN builtin.
-    Type analyzeSin(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze COS builtin.
-    Type analyzeCos(const BuiltinCallExpr &c, const std::vector<Type> &args);
-    /// @brief Analyze POW builtin.
-    Type analyzePow(const BuiltinCallExpr &c, const std::vector<Type> &args);
-
   private:
-    /// @brief Check argument count is within [@p min,@p max].
-    bool checkArgCount(const BuiltinCallExpr &c,
-                       const std::vector<Type> &args,
-                       size_t min,
-                       size_t max);
-    /// @brief Verify argument @p idx is one of @p allowed types.
-    bool checkArgType(const BuiltinCallExpr &c,
-                      size_t idx,
-                      Type argTy,
-                      std::initializer_list<Type> allowed);
+    /// @brief Check builtin argument count using registry metadata.
+    bool checkBuiltinArgCount(const BuiltinCallExpr &c,
+                              const BuiltinInfo &info,
+                              size_t actualCount);
+
+    /// @brief Verify argument @p idx against the signature metadata.
+    bool checkBuiltinArgType(const BuiltinCallExpr &c,
+                             const BuiltinSignature &sig,
+                             size_t idx,
+                             Type argTy);
+
+    /// @brief Infer builtin result type from registry metadata.
+    Type inferBuiltinResult(const BuiltinInfo &info, const std::vector<Type> &args) const;
+
     /// @brief Resolve callee of user-defined call.
     const ProcSignature *resolveCallee(const CallExpr &c);
     /// @brief Collect and validate argument types for user-defined call.


### PR DESCRIPTION
## Summary
- replace BASIC builtin registry callbacks with argument and result metadata
- teach the semantic analyzer to validate builtin calls via metadata-driven helpers and infer return types generically
- extend intrinsic semantic tests with ABS and INSTR coverage for the new diagnostic path

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cc5c111734832495b828bcf7fc7aae