### PR TITLE
feat(il): migrate parser and verifier to Expected APIs

### DIFF
--- a/src/il/api/expected_api.hpp
+++ b/src/il/api/expected_api.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <istream>
-#include <sstream>
 
 #include "support/diag_expected.hpp"
 
@@ -22,12 +21,7 @@ namespace il::api::v2
 /// @return Empty Expected on success; diagnostic payload on parse failure.
 inline il::support::Expected<void> parse_text_expected(std::istream &is, il::core::Module &m)
 {
-    std::ostringstream err;
-    if (il::io::Parser::parse(is, m, err))
-    {
-        return {};
-    }
-    return il::support::Expected<void>{il::support::makeError({}, err.str())};
+    return il::io::Parser::parse(is, m);
 }
 
 /// @brief Verify a module while capturing diagnostics in an Expected result.
@@ -35,12 +29,7 @@ inline il::support::Expected<void> parse_text_expected(std::istream &is, il::cor
 /// @return Empty Expected on success; diagnostic payload on verification failure.
 inline il::support::Expected<void> verify_module_expected(const il::core::Module &m)
 {
-    std::ostringstream err;
-    if (il::verify::Verifier::verify(m, err))
-    {
-        return {};
-    }
-    return il::support::Expected<void>{il::support::makeError({}, err.str())};
+    return il::verify::Verifier::verify(m);
 }
 
 } // namespace il::api::v2

--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -22,7 +22,7 @@ il::support::Expected<void> parseModuleHeader_E(std::istream &is, std::string &l
 namespace il::io
 {
 
-bool Parser::parse(std::istream &is, il::core::Module &m, std::ostream &err)
+il::support::Expected<void> Parser::parse(std::istream &is, il::core::Module &m)
 {
     detail::ParserState st{m};
     std::string line;
@@ -32,15 +32,10 @@ bool Parser::parse(std::istream &is, il::core::Module &m, std::ostream &err)
         line = trim(line);
         if (line.empty() || line.rfind("//", 0) == 0)
             continue;
-        auto result = detail::parseModuleHeader_E(is, line, st);
-        if (!result)
-        {
-            il::support::printDiag(result.error(), err);
-            st.hasError = true;
-            return false;
-        }
+        if (auto result = detail::parseModuleHeader_E(is, line, st); !result)
+            return result;
     }
-    return !st.hasError;
+    return {};
 }
 
 } // namespace il::io

--- a/src/il/io/Parser.hpp
+++ b/src/il/io/Parser.hpp
@@ -10,9 +10,9 @@
 #include "il/io/InstrParser.hpp"
 #include "il/io/ModuleParser.hpp"
 #include "il/io/ParserState.hpp"
+#include "support/diag_expected.hpp"
 
 #include <istream>
-#include <ostream>
 
 namespace il::io
 {
@@ -24,9 +24,9 @@ class Parser
     /// @brief Parse IL from stream into module @p m.
     /// @param is Input stream containing IL text.
     /// @param m Module to populate with parsed contents.
-    /// @param err Diagnostic output stream.
-    /// @return True on success, false if parse errors occurred.
-    static bool parse(std::istream &is, il::core::Module &m, std::ostream &err);
+    /// @return Expected success or diagnostic on failure.
+    static il::support::Expected<void> parse(std::istream &is, il::core::Module &m);
+
 };
 
 } // namespace il::io

--- a/src/il/transform/PassManager.cpp
+++ b/src/il/transform/PassManager.cpp
@@ -15,7 +15,6 @@
 #include "il/core/Value.hpp"
 #include "il/core/Module.hpp"
 #include "il/verify/Verifier.hpp"
-#include <sstream>
 #include <utility>
 
 using namespace il::core;
@@ -473,8 +472,8 @@ void PassManager::run(core::Module &module, const Pipeline &pipeline) const
 #ifndef NDEBUG
         if (verifyBetweenPasses_)
         {
-            std::ostringstream os;
-            assert(il::verify::Verifier::verify(module, os) && "IL verification failed after pass");
+            auto verified = il::verify::Verifier::verify(module);
+            assert(verified && "IL verification failed after pass");
         }
 #endif
     }

--- a/src/il/verify/Verifier.hpp
+++ b/src/il/verify/Verifier.hpp
@@ -9,6 +9,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "support/diag_expected.hpp"
+
 namespace il::core
 {
 struct Extern;
@@ -31,9 +33,9 @@ class Verifier
   public:
     /// @brief Verify module @p m against the IL specification.
     /// @param m Module to verify.
-    /// @param err Stream receiving diagnostic messages.
-    /// @return True if verification succeeds; false otherwise.
-    static bool verify(const il::core::Module &m, std::ostream &err);
+    /// @return Expected success or diagnostic on failure.
+    static il::support::Expected<void> verify(const il::core::Module &m);
+
 
   private:
     /// @brief Validate extern declarations for uniqueness and known signatures.

--- a/tests/unit/test_il_parse_negative.cpp
+++ b/tests/unit/test_il_parse_negative.cpp
@@ -3,7 +3,7 @@
 // and numeric literals. Key invariants: Parser returns false for invalid input. Ownership/Lifetime:
 // Test owns all modules and buffers locally. Links: docs/il-spec.md
 
-#include "il/io/Parser.hpp"
+#include "il/api/expected_api.hpp"
 #include "il/core/Module.hpp"
 #include <cassert>
 #include <fstream>
@@ -25,9 +25,8 @@ int main()
         buf << in.rdbuf();
         buf.seekg(0);
         il::core::Module m;
-        std::ostringstream err;
-        bool ok = il::io::Parser::parse(buf, m, err);
-        assert(!ok);
+        auto parse = il::api::v2::parse_text_expected(buf, m);
+        assert(!parse);
     }
     return 0;
 }

