### PR TITLE
feat(il): add expected-based parser/verifier entry points

### DIFF
--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -10,6 +10,7 @@
 #include "il/io/ModuleParser.hpp"
 #include "il/io/ParserUtil.hpp"
 
+#include <sstream>
 #include <string>
 
 namespace il::io
@@ -29,6 +30,16 @@ bool Parser::parse(std::istream &is, il::core::Module &m, std::ostream &err)
             return false;
     }
     return !st.hasError;
+}
+
+il::support::Expected<void> Parser::parse(std::istream &is, il::core::Module &m)
+{
+    std::ostringstream err;
+    if (parse(is, m, err))
+    {
+        return {};
+    }
+    return std::unexpected(makeError(il::support::SourceLoc{}, err.str()));
 }
 
 } // namespace il::io

--- a/src/il/io/Parser.hpp
+++ b/src/il/io/Parser.hpp
@@ -10,9 +10,15 @@
 #include "il/io/InstrParser.hpp"
 #include "il/io/ModuleParser.hpp"
 #include "il/io/ParserState.hpp"
+#include "support/diag_expected.hpp"
 
 #include <istream>
 #include <ostream>
+
+namespace il::support
+{
+using ::Expected;
+}
 
 namespace il::io
 {
@@ -27,6 +33,12 @@ class Parser
     /// @param err Diagnostic output stream.
     /// @return True on success, false if parse errors occurred.
     static bool parse(std::istream &is, il::core::Module &m, std::ostream &err);
+
+    /// @brief Parse IL from a stream producing structured diagnostics.
+    /// @param is Input stream containing IL text.
+    /// @param m Module to populate with parsed contents.
+    /// @return Empty expected on success; diagnostic encapsulating failure otherwise.
+    static il::support::Expected<void> parse(std::istream &is, il::core::Module &m);
 };
 
 } // namespace il::io

--- a/src/il/verify/Verifier.cpp
+++ b/src/il/verify/Verifier.cpp
@@ -7,6 +7,7 @@
 #include "il/verify/Verifier.hpp"
 
 #include <cstddef>
+#include <sstream>
 #include <utility>
 
 #include "il/core/BasicBlock.hpp"
@@ -52,6 +53,16 @@ bool Verifier::verify(const Module &m, std::ostream &err)
     }
 
     return ok;
+}
+
+il::support::Expected<void> Verifier::verify(const Module &m)
+{
+    std::ostringstream err;
+    if (verify(m, err))
+    {
+        return {};
+    }
+    return std::unexpected(makeError(il::support::SourceLoc{}, err.str()));
 }
 
 bool Verifier::verifyExterns(const Module &m,

--- a/src/il/verify/Verifier.hpp
+++ b/src/il/verify/Verifier.hpp
@@ -5,9 +5,16 @@
 // Links: docs/il-spec.md
 #pragma once
 
+#include "support/diag_expected.hpp"
+
 #include <ostream>
 #include <string>
 #include <unordered_map>
+
+namespace il::support
+{
+using ::Expected;
+}
 
 namespace il::core
 {
@@ -34,6 +41,11 @@ class Verifier
     /// @param err Stream receiving diagnostic messages.
     /// @return True if verification succeeds; false otherwise.
     static bool verify(const il::core::Module &m, std::ostream &err);
+
+    /// @brief Verify module producing structured diagnostics.
+    /// @param m Module to verify.
+    /// @return Empty expected on success; diagnostic encapsulating failure otherwise.
+    static il::support::Expected<void> verify(const il::core::Module &m);
 
   private:
     /// @brief Validate extern declarations for uniqueness and known signatures.


### PR DESCRIPTION
## Summary
- add structured Expected-returning overloads for il::io::Parser and il::verify::Verifier
- funnel the new entry points through the existing bool+ostream implementations to preserve behavior
- wire headers to expose the Expected alias from diag_expected

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cccc6572408324835beb95c7521c3a