### PR TITLE
refactor(frontend): move BlockNamer definitions to source

### DIFF
--- a/src/frontends/basic/Lowerer.cpp
+++ b/src/frontends/basic/Lowerer.cpp
@@ -13,6 +13,7 @@
 #include "il/core/Instr.hpp"
 #include <cassert>
 #include <functional>
+#include <utility>
 #include <vector>
 
 using namespace il::core;
@@ -47,6 +48,115 @@ il::core::Type coreTypeForAstType(::il::frontends::basic::Type ty)
 }
 
 } // namespace
+
+Lowerer::BlockNamer::BlockNamer(std::string p) : proc(std::move(p)) {}
+
+std::string Lowerer::BlockNamer::entry() const
+{
+    return "entry_" + proc;
+}
+
+std::string Lowerer::BlockNamer::ret() const
+{
+    return "ret_" + proc;
+}
+
+std::string Lowerer::BlockNamer::line(int line) const
+{
+    return "L" + std::to_string(line) + "_" + proc;
+}
+
+unsigned Lowerer::BlockNamer::nextIf()
+{
+    return ifCounter++;
+}
+
+std::string Lowerer::BlockNamer::ifTest(unsigned id) const
+{
+    return "if_test_" + std::to_string(id) + "_" + proc;
+}
+
+std::string Lowerer::BlockNamer::ifThen(unsigned id) const
+{
+    return "if_then_" + std::to_string(id) + "_" + proc;
+}
+
+std::string Lowerer::BlockNamer::ifElse(unsigned id) const
+{
+    return "if_else_" + std::to_string(id) + "_" + proc;
+}
+
+std::string Lowerer::BlockNamer::ifEnd(unsigned id) const
+{
+    return "if_end_" + std::to_string(id) + "_" + proc;
+}
+
+unsigned Lowerer::BlockNamer::nextWhile()
+{
+    return loopCounter++;
+}
+
+std::string Lowerer::BlockNamer::whileHead(unsigned id) const
+{
+    return "while_head_" + std::to_string(id) + "_" + proc;
+}
+
+std::string Lowerer::BlockNamer::whileBody(unsigned id) const
+{
+    return "while_body_" + std::to_string(id) + "_" + proc;
+}
+
+std::string Lowerer::BlockNamer::whileEnd(unsigned id) const
+{
+    return "while_end_" + std::to_string(id) + "_" + proc;
+}
+
+unsigned Lowerer::BlockNamer::nextFor()
+{
+    return loopCounter++;
+}
+
+unsigned Lowerer::BlockNamer::nextCall()
+{
+    return loopCounter++;
+}
+
+std::string Lowerer::BlockNamer::forHead(unsigned id) const
+{
+    return "for_head_" + std::to_string(id) + "_" + proc;
+}
+
+std::string Lowerer::BlockNamer::forBody(unsigned id) const
+{
+    return "for_body_" + std::to_string(id) + "_" + proc;
+}
+
+std::string Lowerer::BlockNamer::forInc(unsigned id) const
+{
+    return "for_inc_" + std::to_string(id) + "_" + proc;
+}
+
+std::string Lowerer::BlockNamer::forEnd(unsigned id) const
+{
+    return "for_end_" + std::to_string(id) + "_" + proc;
+}
+
+std::string Lowerer::BlockNamer::callCont(unsigned id) const
+{
+    return "call_cont_" + std::to_string(id) + "_" + proc;
+}
+
+std::string Lowerer::BlockNamer::generic(const std::string &hint)
+{
+    auto &n = genericCounters[hint];
+    std::string label = hint + "_" + std::to_string(n++) + "_" + proc;
+    return label;
+}
+
+std::string Lowerer::BlockNamer::tag(const std::string &base) const
+{
+    return base + "_" + proc;
+}
 
 /// @brief Construct a lowering context.
 /// @param boundsChecks When true, enable allocation of auxiliary slots used to

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -79,116 +79,51 @@ class Lowerer
         unsigned loopCounter{0}; ///< WHILE/FOR/call_cont identifiers
         std::unordered_map<std::string, unsigned> genericCounters; ///< other shapes
 
