### PR TITLE
refactor(il): switch tools and tests to expected wrappers

### DIFF
--- a/src/tools/ilc/cmd_front_basic.cpp
+++ b/src/tools/ilc/cmd_front_basic.cpp
@@ -11,8 +11,8 @@
 #include "frontends/basic/Lowerer.hpp"
 #include "frontends/basic/Parser.hpp"
 #include "frontends/basic/SemanticAnalyzer.hpp"
+#include "il/api/expected_api.hpp"
 #include "il/io/Serializer.hpp"
-#include "il/verify/Verifier.hpp"
 #include "support/source_manager.hpp"
 #include "vm/VM.hpp"
 #include <cstdint>
@@ -124,8 +124,12 @@ int cmdFrontBasic(int argc, char **argv)
         io::Serializer::write(m, std::cout);
         return 0;
     }
-    if (!verify::Verifier::verify(m, std::cerr))
+    auto ve = il::api::v2::verify_module_expected(m);
+    if (!ve)
+    {
+        il::support::printDiag(ve.error(), std::cerr);
         return 1;
+    }
     if (!sharedOpts.stdinPath.empty())
     {
         if (!freopen(sharedOpts.stdinPath.c_str(), "r", stdin))

--- a/src/tools/ilc/cmd_il_opt.cpp
+++ b/src/tools/ilc/cmd_il_opt.cpp
@@ -6,7 +6,7 @@
 
 #include "Passes/Mem2Reg.h"
 #include "cli.hpp"
-#include "il/io/Parser.hpp"
+#include "il/api/expected_api.hpp"
 #include "il/io/Serializer.hpp"
 #include "il/transform/ConstFold.hpp"
 #include "il/transform/DCE.hpp"
@@ -87,8 +87,12 @@ int cmdILOpt(int argc, char **argv)
         return 1;
     }
     core::Module m;
-    if (!io::Parser::parse(ifs, m, std::cerr))
+    auto pe = il::api::v2::parse_text_expected(ifs, m);
+    if (!pe)
+    {
+        il::support::printDiag(pe.error(), std::cerr);
         return 1;
+    }
     transform::PassManager pm;
     pm.registerModulePass(
         "constfold",

--- a/tests/unit/test_il_comments.cpp
+++ b/tests/unit/test_il_comments.cpp
@@ -4,7 +4,7 @@
 // Ownership/Lifetime: Test owns module and buffers locally.
 // Links: docs/il-spec.md
 
-#include "il/io/Parser.hpp"
+#include "il/api/expected_api.hpp"
 #include "il/core/Module.hpp"
 #include <cassert>
 #include <sstream>
@@ -21,10 +21,14 @@ entry:
 )";
     std::istringstream in(src);
     il::core::Module m;
-    std::ostringstream err;
-    bool ok = il::io::Parser::parse(in, m, err);
-    assert(ok);
-    assert(err.str().empty());
+    std::ostringstream diag;
+    auto pe = il::api::v2::parse_text_expected(in, m);
+    if (!pe)
+    {
+        il::support::printDiag(pe.error(), diag);
+    }
+    assert(pe);
+    assert(diag.str().empty());
     assert(m.functions.size() == 1);
     return 0;
 }

--- a/tests/unit/test_il_parse_comment.cpp
+++ b/tests/unit/test_il_parse_comment.cpp
@@ -4,7 +4,7 @@
 // Ownership/Lifetime: Test owns modules and buffers locally.
 // Links: docs/il-spec.md
 
-#include "il/io/Parser.hpp"
+#include "il/api/expected_api.hpp"
 #include "il/core/Module.hpp"
 #include <cassert>
 #include <sstream>
@@ -20,10 +20,14 @@ entry:
 )";
     std::istringstream in(src);
     il::core::Module m;
-    std::ostringstream err;
-    bool ok = il::io::Parser::parse(in, m, err);
-    assert(ok);
-    assert(err.str().empty());
+    std::ostringstream diag;
+    auto pe = il::api::v2::parse_text_expected(in, m);
+    if (!pe)
+    {
+        il::support::printDiag(pe.error(), diag);
+    }
+    assert(pe);
+    assert(diag.str().empty());
     assert(m.functions.size() == 1);
     return 0;
 }

--- a/tests/unit/test_il_parse_extern_missing_arrow.cpp
+++ b/tests/unit/test_il_parse_extern_missing_arrow.cpp
@@ -4,7 +4,7 @@
 // Ownership/Lifetime: Test constructs modules and buffers locally.
 // Links: docs/il-spec.md
 
-#include "il/io/Parser.hpp"
+#include "il/api/expected_api.hpp"
 #include "il/core/Module.hpp"
 #include <cassert>
 #include <sstream>
@@ -20,10 +20,14 @@ entry:
 )";
     std::istringstream in(src);
     il::core::Module m;
