### PR TITLE
Trim header coupling and add IWYU automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,11 @@ jobs:
         run: cmake -S . -B build
       - name: Docs
         run: ctest --test-dir build -L Docs --output-on-failure
+  iwyu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install include-what-you-use
+        run: sudo apt-get update && sudo apt-get install -y include-what-you-use
+      - name: Run IWYU checks
+        run: scripts/run-iwyu.sh

--- a/scripts/run-iwyu.sh
+++ b/scripts/run-iwyu.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# File: scripts/run-iwyu.sh
+# Purpose: Run include-what-you-use on a curated set of translation units.
+# Key invariants: Requires compile_commands.json generated for the build directory.
+# Ownership/Lifetime: Temporary log file removed before exit.
+# Links: https://github.com/include-what-you-use/include-what-you-use
+
+set -euo pipefail
+
+build_dir=${1:-build}
+
+cmake -S . -B "${build_dir}" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+cmake --build "${build_dir}" -j2
+
+# Translation units with heavy headers that benefit from IWYU policing.
+files=(
+  src/vm/VM.cpp
+  src/vm/VMInit.cpp
+  src/il/transform/ConstFold.cpp
+  src/il/transform/DCE.cpp
+  src/il/transform/Peephole.cpp
+  src/il/transform/PassManager.cpp
+  src/il/io/Parser.cpp
+  src/il/io/FunctionParser.cpp
+  src/il/io/InstrParser.cpp
+  src/il/io/ModuleParser.cpp
+  src/il/io/Serializer.cpp
+  src/il/core/Type.cpp
+)
+
+log=$(mktemp)
+trap 'rm -f "$log"' EXIT
+
+iwyu_tool.py -p "${build_dir}" "${files[@]}" >"$log" 2>&1 || {
+  cat "$log"
+  exit 1
+}
+
+cat "$log"
+
+if grep -E "should (add|remove)" "$log" >/dev/null; then
+  echo "include-what-you-use reported header adjustments" >&2
+  exit 1
+fi

--- a/src/il/build/IRBuilder.hpp
+++ b/src/il/build/IRBuilder.hpp
@@ -10,7 +10,7 @@
 #include "il/core/Module.hpp"
 #include "il/core/Opcode.hpp"
 #include "il/core/Value.hpp"
-#include "support/source_manager.hpp"
+#include "support/source_loc.hpp"
 #include <optional>
 #include <unordered_map>
 #include <vector>

--- a/src/il/core/Instr.hpp
+++ b/src/il/core/Instr.hpp
@@ -8,7 +8,7 @@
 #include "il/core/Opcode.hpp"
 #include "il/core/Type.hpp"
 #include "il/core/Value.hpp"
-#include "support/source_manager.hpp"
+#include "support/source_loc.hpp"
 #include <optional>
 #include <string>
 #include <vector>

--- a/src/il/core/Type.cpp
+++ b/src/il/core/Type.cpp
@@ -6,9 +6,34 @@
 
 #include "il/core/Type.hpp"
 
+#include <string>
+
 namespace il::core
 {
 
-// Out-of-line definitions if needed in future.
+std::string kindToString(Type::Kind k)
+{
+    switch (k)
+    {
+        case Type::Kind::Void:
+            return "void";
+        case Type::Kind::I1:
+            return "i1";
+        case Type::Kind::I64:
+            return "i64";
+        case Type::Kind::F64:
+            return "f64";
+        case Type::Kind::Ptr:
+            return "ptr";
+        case Type::Kind::Str:
+            return "str";
+    }
+    return "";
+}
+
+std::string Type::toString() const
+{
+    return kindToString(kind);
+}
 
 } // namespace il::core

--- a/src/il/core/Type.hpp
+++ b/src/il/core/Type.hpp
@@ -37,31 +37,6 @@ struct Type
 /// @brief Convert kind @p k to its mnemonic string.
 /// @param k Kind to convert.
 /// @return Lowercase mnemonic defined in the spec.
