### PR TITLE
build(ilc): move break spec helper to source

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,7 @@ target_link_libraries(il_vm PUBLIC il_core rt support VMTrace)
 add_library(il_codegen_x86_64 STATIC codegen/x86_64/placeholder.cpp)
 set_target_properties(il_codegen_x86_64 PROPERTIES LINKER_LANGUAGE CXX)
 
-add_executable(ilc tools/ilc/main.cpp tools/ilc/cmd_run_il.cpp tools/ilc/cmd_front_basic.cpp tools/ilc/cmd_il_opt.cpp)
+add_executable(ilc tools/ilc/main.cpp tools/ilc/cmd_run_il.cpp tools/ilc/cmd_front_basic.cpp tools/ilc/cmd_il_opt.cpp tools/ilc/break_spec.cpp)
 set_target_properties(ilc PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/ilc)
 target_link_libraries(ilc PRIVATE il_core il_io il_vm il_verify il_transform fe_basic support Passes)
 

--- a/src/tools/ilc/break_spec.cpp
+++ b/src/tools/ilc/break_spec.cpp
@@ -1,0 +1,32 @@
+// File: src/tools/ilc/break_spec.cpp
+// Purpose: Implementation helpers for parsing --break flag specifications.
+// Key invariants: Matches syntactic checks defined in header documentation.
+// Ownership/Lifetime: N/A.
+// Links: docs/class-catalog.md
+
+#include "break_spec.hpp"
+
+#include <cctype>
+
+namespace ilc
+{
+
+bool isSrcBreakSpec(const std::string &spec)
+{
+    /// Position of the colon separating file and line.
+    auto pos = spec.rfind(':');
+    if (pos == std::string::npos || pos + 1 >= spec.size())
+        return false;
+    /// Ensure all characters after the colon are digits.
+    for (std::string::size_type i = pos + 1; i < spec.size(); ++i)
+    {
+        if (!std::isdigit(static_cast<unsigned char>(spec[i])))
+            return false;
+    }
+    /// Portion before the colon; treated as a file path candidate.
+    std::string left = spec.substr(0, pos);
+    return left.find('/') != std::string::npos || left.find('\\') != std::string::npos ||
+           left.find('.') != std::string::npos;
+}
+
+} // namespace ilc

--- a/src/tools/ilc/break_spec.hpp
+++ b/src/tools/ilc/break_spec.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <cctype>
 #include <string>
 
 namespace ilc
@@ -22,22 +21,6 @@ namespace ilc
 /// otherwise.
 /// @note This check is purely syntactic and does not verify file existence or
 /// line bounds.
-inline bool isSrcBreakSpec(const std::string &spec)
-{
-    /// Position of the colon separating file and line.
-    auto pos = spec.rfind(':');
-    if (pos == std::string::npos || pos + 1 >= spec.size())
-        return false;
-    /// Ensure all characters after the colon are digits.
-    for (size_t i = pos + 1; i < spec.size(); ++i)
-    {
-        if (!std::isdigit(static_cast<unsigned char>(spec[i])))
-            return false;
-    }
-    /// Portion before the colon; treated as a file path candidate.
-    std::string left = spec.substr(0, pos);
-    return left.find('/') != std::string::npos || left.find('\\') != std::string::npos ||
-           left.find('.') != std::string::npos;
-}
+bool isSrcBreakSpec(const std::string &spec);
 
 } // namespace ilc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,7 +98,8 @@ add_executable(test_il_utils il/UtilsTests.cpp)
 target_link_libraries(test_il_utils PRIVATE IL)
 add_test(NAME test_il_utils COMMAND test_il_utils)
 
-add_executable(test_tools_break_parsing tools/BreakParsingTests.cpp)
+add_executable(test_tools_break_parsing tools/BreakParsingTests.cpp
+  ${CMAKE_SOURCE_DIR}/src/tools/ilc/break_spec.cpp)
 target_include_directories(test_tools_break_parsing PRIVATE ${CMAKE_SOURCE_DIR}/src)
 add_test(NAME test_tools_break_parsing COMMAND test_tools_break_parsing)
 


### PR DESCRIPTION
## Summary
- move the isSrcBreakSpec helper into a new break_spec.cpp implementation unit
- update the ilc tool and test_tools_break_parsing executable to compile the relocated source

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68cdf0d9ebb48324aa45ee6d9528cf3c