### PR TITLE
refactor(il/core): out-of-line Value helpers

### DIFF
--- a/src/il/core/Value.cpp
+++ b/src/il/core/Value.cpp
@@ -9,9 +9,40 @@
 #include <iomanip>
 #include <limits>
 #include <sstream>
+#include <utility>
 
 namespace il::core
 {
+
+Value Value::temp(unsigned t)
+{
+    return Value{Kind::Temp, 0, 0.0, t, ""};
+}
+
+Value Value::constInt(long long v)
+{
+    return Value{Kind::ConstInt, v, 0.0, 0, ""};
+}
+
+Value Value::constFloat(double v)
+{
+    return Value{Kind::ConstFloat, 0, v, 0, ""};
+}
+
+Value Value::constStr(std::string s)
+{
+    return Value{Kind::ConstStr, 0, 0.0, 0, std::move(s)};
+}
+
+Value Value::global(std::string s)
+{
+    return Value{Kind::GlobalAddr, 0, 0.0, 0, std::move(s)};
+}
+
+Value Value::null()
+{
+    return Value{Kind::NullPtr, 0, 0.0, 0, ""};
+}
 
 std::string toString(const Value &v)
 {

--- a/src/il/core/Value.hpp
+++ b/src/il/core/Value.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <string>
-#include <utility>
 
 namespace il::core
 {
@@ -39,54 +38,36 @@ struct Value
     /// @param t Identifier of the temporary.
     /// @return Value with kind Kind::Temp and id set to t.
     /// @invariant result.kind == Kind::Temp.
-    static Value temp(unsigned t)
-    {
-        return Value{Kind::Temp, 0, 0.0, t, ""};
-    }
+    static Value temp(unsigned t);
 
     /// @brief Construct an integer constant value.
     /// @param v Signed integer literal.
     /// @return Value with kind Kind::ConstInt and i64 set to v.
     /// @invariant result.kind == Kind::ConstInt.
-    static Value constInt(long long v)
-    {
-        return Value{Kind::ConstInt, v, 0.0, 0, ""};
-    }
+    static Value constInt(long long v);
 
     /// @brief Construct a floating-point constant value.
     /// @param v IEEE-754 double literal.
     /// @return Value with kind Kind::ConstFloat and f64 set to v.
     /// @invariant result.kind == Kind::ConstFloat.
-    static Value constFloat(double v)
-    {
-        return Value{Kind::ConstFloat, 0, v, 0, ""};
-    }
+    static Value constFloat(double v);
 
     /// @brief Construct a string constant value.
     /// @param s String literal; moved into the value.
     /// @return Value with kind Kind::ConstStr and str set to @p s.
     /// @invariant result.kind == Kind::ConstStr.
-    static Value constStr(std::string s)
-    {
-        return Value{Kind::ConstStr, 0, 0.0, 0, std::move(s)};
-    }
+    static Value constStr(std::string s);
 
     /// @brief Construct a global address value.
     /// @param s Name of the global symbol; moved into the value.
     /// @return Value with kind Kind::GlobalAddr and str set to @p s.
     /// @invariant result.kind == Kind::GlobalAddr.
-    static Value global(std::string s)
-    {
-        return Value{Kind::GlobalAddr, 0, 0.0, 0, std::move(s)};
-    }
+    static Value global(std::string s);
 
     /// @brief Construct a null pointer value.
     /// @return Value with kind Kind::NullPtr.
     /// @invariant result.kind == Kind::NullPtr.
-    static Value null()
-    {
-        return Value{Kind::NullPtr, 0, 0.0, 0, ""};
-    }
+    static Value null();
 };
 
 std::string toString(const Value &v);


### PR DESCRIPTION
## Summary
- move Value helper definitions from the header to Value.cpp
- add the necessary declarations and includes after the move

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ce3af8f7988324999a8d7d5f0187f8