-inline std::string kindToString(Type::Kind k)
-{
-    switch (k)
-    {
-        case Type::Kind::Void:
-            return "void";
-        case Type::Kind::I1:
-            return "i1";
-        case Type::Kind::I64:
-            return "i64";
-        case Type::Kind::F64:
-            return "f64";
-        case Type::Kind::Ptr:
-            return "ptr";
-        case Type::Kind::Str:
-            return "str";
-    }
-    return "";
-}
-
-/// @brief Stringify this type.
-/// @return Lowercase mnemonic of the kind.
-inline std::string Type::toString() const
-{
-    return kindToString(kind);
-}
+std::string kindToString(Type::Kind k);
 
 } // namespace il::core

--- a/src/il/core/fwd.hpp
+++ b/src/il/core/fwd.hpp
@@ -1,0 +1,18 @@
+// File: src/il/core/fwd.hpp
+// Purpose: Forward declarations for core IL data structures.
+// Key invariants: None.
+// Ownership/Lifetime: Declarations only; definitions live in respective headers.
+// Links: docs/il-spec.md
+#pragma once
+
+namespace il::core
+{
+struct Module;
+struct Function;
+struct BasicBlock;
+struct Instr;
+struct Value;
+struct Extern;
+struct Global;
+struct Param;
+} // namespace il::core

--- a/src/il/io/FunctionParser.cpp
+++ b/src/il/io/FunctionParser.cpp
@@ -6,6 +6,8 @@
 
 #include "il/io/FunctionParser.hpp"
 
+#include "il/core/Function.hpp"
+#include "il/core/Module.hpp"
 #include "il/io/InstrParser.hpp"
 #include "il/io/ParserUtil.hpp"
 #include "il/io/TypeParser.hpp"

--- a/src/il/io/InstrParser.cpp
+++ b/src/il/io/InstrParser.cpp
@@ -6,11 +6,14 @@
 
 #include "il/io/InstrParser.hpp"
 
-#include "il/io/ParserUtil.hpp"
-#include "il/io/TypeParser.hpp"
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
 #include "il/core/Opcode.hpp"
 #include "il/core/OpcodeInfo.hpp"
 #include "il/core/Value.hpp"
+#include "il/io/ParserUtil.hpp"
+#include "il/io/TypeParser.hpp"
 
 #include <cctype>
 #include <exception>

--- a/src/il/io/ModuleParser.cpp
+++ b/src/il/io/ModuleParser.cpp
@@ -6,6 +6,7 @@
 
 #include "il/io/ModuleParser.hpp"
 
+#include "il/core/Module.hpp"
 #include "il/io/FunctionParser.hpp"
 #include "il/io/ParserUtil.hpp"
 #include "il/io/TypeParser.hpp"

--- a/src/il/io/Parser.hpp
+++ b/src/il/io/Parser.hpp
@@ -5,7 +5,7 @@
 // Links: docs/il-spec.md
 #pragma once
 
-#include "il/core/Module.hpp"
+#include "il/core/fwd.hpp"
 #include "il/io/FunctionParser.hpp"
 #include "il/io/InstrParser.hpp"
 #include "il/io/ModuleParser.hpp"

--- a/src/il/io/ParserState.hpp
+++ b/src/il/io/ParserState.hpp
@@ -5,8 +5,8 @@
 // Links: docs/il-spec.md
 #pragma once
 
-#include "il/core/Module.hpp"
-#include "support/source_manager.hpp"
+#include "il/core/fwd.hpp"
+#include "support/source_loc.hpp"
 
 #include <string>
 #include <unordered_map>

--- a/src/il/io/Serializer.cpp
+++ b/src/il/io/Serializer.cpp
@@ -5,6 +5,7 @@
 // Links: docs/il-spec.md
 
 #include "il/io/Serializer.hpp"
+#include "il/core/Module.hpp"
 #include "il/core/Opcode.hpp"
 #include "il/core/Value.hpp"
 #include <algorithm>

--- a/src/il/io/Serializer.hpp
+++ b/src/il/io/Serializer.hpp
@@ -5,7 +5,7 @@
 // Links: docs/il-spec.md
 #pragma once
 
-#include "il/core/Module.hpp"
+#include "il/core/fwd.hpp"
 #include <ostream>
 #include <string>
 

