### PR TITLE
docs(il/transform): document pass manager helpers

### DIFF
--- a/src/il/transform/PassManager.cpp
+++ b/src/il/transform/PassManager.cpp
@@ -1,5 +1,13 @@
 // File: src/il/transform/PassManager.cpp
 // License: MIT License. See LICENSE in the project root for full license information.
+// MIT License Notice: Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use, copy,
+// modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to the following
+// conditions. The Software is provided "AS IS", without warranty of any kind, express or
+// implied, including but not limited to the warranties of merchantability, fitness for a
+// particular purpose and noninfringement.
 // Purpose: Implement the modular IL pass manager and analysis caching.
 // Key invariants: Pipelines execute in registration order; analyses obey preservation contracts.
 // Ownership/Lifetime: PassManager owns factories; AnalysisManager caches live within a run.
@@ -33,6 +41,11 @@ struct BlockState
 };
 
 /// @brief Construct predecessor and successor relationships for a function.
+/// @details Creates an empty adjacency entry for each basic block, then scans
+/// branch terminators to resolve their label targets and populate the successor
+/// and predecessor vectors inside the CFGInfo that is returned. The function
+/// only mutates the adjacency lists in the local CFGInfo; @p module and @p fn
+/// are not modified.
 /// @param module Module that owns @p fn (unused, maintained for signature parity).
 /// @param fn Function whose control-flow graph is being synthesized.
 /// @return CFG adjacency information for all blocks in @p fn.
@@ -66,6 +79,11 @@ CFGInfo buildCFG(core::Module &, core::Function &fn)
     return info;
 }
 /// @brief Compute liveness information for each block within @p fn.
+/// @details Builds a CFG, records block-local def/use sets, and then iterates a
+/// backward data-flow fixpoint that pushes successor live-in values to
+/// predecessors until convergence. The temporary BlockState map is mutated
+/// during iteration, after which the final live-in/live-out sets are copied into
+/// the returned LivenessInfo structure. Neither @p module nor @p fn is mutated.
 /// @param module Owning module used for analysis context.
 /// @param fn Function whose live-in/live-out sets should be determined.
 /// @return Liveness summary describing values live on block entry and exit.
@@ -145,17 +163,30 @@ LivenessInfo computeLiveness(core::Module &module, core::Function &fn)
 }
 
 /// @brief Adapter that wraps a module-pass callback into the ModulePass API.
+/// @details Captures a module pass identifier and callback so the pass manager
+/// can lazily produce ModulePass instances. Construction mutates only the
+/// adapter's identifier and callback members; the wrapped callable controls
+/// module mutation when invoked.
 class LambdaModulePass : public ModulePass
 {
   public:
     /// @brief Construct an adapter around the provided callback and identifier.
+    /// @details Moves @p id and @p cb into the adapter's private members so they
+    /// remain available for subsequent runs.
     LambdaModulePass(std::string id, PassManager::ModulePassCallback cb)
         : id_(std::move(id)), callback_(std::move(cb))
     {
     }
 
+    /// @brief Expose the identifier assigned to the wrapped module pass.
+    /// @details Returns a view of the cached identifier without mutating state
+    /// so the pass manager can report which pass is executing.
     std::string_view id() const override { return id_; }
 
+    /// @brief Invoke the wrapped module callback.
+    /// @details Forwards @p module and @p analysis to the stored callback which
+    /// may mutate the module and reports preservation state. The adapter keeps
+    /// its cached identifier and callback unchanged.
     PreservedAnalyses run(core::Module &module, AnalysisManager &analysis) override
     {
         return callback_(module, analysis);
@@ -167,17 +198,30 @@ class LambdaModulePass : public ModulePass
 };
 
 /// @brief Adapter that wraps a function-pass callback into the FunctionPass API.
+/// @details Captures a function pass identifier and callback so the pass manager
+/// can instantiate lightweight FunctionPass objects on demand. Construction
+/// mutates only the stored identifier and callback; function bodies are mutated
+/// by the wrapped callable at run time.
 class LambdaFunctionPass : public FunctionPass
 {
   public:
     /// @brief Construct an adapter around the provided callback and identifier.
+    /// @details Moves @p id and @p cb into the adapter to preserve them for
+    /// subsequent invocations.
     LambdaFunctionPass(std::string id, PassManager::FunctionPassCallback cb)
         : id_(std::move(id)), callback_(std::move(cb))
     {
     }
 
+    /// @brief Expose the identifier assigned to the wrapped function pass.
+    /// @details Returns a view of the cached identifier without modifying
+    /// adapter state, supporting pass diagnostics.
     std::string_view id() const override { return id_; }
 
+    /// @brief Invoke the wrapped function callback.
+    /// @details Forwards @p function and @p analysis to the stored callback,
+    /// allowing it to mutate the function and describe preserved analyses while
+    /// leaving the adapter's cached state untouched.
     PreservedAnalyses run(core::Function &function, AnalysisManager &analysis) override
     {
         return callback_(function, analysis);
@@ -191,6 +235,9 @@ class LambdaFunctionPass : public FunctionPass
 } // namespace
 
 /// @brief Return a preservation set that keeps all analyses valid.
+/// @details Sets both global preservation flags inside a local PreservedAnalyses
+/// instance and returns it, signalling that downstream passes should keep every
+/// cached analysis result.
 PreservedAnalyses PreservedAnalyses::all()
 {
     PreservedAnalyses p;
@@ -200,12 +247,17 @@ PreservedAnalyses PreservedAnalyses::all()
 }
 
 /// @brief Return a preservation set that invalidates every analysis.
+/// @details Returns a default-constructed PreservedAnalyses where no flags or
+/// explicit preservations are set, instructing the analysis manager to drop all
+/// cached data.
 PreservedAnalyses PreservedAnalyses::none()
 {
     return PreservedAnalyses{};
 }
 
 /// @brief Preserve a single module-level analysis by identifier.
+/// @details Inserts @p id into the module preservation set so invalidate
+/// routines retain that cached analysis.
 /// @param id Registered analysis identifier to retain.
 /// @return Reference to the updated preservation summary.
 PreservedAnalyses &PreservedAnalyses::preserveModule(const std::string &id)
@@ -215,6 +267,8 @@ PreservedAnalyses &PreservedAnalyses::preserveModule(const std::string &id)
 }
 
 /// @brief Preserve a single function-level analysis by identifier.
+/// @details Inserts @p id into the function preservation set so cached
+/// per-function analyses remain valid across passes.
 /// @param id Registered analysis identifier to retain.
 /// @return Reference to the updated preservation summary.
 PreservedAnalyses &PreservedAnalyses::preserveFunction(const std::string &id)
@@ -224,6 +278,8 @@ PreservedAnalyses &PreservedAnalyses::preserveFunction(const std::string &id)
 }
 
 /// @brief Mark that all module analyses remain valid after a pass.
