### PR TITLE
docs(il/io): add Serializer comments and license header

### DIFF
--- a/src/il/io/Serializer.cpp
+++ b/src/il/io/Serializer.cpp
@@ -1,4 +1,5 @@
 // File: src/il/io/Serializer.cpp
+// License: MIT License. See LICENSE in the project root for full license information.
 // Purpose: Implements serializer for IL modules to text.
 // Key invariants: Output is deterministic in canonical mode.
 // Ownership/Lifetime: Serializer does not own modules.
@@ -164,6 +165,14 @@ void printInstr(const Instr &in, std::ostream &os)
 
 } // namespace
 
+/// @brief Serialize an IL module into a textual stream.
+/// @param m Module to serialize; not owned.
+/// @param os Stream that receives output; not owned.
+/// @param mode Controls whether externs are emitted canonically or in definition order.
+/// Workflow: print the IL version header, emit externs (sorting them when canonical),
+/// then globals and functions by walking their basic blocks and delegating instruction
+/// formatting to @c printInstr.
+/// @returns Nothing; the serialized form is written directly to @p os.
 void Serializer::write(const Module &m, std::ostream &os, Mode mode)
 {
     os << "il " << m.version << "\n";
@@ -218,6 +227,12 @@ void Serializer::write(const Module &m, std::ostream &os, Mode mode)
     }
 }
 
+/// @brief Materialize a module's textual IL into an owned string.
+/// @param m Module to serialize; not owned.
+/// @param mode Printing strategy forwarded to @c write.
+/// Workflow: accumulate output in an @c ostringstream by delegating to @c write
+/// with the requested @p mode and return the resulting buffer.
+/// @returns Canonical or declared-order IL text depending on @p mode.
 std::string Serializer::toString(const Module &m, Mode mode)
 {
     std::ostringstream oss;


### PR DESCRIPTION
## Summary
- add the MIT license notice to the Serializer.cpp file prologue
- document Serializer::write and Serializer::toString with Doxygen-style comments covering parameters and workflow

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cde879df0c8324a3fb4c5d37da43d4