--- a/src/il/transform/ConstFold.cpp
+++ b/src/il/transform/ConstFold.cpp
@@ -5,7 +5,9 @@
 // Links: docs/class-catalog.md
 
 #include "il/transform/ConstFold.hpp"
+#include "il/core/Function.hpp"
 #include "il/core/Instr.hpp"
+#include "il/core/Module.hpp"
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>

--- a/src/il/transform/ConstFold.hpp
+++ b/src/il/transform/ConstFold.hpp
@@ -6,7 +6,7 @@
 // Links: docs/class-catalog.md
 #pragma once
 
-#include "il/core/Module.hpp"
+#include "il/core/fwd.hpp"
 
 namespace il::transform
 {

--- a/src/il/transform/DCE.cpp
+++ b/src/il/transform/DCE.cpp
@@ -5,6 +5,9 @@
 // Links: docs/class-catalog.md
 
 #include "il/transform/DCE.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Module.hpp"
 #include <unordered_map>
 #include <unordered_set>
 

--- a/src/il/transform/DCE.hpp
+++ b/src/il/transform/DCE.hpp
@@ -5,7 +5,7 @@
 // Links: docs/class-catalog.md
 #pragma once
 
-#include "il/core/Module.hpp"
+#include "il/core/fwd.hpp"
 
 namespace il::transform
 {

--- a/src/il/transform/PassManager.cpp
+++ b/src/il/transform/PassManager.cpp
@@ -5,6 +5,7 @@
 // Links: docs/class-catalog.md
 
 #include "il/transform/PassManager.hpp"
+#include "il/core/Module.hpp"
 #include "il/verify/Verifier.hpp"
 #include <cassert>
 #include <sstream>

--- a/src/il/transform/PassManager.hpp
+++ b/src/il/transform/PassManager.hpp
@@ -5,7 +5,7 @@
 // Links: docs/class-catalog.md
 #pragma once
 
-#include "il/core/Module.hpp"
+#include "il/core/fwd.hpp"
 #include <functional>
 #include <string>
 #include <unordered_map>

--- a/src/il/transform/Peephole.cpp
+++ b/src/il/transform/Peephole.cpp
@@ -7,6 +7,7 @@
 #include "il/transform/Peephole.hpp"
 #include "il/core/Function.hpp"
 #include "il/core/Instr.hpp"
+#include "il/core/Module.hpp"
 
 using namespace il::core;
 

--- a/src/il/transform/Peephole.hpp
+++ b/src/il/transform/Peephole.hpp
@@ -7,7 +7,8 @@
 
 #include <array>
 
-#include "il/core/Module.hpp"
+#include "il/core/Opcode.hpp"
+#include "il/core/fwd.hpp"
 
 namespace il::transform
 {

--- a/src/il/verify/Verifier.cpp
+++ b/src/il/verify/Verifier.cpp
@@ -5,6 +5,13 @@
 // Links: docs/il-spec.md
 
 #include "il/verify/Verifier.hpp"
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Extern.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Global.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Module.hpp"
 #include "il/verify/ControlFlowChecker.hpp"
 #include "il/verify/InstructionChecker.hpp"
 #include "il/verify/TypeInference.hpp"

--- a/src/il/verify/Verifier.hpp
+++ b/src/il/verify/Verifier.hpp
@@ -5,7 +5,8 @@
 // Links: docs/il-spec.md
 #pragma once
 
-#include "il/core/Module.hpp"
+#include "il/core/Type.hpp"
+#include "il/core/fwd.hpp"
 #include <ostream>
 #include <unordered_map>
 #include <unordered_set>

--- a/src/support/source_loc.hpp
+++ b/src/support/source_loc.hpp
@@ -1,0 +1,31 @@
+// File: src/support/source_loc.hpp
+// Purpose: Declares lightweight source location POD used across IL components.
+// Key invariants: File id zero denotes an unknown location.
+// Ownership/Lifetime: Simple value type stored by clients; no ownership semantics.
+// Links: docs/class-catalog.md
+#pragma once
+
+#include <cstdint>
+
+namespace il::support
+{
+/// @brief Absolute position within a source file.
+struct SourceLoc
+{
+    /// Identifier assigned by SourceManager; 0 indicates an invalid location.
+    uint32_t file_id = 0;
+
+    /// 1-based line number within the file; 0 if unknown.
+    uint32_t line = 0;
+
+    /// 1-based column number within the line; 0 if unknown.
+    uint32_t column = 0;
+
+    /// @brief Whether this location refers to a tracked file.
+    [[nodiscard]] bool isValid() const
+    {
+        return file_id != 0;
+    }
+};
+
+} // namespace il::support

--- a/src/support/source_manager.hpp
+++ b/src/support/source_manager.hpp
@@ -5,7 +5,8 @@
 // Links: docs/class-catalog.md
 #pragma once
 
-#include <cstdint>
+#include "support/source_loc.hpp"
+
 #include <string>
 #include <string_view>
 #include <vector>
@@ -15,26 +16,6 @@
 /// @ownership Owns stored file path strings.
 namespace il::support
 {
-
-/// Represents an absolute position within a source file as tracked by
-/// SourceManager. A zero file_id denotes an invalid location.
-struct SourceLoc
-{
-    /// Identifier assigned by SourceManager; 0 indicates an invalid location.
-    uint32_t file_id = 0;
-
-    /// 1-based line number within the file; 0 if the line is unknown.
-    uint32_t line = 0;
-
-    /// 1-based column number within the line; 0 if the column is unknown.
-    uint32_t column = 0;
-
-    /// @brief Whether this location refers to a real file.
-    bool isValid() const
-    {
-        return file_id != 0;
-    }
-};
 
 /// Maintains the mapping between numeric file identifiers and their
 /// corresponding filesystem paths. Clients can register files and look up

--- a/src/tools/il-verify/il-verify.cpp
+++ b/src/tools/il-verify/il-verify.cpp
@@ -4,6 +4,7 @@
 // Ownership/Lifetime: Tool owns parsed module.
 // Links: docs/class-catalog.md
 
+#include "il/core/Module.hpp"
 #include "il/io/Parser.hpp"
 #include "il/verify/Verifier.hpp"
 #include <fstream>

--- a/src/tools/ilc/cmd_run_il.cpp
+++ b/src/tools/ilc/cmd_run_il.cpp
@@ -9,6 +9,8 @@
 #include "VM/Trace.h"
 #include "break_spec.hpp"
 #include "cli.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Module.hpp"
 #include "il/io/Parser.hpp"
 #include "il/verify/Verifier.hpp"
 #include "support/source_manager.hpp"

--- a/src/vm/OpHandlers.cpp
+++ b/src/vm/OpHandlers.cpp
@@ -6,6 +6,9 @@
 
 #include "vm/OpHandlers.hpp"
 
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
 #include "il/core/Opcode.hpp"
 #include "il/core/OpcodeInfo.hpp"
 #include "vm/RuntimeBridge.hpp"

--- a/src/vm/RuntimeBridge.hpp
+++ b/src/vm/RuntimeBridge.hpp
@@ -6,7 +6,7 @@
 #pragma once
 
 #include "rt.hpp"
-#include "support/source_manager.hpp"
+#include "support/source_loc.hpp"
 #include <string>
 #include <vector>
 

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -5,6 +5,8 @@
 // Links: docs/il-spec.md
 
 #include "vm/VM.hpp"
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
 #include "il/core/Instr.hpp"
 #include "il/core/Opcode.hpp"
 #include "vm/RuntimeBridge.hpp"

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -7,8 +7,8 @@
 
 #include "VM/Debug.h"
 #include "VM/Trace.h"
-#include "il/core/Module.hpp"
 #include "il/core/Opcode.hpp"
+#include "il/core/fwd.hpp"
 #include "rt.hpp"
 #include <array>
 #include <cstdint>

--- a/src/vm/VMDebug.cpp
+++ b/src/vm/VMDebug.cpp
@@ -7,6 +7,11 @@
 #include "vm/VM.hpp"
 #include "VM/DebugScript.h"
 
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "support/source_manager.hpp"
+
 #include <filesystem>
 #include <iostream>
 #include <string>

--- a/src/vm/VMInit.cpp
+++ b/src/vm/VMInit.cpp
@@ -6,6 +6,8 @@
 
 #include "vm/VM.hpp"
 
+#include "il/core/Module.hpp"
+
 #include <cassert>
 #include <utility>
 

--- a/tests/unit/test_il_comments.cpp
+++ b/tests/unit/test_il_comments.cpp
@@ -4,6 +4,7 @@
 // Ownership/Lifetime: Test owns module and buffers locally.
 // Links: docs/il-spec.md
 
+#include "il/core/Module.hpp"
 #include "il/io/Parser.hpp"
 #include <cassert>
 #include <sstream>

--- a/tests/unit/test_il_parse_comment.cpp
+++ b/tests/unit/test_il_parse_comment.cpp
@@ -4,6 +4,7 @@
 // Ownership/Lifetime: Test owns modules and buffers locally.
 // Links: docs/il-spec.md
 
+#include "il/core/Module.hpp"
 #include "il/io/Parser.hpp"
 #include <cassert>
 #include <sstream>

--- a/tests/unit/test_il_parse_extern_missing_arrow.cpp
+++ b/tests/unit/test_il_parse_extern_missing_arrow.cpp
@@ -4,6 +4,7 @@
 // Ownership/Lifetime: Test constructs modules and buffers locally.
 // Links: docs/il-spec.md
 
+#include "il/core/Module.hpp"
 #include "il/io/Parser.hpp"
 #include <cassert>
 #include <sstream>

--- a/tests/unit/test_il_parse_invalid_type.cpp
+++ b/tests/unit/test_il_parse_invalid_type.cpp
@@ -4,6 +4,7 @@
 // Ownership/Lifetime: Test constructs modules and streams locally.
 // Links: docs/il-spec.md
 
+#include "il/core/Module.hpp"
 #include "il/io/Parser.hpp"
 #include <cassert>
 #include <sstream>

--- a/tests/unit/test_il_parse_malformed_func_header.cpp
+++ b/tests/unit/test_il_parse_malformed_func_header.cpp
@@ -4,6 +4,7 @@
 // Ownership/Lifetime: Test constructs modules and streams locally.
 // Links: docs/il-spec.md
 
+#include "il/core/Module.hpp"
 #include "il/io/Parser.hpp"
 #include <cassert>
 #include <sstream>

--- a/tests/unit/test_il_parse_missing_eq.cpp
+++ b/tests/unit/test_il_parse_missing_eq.cpp
@@ -4,6 +4,7 @@
 // Ownership/Lifetime: Test constructs modules and buffers locally.
 // Links: docs/il-spec.md
 
+#include "il/core/Module.hpp"
 #include "il/io/Parser.hpp"
 #include <cassert>
 #include <sstream>

--- a/tests/unit/test_il_parse_negative.cpp
+++ b/tests/unit/test_il_parse_negative.cpp
@@ -3,6 +3,7 @@
 // and numeric literals. Key invariants: Parser returns false for invalid input. Ownership/Lifetime:
 // Test owns all modules and buffers locally. Links: docs/il-spec.md
 
+#include "il/core/Module.hpp"
 #include "il/io/Parser.hpp"
 #include <cassert>
 #include <fstream>

--- a/tests/unit/test_il_roundtrip.cpp
+++ b/tests/unit/test_il_roundtrip.cpp
@@ -1,3 +1,4 @@
+#include "il/core/Module.hpp"
 #include "il/io/Parser.hpp"
 #include "il/io/Serializer.hpp"
 #include "il/verify/Verifier.hpp"

--- a/tests/unit/test_vm_addr_of.cpp
+++ b/tests/unit/test_vm_addr_of.cpp
@@ -4,6 +4,7 @@
 // Ownership: Test constructs IL module and executes VM.
 // Links: docs/il-reference.md
 
+#include "il/core/Module.hpp"
 #include "il/io/Parser.hpp"
 #include "rt_internal.h"
 #include "vm/VM.hpp"

--- a/tests/unit/test_vm_opcode_dispatch.cpp
+++ b/tests/unit/test_vm_opcode_dispatch.cpp
@@ -4,6 +4,7 @@
 // Ownership: Test parses in-memory IL text and executes the VM in-process.
 // Links: docs/il-spec.md
 
+#include "il/core/Module.hpp"
 #include "il/io/Parser.hpp"
 #include "vm/VM.hpp"
 #include <cassert>

--- a/tui/include/tui/input/keymap.hpp
+++ b/tui/include/tui/input/keymap.hpp
@@ -9,7 +9,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "tui/term/input.hpp"
+#include "tui/term/key_event.hpp"
 #include "tui/ui/widget.hpp"
 
 namespace viper::tui::input

--- a/tui/include/tui/term/input.hpp
+++ b/tui/include/tui/term/input.hpp
@@ -4,80 +4,14 @@
 // @ownership Does not own input buffers; owns internal event queue.
 #pragma once
 
-#include <cstdint>
+#include "tui/term/key_event.hpp"
+
 #include <string>
 #include <string_view>
 #include <vector>
 
 namespace viper::tui::term
 {
-struct KeyEvent
-{
-    enum class Code
-    {
-        Enter,
-        Esc,
-        Tab,
-        Backspace,
-        Up,
-        Down,
-        Left,
-        Right,
-        Home,
-        End,
-        PageUp,
-        PageDown,
-        Insert,
-        Delete,
-        F1,
-        F2,
-        F3,
-        F4,
-        F5,
-        F6,
-        F7,
-        F8,
-        F9,
-        F10,
-        F11,
-        F12,
-        Unknown
-    };
-
-    enum Mods : unsigned
-    {
-        Shift = 1,
-        Alt = 2,
-        Ctrl = 4
-    };
-
-    uint32_t codepoint{0};
-    Code code{Code::Unknown};
-    unsigned mods{0};
-};
-
-struct MouseEvent
-{
-    enum class Type
-    {
-        Down,
-        Up,
-        Move,
-        Wheel
-    };
-
-    Type type{Type::Move};
-    int x{0};
-    int y{0};
-    unsigned buttons{0};
-    unsigned mods{0};
-};
-
-struct PasteEvent
-{
-    std::string text{};
-};
-
 /// @brief Incremental UTF-8 decoder producing key events.
 /// @invariant Handles partial sequences across feed() calls.
 /// @ownership Stores decoded events internally.

--- a/tui/include/tui/term/key_event.hpp
+++ b/tui/include/tui/term/key_event.hpp
@@ -1,0 +1,84 @@
+// tui/include/tui/term/key_event.hpp
+// @brief Lightweight POD event types shared between term input and UI layers.
+// @invariant Modifier bits use the Mods enum; Code enumerators cover supported keys.
+// @ownership Plain value types; no ownership semantics.
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace viper::tui::term
+{
+/// @brief Discrete keyboard key event with optional Unicode codepoint.
+struct KeyEvent
+{
+    /// @brief Logical key codes recognised by the terminal decoder.
+    enum class Code
+    {
+        Enter,
+        Esc,
+        Tab,
+        Backspace,
+        Up,
+        Down,
+        Left,
+        Right,
+        Home,
+        End,
+        PageUp,
+        PageDown,
+        Insert,
+        Delete,
+        F1,
+        F2,
+        F3,
+        F4,
+        F5,
+        F6,
+        F7,
+        F8,
+        F9,
+        F10,
+        F11,
+        F12,
+        Unknown
+    };
+
+    /// @brief Modifier bit flags associated with a key press.
+    enum Mods : unsigned
+    {
+        Shift = 1,
+        Alt = 2,
+        Ctrl = 4
+    };
+
+    uint32_t codepoint{0}; ///< Unicode codepoint when available.
+    Code code{Code::Unknown}; ///< Logical key identifier.
+    unsigned mods{0};        ///< Modifier mask composed of Mods values.
+};
+
+/// @brief Terminal mouse event with button/modifier information.
+struct MouseEvent
+{
+    enum class Type
+    {
+        Down,
+        Up,
+        Move,
+        Wheel
+    };
+
+    Type type{Type::Move}; ///< Event kind.
+    int x{0};              ///< Column coordinate.
+    int y{0};              ///< Row coordinate.
+    unsigned buttons{0};   ///< Button bitmask.
+    unsigned mods{0};      ///< Modifier mask.
+};
+
+/// @brief Paste event carrying textual data.
+struct PasteEvent
+{
+    std::string text{};
+};
+
+} // namespace viper::tui::term

--- a/tui/include/tui/ui/widget.hpp
+++ b/tui/include/tui/ui/widget.hpp
@@ -4,8 +4,12 @@
 // @ownership Derived classes own their state; Widget stores layout rect.
 #pragma once
 
-#include "tui/render/screen.hpp"
-#include "tui/term/input.hpp"
+#include "tui/term/key_event.hpp"
+
+namespace viper::tui::render
+{
+class ScreenBuffer;
+} // namespace viper::tui::render
 
 namespace viper::tui::ui
 {

--- a/tui/src/ui/modal.cpp
+++ b/tui/src/ui/modal.cpp
@@ -4,6 +4,7 @@
 // @ownership ModalHost owns root and modals; Popup borrows dismiss callback.
 
 #include "tui/ui/modal.hpp"
+#include "tui/render/screen.hpp"
 
 #include <algorithm>
 

--- a/tui/tests/test_focus.cpp
+++ b/tui/tests/test_focus.cpp
@@ -4,7 +4,7 @@
 // @ownership Test owns widgets, app, and TermIO.
 
 #include "tui/app.hpp"
-#include "tui/term/input.hpp"
+#include "tui/term/key_event.hpp"
 #include "tui/term/term_io.hpp"
 #include "tui/ui/container.hpp"
 

--- a/tui/tests/test_keymap_palette.cpp
+++ b/tui/tests/test_keymap_palette.cpp
@@ -7,6 +7,7 @@
 #include "tui/render/renderer.hpp"
 #include "tui/render/screen.hpp"
 #include "tui/style/theme.hpp"
+#include "tui/term/key_event.hpp"
 #include "tui/term/term_io.hpp"
 #include "tui/widgets/command_palette.hpp"
 #include "tui/widgets/label.hpp"

--- a/tui/tests/test_list_tree.cpp
+++ b/tui/tests/test_list_tree.cpp
@@ -6,6 +6,7 @@
 #include "tui/render/renderer.hpp"
 #include "tui/render/screen.hpp"
 #include "tui/style/theme.hpp"
+#include "tui/term/key_event.hpp"
 #include "tui/term/term_io.hpp"
 #include "tui/widgets/list_view.hpp"
 #include "tui/widgets/tree_view.hpp"

--- a/tui/tests/test_modal.cpp
+++ b/tui/tests/test_modal.cpp
@@ -4,6 +4,7 @@
 // @ownership Test owns widgets, modal host, app, and TermIO.
 
 #include "tui/app.hpp"
+#include "tui/term/key_event.hpp"
 #include "tui/term/term_io.hpp"
 #include "tui/ui/modal.hpp"
 

--- a/tui/tests/test_search.cpp
+++ b/tui/tests/test_search.cpp
@@ -5,6 +5,7 @@
 
 #include "tui/render/screen.hpp"
 #include "tui/style/theme.hpp"
+#include "tui/term/key_event.hpp"
 #include "tui/text/search.hpp"
 #include "tui/text/text_buffer.hpp"
 #include "tui/views/text_view.hpp"

--- a/tui/tests/test_widgets_basic.cpp
+++ b/tui/tests/test_widgets_basic.cpp
@@ -6,6 +6,7 @@
 #include "tui/render/renderer.hpp"
 #include "tui/render/screen.hpp"
 #include "tui/style/theme.hpp"
+#include "tui/term/key_event.hpp"
 #include "tui/term/term_io.hpp"
 #include "tui/widgets/button.hpp"
 #include "tui/widgets/label.hpp"


### PR DESCRIPTION
## Summary
- introduce il/core/fwd.hpp and use it to slim VM and transform headers
- split SourceLoc into its own header and adjust parsers/tests for direct Module access
- decouple TUI widget headers, add term/key_event.hpp, and wire IWYU checks into CI

## Testing
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cc7dd1588c8324b1333b63c22598d5