### PR TITLE
refactor(support): centralize diag helper implementations

### DIFF
--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(support STATIC
   source_manager.cpp
   diagnostics.cpp
   arena.cpp
+  diag_expected.cpp
 )
 
 target_include_directories(support PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/src/support/diag_expected.cpp
+++ b/src/support/diag_expected.cpp
@@ -1,0 +1,44 @@
+// File: src/support/diag_expected.cpp
+// Purpose: Implements diagnostic helper functions shared across Expected utilities.
+// License: MIT License. See LICENSE in the project root for details.
+// Key invariants: Diagnostics consistently report severity and optional source locations.
+// Ownership/Lifetime: Diagnostics own their message strings; no additional ownership here.
+// Links: docs/class-catalog.md
+
+#include "diag_expected.hpp"
+
+namespace il::support
+{
+namespace detail
+{
+const char *diagSeverityToString(Severity severity)
+{
+    switch (severity)
+    {
+        case Severity::Note:
+            return "note";
+        case Severity::Warning:
+            return "warning";
+        case Severity::Error:
+            return "error";
+    }
+    return "";
+}
+} // namespace detail
+
+Diag makeError(SourceLoc loc, std::string msg)
+{
+    return Diag{Severity::Error, std::move(msg), loc};
+}
+
+void printDiag(const Diag &diag, std::ostream &os, const SourceManager *sm)
+{
+    if (diag.loc.isValid() && sm)
+    {
+        auto path = sm->getPath(diag.loc.file_id);
+        os << path << ":" << diag.loc.line << ":" << diag.loc.column << ": ";
+    }
+    os << detail::diagSeverityToString(diag.severity) << ": " << diag.message
+       << '\n';
+}
+} // namespace il::support

--- a/src/support/diag_expected.hpp
+++ b/src/support/diag_expected.hpp
@@ -104,44 +104,20 @@ template <> class Expected<void>
 namespace detail
 {
 /// @brief Convert diagnostic severity to lowercase string.
-inline const char *diagSeverityToString(Severity severity)
-{
-    switch (severity)
-    {
-        case Severity::Note:
-            return "note";
-        case Severity::Warning:
-            return "warning";
-        case Severity::Error:
-            return "error";
-    }
-    return "";
-}
+const char *diagSeverityToString(Severity severity);
 } // namespace detail
 
 /// @brief Create an error diagnostic with location and message.
 /// @param loc Optional source location associated with the diagnostic.
 /// @param msg Human-readable diagnostic message.
 /// @return Diagnostic marked as an error severity.
-inline Diag makeError(SourceLoc loc, std::string msg)
-{
-    return Diag{Severity::Error, std::move(msg), loc};
-}
+Diag makeError(SourceLoc loc, std::string msg);
 
 /// @brief Print a single diagnostic to the provided stream.
 /// @param diag Diagnostic to format.
 /// @param os Output stream receiving the text.
 /// @param sm Optional source manager to resolve file paths.
 /// @note Follows DiagnosticEngine::printAll formatting for consistency.
-inline void printDiag(const Diag &diag, std::ostream &os,
-                      const SourceManager *sm = nullptr)
-{
-    if (diag.loc.isValid() && sm)
-    {
-        auto path = sm->getPath(diag.loc.file_id);
-        os << path << ":" << diag.loc.line << ":" << diag.loc.column << ": ";
-    }
-    os << detail::diagSeverityToString(diag.severity) << ": " << diag.message
-       << '\n';
-}
+void printDiag(const Diag &diag, std::ostream &os,
+               const SourceManager *sm = nullptr);
 } // namespace il::support


### PR DESCRIPTION
## Summary
- move diagnostic helper definitions out of the header into a new src/support/diag_expected.cpp
- declare the helpers in src/support/diag_expected.hpp while keeping template definitions intact
- ensure the support target builds the new compilation unit

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cdedc4cb0c8324bddc7f0b25ce4104