### PR TITLE
docs(ilc): add license note and comment steps

### DIFF
--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -2,6 +2,7 @@
 // Purpose: Dispatcher for ilc subcommands.
 // Key invariants: None.
 // Ownership/Lifetime: Tool owns loaded modules.
+// License: MIT.
 // Links: docs/class-catalog.md
 
 #include "cli.hpp"
@@ -14,7 +15,10 @@
 ///          along with their expected arguments. This function serves as a
 ///          reference when no or invalid arguments are provided and mirrors the
 ///          capabilities of the associated handlers `cmdRunIL`, `cmdFrontBasic`,
-///          and `cmdILOpt`.
+///          and `cmdILOpt`. Step-by-step summary:
+///          1. Print the tool banner and each usage synopsis line.
+///          2. Emit BASIC-specific guidance.
+///          3. Append the intrinsic name list provided by the BASIC frontend.
 void usage()
 {
     std::cerr
@@ -41,9 +45,12 @@ void usage()
 /// @return Exit status of the selected subcommand or `1` on error.
 /// @details The first argument determines which handler processes the request:
 ///          `cmdRunIL` executes `.il` programs, `cmdILOpt` performs optimization
-///          passes, and `cmdFrontBasic` drives the BASIC front end. Overall
-///          flow: validate the argument count, parse the subcommand, dispatch to
-///          the matching handler, and show usage on failure.
+///          passes, and `cmdFrontBasic` drives the BASIC front end. Step-by-step
+///          summary:
+///          1. Verify that at least one subcommand argument is provided.
+///          2. Parse the subcommand token to determine the execution mode.
+///          3. Dispatch to the matching handler with the remaining arguments.
+///          4. Fall back to displaying usage when no match exists.
 int main(int argc, char **argv)
 {
     if (argc < 2)


### PR DESCRIPTION
## Summary
- add an MIT license line to the ilc main translation unit header comment
- expand the usage helper documentation with a step-by-step description of the string assembly
- extend the main entry point documentation with a step-by-step description of the argument parsing and dispatch logic

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cde028bc7483249cec291286f59366