### PR TITLE
docs: reference MIT license in source manager

### DIFF
--- a/src/support/source_manager.cpp
+++ b/src/support/source_manager.cpp
@@ -1,5 +1,6 @@
 // File: src/support/source_manager.cpp
 // Purpose: Implements utilities to manage source buffers.
+// License: MIT License. See LICENSE in the project root for details.
 // Key invariants: None.
 // Ownership/Lifetime: SourceManager owns loaded buffers.
 // Links: docs/class-catalog.md
@@ -12,7 +13,7 @@ namespace il::support
 {
 
 /// @brief Register a new file path and assign it a unique identifier.
-/// @param path Filesystem path to canonicalize and store.
+/// @param path Filesystem path to lexically normalize and store.
 /// @return Identifier (>0) representing the stored path.
 uint32_t SourceManager::addFile(std::string path)
 {
@@ -22,7 +23,7 @@ uint32_t SourceManager::addFile(std::string path)
 }
 
 /// @brief Retrieve the canonical path associated with @p file_id.
-/// @param file_id Identifier previously returned by addFile().
+/// @param file_id 1-based identifier previously returned by addFile().
 /// @return Stored path, or empty string view if @p file_id is invalid.
 std::string_view SourceManager::getPath(uint32_t file_id) const
 {


### PR DESCRIPTION
## Summary
- mention the MIT license in the SourceManager implementation header
- clarify the addFile and getPath documentation about lexical normalization and 1-based identifiers

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cdea6a01188324958b7e251d9a6ade