-        explicit BlockNamer(std::string p) : proc(std::move(p)) {}
+        explicit BlockNamer(std::string p);
 
-        std::string entry() const
-        {
-            return "entry_" + proc;
-        }
+        std::string entry() const;
 
-        std::string ret() const
-        {
-            return "ret_" + proc;
-        }
+        std::string ret() const;
 
-        std::string line(int line) const
-        {
-            return "L" + std::to_string(line) + "_" + proc;
-        }
+        std::string line(int line) const;
 
-        unsigned nextIf()
-        {
-            return ifCounter++;
-        }
+        unsigned nextIf();
 
-        std::string ifTest(unsigned id) const
-        {
-            return "if_test_" + std::to_string(id) + "_" + proc;
-        }
+        std::string ifTest(unsigned id) const;
 
-        std::string ifThen(unsigned id) const
-        {
-            return "if_then_" + std::to_string(id) + "_" + proc;
-        }
+        std::string ifThen(unsigned id) const;
 
-        std::string ifElse(unsigned id) const
-        {
-            return "if_else_" + std::to_string(id) + "_" + proc;
-        }
+        std::string ifElse(unsigned id) const;
 
-        std::string ifEnd(unsigned id) const
-        {
-            return "if_end_" + std::to_string(id) + "_" + proc;
-        }
+        std::string ifEnd(unsigned id) const;
 
-        unsigned nextWhile()
-        {
-            return loopCounter++;
-        }
+        unsigned nextWhile();
 
-        std::string whileHead(unsigned id) const
-        {
-            return "while_head_" + std::to_string(id) + "_" + proc;
-        }
+        std::string whileHead(unsigned id) const;
 
-        std::string whileBody(unsigned id) const
-        {
-            return "while_body_" + std::to_string(id) + "_" + proc;
-        }
+        std::string whileBody(unsigned id) const;
 
-        std::string whileEnd(unsigned id) const
-        {
-            return "while_end_" + std::to_string(id) + "_" + proc;
-        }
+        std::string whileEnd(unsigned id) const;
 
-        unsigned nextFor()
-        {
-            return loopCounter++;
-        }
+        unsigned nextFor();
 
         /// @brief Allocate next sequential ID for a call continuation.
-        unsigned nextCall()
-        {
-            return loopCounter++;
-        }
+        unsigned nextCall();
 
-        std::string forHead(unsigned id) const
-        {
-            return "for_head_" + std::to_string(id) + "_" + proc;
-        }
+        std::string forHead(unsigned id) const;
 
-        std::string forBody(unsigned id) const
-        {
-            return "for_body_" + std::to_string(id) + "_" + proc;
-        }
+        std::string forBody(unsigned id) const;
 
-        std::string forInc(unsigned id) const
-        {
-            return "for_inc_" + std::to_string(id) + "_" + proc;
-        }
+        std::string forInc(unsigned id) const;
 
-        std::string forEnd(unsigned id) const
-        {
-            return "for_end_" + std::to_string(id) + "_" + proc;
-        }
+        std::string forEnd(unsigned id) const;
 
         /// @brief Build label for a synthetic call continuation block.
-        std::string callCont(unsigned id) const
-        {
-            return "call_cont_" + std::to_string(id) + "_" + proc;
-        }
+        std::string callCont(unsigned id) const;
 
-        std::string generic(const std::string &hint)
-        {
-            auto &n = genericCounters[hint];
-            std::string label = hint + "_" + std::to_string(n++) + "_" + proc;
-            return label;
-        }
+        std::string generic(const std::string &hint);
 
-        std::string tag(const std::string &base) const
-        {
-            return base + "_" + proc;
-        }
+        std::string tag(const std::string &base) const;
     };
 
     struct ForBlocks


### PR DESCRIPTION
## Summary
- declare BlockNamer members in Lowerer.hpp and move their definitions into Lowerer.cpp
- include <utility> for std::move in the implementation file

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ce369025608324a8701edd0ee39e4b