### PR TITLE
docs: note MIT license in BASIC parser header

### DIFF
--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -3,6 +3,7 @@
 //          delegating statement parsing to Parser_Stmt.cpp.
 // Key invariants: Relies on token buffer for lookahead.
 // Ownership/Lifetime: Parser owns tokens produced by lexer.
+// License: MIT (see LICENSE).
 // Links: docs/class-catalog.md
 
 #include "frontends/basic/Parser.hpp"


### PR DESCRIPTION
## Summary
- document the MIT licensing context in the BASIC parser implementation header comment

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cde898c9348324b386c8040f37090a