### PR TITLE
docs(il/verify): detail type inference diagnostics

### DIFF
--- a/src/il/verify/TypeInference.cpp
+++ b/src/il/verify/TypeInference.cpp
@@ -1,3 +1,4 @@
+// MIT License. See LICENSE in the project root for full license information.
 // File: src/il/verify/TypeInference.cpp
 // Purpose: Implements IL verifier type inference and operand validation helpers.
 // Key invariants: Maintains consistency between temporary maps and defined sets.
@@ -22,6 +23,11 @@ namespace il::verify
 namespace
 {
 
+/// @brief Format the operand sequence for inclusion in diagnostics.
+/// @details Serialises value operands and successor labels so that
+///          @ref makeSnippet and operand error messages mirror IL syntax.
+/// @param instr Instruction whose operands are formatted.
+/// @return Space-prefixed operand string used by error builders.
 std::string formatOperands(const Instr &instr)
 {
     std::ostringstream os;
@@ -32,6 +38,15 @@ std::string formatOperands(const Instr &instr)
     return os.str();
 }
 
+/// @brief Build a fully qualified diagnostic line for operand issues.
+/// @details Combines function, block, formatted instruction snippet, and
+///          message text so that operand errors can report both the location
+///          and whether the issue was an unknown temporary or a use-before-def.
+/// @param fn Function containing @p instr.
+/// @param bb Basic block containing @p instr.
+/// @param instr Instruction triggering the diagnostic.
+/// @param message Specific error detail to append.
+/// @return Formatted diagnostic string used in Expected payloads.
 std::string formatInstrDiag(const Function &fn,
                             const BasicBlock &bb,
                             const Instr &instr,
@@ -46,6 +61,12 @@ std::string formatInstrDiag(const Function &fn,
 
 } // namespace
 
+/// @brief Compose a verifier snippet for operand diagnostics.
+/// @details Includes the destination temporary (if any) together with opcode
+///          and operands formatted via @ref formatOperands so diagnostics can
+///          echo the failing instruction.
+/// @param instr Instruction whose snippet is generated.
+/// @return Single-line textual representation of @p instr.
 std::string makeSnippet(const Instr &instr)
 {
     std::ostringstream os;

--- a/src/il/verify/TypeInference.hpp
+++ b/src/il/verify/TypeInference.hpp
@@ -1,3 +1,4 @@
+// MIT License. See LICENSE in the project root for full license information.
 // File: src/il/verify/TypeInference.hpp
 // Purpose: Declares utilities for IL verifier type inference and operand validation.
 // Key invariants: Tracks temporary definitions and exposes queries for operand types.
@@ -22,37 +23,62 @@ namespace il::verify
 {
 
 /// @brief Render an instruction to a short single-line snippet for diagnostics.
+/// @details The snippet mirrors the verifier trace format and is embedded into
+///          operand definition diagnostics produced by @ref TypeInference.
 /// @param instr Instruction whose textual form is requested.
 /// @return Human-readable representation used in error messages.
 std::string makeSnippet(const il::core::Instr &instr);
 
 /// @brief Helper providing operand type queries and definition tracking for verification.
+/// @details The helper keeps a shared map of temporary identifiers to inferred
+///          types plus a set describing which temporaries have been defined at
+///          a given program point.  Verification routines feed instructions to
+///          @ref recordResult and query operand state through
+///          @ref ensureOperandsDefined_E or @ref ensureOperandsDefined to
+///          surface "unknown temporary" and "use before definition" errors.
 class TypeInference
 {
   public:
     /// @brief Construct a type inference helper backed by caller storage.
+    /// @details The helper stores references to the caller-provided temporary
+    ///          table and definition set so that verifier passes can share
+    ///          state while walking a function.
     /// @param temps Mapping from temporary id to statically inferred type.
     /// @param defined Set of temporaries considered defined at the current program point.
     TypeInference(std::unordered_map<unsigned, il::core::Type> &temps,
                   std::unordered_set<unsigned> &defined);
 
     /// @brief Return the static type of a value.
+    /// @details Const and global operands map to their intrinsic types. For
+    ///          temporaries, the helper consults @p temps and optionally marks
+    ///          @p missing when an operand references an unknown id so callers
+    ///          can emit precise diagnostics.
     /// @param value Value to inspect.
     /// @param missing Optional flag set when the referenced temporary is undefined.
     /// @return The inferred type or void when unknown.
     il::core::Type valueType(const il::core::Value &value, bool *missing = nullptr) const;
 
-    /// @brief Compute the size in bytes of a primitive type.
+    /// @brief Compute the size in bytes of a primitive type tracked by the verifier.
+    /// @details Width information is used by verifier checks that must reason
+    ///          about operand footprint (e.g., memory operations). Types with
+    ///          unknown sizes report zero.
     /// @param kind Type enumerator to inspect.
     /// @return Byte width or zero when the size is unknown.
     static size_t typeSize(il::core::Type::Kind kind);
 
     /// @brief Register the result of an instruction.
+    /// @details If @p instr produces a result temporary the helper updates the
+    ///          shared table with the inferred @p type and adds the id to the
+    ///          definition set so subsequent operand checks see it as defined.
     /// @param instr Instruction whose result is being defined.
     /// @param type Static type assigned to the result temporary.
     void recordResult(const il::core::Instr &instr, il::core::Type type);
 
     /// @brief Verify that all operands of an instruction are defined.
+    /// @details Streams diagnostics to @p err describing either unknown
+    ///          temporaries (ids missing from the type table) or uses that
+    ///          precede a definition.  The helper differentiates the two cases
+    ///          via @ref valueType and @ref isDefined for precise messaging.
     /// @param fn Enclosing function used for diagnostics.
     /// @param bb Owning basic block used for diagnostics.
     /// @param instr Instruction whose operands are checked.
@@ -64,6 +90,9 @@ class TypeInference
                                std::ostream &err) const;
 
     /// @brief Verify operand definitions returning a diagnostic payload on failure.
+    /// @details Returns a populated diagnostic differentiating between unknown
+    ///          temporaries and use-before-definition errors, annotated with
+    ///          the formatted instruction snippet produced by @ref makeSnippet.
     /// @param fn Enclosing function used for diagnostics.
     /// @param bb Owning basic block used for diagnostics.
     /// @param instr Instruction whose operands are checked.


### PR DESCRIPTION
## Summary
- add the MIT license header notice to the TypeInference implementation and declaration units
- expand Doxygen comments for the instruction formatting helpers and TypeInference API to describe operand tracking and reported diagnostics

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cdc707d6cc83248db6fb54d558efb9