-    std::ostringstream err;
-    bool ok = il::io::Parser::parse(in, m, err);
-    assert(!ok);
-    std::string msg = err.str();
+    std::ostringstream diag;
+    auto pe = il::api::v2::parse_text_expected(in, m);
+    if (!pe)
+    {
+        il::support::printDiag(pe.error(), diag);
+    }
+    assert(!pe);
+    std::string msg = diag.str();
     assert(msg.find("missing '->'") != std::string::npos);
     return 0;
 }

--- a/tests/unit/test_il_parse_invalid_type.cpp
+++ b/tests/unit/test_il_parse_invalid_type.cpp
@@ -4,7 +4,7 @@
 // Ownership/Lifetime: Test constructs modules and streams locally.
 // Links: docs/il-spec.md
 
-#include "il/io/Parser.hpp"
+#include "il/api/expected_api.hpp"
 #include "il/core/Module.hpp"
 #include <cassert>
 #include <sstream>
@@ -16,10 +16,14 @@ extern @foo(i32) -> i64
 )";
     std::istringstream in(src);
     il::core::Module m;
-    std::ostringstream err;
-    bool ok = il::io::Parser::parse(in, m, err);
-    assert(!ok);
-    std::string msg = err.str();
+    std::ostringstream diag;
+    auto pe = il::api::v2::parse_text_expected(in, m);
+    if (!pe)
+    {
+        il::support::printDiag(pe.error(), diag);
+    }
+    assert(!pe);
+    std::string msg = diag.str();
     assert(msg.find("unknown type") != std::string::npos);
     return 0;
 }

--- a/tests/unit/test_il_parse_malformed_func_header.cpp
+++ b/tests/unit/test_il_parse_malformed_func_header.cpp
@@ -4,7 +4,7 @@
 // Ownership/Lifetime: Test constructs modules and streams locally.
 // Links: docs/il-spec.md
 
-#include "il/io/Parser.hpp"
+#include "il/api/expected_api.hpp"
 #include "il/core/Module.hpp"
 #include <cassert>
 #include <sstream>
@@ -16,10 +16,14 @@ func @main() -> i32
 )";
     std::istringstream in(src);
     il::core::Module m;
-    std::ostringstream err;
-    bool ok = il::io::Parser::parse(in, m, err);
-    assert(!ok);
-    std::string msg = err.str();
+    std::ostringstream diag;
+    auto pe = il::api::v2::parse_text_expected(in, m);
+    if (!pe)
+    {
+        il::support::printDiag(pe.error(), diag);
+    }
+    assert(!pe);
+    std::string msg = diag.str();
     assert(msg.find("malformed function header") != std::string::npos);
     return 0;
 }

--- a/tests/unit/test_il_parse_missing_eq.cpp
+++ b/tests/unit/test_il_parse_missing_eq.cpp
@@ -4,7 +4,7 @@
 // Ownership/Lifetime: Test constructs modules and buffers locally.
 // Links: docs/il-spec.md
 
-#include "il/io/Parser.hpp"
+#include "il/api/expected_api.hpp"
 #include "il/core/Module.hpp"
 #include <cassert>
 #include <sstream>
@@ -19,10 +19,14 @@ entry:
 )";
     std::istringstream in(src);
     il::core::Module m;
-    std::ostringstream err;
-    bool ok = il::io::Parser::parse(in, m, err);
-    assert(!ok);
-    std::string msg = err.str();
+    std::ostringstream diag;
+    auto pe = il::api::v2::parse_text_expected(in, m);
+    if (!pe)
+    {
+        il::support::printDiag(pe.error(), diag);
+    }
+    assert(!pe);
+    std::string msg = diag.str();
     assert(msg.find("missing '='") != std::string::npos);
     return 0;
 }

--- a/tests/unit/test_il_verify_trap.cpp
+++ b/tests/unit/test_il_verify_trap.cpp
@@ -4,12 +4,12 @@
 // Ownership/Lifetime: Constructs module locally for verification.
 // Links: docs/il-spec.md
 
+#include "il/api/expected_api.hpp"
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Function.hpp"
 #include "il/core/Instr.hpp"
 #include "il/core/Module.hpp"
 #include "il/core/Opcode.hpp"
-#include "il/verify/Verifier.hpp"
 #include <cassert>
 #include <sstream>
 
@@ -33,10 +33,14 @@ int main()
     fn.blocks.push_back(bb);
     m.functions.push_back(fn);
 
-    std::ostringstream err;
-    bool ok = il::verify::Verifier::verify(m, err);
-    assert(ok);
-    assert(err.str().empty());
+    std::ostringstream diag;
+    auto ve = il::api::v2::verify_module_expected(m);
+    if (!ve)
+    {
+        il::support::printDiag(ve.error(), diag);
+    }
+    assert(ve);
+    assert(diag.str().empty());
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- switch ilc subcommands that parse or verify IL to the new `il::api::v2` expected-based helpers so diagnostics are reported uniformly via `printDiag`
- update a representative batch of parser/verifier diagnostic unit tests to use the expected helpers while keeping their textual expectations intact

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cd89e3db888324baeb46cb43aa01ef