### PR TITLE
build(il/api): centralize expected wrappers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,12 @@ add_library(il_verify STATIC
 target_link_libraries(il_verify PUBLIC il_core il_runtime)
 target_include_directories(il_verify PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_library(il_api STATIC il/api/expected_api.cpp)
+target_link_libraries(il_api
+  PUBLIC support
+  PRIVATE il_io il_verify il_core)
+target_include_directories(il_api PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_library(il_transform STATIC
   il/transform/PassManager.cpp
   il/transform/Peephole.cpp
@@ -64,11 +70,11 @@ add_executable(ilc
   tools/ilc/cli.cpp
   tools/ilc/break_spec.cpp)
 set_target_properties(ilc PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/ilc)
-target_link_libraries(ilc PRIVATE il_core il_io il_vm il_verify il_transform fe_basic support Passes)
+target_link_libraries(ilc PRIVATE il_core il_io il_vm il_verify il_transform fe_basic il_api support Passes)
 
 add_executable(il-verify tools/il-verify/il-verify.cpp)
 set_target_properties(il-verify PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/il-verify)
-target_link_libraries(il-verify PRIVATE support il_core il_build il_io il_vm il_verify)
+target_link_libraries(il-verify PRIVATE support il_core il_build il_io il_vm il_verify il_api)
 
 add_executable(il-dis tools/il-dis/main.cpp)
 set_target_properties(il-dis PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/il-dis)

--- a/src/il/api/expected_api.cpp
+++ b/src/il/api/expected_api.cpp
@@ -1,0 +1,22 @@
+// File: src/il/api/expected_api.cpp
+// Purpose: Provide Expected-based implementations for IL parsing and verification wrappers.
+// Key invariants: Mirrors legacy bool-returning APIs while emitting diagnostics through Expected.
+// Ownership/Lifetime: Callers retain ownership of modules and streams passed by reference.
+// Links: docs/il-spec.md
+
+#include "il/api/expected_api.hpp"
+
+namespace il::api::v2
+{
+
+il::support::Expected<void> parse_text_expected(std::istream &is, il::core::Module &m)
+{
+    return il::io::Parser::parse(is, m);
+}
+
+il::support::Expected<void> verify_module_expected(const il::core::Module &m)
+{
+    return il::verify::Verifier::verify(m);
+}
+
+} // namespace il::api::v2

--- a/src/il/api/expected_api.hpp
+++ b/src/il/api/expected_api.hpp
@@ -19,17 +19,11 @@ namespace il::api::v2
 /// @param is Input stream containing IL text.
 /// @param m Module instance populated on successful parse.
 /// @return Empty Expected on success; diagnostic payload on parse failure.
-inline il::support::Expected<void> parse_text_expected(std::istream &is, il::core::Module &m)
-{
-    return il::io::Parser::parse(is, m);
-}
+il::support::Expected<void> parse_text_expected(std::istream &is, il::core::Module &m);
 
 /// @brief Verify a module while capturing diagnostics in an Expected result.
 /// @param m Module to be verified.
 /// @return Empty Expected on success; diagnostic payload on verification failure.
-inline il::support::Expected<void> verify_module_expected(const il::core::Module &m)
-{
-    return il::verify::Verifier::verify(m);
-}
+il::support::Expected<void> verify_module_expected(const il::core::Module &m);
 
 } // namespace il::api::v2

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,41 +41,41 @@ target_link_libraries(test_irbuilder_call_unknown PRIVATE il_core il_build suppo
 add_test(NAME test_irbuilder_call_unknown COMMAND test_irbuilder_call_unknown)
 
 add_executable(test_il_roundtrip unit/test_il_roundtrip.cpp)
-target_link_libraries(test_il_roundtrip PRIVATE il_core il_io il_verify support)
+target_link_libraries(test_il_roundtrip PRIVATE il_core il_io il_verify il_api)
 target_compile_definitions(test_il_roundtrip PRIVATE EXAMPLES_DIR="${CMAKE_SOURCE_DIR}/examples" ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/roundtrip")
 add_test(NAME test_il_roundtrip COMMAND test_il_roundtrip)
 
 add_executable(test_il_parse_negative unit/test_il_parse_negative.cpp)
-target_link_libraries(test_il_parse_negative PRIVATE il_core il_io support)
+target_link_libraries(test_il_parse_negative PRIVATE il_core il_io il_api)
 target_compile_definitions(test_il_parse_negative PRIVATE BAD_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse")
 add_test(NAME test_il_parse_negative COMMAND test_il_parse_negative)
 
 add_executable(test_il_parse_comment unit/test_il_parse_comment.cpp)
-target_link_libraries(test_il_parse_comment PRIVATE il_core il_io support)
+target_link_libraries(test_il_parse_comment PRIVATE il_core il_io il_api)
 add_test(NAME test_il_parse_comment COMMAND test_il_parse_comment)
 
 add_executable(test_il_comments unit/test_il_comments.cpp)
-target_link_libraries(test_il_comments PRIVATE il_core il_io support)
+target_link_libraries(test_il_comments PRIVATE il_core il_io il_api)
 add_test(NAME test_il_comments COMMAND test_il_comments)
 
 add_executable(test_il_parse_missing_eq unit/test_il_parse_missing_eq.cpp)
-target_link_libraries(test_il_parse_missing_eq PRIVATE il_core il_io support)
+target_link_libraries(test_il_parse_missing_eq PRIVATE il_core il_io il_api)
 add_test(NAME test_il_parse_missing_eq COMMAND test_il_parse_missing_eq)
 
 add_executable(test_il_parse_first_error unit/test_il_parse_first_error.cpp)
-target_link_libraries(test_il_parse_first_error PRIVATE il_core il_io support)
+target_link_libraries(test_il_parse_first_error PRIVATE il_core il_io il_api)
 add_test(NAME test_il_parse_first_error COMMAND test_il_parse_first_error)
 
 add_executable(test_il_parse_invalid_type unit/test_il_parse_invalid_type.cpp)
-target_link_libraries(test_il_parse_invalid_type PRIVATE il_core il_io support)
+target_link_libraries(test_il_parse_invalid_type PRIVATE il_core il_io il_api)
 add_test(NAME test_il_parse_invalid_type COMMAND test_il_parse_invalid_type)
 
 add_executable(test_expected_api_build unit/test_expected_api_build.cpp)
-target_link_libraries(test_expected_api_build PRIVATE il_core il_io support)
+target_link_libraries(test_expected_api_build PRIVATE il_core il_io il_api)
 add_test(NAME test_expected_api_build COMMAND test_expected_api_build)
 
 add_executable(test_il_verify_trap unit/test_il_verify_trap.cpp)
-target_link_libraries(test_il_verify_trap PRIVATE il_core il_verify support)
+target_link_libraries(test_il_verify_trap PRIVATE il_core il_verify il_api)
 add_test(NAME test_il_verify_trap COMMAND test_il_verify_trap)
 
 add_executable(test_il_type_inference unit/test_il_type_inference.cpp)
@@ -505,15 +505,15 @@ target_link_libraries(test_vm_many_temps PRIVATE il_vm support)
 add_test(NAME test_vm_many_temps COMMAND test_vm_many_temps)
 
 add_executable(test_vm_addr_of unit/test_vm_addr_of.cpp)
-target_link_libraries(test_vm_addr_of PRIVATE il_io il_vm support)
+target_link_libraries(test_vm_addr_of PRIVATE il_io il_vm il_api)
 add_test(NAME test_vm_addr_of COMMAND test_vm_addr_of)
 
 add_executable(test_vm_opcode_dispatch unit/test_vm_opcode_dispatch.cpp)
-target_link_libraries(test_vm_opcode_dispatch PRIVATE il_io il_vm support)
+target_link_libraries(test_vm_opcode_dispatch PRIVATE il_io il_vm il_api)
 add_test(NAME test_vm_opcode_dispatch COMMAND test_vm_opcode_dispatch)
 
 add_executable(test_il_pass_manager unit/test_il_pass_manager.cpp)
-target_link_libraries(test_il_pass_manager PRIVATE il_io il_transform support)
+target_link_libraries(test_il_pass_manager PRIVATE il_io il_transform il_api)
 add_test(NAME test_il_pass_manager COMMAND test_il_pass_manager)
 
 add_executable(test_vm_normalize_path unit/test_vm_normalize_path.cpp)


### PR DESCRIPTION
## Summary
- move the expected-api wrappers into a shared il_api static library
- update tools and unit tests to link against il_api so the shared implementation is used everywhere

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ce2dbf46908324be789aa3e4de48ac