### PR TITLE
fix(frontends/basic): add semantic diagnostics implementation

### DIFF
--- a/src/frontends/basic/CMakeLists.txt
+++ b/src/frontends/basic/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(fe_basic STATIC
   ConstFolder.cpp
   Intrinsics.cpp
   DiagnosticEmitter.cpp
+  SemanticDiagnostics.cpp
 )
 
 target_link_libraries(fe_basic PUBLIC support il_build il_core il_runtime)

--- a/src/frontends/basic/SemanticDiagnostics.cpp
+++ b/src/frontends/basic/SemanticDiagnostics.cpp
@@ -1,0 +1,44 @@
+// File: src/frontends/basic/SemanticDiagnostics.cpp
+// Purpose: Implements semantic diagnostic helpers for BASIC front-end analysis.
+// Key invariants: Diagnostics are forwarded without altering DiagnosticEmitter state.
+// Ownership/Lifetime: Borrows DiagnosticEmitter references; no ownership transfer.
+// Links: docs/class-catalog.md
+
+#include "frontends/basic/SemanticDiagnostics.hpp"
+
+#include <string>
+
+namespace il::frontends::basic
+{
+
+std::string SemanticDiagnostics::formatNonBooleanCondition(std::string_view typeName,
+                                                           std::string_view exprText)
+{
+    std::string message(NonBooleanConditionMessage);
+    const auto replace = [](std::string &subject,
+                            std::string_view placeholder,
+                            std::string_view value) {
+        if (auto pos = subject.find(placeholder); pos != std::string::npos)
+        {
+            subject.replace(pos, placeholder.size(), value);
+        }
+    };
+    replace(message, "{type}", typeName);
+    replace(message, "{expr}", exprText);
+    return message;
+}
+
+void SemanticDiagnostics::emitNonBooleanCondition(std::string code,
+                                                  il::support::SourceLoc loc,
+                                                  uint32_t length,
+                                                  std::string_view typeName,
+                                                  std::string_view exprText)
+{
+    emit(il::support::Severity::Error,
+         std::move(code),
+         loc,
+         length,
+         formatNonBooleanCondition(typeName, exprText));
+}
+
+} // namespace il::frontends::basic

--- a/src/frontends/basic/SemanticDiagnostics.hpp
+++ b/src/frontends/basic/SemanticDiagnostics.hpp
@@ -69,33 +69,3 @@ class SemanticDiagnostics
 };
 
 } // namespace il::frontends::basic
-
-inline std::string
-il::frontends::basic::SemanticDiagnostics::formatNonBooleanCondition(std::string_view typeName,
-                                                                     std::string_view exprText)
-{
-    std::string message(NonBooleanConditionMessage);
-    const auto replace = [](std::string &subject,
-                            std::string_view placeholder,
-                            std::string_view value) {
-        if (auto pos = subject.find(placeholder); pos != std::string::npos)
-            subject.replace(pos, placeholder.size(), value);
-    };
-    replace(message, "{type}", typeName);
-    replace(message, "{expr}", exprText);
-    return message;
-}
-
-inline void il::frontends::basic::SemanticDiagnostics::emitNonBooleanCondition(
-    std::string code,
-    il::support::SourceLoc loc,
-    uint32_t length,
-    std::string_view typeName,
-    std::string_view exprText)
-{
-    emit(il::support::Severity::Error,
-         std::move(code),
-         loc,
-         length,
-         formatNonBooleanCondition(typeName, exprText));
-}


### PR DESCRIPTION
## Summary
- move SemanticDiagnostics non-trivial definitions into a new translation unit
- update fe_basic library configuration to build the new source file

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ce2db802dc8324b899b87eda884a2d