### PR TITLE
Refactor parser internals to use Expected diagnostics

### DIFF
--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -9,8 +9,15 @@
 
 #include "il/io/ModuleParser.hpp"
 #include "il/io/ParserUtil.hpp"
+#include "support/diag_expected.hpp"
 
 #include <string>
+
+namespace il::io::detail
+{
+il::support::Expected<void> parseModuleHeader_E(std::istream &is, std::string &line,
+                                                ParserState &st);
+}
 
 namespace il::io
 {
@@ -25,8 +32,13 @@ bool Parser::parse(std::istream &is, il::core::Module &m, std::ostream &err)
         line = trim(line);
         if (line.empty() || line.rfind("//", 0) == 0)
             continue;
-        if (!detail::parseModuleHeader(is, line, st, err))
+        auto result = detail::parseModuleHeader_E(is, line, st);
+        if (!result)
+        {
+            il::support::printDiag(result.error(), err);
+            st.hasError = true;
             return false;
+        }
     }
     return !st.hasError;
 }


### PR DESCRIPTION
## Summary
- convert the function parser's internal helpers to return `Expected<void>` while keeping the public bool shims
- switch module-level parsing to the new Expected helpers and adapt the parser loop accordingly
- update `Parser::parse` to call the Expected-based helpers and funnel diagnostics through the facade

## Testing
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cd7c3d2a7c8324acb77abcad05c285