### PR TITLE
refactor(il/core): out-of-line opcode helpers

### DIFF
--- a/src/il/core/OpcodeInfo.cpp
+++ b/src/il/core/OpcodeInfo.cpp
@@ -36,6 +36,16 @@ const std::array<OpcodeInfo, kNumOpcodes> kOpcodeTable = {
 
 static_assert(kOpcodeTable.size() == kNumOpcodes, "Opcode table must match enum count");
 
+const OpcodeInfo &getOpcodeInfo(Opcode op)
+{
+    return kOpcodeTable[static_cast<size_t>(op)];
+}
+
+bool isVariadicOperandCount(uint8_t value)
+{
+    return value == kVariadicOperandCount;
+}
+
 /**
  * @brief Returns the mnemonic associated with the provided opcode.
  *

--- a/src/il/core/OpcodeInfo.hpp
+++ b/src/il/core/OpcodeInfo.hpp
@@ -105,15 +105,9 @@ extern const std::array<OpcodeInfo, kNumOpcodes> kOpcodeTable;
 /// @brief Access metadata for a specific opcode.
 /// @param op Opcode to query.
 /// @return Reference to the metadata entry for @p op.
-inline const OpcodeInfo &getOpcodeInfo(Opcode op)
-{
-    return kOpcodeTable[static_cast<size_t>(op)];
-}
+const OpcodeInfo &getOpcodeInfo(Opcode op);
 
 /// @brief Determine whether @p value denotes a variadic operand upper bound.
-inline bool isVariadicOperandCount(uint8_t value)
-{
-    return value == kVariadicOperandCount;
-}
+bool isVariadicOperandCount(uint8_t value);
 
 } // namespace il::core


### PR DESCRIPTION
## Summary
- move `getOpcodeInfo` and `isVariadicOperandCount` definitions from the header into `OpcodeInfo.cpp`
- keep declarations in the header alongside the opcode metadata table

## Testing
- cmake -S . -B build
- cmake --build build -j

------
https://chatgpt.com/codex/tasks/task_e_68ce2c554f4883249ea1bfc7635ff9e1