### PR TITLE
docs(vm): document control flow handlers

### DIFF
--- a/src/vm/control_flow.cpp
+++ b/src/vm/control_flow.cpp
@@ -1,3 +1,4 @@
+// MIT License. See LICENSE in the project root for full license information.
 // File: src/vm/control_flow.cpp
 // Purpose: Implement VM handlers for branching, calls, and traps.
 // Key invariants: Control-flow handlers maintain block parameters and frame state.
@@ -20,6 +21,18 @@ using namespace il::core;
 
 namespace il::vm::detail
 {
+/// @brief Transfer control to a branch target and seed its parameter slots.
+/// @param vm Active VM used to evaluate branch argument values.
+/// @param fr Current frame receiving parameter updates for the successor block.
+/// @param in Branch or terminator instruction describing successor labels and arguments.
+/// @param idx Index of the branch label/argument tuple that should be taken.
+/// @param blocks Mapping from block labels to IR blocks; lookup must succeed (verified).
+/// @param bb Output reference updated to the resolved successor block pointer.
+/// @param ip Output instruction index reset to start executing at the new block.
+/// @return Execution result flagged as a jump without producing a value.
+/// @note Invariant: the branch target must exist in @p blocks; malformed IL would have
+///       been rejected earlier by verification. When present, branch arguments are
+///       evaluated and copied into the target block parameters before control moves.
 VM::ExecResult OpHandlers::branchToTarget(VM &vm,
                                           Frame &fr,
                                           const Instr &in,
@@ -48,6 +61,17 @@ VM::ExecResult OpHandlers::branchToTarget(VM &vm,
     return result;
 }
 
+/// @brief Handle an unconditional `br` terminator by taking the sole successor.
+/// @param vm Active VM instance (forwarded to @ref branchToTarget for argument eval).
+/// @param fr Current execution frame that will carry the successor's parameters.
+/// @param in Instruction describing the successor label and optional argument tuple.
+/// @param blocks Mapping of reachable blocks for the parent function.
+/// @param bb Output reference receiving the successor block pointer.
+/// @param ip Output instruction index reset to the start of the new block.
+/// @return Execution result indicating a taken jump.
+/// @note Invariant: the first label entry in @p in is the unconditional successor and
+///       must resolve within @p blocks; argument propagation mirrors
+///       @ref OpHandlers::branchToTarget.
 VM::ExecResult OpHandlers::handleBr(VM &vm,
                                     Frame &fr,
                                     const Instr &in,
@@ -58,6 +82,17 @@ VM::ExecResult OpHandlers::handleBr(VM &vm,
     return branchToTarget(vm, fr, in, 0, blocks, bb, ip);
 }
 
+/// @brief Handle a conditional `cbr` terminator by selecting between two successors.
+/// @param vm Active VM used to evaluate the boolean branch condition.
+/// @param fr Current frame whose parameters are rewritten for the chosen successor.
+/// @param in Instruction providing the condition operand and two successor labels.
+/// @param blocks Mapping of blocks for the current function; both labels must resolve.
+/// @param bb Output reference receiving the chosen successor block pointer.
+/// @param ip Output instruction index reset to the beginning of the successor block.
+/// @return Execution result indicating a taken jump to the selected block.
+/// @note Invariant: @p in must supply exactly two branch labels whose entries exist in
+///       @p blocks. The truthiness of the evaluated `i1` operand selects between index
+///       0 (true) and 1 (false) before delegating to @ref branchToTarget.
 VM::ExecResult OpHandlers::handleCBr(VM &vm,
                                      Frame &fr,
                                      const Instr &in,
@@ -70,6 +105,17 @@ VM::ExecResult OpHandlers::handleCBr(VM &vm,
     return branchToTarget(vm, fr, in, targetIdx, blocks, bb, ip);
 }
 
+/// @brief Handle a `ret` terminator by yielding control to the caller.
+/// @param vm Active VM used to evaluate an optional return operand.
+/// @param fr Current frame whose result is propagated through @ref VM::ExecResult.
+/// @param in Instruction describing the return operand (if present).
+/// @param blocks Unused lookup table required by the handler signature.
+/// @param bb Unused basic block reference for this terminator.
+/// @param ip Unused instruction pointer reference for this terminator.
+/// @return Execution result flagged with @c returned and carrying an optional value.
+/// @note Invariant: when a return operand exists it is evaluated exactly once and the
+///       resulting slot is stored in the execution result; control never touches
+///       subsequent instructions within the block.
 VM::ExecResult OpHandlers::handleRet(VM &vm,
                                      Frame &fr,
                                      const Instr &in,
@@ -87,6 +133,18 @@ VM::ExecResult OpHandlers::handleRet(VM &vm,
     return result;
 }
 
+/// @brief Handle direct and indirect function calls from within the VM.
+/// @param vm Active VM responsible for resolving internal callee definitions.
+/// @param fr Current frame providing argument values and storing call results.
+/// @param in Instruction describing the callee symbol and operand list.
+/// @param blocks Unused block map parameter required by the generic handler signature.
+/// @param bb Current basic block, used only for diagnostic context if bridging.
+/// @param ip Unused instruction pointer reference for this opcode.
+/// @return Execution result representing normal fallthrough.
+/// @note Invariant: all operand slots are evaluated prior to dispatch. If the callee
+///       exists in @p vm.fnMap, the VM executes it natively; otherwise
+///       @ref RuntimeBridge routes the call to the runtime. Any produced value is
+///       stored via @ref ops::storeResult, ensuring the destination slot is updated.
 VM::ExecResult OpHandlers::handleCall(VM &vm,
                                       Frame &fr,
                                       const Instr &in,
@@ -111,6 +169,17 @@ VM::ExecResult OpHandlers::handleCall(VM &vm,
     return {};
 }
 
+/// @brief Handle the `trap` terminator by delegating to the runtime bridge.
+/// @param vm Active VM (unused) included for signature uniformity.
+/// @param fr Current frame providing function metadata for diagnostics.
+/// @param in Instruction containing source location metadata for the trap.
+/// @param blocks Unused block map reference required by the handler interface.
+/// @param bb Current block pointer supplying the trap's label in diagnostics.
+/// @param ip Unused instruction pointer reference for this terminator.
+/// @return Execution result flagged as @c returned to signal termination of the frame.
+/// @note Invariant: @ref RuntimeBridge::trap never returns normally; invoking it reports
+///       the trap and hands control back to the embedding host. The handler still marks
+///       the frame as returned so the VM unwinds without executing further IL.
 VM::ExecResult OpHandlers::handleTrap(VM &vm,
                                       Frame &fr,
                                       const Instr &in,


### PR DESCRIPTION
## Summary
- add an MIT license notice to the control flow handler implementation header comment
- document branch, call, and trap handlers with Doxygen comments covering invariants and runtime bridge behaviour

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cd9e1070148324948b7059aca29b4e