### PR TITLE
refactor(tui): move mock clipboard accessors out of header

### DIFF
--- a/tui/include/tui/term/clipboard.hpp
+++ b/tui/include/tui/term/clipboard.hpp
@@ -36,15 +36,9 @@ class MockClipboard : public Clipboard
     bool copy(std::string_view text) override;
     std::string paste() override;
 
-    const std::string &last() const
-    {
-        return last_;
-    }
+    const std::string &last() const;
 
-    void clear()
-    {
-        last_.clear();
-    }
+    void clear();
 
   private:
     std::string last_{};

--- a/tui/src/term/clipboard.cpp
+++ b/tui/src/term/clipboard.cpp
@@ -166,4 +166,14 @@ std::string MockClipboard::paste()
     return out;
 }
 
+const std::string &MockClipboard::last() const
+{
+    return last_;
+}
+
+void MockClipboard::clear()
+{
+    last_.clear();
+}
+
 } // namespace tui::term


### PR DESCRIPTION
## Summary
- declare `MockClipboard::last()` and `MockClipboard::clear()` in the header
- define the mock clipboard helpers in the implementation file to reduce header surface

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ce36252fc48324a732df5eaa431bfb