+/// @details Sets the `preserveAllModules_` flag so cache invalidation can skip
+/// module analyses entirely.
 /// @return Reference to the updated preservation summary.
 PreservedAnalyses &PreservedAnalyses::preserveAllModules()
 {
@@ -232,6 +288,8 @@ PreservedAnalyses &PreservedAnalyses::preserveAllModules()
 }
 
 /// @brief Mark that all function analyses remain valid after a pass.
+/// @details Sets the `preserveAllFunctions_` flag so cache invalidation can skip
+/// per-function analyses entirely.
 /// @return Reference to the updated preservation summary.
 PreservedAnalyses &PreservedAnalyses::preserveAllFunctions()
 {
@@ -240,18 +298,25 @@ PreservedAnalyses &PreservedAnalyses::preserveAllFunctions()
 }
 
 /// @brief Determine whether every module analysis remains preserved.
+/// @details Returns the value of `preserveAllModules_` without mutating state,
+/// allowing callers to avoid further module analysis checks when true.
 bool PreservedAnalyses::preservesAllModuleAnalyses() const
 {
     return preserveAllModules_;
 }
 
 /// @brief Determine whether every function analysis remains preserved.
+/// @details Returns the value of `preserveAllFunctions_` without mutating
+/// state, allowing callers to avoid further function analysis checks when true.
 bool PreservedAnalyses::preservesAllFunctionAnalyses() const
 {
     return preserveAllFunctions_;
 }
 
 /// @brief Check whether a specific module analysis was preserved.
+/// @details Returns true when either the global module flag is set or @p id is
+/// present in the explicit module preservation set; the query does not mutate
+/// the tracked preservation data.
 /// @param id Analysis identifier to query.
 bool PreservedAnalyses::isModulePreserved(const std::string &id) const
 {
@@ -259,6 +324,9 @@ bool PreservedAnalyses::isModulePreserved(const std::string &id) const
 }
 
 /// @brief Check whether a specific function analysis was preserved.
+/// @details Returns true when either the global function flag is set or @p id is
+/// present in the explicit function preservation set; the query leaves
+/// preservation data untouched.
 /// @param id Analysis identifier to query.
 bool PreservedAnalyses::isFunctionPreserved(const std::string &id) const
 {
@@ -266,17 +334,28 @@ bool PreservedAnalyses::isFunctionPreserved(const std::string &id) const
 }
 
 /// @brief Determine whether any module analysis was preserved explicitly.
