### PR TITLE
Refactor BASIC AST to support visitors and migrate constant folding

### DIFF
--- a/src/frontends/basic/AST.cpp
+++ b/src/frontends/basic/AST.cpp
@@ -9,5 +9,128 @@
 namespace il::frontends::basic
 {
 
-// No additional implementation needed.
+void IntExpr::accept(ExprVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void FloatExpr::accept(ExprVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void StringExpr::accept(ExprVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void BoolExpr::accept(ExprVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void VarExpr::accept(ExprVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void ArrayExpr::accept(ExprVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void UnaryExpr::accept(ExprVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void BinaryExpr::accept(ExprVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void BuiltinCallExpr::accept(ExprVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void CallExpr::accept(ExprVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void PrintStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void LetStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void DimStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void RandomizeStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void IfStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void WhileStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void ForStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void NextStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void GotoStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void EndStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void InputStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void ReturnStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void FunctionDecl::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void SubDecl::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void StmtList::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
 }


### PR DESCRIPTION
## Summary
- add expression and statement visitor interfaces to the BASIC AST and implement accept methods on each node
- rework the constant folder to use a dedicated visitor pass instead of dynamic_cast chains

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cc65d1cec48324b65d237adeb48e38