### PR TITLE
Add MIT license note to BASIC token implementation

### DIFF
--- a/src/frontends/basic/Token.cpp
+++ b/src/frontends/basic/Token.cpp
@@ -2,6 +2,7 @@
 // Purpose: Provides token utilities for BASIC frontend.
 // Key invariants: None.
 // Ownership/Lifetime: Tokens passed by value.
+// License: MIT License. See LICENSE in the project root for full license information.
 // Links: docs/class-catalog.md
 
 #include "frontends/basic/Token.hpp"


### PR DESCRIPTION
## Summary
- add the standard MIT license reference to the BASIC token implementation file header so it matches the other frontend sources

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68cde88efb648324a504b0406fa51e56