### PR TITLE
Refactor Type helpers out of the header

### DIFF
--- a/src/il/core/Type.cpp
+++ b/src/il/core/Type.cpp
@@ -9,6 +9,29 @@
 namespace il::core
 {
 
-// Out-of-line definitions if needed in future.
+std::string kindToString(Type::Kind k)
+{
+    switch (k)
+    {
+        case Type::Kind::Void:
+            return "void";
+        case Type::Kind::I1:
+            return "i1";
+        case Type::Kind::I64:
+            return "i64";
+        case Type::Kind::F64:
+            return "f64";
+        case Type::Kind::Ptr:
+            return "ptr";
+        case Type::Kind::Str:
+            return "str";
+    }
+    return "";
+}
+
+std::string Type::toString() const
+{
+    return kindToString(kind);
+}
 
 } // namespace il::core

--- a/src/il/core/Type.hpp
+++ b/src/il/core/Type.hpp
@@ -37,31 +37,6 @@ struct Type
 /// @brief Convert kind @p k to its mnemonic string.
 /// @param k Kind to convert.
 /// @return Lowercase mnemonic defined in the spec.
-inline std::string kindToString(Type::Kind k)
-{
-    switch (k)
-    {
-        case Type::Kind::Void:
-            return "void";
-        case Type::Kind::I1:
-            return "i1";
-        case Type::Kind::I64:
-            return "i64";
-        case Type::Kind::F64:
-            return "f64";
-        case Type::Kind::Ptr:
-            return "ptr";
-        case Type::Kind::Str:
-            return "str";
-    }
-    return "";
-}
-
-/// @brief Stringify this type.
-/// @return Lowercase mnemonic of the kind.
-inline std::string Type::toString() const
-{
-    return kindToString(kind);
-}
+std::string kindToString(Type::Kind k);
 
 } // namespace il::core


### PR DESCRIPTION
## Summary
- declare `kindToString` in the header and move its body to `Type.cpp`
- define `Type::toString` alongside `kindToString` in `Type.cpp`

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ce29bbafa08324bec9763b72abee07