### PR TITLE
refactor(il/core): move Value formatting out-of-line

### DIFF
--- a/src/il/core/Value.cpp
+++ b/src/il/core/Value.cpp
@@ -6,9 +6,46 @@
 
 #include "il/core/Value.hpp"
 
+#include <iomanip>
+#include <limits>
+#include <sstream>
+
 namespace il::core
 {
 
-// No out-of-line logic yet.
+std::string toString(const Value &v)
+{
+    switch (v.kind)
+    {
+        case Value::Kind::Temp:
+            return "%t" + std::to_string(v.id);
+        case Value::Kind::ConstInt:
+            return std::to_string(v.i64);
+        case Value::Kind::ConstFloat:
+        {
+            std::ostringstream oss;
+            oss.setf(std::ios::fmtflags(0), std::ios::floatfield);
+            oss << std::setprecision(std::numeric_limits<double>::digits10 + 1) << v.f64;
+            std::string s = oss.str();
+            if (v.f64 == 0.0)
+                return "0.0";
+            if (s.find('.') != std::string::npos)
+            {
+                while (!s.empty() && s.back() == '0')
+                    s.pop_back();
+                if (!s.empty() && s.back() == '.')
+                    s.pop_back();
+            }
+            return s;
+        }
+        case Value::Kind::ConstStr:
+            return "\"" + v.str + "\"";
+        case Value::Kind::GlobalAddr:
+            return "@" + v.str;
+        case Value::Kind::NullPtr:
+            return "null";
+    }
+    return "";
+}
 
 } // namespace il::core

--- a/src/il/core/Value.hpp
+++ b/src/il/core/Value.hpp
@@ -5,10 +5,8 @@
 // Links: docs/il-spec.md
 #pragma once
 
-#include <iomanip>
-#include <limits>
-#include <sstream>
 #include <string>
+#include <utility>
 
 namespace il::core
 {
@@ -91,39 +89,6 @@ struct Value
     }
 };
 
-inline std::string toString(const Value &v)
-{
-    switch (v.kind)
-    {
-        case Value::Kind::Temp:
-            return "%t" + std::to_string(v.id);
-        case Value::Kind::ConstInt:
-            return std::to_string(v.i64);
-        case Value::Kind::ConstFloat:
-        {
-            std::ostringstream oss;
-            oss.setf(std::ios::fmtflags(0), std::ios::floatfield);
-            oss << std::setprecision(std::numeric_limits<double>::digits10 + 1) << v.f64;
-            std::string s = oss.str();
-            if (v.f64 == 0.0)
-                return "0.0";
-            if (s.find('.') != std::string::npos)
-            {
-                while (!s.empty() && s.back() == '0')
-                    s.pop_back();
-                if (!s.empty() && s.back() == '.')
-                    s.pop_back();
-            }
-            return s;
-        }
-        case Value::Kind::ConstStr:
-            return "\"" + v.str + "\"";
-        case Value::Kind::GlobalAddr:
-            return "@" + v.str;
-        case Value::Kind::NullPtr:
-            return "null";
-    }
-    return "";
-}
+std::string toString(const Value &v);
 
 } // namespace il::core


### PR DESCRIPTION
## Summary
- move il::core::toString out of the header and into Value.cpp so it is emitted once
- prune formatting headers from Value.hpp, leaving only the declarations
- add the necessary `<iomanip>`, `<limits>`, and `<sstream>` includes to Value.cpp

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68ce26c882dc832485b7229579cd9a72