### PR TITLE
fix(frontends/basic): move diagnostic counts to implementation

### DIFF
--- a/src/frontends/basic/DiagnosticEmitter.cpp
+++ b/src/frontends/basic/DiagnosticEmitter.cpp
@@ -122,4 +122,18 @@ void DiagnosticEmitter::printAll(std::ostream &os) const
     }
 }
 
+/// @brief Retrieve the number of errors emitted so far.
+/// @return Count of error-severity diagnostics from the underlying engine.
+size_t DiagnosticEmitter::errorCount() const
+{
+    return de_.errorCount();
+}
+
+/// @brief Retrieve the number of warnings emitted so far.
+/// @return Count of warning-severity diagnostics from the underlying engine.
+size_t DiagnosticEmitter::warningCount() const
+{
+    return de_.warningCount();
+}
+
 } // namespace il::frontends::basic

--- a/src/frontends/basic/DiagnosticEmitter.hpp
+++ b/src/frontends/basic/DiagnosticEmitter.hpp
@@ -55,16 +55,10 @@ class DiagnosticEmitter
     void printAll(std::ostream &os) const;
 
     /// @brief Number of errors reported.
-    size_t errorCount() const
-    {
-        return de_.errorCount();
-    }
+    size_t errorCount() const;
 
     /// @brief Number of warnings reported.
-    size_t warningCount() const
-    {
-        return de_.warningCount();
-    }
+    size_t warningCount() const;
 
   private:
     /// @brief Diagnostic record captured for later printing.


### PR DESCRIPTION
## Summary
- declare DiagnosticEmitter count accessors in the header and implement them in the .cpp
- continue forwarding to DiagnosticEngine for error and warning totals
- noted that `fe_basic` already links against the support diagnostics library via its existing CMake configuration

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68ce3ad0d10c8324be95f1b0bf60d6d1