### PR TITLE
feat(il): add expected entry points

### DIFF
--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -10,10 +10,19 @@
 #include "il/io/ModuleParser.hpp"
 #include "il/io/ParserUtil.hpp"
 
+#include <sstream>
 #include <string>
 
 namespace il::io
 {
+
+il::support::Expected<void> Parser::parse(std::istream &is, il::core::Module &m)
+{
+    std::ostringstream err;
+    if (parse(is, m, err))
+        return {};
+    return std::unexpected(makeError({}, err.str()));
+}
 
 bool Parser::parse(std::istream &is, il::core::Module &m, std::ostream &err)
 {

--- a/src/il/io/Parser.hpp
+++ b/src/il/io/Parser.hpp
@@ -10,9 +10,15 @@
 #include "il/io/InstrParser.hpp"
 #include "il/io/ModuleParser.hpp"
 #include "il/io/ParserState.hpp"
+#include "support/diag_expected.hpp"
 
 #include <istream>
 #include <ostream>
+
+namespace il::support
+{
+using ::Expected;
+}
 
 namespace il::io
 {
@@ -21,12 +27,18 @@ namespace il::io
 class Parser
 {
   public:
-    /// @brief Parse IL from stream into module @p m.
+    /// @brief Parse IL from stream into module @p m producing diagnostics in-stream.
     /// @param is Input stream containing IL text.
     /// @param m Module to populate with parsed contents.
     /// @param err Diagnostic output stream.
     /// @return True on success, false if parse errors occurred.
     static bool parse(std::istream &is, il::core::Module &m, std::ostream &err);
+
+    /// @brief Parse IL from stream into module @p m without writing to streams.
+    /// @param is Input stream containing IL text.
+    /// @param m Module to populate with parsed contents.
+    /// @return Empty on success, diagnostic on failure.
+    static il::support::Expected<void> parse(std::istream &is, il::core::Module &m);
 };
 
 } // namespace il::io

--- a/src/il/verify/Verifier.cpp
+++ b/src/il/verify/Verifier.cpp
@@ -7,6 +7,7 @@
 #include "il/verify/Verifier.hpp"
 
 #include <cstddef>
+#include <sstream>
 #include <utility>
 
 #include "il/core/BasicBlock.hpp"
@@ -30,6 +31,14 @@ using namespace il::core;
 
 namespace il::verify
 {
+
+il::support::Expected<void> Verifier::verify(const Module &m)
+{
+    std::ostringstream err;
+    if (verify(m, err))
+        return {};
+    return std::unexpected(makeError({}, err.str()));
+}
 
 bool Verifier::verify(const Module &m, std::ostream &err)
 {

--- a/src/il/verify/Verifier.hpp
+++ b/src/il/verify/Verifier.hpp
@@ -9,6 +9,13 @@
 #include <string>
 #include <unordered_map>
 
+#include "support/diag_expected.hpp"
+
+namespace il::support
+{
+using ::Expected;
+}
+
 namespace il::core
 {
 struct Extern;
@@ -34,6 +41,11 @@ class Verifier
     /// @param err Stream receiving diagnostic messages.
     /// @return True if verification succeeds; false otherwise.
     static bool verify(const il::core::Module &m, std::ostream &err);
+
+    /// @brief Verify module @p m without emitting diagnostics to streams.
+    /// @param m Module to verify.
+    /// @return Empty on success, diagnostic on failure.
+    static il::support::Expected<void> verify(const il::core::Module &m);
 
   private:
     /// @brief Validate extern declarations for uniqueness and known signatures.


### PR DESCRIPTION
## Summary
- add Expected-returning parser entry point that wraps the existing ostream-based API
- add Expected-returning verifier entry point wrapping the legacy surface to produce a single diagnostic

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ccc91be1f88324a31afdc965f81ec2