+/// @details Reports whether the global module flag is set or the explicit set
+/// contains entries without mutating the tracked data, guiding cache
+/// invalidation strategies.
 bool PreservedAnalyses::hasModulePreservations() const
 {
     return preserveAllModules_ || !moduleAnalyses_.empty();
 }
 
 /// @brief Determine whether any function analysis was preserved explicitly.
+/// @details Reports whether the global function flag is set or the explicit set
+/// contains entries without mutating the tracked data, guiding cache
+/// invalidation strategies.
 bool PreservedAnalyses::hasFunctionPreservations() const
 {
     return preserveAllFunctions_ || !functionAnalyses_.empty();
 }
 
+/// @brief Construct an analysis manager with registered analysis metadata.
+/// @details Stores references to the owning module along with maps describing
+/// available module and function analyses so results can be instantiated and
+/// cached later. Only internal pointers and references are initialised; caches
+/// remain empty until queries occur.
 AnalysisManager::AnalysisManager(core::Module &module,
                                  const ModuleAnalysisMap &moduleAnalyses,
                                  const FunctionAnalysisMap &functionAnalyses)
@@ -285,6 +364,12 @@ AnalysisManager::AnalysisManager(core::Module &module,
 }
 
 /// @brief Invalidate cached results following execution of a module pass.
+/// @details Clears or prunes module and function caches depending on the
+/// preservation summary returned by the pass. When @p preserved keeps no module
+/// analyses, the entire module cache is cleared; otherwise individual entries
+/// not flagged as preserved are removed. Function caches follow the same logic
+/// but remove entire maps when no analyses are retained. Both cache containers
+/// may be mutated in-place.
 /// @param preserved Preservation summary describing retained analyses.
 void AnalysisManager::invalidateAfterModulePass(const PreservedAnalyses &preserved)
 {
@@ -330,6 +415,10 @@ void AnalysisManager::invalidateAfterModulePass(const PreservedAnalyses &preserv
 }
 
 /// @brief Invalidate cached results following execution of a function pass.
+/// @details Applies the module-level invalidation logic and then removes cached
+/// function analyses associated with @p fn when they are not preserved. Buckets
+/// emptied by the removal are erased, so the per-function cache map is updated
+/// in-place.
 /// @param preserved Preservation summary describing retained analyses.
 /// @param fn Function whose cached analyses should be reconsidered.
 void AnalysisManager::invalidateAfterFunctionPass(const PreservedAnalyses &preserved, core::Function &fn)
@@ -385,6 +474,10 @@ void AnalysisManager::invalidateAfterFunctionPass(const PreservedAnalyses &prese
 }
 
 /// @brief Construct a pass manager with default analyses and verification state.
+/// @details Sets `verifyBetweenPasses_` based on build configuration and
+/// registers built-in CFG, dominator tree, and liveness analyses so they are
+/// available for later queries. Mutates the pass manager's analysis registry
+/// members while leaving the module registry empty for callers to populate.
 PassManager::PassManager()
 {
 #ifndef NDEBUG
@@ -408,6 +501,9 @@ PassManager::PassManager()
 }
 
 /// @brief Register a module pass factory under the provided identifier.
+/// @details Writes or replaces an entry in `passRegistry_` so later pipeline
+/// execution can instantiate module passes via @p factory. Mutates only the
+/// registry map.
 /// @param id Unique module pass identifier.
 /// @param factory Factory constructing a ModulePass each time the pass is scheduled.
 void PassManager::registerModulePass(const std::string &id, ModulePassFactory factory)
@@ -416,6 +512,9 @@ void PassManager::registerModulePass(const std::string &id, ModulePassFactory fa
 }
 
 /// @brief Register a module pass backed by a callback.
+/// @details Wraps @p callback in a LambdaModulePass-producing factory and stores
+/// it in `passRegistry_`, enabling pipelines to run the lambda without callers
+/// manually creating ModulePass subclasses.
 /// @param id Unique module pass identifier.
 /// @param callback Callable invoked when the pass executes.
 void PassManager::registerModulePass(const std::string &id, ModulePassCallback callback)
@@ -428,6 +527,9 @@ void PassManager::registerModulePass(const std::string &id, ModulePassCallback c
 }
 
 /// @brief Register a module pass that executes a simple mutator lambda.
+/// @details Converts the provided mutator @p fn into a callback-based module
+/// pass that always reports `PreservedAnalyses::none`, guaranteeing cached
+/// analyses are purged. Updates only the pass registry.
 /// @param id Unique module pass identifier.
 /// @param fn Callable invoked for each run; assumed to invalidate all analyses.
 void PassManager::registerModulePass(const std::string &id, const std::function<void(core::Module &)> &fn)
@@ -439,6 +541,9 @@ void PassManager::registerModulePass(const std::string &id, const std::function<
 }
 
 /// @brief Register a function pass factory under the provided identifier.
+/// @details Stores @p factory in `passRegistry_` so a new FunctionPass can be
+/// materialised for each function when the pass executes. Mutates only the
+/// registry map.
 /// @param id Unique function pass identifier.
 /// @param factory Factory constructing a FunctionPass for each function invocation.
 void PassManager::registerFunctionPass(const std::string &id, FunctionPassFactory factory)
@@ -447,6 +552,9 @@ void PassManager::registerFunctionPass(const std::string &id, FunctionPassFactor
 }
 
 /// @brief Register a function pass backed by a callback.
+/// @details Wraps @p callback in a LambdaFunctionPass-producing factory stored
+/// in `passRegistry_`, allowing pipelines to execute the lambda for each
+/// function without bespoke FunctionPass classes.
 /// @param id Unique function pass identifier.
 /// @param callback Callable invoked for each function execution.
 void PassManager::registerFunctionPass(const std::string &id, FunctionPassCallback callback)
@@ -459,6 +567,9 @@ void PassManager::registerFunctionPass(const std::string &id, FunctionPassCallba
 }
 
 /// @brief Register a function pass that executes a simple mutator lambda.
+/// @details Wraps the provided mutator @p fn in a callback that always reports
+/// `PreservedAnalyses::none`, ensuring caches associated with each function are
+/// cleared after the pass. Updates the pass registry entry for @p id.
 /// @param id Unique function pass identifier.
 /// @param fn Callable invoked for each function; assumed to invalidate all analyses.
 void PassManager::registerFunctionPass(const std::string &id, const std::function<void(core::Function &)> &fn)
@@ -470,6 +581,8 @@ void PassManager::registerFunctionPass(const std::string &id, const std::functio
 }
 
 /// @brief Register a reusable ordered list of pass identifiers.
+/// @details Moves @p pipeline into the `pipelines_` map under @p id, replacing
+/// any existing sequence so callers can execute the updated ordering later.
 /// @param id Pipeline identifier used for lookup when executing.
 /// @param pipeline Sequence of pass identifiers to execute in order.
 void PassManager::registerPipeline(const std::string &id, Pipeline pipeline)
@@ -478,6 +591,8 @@ void PassManager::registerPipeline(const std::string &id, Pipeline pipeline)
 }
 
 /// @brief Retrieve a previously registered pipeline by identifier.
