### PR TITLE
Switch il-verify to expected API wrappers

### DIFF
--- a/src/il/api/expected_api.hpp
+++ b/src/il/api/expected_api.hpp
@@ -27,7 +27,7 @@ inline il::support::Expected<void> parse_text_expected(std::istream &is, il::cor
     {
         return {};
     }
-    return std::unexpected(makeError({}, err.str()));
+    return il::support::Expected<void>{il::support::makeError({}, err.str())};
 }
 
 /// @brief Verify a module while capturing diagnostics in an Expected result.
@@ -40,7 +40,7 @@ inline il::support::Expected<void> verify_module_expected(const il::core::Module
     {
         return {};
     }
-    return std::unexpected(makeError({}, err.str()));
+    return il::support::Expected<void>{il::support::makeError({}, err.str())};
 }
 
 } // namespace il::api::v2

--- a/src/support/diag_expected.hpp
+++ b/src/support/diag_expected.hpp
@@ -17,6 +17,13 @@ using Diag = il::support::Diagnostic;
 
 template <class T> using Expected = std::expected<T, Diag>;
 
+namespace il::support
+{
+using ::Diag;
+
+template <class T> using Expected = ::Expected<T>;
+} // namespace il::support
+
 namespace il::support::detail
 {
 /// @brief Convert diagnostic severity to lowercase string.

--- a/src/tools/il-verify/il-verify.cpp
+++ b/src/tools/il-verify/il-verify.cpp
@@ -40,13 +40,13 @@ int main(int argc, char **argv)
     auto pe = il::api::v2::parse_text_expected(in, m);
     if (!pe)
     {
-        printDiag(pe.error(), std::cerr);
+        il::support::printDiag(pe.error(), std::cerr);
         return 1;
     }
     auto ve = il::api::v2::verify_module_expected(m);
     if (!ve)
     {
-        printDiag(ve.error(), std::cerr);
+        il::support::printDiag(ve.error(), std::cerr);
         return 1;
     }
     std::cout << "OK\n";

--- a/src/tools/il-verify/il-verify.cpp
+++ b/src/tools/il-verify/il-verify.cpp
@@ -4,12 +4,10 @@
 // Ownership/Lifetime: Tool owns parsed module.
 // Links: docs/class-catalog.md
 
-#include "il/io/Parser.hpp"
+#include "il/api/expected_api.hpp"
 #include "il/core/Module.hpp"
-#include "il/verify/Verifier.hpp"
 #include <fstream>
 #include <iostream>
-#include <sstream>
 #include <string>
 
 /// @brief CLI entry for verifying IL modules.
@@ -39,12 +37,16 @@ int main(int argc, char **argv)
         return 1;
     }
     il::core::Module m;
-    if (!il::io::Parser::parse(in, m, std::cerr))
-        return 1;
-    std::ostringstream diag;
-    if (!il::verify::Verifier::verify(m, diag))
+    auto pe = il::api::v2::parse_text_expected(in, m);
+    if (!pe)
     {
-        std::cerr << diag.str();
+        printDiag(pe.error(), std::cerr);
+        return 1;
+    }
+    auto ve = il::api::v2::verify_module_expected(m);
+    if (!ve)
+    {
+        printDiag(ve.error(), std::cerr);
         return 1;
     }
     std::cout << "OK\n";


### PR DESCRIPTION
## Summary
- include the header-only expected API in il-verify and switch the CLI to use the expected-based parse/verify helpers
- expose the Expected alias inside the il::support namespace so the wrappers compile cleanly

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68cd66032d3c83248954a7cd858c1b23