--- a/tests/unit/test_il_pass_manager.cpp
+++ b/tests/unit/test_il_pass_manager.cpp
@@ -4,8 +4,8 @@
 // Ownership: Test constructs a module in-memory and runs passes locally.
 // Links: docs/class-catalog.md
 
+#include "il/api/expected_api.hpp"
 #include "il/core/Module.hpp"
-#include "il/io/Parser.hpp"
 #include "il/transform/PassManager.hpp"
 #include <cassert>
 #include <sstream>
@@ -27,9 +27,8 @@ int main()
 {
     core::Module module;
     std::istringstream input(kProgram);
-    std::ostringstream errs;
-    bool parsed = io::Parser::parse(input, module, errs);
-    assert(parsed && errs.str().empty());
+    auto parsed = il::api::v2::parse_text_expected(input, module);
+    assert(parsed);
 
     transform::PassManager pm;
 

--- a/tests/unit/test_il_roundtrip.cpp
+++ b/tests/unit/test_il_roundtrip.cpp
@@ -1,7 +1,6 @@
-#include "il/io/Parser.hpp"
+#include "il/api/expected_api.hpp"
 #include "il/core/Module.hpp"
 #include "il/io/Serializer.hpp"
-#include "il/verify/Verifier.hpp"
 #include <cassert>
 #include <fstream>
 #include <sstream>
@@ -23,15 +22,13 @@ int main()
         buf << in.rdbuf();
         buf.seekg(0);
         il::core::Module m1;
-        std::ostringstream err1;
-        bool ok = il::io::Parser::parse(buf, m1, err1);
-        assert(ok && err1.str().empty());
+        auto parse1 = il::api::v2::parse_text_expected(buf, m1);
+        assert(parse1);
         std::string s1 = il::io::Serializer::toString(m1);
         std::istringstream in2(s1);
         il::core::Module m2;
-        std::ostringstream err2;
-        ok = il::io::Parser::parse(in2, m2, err2);
-        assert(ok && err2.str().empty());
+        auto parse2 = il::api::v2::parse_text_expected(in2, m2);
+        assert(parse2);
         std::string s2 = il::io::Serializer::toString(m2);
         if (!s1.empty() && s1.back() == '\n')
             s1.pop_back();

--- a/tests/unit/test_vm_addr_of.cpp
+++ b/tests/unit/test_vm_addr_of.cpp
@@ -4,7 +4,7 @@
 // Ownership: Test constructs IL module and executes VM.
 // Links: docs/il-reference.md
 
-#include "il/io/Parser.hpp"
+#include "il/api/expected_api.hpp"
 #include "il/core/Module.hpp"
 #include "rt_internal.h"
 #include "vm/VM.hpp"
@@ -27,9 +27,8 @@ int main()
 
     il::core::Module m;
     std::istringstream is(il);
-    std::ostringstream err;
-    bool ok = il::io::Parser::parse(is, m, err);
-    assert(ok && err.str().empty());
+    auto parse = il::api::v2::parse_text_expected(is, m);
+    assert(parse);
 
     il::vm::VM vm(m);
     int64_t rv = vm.run();

--- a/tests/unit/test_vm_opcode_dispatch.cpp
+++ b/tests/unit/test_vm_opcode_dispatch.cpp
@@ -4,7 +4,7 @@
 // Ownership: Test parses in-memory IL text and executes the VM in-process.
 // Links: docs/il-spec.md
 
-#include "il/io/Parser.hpp"
+#include "il/api/expected_api.hpp"
 #include "il/core/Module.hpp"
 #include "vm/VM.hpp"
 #include <cassert>
@@ -74,9 +74,8 @@ merge(%val: i64, %flag: i64):
 
     il::core::Module m;
     std::istringstream is(il);
-    std::ostringstream err;
-    bool ok = il::io::Parser::parse(is, m, err);
-    assert(ok && err.str().empty());
+    auto parse = il::api::v2::parse_text_expected(is, m);
+    assert(parse);
 
     il::vm::VM vm(m);
     int64_t rv = vm.run();


### PR DESCRIPTION
## Summary
- expose Expected-based parser and verifier entry points and aggregate verifier warnings into returned diagnostics
- route the v2 Expected helpers and debug-time pass manager verification through the new APIs
- update unit tests to consume the Expected wrappers and remove the legacy bool overloads

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68cd8e69d8c483248af881021bf09c32