### PR TITLE
fix(fe_basic): centralize binary fold lookup

### DIFF
--- a/src/frontends/basic/ConstFolder.cpp
+++ b/src/frontends/basic/ConstFolder.cpp
@@ -74,6 +74,16 @@ ExprPtr foldStringNe(const StringExpr &l, const StringExpr &r)
                           return out;
                       });
 }
+
+const BinaryFoldEntry *findBinaryFold(BinaryExpr::Op op)
+{
+    for (const auto &entry : kBinaryFoldTable)
+    {
+        if (entry.op == op)
+            return &entry;
+    }
+    return nullptr;
+}
 } // namespace detail
 
 /// @brief Fold numeric binary expression using callback @p op.

--- a/src/frontends/basic/ConstFolder.hpp
+++ b/src/frontends/basic/ConstFolder.hpp
@@ -157,15 +157,7 @@ inline constexpr std::array<BinaryFoldEntry, 16> kBinaryFoldTable = {{
 
 /// @brief Look up folding handlers for a BASIC binary operator.
 /// @return Pointer to the table entry or nullptr when the operator is unsupported.
-inline const BinaryFoldEntry *findBinaryFold(BinaryExpr::Op op)
-{
-    for (const auto &entry : kBinaryFoldTable)
-    {
-        if (entry.op == op)
-            return &entry;
-    }
-    return nullptr;
-}
+const BinaryFoldEntry *findBinaryFold(BinaryExpr::Op op);
 } // namespace detail
 
 } // namespace il::frontends::basic


### PR DESCRIPTION
## Summary
- move detail::findBinaryFold from the header into ConstFolder.cpp so it has a single definition
- reuse the existing constexpr table for the lookup logic in the implementation file

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68ce2c93bb8083248d77c32305a4c1d5