### PR TITLE
docs(vm): document integer op handlers

### DIFF
--- a/src/vm/int_ops.cpp
+++ b/src/vm/int_ops.cpp
@@ -1,8 +1,11 @@
+// MIT License. See LICENSE in the project root for full license information.
 // File: src/vm/int_ops.cpp
-// Purpose: Implement VM handlers for integer arithmetic and comparisons.
-// Key invariants: Results use 64-bit two's complement semantics consistent with the IL spec.
-// Ownership/Lifetime: Handlers mutate the current frame without persisting state.
-// Links: docs/il-spec.md
+// Purpose: Implement VM handlers for integer arithmetic, bitwise logic, comparisons, and
+//          1-bit conversions.
+// Key invariants: Results use 64-bit two's complement semantics consistent with the IL
+//                 reference, and handlers only mutate the current frame.
+// Links: docs/il-reference.md §Integer Arithmetic, §Bitwise and Shifts, §Comparisons,
+//        §Conversions
 
 #include "vm/OpHandlers.hpp"
 
@@ -16,6 +19,17 @@ namespace il::vm::detail
 {
 namespace
 {
+    /// @brief Apply a binary integer VM operation using evaluated operands.
+    /// @param fr Current frame that will receive the result via @c ops::storeResult.
+    /// @param in Instruction describing the opcode and destination slot.
+    /// @param lhs Pre-evaluated left operand slot.
+    /// @param rhs Pre-evaluated right operand slot.
+    /// @param compute Callable writing the resulting integer into @p out with the
+    ///        IL's wrap-around semantics for `i64` values (see docs/il-reference.md
+    ///        §Integer Arithmetic and §Types).
+    /// @return Execution result signalling normal fallthrough.
+    /// @note The helper isolates operand fetching so individual opcode handlers only
+    ///       specify the arithmetic rule while maintaining the frame mutation contract.
     template <typename Compute>
     VM::ExecResult applyBinary(Frame &fr,
                                const Instr &in,
@@ -29,6 +43,15 @@ namespace
         return {};
     }
 
+    /// @brief Apply an integer comparison producing a canonical `i1` result.
+    /// @param fr Current frame that will be updated with a 0/1 boolean outcome.
+    /// @param in Instruction describing the comparison opcode and destination slot.
+    /// @param lhs Pre-evaluated left operand slot.
+    /// @param rhs Pre-evaluated right operand slot.
+    /// @param compare Callable returning @c true when the comparison succeeds.
+    /// @return Execution result signalling normal fallthrough.
+    /// @note The result is canonicalised to the IL boolean domain (`0` or `1`) per
+    ///       docs/il-reference.md §Comparisons.
     template <typename Compare>
     VM::ExecResult applyCompare(Frame &fr,
                                 const Instr &in,
@@ -43,6 +66,17 @@ namespace
     }
 } // namespace
 
+/// @brief Interpret the `add` opcode for 64-bit integers.
+/// @param vm Active VM used to evaluate operand values.
+/// @param fr Execution frame mutated to hold the result.
+/// @param in Instruction carrying operand descriptors and destination register.
+/// @param blocks Unused lookup table for this opcode (required by signature).
+/// @param bb Unused basic block pointer for this opcode.
+/// @param ip Unused instruction index for this opcode.
+/// @return Normal execution result without control transfer.
+/// @note Operands are summed as signed 64-bit values with two's complement
+///       wrap-around, matching docs/il-reference.md §Integer Arithmetic and the
+///       `i64` type rules in §Types.
 VM::ExecResult OpHandlers::handleAdd(VM &vm,
                                      Frame &fr,
                                      const Instr &in,
@@ -59,6 +93,9 @@ VM::ExecResult OpHandlers::handleAdd(VM &vm,
                                            { out.i64 = lhsVal.i64 + rhsVal.i64; });
 }
 
+/// @brief Interpret the `sub` opcode for 64-bit integers.
+/// @note Operand evaluation and frame updates mirror @ref OpHandlers::handleAdd, with subtraction
+///       obeying two's complement wrap semantics per docs/il-reference.md §Integer Arithmetic.
 VM::ExecResult OpHandlers::handleSub(VM &vm,
                                      Frame &fr,
                                      const Instr &in,
@@ -75,6 +112,10 @@ VM::ExecResult OpHandlers::handleSub(VM &vm,
                                            { out.i64 = lhsVal.i64 - rhsVal.i64; });
 }
 
+/// @brief Interpret the `mul` opcode for 64-bit integers.
+/// @note Multiplication uses the same operand handling helpers as addition, wraps
+///       modulo 2^64 per docs/il-reference.md §Integer Arithmetic, and stores the
+///       result back into the destination register.
 VM::ExecResult OpHandlers::handleMul(VM &vm,
                                      Frame &fr,
                                      const Instr &in,
@@ -91,6 +132,9 @@ VM::ExecResult OpHandlers::handleMul(VM &vm,
                                            { out.i64 = lhsVal.i64 * rhsVal.i64; });
 }
 
+/// @brief Interpret the `xor` opcode for 64-bit integers.
+/// @note Operands are evaluated via @c vm.eval and the bitwise result is stored back
+///       into the destination register, matching docs/il-reference.md §Bitwise and Shifts.
 VM::ExecResult OpHandlers::handleXor(VM &vm,
                                      Frame &fr,
                                      const Instr &in,
@@ -107,6 +151,10 @@ VM::ExecResult OpHandlers::handleXor(VM &vm,
                                            { out.i64 = lhsVal.i64 ^ rhsVal.i64; });
 }
 
+/// @brief Interpret the `shl` opcode for integer left shifts.
+/// @note The shift count is taken from the second operand; well-formed IL keeps it within
+///       [0, 63] so the host operation remains defined, and the result is written back
+///       to the frame (docs/il-reference.md §Bitwise and Shifts).
 VM::ExecResult OpHandlers::handleShl(VM &vm,
                                      Frame &fr,
                                      const Instr &in,
@@ -123,6 +171,9 @@ VM::ExecResult OpHandlers::handleShl(VM &vm,
                                            { out.i64 = lhsVal.i64 << rhsVal.i64; });
 }
 
+/// @brief Interpret the `icmp_eq` opcode for integer equality comparisons.
+/// @note Produces a canonical `i1` value (0 or 1) stored via @c ops::storeResult,
+///       following docs/il-reference.md §Comparisons.
 VM::ExecResult OpHandlers::handleICmpEq(VM &vm,
                                         Frame &fr,
                                         const Instr &in,
@@ -139,6 +190,8 @@ VM::ExecResult OpHandlers::handleICmpEq(VM &vm,
                                           { return lhsVal.i64 == rhsVal.i64; });
 }
 
+/// @brief Interpret the `icmp_ne` opcode for integer inequality comparisons.
+/// @note Semantics mirror @ref OpHandlers::handleICmpEq with negated predicate per docs/il-reference.md §Comparisons.
 VM::ExecResult OpHandlers::handleICmpNe(VM &vm,
                                         Frame &fr,
                                         const Instr &in,
@@ -155,6 +208,9 @@ VM::ExecResult OpHandlers::handleICmpNe(VM &vm,
                                           { return lhsVal.i64 != rhsVal.i64; });
 }
 
+/// @brief Interpret the `scmp_gt` opcode for signed greater-than comparisons.
+/// @note Reads both operands as signed 64-bit integers and stores a canonical `i1`
+///       result, consistent with docs/il-reference.md §Comparisons.
 VM::ExecResult OpHandlers::handleSCmpGT(VM &vm,
                                         Frame &fr,
                                         const Instr &in,
@@ -171,6 +227,9 @@ VM::ExecResult OpHandlers::handleSCmpGT(VM &vm,
                                           { return lhsVal.i64 > rhsVal.i64; });
 }
 
+/// @brief Interpret the `scmp_lt` opcode for signed less-than comparisons.
+/// @note Shares operand evaluation and storage behaviour with other comparison handlers,
+///       producing canonical booleans per docs/il-reference.md §Comparisons.
 VM::ExecResult OpHandlers::handleSCmpLT(VM &vm,
                                         Frame &fr,
                                         const Instr &in,
@@ -187,6 +246,9 @@ VM::ExecResult OpHandlers::handleSCmpLT(VM &vm,
                                           { return lhsVal.i64 < rhsVal.i64; });
 }
 
+/// @brief Interpret the `scmp_le` opcode for signed less-or-equal comparisons.
+/// @note Uses signed ordering per docs/il-reference.md §Comparisons and returns a
+///       canonical `i1` result written into the destination register.
 VM::ExecResult OpHandlers::handleSCmpLE(VM &vm,
                                         Frame &fr,
                                         const Instr &in,
@@ -203,6 +265,9 @@ VM::ExecResult OpHandlers::handleSCmpLE(VM &vm,
                                           { return lhsVal.i64 <= rhsVal.i64; });
 }
 
+/// @brief Interpret the `scmp_ge` opcode for signed greater-or-equal comparisons.
+/// @note Completes the signed comparison set defined in docs/il-reference.md §Comparisons
+///       by writing 0 or 1 into the destination register.
 VM::ExecResult OpHandlers::handleSCmpGE(VM &vm,
                                         Frame &fr,
                                         const Instr &in,
@@ -219,6 +284,9 @@ VM::ExecResult OpHandlers::handleSCmpGE(VM &vm,
                                           { return lhsVal.i64 >= rhsVal.i64; });
 }
 
+/// @brief Interpret the `trunc1`/`zext1` opcodes that normalise between `i1` and `i64`.
+/// @note The operand is masked to the least-significant bit so the stored value is a
+///       canonical boolean per docs/il-reference.md §Conversions.
 VM::ExecResult OpHandlers::handleTruncOrZext1(VM &vm,
                                               Frame &fr,
                                               const Instr &in,


### PR DESCRIPTION
## Summary
- add an MIT license notice and expanded header for the integer opcode handlers
- document the integer helper templates and per-op handlers with Doxygen comments and IL spec references

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cd9a7785e08324bcf6c4a9c105b1b0