### PR TITLE
Add compile-only expected API unit test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,10 @@ add_executable(test_il_parse_invalid_type unit/test_il_parse_invalid_type.cpp)
 target_link_libraries(test_il_parse_invalid_type PRIVATE il_core il_io support)
 add_test(NAME test_il_parse_invalid_type COMMAND test_il_parse_invalid_type)
 
+add_executable(test_expected_api_build unit/test_expected_api_build.cpp)
+target_link_libraries(test_expected_api_build PRIVATE il_core il_io support)
+add_test(NAME test_expected_api_build COMMAND test_expected_api_build)
+
 add_executable(test_il_verify_trap unit/test_il_verify_trap.cpp)
 target_link_libraries(test_il_verify_trap PRIVATE il_core il_verify support)
 add_test(NAME test_il_verify_trap COMMAND test_il_verify_trap)

--- a/tests/unit/test_expected_api_build.cpp
+++ b/tests/unit/test_expected_api_build.cpp
@@ -1,0 +1,19 @@
+// File: tests/unit/test_expected_api_build.cpp
+// Purpose: Compile-only coverage for Expected-based IL API wrappers.
+// Key invariants: Ensures headers compile and link under Clang in unit test matrix.
+// Ownership/Lifetime: Main owns module and stream for the duration of the test.
+// Links: docs/il-spec.md
+
+#include <sstream>
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+
+int main()
+{
+    il::core::Module module;
+    std::istringstream fake_stream("");
+    auto parse_result = il::api::v2::parse_text_expected(fake_stream, module);
+    (void)parse_result;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a compile-only unit test that includes the Expected API wrappers
- hook the new test into the test suite build so CI exercises the header

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cd6cb033f483249b9e990c3d05577f