### PR TITLE
docs(frontends/basic): add license to diagnostic emitter header

### DIFF
--- a/src/frontends/basic/DiagnosticEmitter.cpp
+++ b/src/frontends/basic/DiagnosticEmitter.cpp
@@ -1,4 +1,5 @@
 // File: src/frontends/basic/DiagnosticEmitter.cpp
+// License: MIT License. See LICENSE in the project root for full license information.
 // Purpose: Implements BASIC diagnostic formatting with codes and carets.
 // Key invariants: Diagnostics printed in emission order.
 // Ownership/Lifetime: Holds copies of source text; borrows engine and manager.


### PR DESCRIPTION
## Summary
- add the standard MIT license line to DiagnosticEmitter.cpp's file header comment

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cde886aff88324a1ada4e610ec8d37