### PR TITLE
feat(il): add Expected entry points

### DIFF
--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -11,9 +11,20 @@
 #include "il/io/ParserUtil.hpp"
 
 #include <string>
+#include <sstream>
 
 namespace il::io
 {
+
+il::support::Expected<void> Parser::parse(std::istream &is, il::core::Module &m)
+{
+    std::ostringstream err;
+    if (parse(is, m, err))
+    {
+        return {};
+    }
+    return std::unexpected(makeError({}, err.str()));
+}
 
 bool Parser::parse(std::istream &is, il::core::Module &m, std::ostream &err)
 {

--- a/src/il/io/Parser.hpp
+++ b/src/il/io/Parser.hpp
@@ -10,9 +10,15 @@
 #include "il/io/InstrParser.hpp"
 #include "il/io/ModuleParser.hpp"
 #include "il/io/ParserState.hpp"
+#include "support/diag_expected.hpp"
 
 #include <istream>
 #include <ostream>
+
+namespace il::support
+{
+using ::Expected;
+}
 
 namespace il::io
 {
@@ -21,6 +27,12 @@ namespace il::io
 class Parser
 {
   public:
+    /// @brief Parse IL into module @p m returning structured diagnostics.
+    /// @param is Input stream containing IL text.
+    /// @param m Module to populate with parsed contents.
+    /// @return Empty on success, diagnostic on failure.
+    static il::support::Expected<void> parse(std::istream &is, il::core::Module &m);
+
     /// @brief Parse IL from stream into module @p m.
     /// @param is Input stream containing IL text.
     /// @param m Module to populate with parsed contents.

--- a/src/il/verify/Verifier.cpp
+++ b/src/il/verify/Verifier.cpp
@@ -22,6 +22,7 @@
 #include "il/verify/InstructionChecker.hpp"
 #include "il/verify/TypeInference.hpp"
 #include "il/runtime/RuntimeSignatures.hpp"
+#include <sstream>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -30,6 +31,16 @@ using namespace il::core;
 
 namespace il::verify
 {
+
+il::support::Expected<void> Verifier::verify(const Module &m)
+{
+    std::ostringstream err;
+    if (verify(m, err))
+    {
+        return {};
+    }
+    return std::unexpected(makeError({}, err.str()));
+}
 
 bool Verifier::verify(const Module &m, std::ostream &err)
 {

--- a/src/il/verify/Verifier.hpp
+++ b/src/il/verify/Verifier.hpp
@@ -5,9 +5,16 @@
 // Links: docs/il-spec.md
 #pragma once
 
+#include "support/diag_expected.hpp"
+
 #include <ostream>
 #include <string>
 #include <unordered_map>
+
+namespace il::support
+{
+using ::Expected;
+}
 
 namespace il::core
 {
@@ -29,6 +36,11 @@ class TypeInference;
 class Verifier
 {
   public:
+    /// @brief Verify module @p m returning structured diagnostics.
+    /// @param m Module to verify.
+    /// @return Empty on success, diagnostic on failure.
+    static il::support::Expected<void> verify(const il::core::Module &m);
+
     /// @brief Verify module @p m against the IL specification.
     /// @param m Module to verify.
     /// @param err Stream receiving diagnostic messages.


### PR DESCRIPTION
## Summary
- add an Expected-returning parse wrapper that funnels diagnostics through the existing bool + ostream implementation
- add an Expected-returning verify wrapper that reuses the current stream-based verifier
- surface the diag expected alias inside the parser and verifier headers so il::support::Expected works

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ccc91be1f88324a31afdc965f81ec2