### PR TITLE
feat(il): add expected entry points for parser and verifier

### DIFF
--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -10,10 +10,19 @@
 #include "il/io/ModuleParser.hpp"
 #include "il/io/ParserUtil.hpp"
 
+#include <sstream>
 #include <string>
 
 namespace il::io
 {
+
+il::support::Expected<void> Parser::parse(std::istream &is, il::core::Module &m)
+{
+    std::ostringstream err;
+    if (Parser::parse(is, m, err))
+        return {};
+    return std::unexpected(makeError({}, err.str()));
+}
 
 bool Parser::parse(std::istream &is, il::core::Module &m, std::ostream &err)
 {

--- a/src/il/io/Parser.hpp
+++ b/src/il/io/Parser.hpp
@@ -10,9 +10,19 @@
 #include "il/io/InstrParser.hpp"
 #include "il/io/ModuleParser.hpp"
 #include "il/io/ParserState.hpp"
+#include "support/diag_expected.hpp"
 
 #include <istream>
 #include <ostream>
+
+#ifndef IL_SUPPORT_EXPECTED_NS_ALIAS
+#define IL_SUPPORT_EXPECTED_NS_ALIAS
+namespace il::support
+{
+template <class T>
+using Expected = ::Expected<T>;
+}
+#endif
 
 namespace il::io
 {
@@ -27,6 +37,12 @@ class Parser
     /// @param err Diagnostic output stream.
     /// @return True on success, false if parse errors occurred.
     static bool parse(std::istream &is, il::core::Module &m, std::ostream &err);
+
+    /// @brief Parse IL from stream into module @p m returning a structured result.
+    /// @param is Input stream containing IL text.
+    /// @param m Module to populate with parsed contents.
+    /// @return Empty Expected on success, diagnostic error on failure.
+    static il::support::Expected<void> parse(std::istream &is, il::core::Module &m);
 };
 
 } // namespace il::io

--- a/src/il/verify/Verifier.cpp
+++ b/src/il/verify/Verifier.cpp
@@ -7,6 +7,7 @@
 #include "il/verify/Verifier.hpp"
 
 #include <cstddef>
+#include <sstream>
 #include <utility>
 
 #include "il/core/BasicBlock.hpp"
@@ -30,6 +31,14 @@ using namespace il::core;
 
 namespace il::verify
 {
+
+il::support::Expected<void> Verifier::verify(const Module &m)
+{
+    std::ostringstream err;
+    if (Verifier::verify(m, err))
+        return {};
+    return std::unexpected(makeError({}, err.str()));
+}
 
 bool Verifier::verify(const Module &m, std::ostream &err)
 {

--- a/src/il/verify/Verifier.hpp
+++ b/src/il/verify/Verifier.hpp
@@ -9,6 +9,17 @@
 #include <string>
 #include <unordered_map>
 
+#include "support/diag_expected.hpp"
+
+#ifndef IL_SUPPORT_EXPECTED_NS_ALIAS
+#define IL_SUPPORT_EXPECTED_NS_ALIAS
+namespace il::support
+{
+template <class T>
+using Expected = ::Expected<T>;
+}
+#endif
+
 namespace il::core
 {
 struct Extern;
@@ -34,6 +45,11 @@ class Verifier
     /// @param err Stream receiving diagnostic messages.
     /// @return True if verification succeeds; false otherwise.
     static bool verify(const il::core::Module &m, std::ostream &err);
+
+    /// @brief Verify module @p m returning a structured diagnostic on failure.
+    /// @param m Module to verify.
+    /// @return Empty Expected on success; diagnostic error on failure.
+    static il::support::Expected<void> verify(const il::core::Module &m);
 
   private:
     /// @brief Validate extern declarations for uniqueness and known signatures.


### PR DESCRIPTION
## Summary
- add `Parser::parse` overload returning `il::support::Expected<void>` while keeping the existing bool+ostream API
- introduce a matching `Verifier::verify` overload and aggregate diagnostics into a single `Diag`
- re-export the `Expected` alias in the `il::support` namespace so the new signatures compile without touching other headers

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ccc91be1f88324a31afdc965f81ec2