+/// @details Searches `pipelines_` for @p id and returns a pointer to the stored
+/// sequence so callers can execute or inspect it without copying.
 /// @param id Pipeline identifier to search for.
 /// @return Pointer to the stored pipeline or nullptr when not registered.
 const PassManager::Pipeline *PassManager::getPipeline(const std::string &id) const
@@ -487,6 +602,8 @@ const PassManager::Pipeline *PassManager::getPipeline(const std::string &id) con
 }
 
 /// @brief Enable or disable verifier checks executed between passes.
+/// @details Mutates the `verifyBetweenPasses_` flag so debug builds either call
+/// the IL verifier after each pass or skip the extra validation step.
 /// @param enable Whether verification should run after each pass (debug only).
 void PassManager::setVerifyBetweenPasses(bool enable)
 {
@@ -494,6 +611,13 @@ void PassManager::setVerifyBetweenPasses(bool enable)
 }
 
 /// @brief Execute the provided pipeline on the supplied module.
+/// @details Constructs an AnalysisManager for @p module, iterates each
+/// identifier in @p pipeline, instantiates the referenced pass, and executes it.
+/// Module passes run once per pipeline, whereas function passes run once per
+/// function. After each pass the reported preservation summary is fed back into
+/// the analysis manager to drop invalidated caches, and debug builds optionally
+/// rerun the IL verifier. Invoked passes may mutate the module and analysis
+/// caches.
 /// @param module Module to transform.
 /// @param pipeline Ordered list of pass identifiers to execute.
 void PassManager::run(core::Module &module, const Pipeline &pipeline) const
@@ -547,6 +671,9 @@ void PassManager::run(core::Module &module, const Pipeline &pipeline) const
 }
 
 /// @brief Execute a named pipeline if it has been registered.
+/// @details Looks up @p pipelineId in the pipeline registry and delegates to
+/// `run` when present. Leaves the module untouched and returns false if the
+/// pipeline has not been registered.
 /// @param module Module to transform.
 /// @param pipelineId Identifier of the pipeline to execute.
 /// @return True if the pipeline was found and executed; otherwise false.


### PR DESCRIPTION
## Summary
- add the MIT license notice to the pass manager implementation header comment
- expand Doxygen documentation for helper functions and pass-manager methods with algorithm flow and mutation details

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cdc7213d088324bcc678c6b29a3ed8