### PR TITLE
refactor(ilc): move shared CLI parsing implementation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,13 @@ target_link_libraries(il_vm PUBLIC il_core rt support VMTrace)
 add_library(il_codegen_x86_64 STATIC codegen/x86_64/placeholder.cpp)
 set_target_properties(il_codegen_x86_64 PROPERTIES LINKER_LANGUAGE CXX)
 
-add_executable(ilc tools/ilc/main.cpp tools/ilc/cmd_run_il.cpp tools/ilc/cmd_front_basic.cpp tools/ilc/cmd_il_opt.cpp tools/ilc/break_spec.cpp)
+add_executable(ilc
+  tools/ilc/main.cpp
+  tools/ilc/cmd_run_il.cpp
+  tools/ilc/cmd_front_basic.cpp
+  tools/ilc/cmd_il_opt.cpp
+  tools/ilc/cli.cpp
+  tools/ilc/break_spec.cpp)
 set_target_properties(ilc PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/ilc)
 target_link_libraries(ilc PRIVATE il_core il_io il_vm il_verify il_transform fe_basic support Passes)
 

--- a/src/tools/ilc/cli.cpp
+++ b/src/tools/ilc/cli.cpp
@@ -1,0 +1,55 @@
+// File: src/tools/ilc/cli.cpp
+// Purpose: Implements shared CLI option parsing for ilc subcommands.
+// Key invariants: None.
+// Ownership/Lifetime: N/A.
+// License: MIT (see LICENSE).
+// Links: docs/class-catalog.md
+
+#include "cli.hpp"
+
+namespace ilc
+{
+
+SharedOptionParseResult parseSharedOption(int &index,
+                                         int argc,
+                                         char **argv,
+                                         SharedCliOptions &opts)
+{
+    const std::string arg = argv[index];
+    if (arg == "--trace" || arg == "--trace=il")
+    {
+        opts.trace.mode = il::vm::TraceConfig::IL;
+        return SharedOptionParseResult::Parsed;
+    }
+    if (arg == "--trace=src")
+    {
+        opts.trace.mode = il::vm::TraceConfig::SRC;
+        return SharedOptionParseResult::Parsed;
+    }
+    if (arg == "--stdin-from")
+    {
+        if (index + 1 >= argc)
+        {
+            return SharedOptionParseResult::Error;
+        }
+        opts.stdinPath = argv[++index];
+        return SharedOptionParseResult::Parsed;
+    }
+    if (arg == "--max-steps")
+    {
+        if (index + 1 >= argc)
+        {
+            return SharedOptionParseResult::Error;
+        }
+        opts.maxSteps = std::stoull(argv[++index]);
+        return SharedOptionParseResult::Parsed;
+    }
+    if (arg == "--bounds-checks")
+    {
+        opts.boundsChecks = true;
+        return SharedOptionParseResult::Parsed;
+    }
+    return SharedOptionParseResult::NotMatched;
+}
+
+} // namespace ilc

--- a/src/tools/ilc/cli.hpp
+++ b/src/tools/ilc/cli.hpp
@@ -44,47 +44,10 @@ enum class SharedOptionParseResult
 /// @param argv Argument vector.
 /// @param opts Accumulator receiving parsed option values.
 /// @return Parsing outcome describing whether the argument was handled.
-inline SharedOptionParseResult parseSharedOption(int &index,
-                                                 int argc,
-                                                 char **argv,
-                                                 SharedCliOptions &opts)
-{
-    const std::string arg = argv[index];
-    if (arg == "--trace" || arg == "--trace=il")
-    {
-        opts.trace.mode = il::vm::TraceConfig::IL;
-        return SharedOptionParseResult::Parsed;
-    }
-    if (arg == "--trace=src")
-    {
-        opts.trace.mode = il::vm::TraceConfig::SRC;
-        return SharedOptionParseResult::Parsed;
-    }
-    if (arg == "--stdin-from")
-    {
-        if (index + 1 >= argc)
-        {
-            return SharedOptionParseResult::Error;
-        }
-        opts.stdinPath = argv[++index];
-        return SharedOptionParseResult::Parsed;
-    }
-    if (arg == "--max-steps")
-    {
-        if (index + 1 >= argc)
-        {
-            return SharedOptionParseResult::Error;
-        }
-        opts.maxSteps = std::stoull(argv[++index]);
-        return SharedOptionParseResult::Parsed;
-    }
-    if (arg == "--bounds-checks")
-    {
-        opts.boundsChecks = true;
-        return SharedOptionParseResult::Parsed;
-    }
-    return SharedOptionParseResult::NotMatched;
-}
+SharedOptionParseResult parseSharedOption(int &index,
+                                         int argc,
+                                         char **argv,
+                                         SharedCliOptions &opts);
 
 } // namespace ilc
 


### PR DESCRIPTION
## Summary
- move `parseSharedOption` out of the header into a dedicated `cli.cpp`
- update the ilc executable target to compile the new source file

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68ce1f0d5bf88324862273bd029727e3