### PR TITLE
docs(frontends): document BASIC builtin lookups

### DIFF
--- a/src/frontends/basic/BuiltinRegistry.cpp
+++ b/src/frontends/basic/BuiltinRegistry.cpp
@@ -1,4 +1,6 @@
 // File: src/frontends/basic/BuiltinRegistry.cpp
+// License: MIT License. See LICENSE in the project root for full license
+//          information.
 // Purpose: Implements registry of BASIC built-ins for semantic analysis and
 //          lowering dispatch.
 // Key invariants: Registry entries correspond 1:1 with BuiltinCallExpr::Builtin
@@ -18,6 +20,9 @@ namespace
 {
 using B = BuiltinCallExpr::Builtin;
 
+// Dense metadata table indexed by BuiltinCallExpr::Builtin enumerators. The
+// order must remain in lockstep with the enum definition so that we can index
+// directly without translation.
 static const std::array<BuiltinInfo, 23> kBuiltins = {{
     {"LEN", 1, 1, &SemanticAnalyzer::analyzeLen, &Lowerer::lowerLen, &Lowerer::scanLen},
     {"MID$", 2, 3, &SemanticAnalyzer::analyzeMid, &Lowerer::lowerMid, &Lowerer::scanMid},
@@ -44,6 +49,8 @@ static const std::array<BuiltinInfo, 23> kBuiltins = {{
     {"ASC", 1, 1, &SemanticAnalyzer::analyzeAsc, &Lowerer::lowerAsc, &Lowerer::scanAsc},
 }};
 
+// Maps canonical BASIC source spellings to enum entries. Names must already be
+// normalized to uppercase with any suffix characters (e.g., $) preserved.
 static const std::unordered_map<std::string_view, B> kByName = {
     {"LEN", B::Len},      {"MID$", B::Mid},     {"LEFT$", B::Left}, {"RIGHT$", B::Right},
     {"STR$", B::Str},     {"VAL", B::Val},      {"INT", B::Int},    {"SQR", B::Sqr},
@@ -54,11 +61,24 @@ static const std::unordered_map<std::string_view, B> kByName = {
 };
 } // namespace
 
+/// @brief Fetch metadata for a BASIC built-in represented by its enum value.
+/// @param b Builtin enumerator to inspect.
+/// @return Reference to the metadata describing semantic, lowering, and scan
+///         hooks.
+/// @pre @p b must be a valid BuiltinCallExpr::Builtin enumerator; passing an
+///      out-of-range value results in undefined behavior due to direct array
+///      indexing.
 const BuiltinInfo &getBuiltinInfo(BuiltinCallExpr::Builtin b)
 {
     return kBuiltins[static_cast<std::size_t>(b)];
 }
 
+/// @brief Resolve a BASIC built-in enum from its source spelling.
+/// @param name Canonical BASIC keyword spelling to look up. The string is
+///        matched exactly; callers must provide the normalized uppercase form
+///        including any suffix markers.
+/// @return Built-in enumerator on success; std::nullopt when the name is not
+///         registered.
 std::optional<BuiltinCallExpr::Builtin> lookupBuiltin(std::string_view name)
 {
     auto it = kByName.find(name);


### PR DESCRIPTION
## Summary
- add the MIT license note to the BuiltinRegistry implementation header block
- document builtin metadata tables and lookup helpers with Doxygen context to clarify lookup expectations

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68cdbb5231a883248314ea75120173c3