### PR TITLE
refactor(support): move diag_capture definitions to cpp

### DIFF
--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(support STATIC
   diagnostics.cpp
   arena.cpp
   diag_expected.cpp
+  diag_capture.cpp
 )
 
 target_include_directories(support PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/src/support/diag_capture.cpp
+++ b/src/support/diag_capture.cpp
@@ -1,0 +1,21 @@
+// File: src/support/diag_capture.cpp
+// Purpose: Provide out-of-line definitions for DiagCapture helper methods.
+// Key invariants: The stored string stream contents are preserved when converting
+//                 to a Diagnostic; print operations delegate to printDiag.
+// Ownership/Lifetime: DiagCapture owns its string buffer; diagnostics copy the text.
+// Links: docs/class-catalog.md
+
+#include "support/diag_capture.hpp"
+
+namespace il::support
+{
+void DiagCapture::printTo(std::ostream &out, const Diag &diag)
+{
+    printDiag(diag, out);
+}
+
+Diag DiagCapture::toDiag() const
+{
+    return makeError({}, ss.str());
+}
+} // namespace il::support

--- a/src/support/diag_capture.hpp
+++ b/src/support/diag_capture.hpp
@@ -22,17 +22,11 @@ struct DiagCapture
     /// @brief Forward a diagnostic to an output stream using standard formatting.
     /// @param out Stream receiving the formatted diagnostic.
     /// @param diag Diagnostic to print.
-    void printTo(std::ostream &out, const Diag &diag)
-    {
-        printDiag(diag, out);
-    }
+    void printTo(std::ostream &out, const Diag &diag);
 
     /// @brief Convert the captured text into an error diagnostic without a location.
     /// @return Diagnostic containing the captured message.
-    [[nodiscard]] Diag toDiag() const
-    {
-        return makeError({}, ss.str());
-    }
+    [[nodiscard]] Diag toDiag() const;
 };
 
 /// @brief Adapt a legacy bool plus ostream diagnostic API to Expected<void>.


### PR DESCRIPTION
## Summary
- move `DiagCapture` method definitions out of the header and into a new translation unit
- update the support target so the new implementation file is compiled

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68ce3600c89083249397469a6ce49a7f