### PR TITLE
docs(vm): document memory op handler invariants

### DIFF
--- a/src/vm/mem_ops.cpp
+++ b/src/vm/mem_ops.cpp
@@ -1,6 +1,8 @@
 // File: src/vm/mem_ops.cpp
-// Purpose: Implement VM handlers for memory and pointer operations.
-// Key invariants: Operations respect frame stack bounds and type semantics.
+// Purpose: Implement VM handlers for memory and pointer operations (MIT License,
+// see LICENSE).
+// Key invariants: Operations respect frame stack bounds, pointer provenance,
+// and type semantics.
 // Ownership/Lifetime: Handlers mutate the active frame without retaining state.
 // Links: docs/il-spec.md
 
@@ -20,6 +22,19 @@ using namespace il::core;
 namespace il::vm::detail
 {
 
+/// Handles `alloca` instructions by reserving zero-initialized stack space for
+/// the current frame.
+///
+/// The handler expects an operand describing the allocation size in bytes and
+/// raises a runtime trap when it is missing or negative. The frame stack is
+/// treated as a bump allocator; callers rely on the invariant that `fr.sp +
+/// size <= fr.stack.size()` (enforced in debug builds) so allocations never
+/// escape the stack bounds.
+///
+/// @param vm   Virtual machine instance used for operand evaluation and traps.
+/// @param fr   Active frame whose stack pointer is advanced.
+/// @param in   IL instruction supplying the allocation size and destination.
+/// @return ExecResult indicating whether execution should continue or unwind.
 VM::ExecResult OpHandlers::handleAlloca(VM &vm,
                                         Frame &fr,
                                         const Instr &in,
@@ -59,6 +74,18 @@ VM::ExecResult OpHandlers::handleAlloca(VM &vm,
     return {};
 }
 
+/// Loads a value from memory into a temporary according to the instruction's
+/// type annotation.
+///
+/// The handler evaluates the source pointer operand, asserting that it is
+/// non-null, and then performs a type-directed `switch` to reinterpret the
+/// pointed-to bytes. Callers must ensure the pointer references a live object
+/// of the declared type; violating this breaks pointer provenance invariants
+/// and is undefined from the VM's perspective.
+///
+/// @param vm Virtual machine providing operand evaluation.
+/// @param fr Current frame receiving the loaded slot.
+/// @param in Instruction describing the pointer operand and result type.
 VM::ExecResult OpHandlers::handleLoad(VM &vm,
                                       Frame &fr,
                                       const Instr &in,
@@ -100,6 +127,18 @@ VM::ExecResult OpHandlers::handleLoad(VM &vm,
     return {};
 }
 
+/// Stores a value to memory using type-directed semantics and triggers debug
+/// notifications for observable writes.
+///
+/// The handler evaluates the destination pointer and value operands, asserting
+/// that the pointer is non-null before dispatching on the instruction type. The
+/// type switch mirrors `handleLoad` to preserve load/store symmetry. After the
+/// write, any named temporaries route through `vm.debug.onStore`, allowing
+/// tracing hooks to observe the operation.
+///
+/// @param vm Virtual machine used to evaluate operands and access debug hooks.
+/// @param fr Active frame supplying locals and metadata.
+/// @param in Instruction describing the destination pointer, value, and type.
 VM::ExecResult OpHandlers::handleStore(VM &vm,
                                        Frame &fr,
                                        const Instr &in,
@@ -147,6 +186,17 @@ VM::ExecResult OpHandlers::handleStore(VM &vm,
     return {};
 }
 
+/// Computes a pointer by applying a byte offset to a base address, emulating
+/// the IL `gep` semantics.
+///
+/// The base pointer and offset operands are evaluated and combined with
+/// byte-level pointer arithmetic. Callers are responsible for ensuring the
+/// resulting pointer remains within the same allocation; violating that
+/// invariant undermines stack discipline and may be trapped by later loads.
+///
+/// @param vm Virtual machine used for operand evaluation.
+/// @param fr Active frame that stores the computed pointer.
+/// @param in Instruction providing the base pointer and offset.
 VM::ExecResult OpHandlers::handleGEP(VM &vm,
                                      Frame &fr,
                                      const Instr &in,
@@ -165,6 +215,16 @@ VM::ExecResult OpHandlers::handleGEP(VM &vm,
     return {};
 }
 
+/// Reifies the address of a runtime string constant for use in pointer-typed
+/// temporaries.
+///
+/// The handler forwards the runtime string pointer stored in the operand slot.
+/// The operand must already represent an immutable string managed by the
+/// runtime; consumers must not mutate through the resulting pointer.
+///
+/// @param vm Virtual machine context.
+/// @param fr Frame receiving the pointer value.
+/// @param in Instruction referencing the source string slot.
 VM::ExecResult OpHandlers::handleAddrOf(VM &vm,
                                         Frame &fr,
                                         const Instr &in,
@@ -182,6 +242,15 @@ VM::ExecResult OpHandlers::handleAddrOf(VM &vm,
     return {};
 }
 
+/// Materializes a constant string slot by forwarding the evaluated operand.
+///
+/// The handler assumes the operand already yields a pointer or tagged runtime
+/// string object and simply stores it in the destination without further
+/// transformation.
+///
+/// @param vm Virtual machine context.
+/// @param fr Frame storing the resulting slot.
+/// @param in Instruction whose first operand encodes the constant string.
 VM::ExecResult OpHandlers::handleConstStr(VM &vm,
                                           Frame &fr,
                                           const Instr &in,


### PR DESCRIPTION
## Summary
- reference the MIT license in the mem_ops.cpp header and clarify pointer invariants
- add Doxygen documentation for memory operation handlers covering traps, type switching, and debug hooks

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68cd9a91690c83249ef4a2ada5d2dc91