### PR TITLE
refactor(vm): move storeResult helper out of header

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(il_vm STATIC
   vm/VMDebug.cpp
   vm/RuntimeBridge.cpp
   vm/OpHandlers.cpp
+  vm/OpHandlerUtils.cpp
   vm/mem_ops.cpp
   vm/int_ops.cpp
   vm/fp_ops.cpp

--- a/src/vm/OpHandlerUtils.cpp
+++ b/src/vm/OpHandlerUtils.cpp
@@ -1,0 +1,26 @@
+// File: src/vm/OpHandlerUtils.cpp
+// License: MIT License. See LICENSE in the project root for full details.
+// Purpose: Implement shared helper routines for VM opcode handlers.
+// Key invariants: Helpers operate on VM frames without leaking references.
+// Ownership/Lifetime: Functions mutate frame state in-place without storing globals.
+// Links: docs/il-spec.md
+
+#include "vm/OpHandlerUtils.hpp"
+
+#include "il/core/Instr.hpp"
+
+namespace il::vm::detail
+{
+namespace ops
+{
+void storeResult(Frame &fr, const il::core::Instr &in, const Slot &val)
+{
+    if (!in.result)
+        return;
+    if (fr.regs.size() <= *in.result)
+        fr.regs.resize(*in.result + 1);
+    fr.regs[*in.result] = val;
+}
+} // namespace ops
+} // namespace il::vm::detail
+

--- a/src/vm/OpHandlerUtils.hpp
+++ b/src/vm/OpHandlerUtils.hpp
@@ -15,14 +15,7 @@ namespace ops
 /// @param fr Current execution frame.
 /// @param in Instruction being executed.
 /// @param val Slot to write into the destination register.
-inline void storeResult(Frame &fr, const il::core::Instr &in, const Slot &val)
-{
-    if (!in.result)
-        return;
-    if (fr.regs.size() <= *in.result)
-        fr.regs.resize(*in.result + 1);
-    fr.regs[*in.result] = val;
-}
+void storeResult(Frame &fr, const il::core::Instr &in, const Slot &val);
 } // namespace ops
 } // namespace il::vm::detail
 


### PR DESCRIPTION
## Summary
- move ops::storeResult implementation from the header into a new OpHandlerUtils.cpp translation unit
- register the new implementation file with the il_vm library so the helper links correctly

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ce229af3e48324a6b900f288458585