### PR TITLE
docs(ilc): clarify cmdRunIL documentation

### DIFF
--- a/src/tools/ilc/cmd_run_il.cpp
+++ b/src/tools/ilc/cmd_run_il.cpp
@@ -1,5 +1,6 @@
 // File: src/tools/ilc/cmd_run_il.cpp
 // Purpose: Implements execution of IL programs.
+// License: MIT (see LICENSE).
 // Key invariants: None.
 // Ownership/Lifetime: Tool owns loaded modules.
 // Links: docs/class-catalog.md
@@ -28,6 +29,13 @@ using namespace il;
 
 /**
  * @brief Run an IL program from file.
+ *
+ * Execution proceeds through the following phases:
+ * 1. Process debugging-related CLI flags alongside shared `ilc` options.
+ * 2. Read the requested IL file into a module via the expected API.
+ * 3. Verify the parsed module and surface diagnostics on failure.
+ * 4. Configure the VM with stdin redirection, trace controls, and debugger setup.
+ * 5. Execute the program and report optional instruction counts and timing metrics.
  *
  * @param argc Number of subcommand arguments (excluding `-run`).
  * @param argv Argument list starting with the IL file path.


### PR DESCRIPTION
## Summary
- document the MIT license in the cmd_run_il.cpp header comment
- expand the cmdRunIL function comment to describe its main execution phases

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cde03582bc8324b85f0c32e5178d20