### PR TITLE
refactor(frontends/basic): move ProcRegistry implementation

### DIFF
--- a/src/frontends/basic/CMakeLists.txt
+++ b/src/frontends/basic/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(fe_basic STATIC
   ConstFolder.cpp
   Intrinsics.cpp
   DiagnosticEmitter.cpp
+  ProcRegistry.cpp
   SemanticDiagnostics.cpp
 )
 

--- a/src/frontends/basic/ProcRegistry.cpp
+++ b/src/frontends/basic/ProcRegistry.cpp
@@ -1,0 +1,115 @@
+// File: src/frontends/basic/ProcRegistry.cpp
+// Purpose: Implements BASIC procedure registry behaviors and diagnostics.
+// Key invariants: Registry maintains unique procedure names and signatures.
+// Ownership/Lifetime: ProcRegistry borrows SemanticDiagnostics lifetime.
+// Links: docs/class-catalog.md
+
+#include "frontends/basic/ProcRegistry.hpp"
+
+#include <unordered_set>
+#include <utility>
+
+namespace il::frontends::basic
+{
+
+ProcRegistry::ProcRegistry(SemanticDiagnostics &d) : de(d) {}
+
+void ProcRegistry::clear()
+{
+    procs_.clear();
+}
+
+void ProcRegistry::registerProc(const FunctionDecl &f)
+{
+    if (procs_.count(f.name))
+    {
+        std::string msg = "duplicate procedure '" + f.name + "'";
+        de.emit(il::support::Severity::Error,
+                "B1004",
+                f.loc,
+                static_cast<uint32_t>(f.name.size()),
+                std::move(msg));
+        return;
+    }
+    ProcSignature sig;
+    sig.kind = ProcSignature::Kind::Function;
+    sig.retType = f.ret;
+    std::unordered_set<std::string> paramNames;
+    for (const auto &p : f.params)
+    {
+        if (!paramNames.insert(p.name).second)
+        {
+            std::string msg = "duplicate parameter '" + p.name + "'";
+            de.emit(il::support::Severity::Error,
+                    "B1005",
+                    p.loc,
+                    static_cast<uint32_t>(p.name.size()),
+                    std::move(msg));
+        }
+        if (p.is_array && p.type != Type::I64 && p.type != Type::Str && p.type != Type::Bool)
+        {
+            std::string msg = "array parameter must be i64 or str";
+            de.emit(il::support::Severity::Error,
+                    "B2004",
+                    p.loc,
+                    static_cast<uint32_t>(p.name.size()),
+                    std::move(msg));
+        }
+        sig.params.push_back({p.type, p.is_array});
+    }
+    procs_.emplace(f.name, std::move(sig));
+}
+
+void ProcRegistry::registerProc(const SubDecl &s)
+{
+    if (procs_.count(s.name))
+    {
+        std::string msg = "duplicate procedure '" + s.name + "'";
+        de.emit(il::support::Severity::Error,
+                "B1004",
+                s.loc,
+                static_cast<uint32_t>(s.name.size()),
+                std::move(msg));
+        return;
+    }
+    ProcSignature sig;
+    sig.kind = ProcSignature::Kind::Sub;
+    sig.retType = std::nullopt;
+    std::unordered_set<std::string> paramNames;
+    for (const auto &p : s.params)
+    {
+        if (!paramNames.insert(p.name).second)
+        {
+            std::string msg = "duplicate parameter '" + p.name + "'";
+            de.emit(il::support::Severity::Error,
+                    "B1005",
+                    p.loc,
+                    static_cast<uint32_t>(p.name.size()),
+                    std::move(msg));
+        }
+        if (p.is_array && p.type != Type::I64 && p.type != Type::Str && p.type != Type::Bool)
+        {
+            std::string msg = "array parameter must be i64 or str";
+            de.emit(il::support::Severity::Error,
+                    "B2004",
+                    p.loc,
+                    static_cast<uint32_t>(p.name.size()),
+                    std::move(msg));
+        }
+        sig.params.push_back({p.type, p.is_array});
+    }
+    procs_.emplace(s.name, std::move(sig));
+}
+
+const ProcTable &ProcRegistry::procs() const
+{
+    return procs_;
+}
+
+const ProcSignature *ProcRegistry::lookup(const std::string &name) const
+{
+    auto it = procs_.find(name);
+    return it == procs_.end() ? nullptr : &it->second;
+}
+
+} // namespace il::frontends::basic

--- a/src/frontends/basic/ProcRegistry.hpp
+++ b/src/frontends/basic/ProcRegistry.hpp
@@ -8,7 +8,6 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "frontends/basic/AST.hpp"
@@ -40,105 +39,17 @@ using ProcTable = std::unordered_map<std::string, ProcSignature>;
 class ProcRegistry
 {
   public:
-    explicit ProcRegistry(SemanticDiagnostics &d) : de(d) {}
+    explicit ProcRegistry(SemanticDiagnostics &d);
 
-    void clear()
-    {
-        procs_.clear();
-    }
+    void clear();
 
-    void registerProc(const FunctionDecl &f)
-    {
-        if (procs_.count(f.name))
-        {
-            std::string msg = "duplicate procedure '" + f.name + "'";
-            de.emit(il::support::Severity::Error,
-                    "B1004",
-                    f.loc,
-                    static_cast<uint32_t>(f.name.size()),
-                    std::move(msg));
-            return;
-        }
-        ProcSignature sig;
-        sig.kind = ProcSignature::Kind::Function;
-        sig.retType = f.ret;
-        std::unordered_set<std::string> paramNames;
-        for (const auto &p : f.params)
-        {
-            if (!paramNames.insert(p.name).second)
-            {
-                std::string msg = "duplicate parameter '" + p.name + "'";
-                de.emit(il::support::Severity::Error,
-                        "B1005",
-                        p.loc,
-                        static_cast<uint32_t>(p.name.size()),
-                        std::move(msg));
-            }
-            if (p.is_array && p.type != Type::I64 && p.type != Type::Str && p.type != Type::Bool)
-            {
-                std::string msg = "array parameter must be i64 or str";
-                de.emit(il::support::Severity::Error,
-                        "B2004",
-                        p.loc,
-                        static_cast<uint32_t>(p.name.size()),
-                        std::move(msg));
-            }
-            sig.params.push_back({p.type, p.is_array});
-        }
-        procs_.emplace(f.name, std::move(sig));
-    }
+    void registerProc(const FunctionDecl &f);
 
-    void registerProc(const SubDecl &s)
-    {
-        if (procs_.count(s.name))
-        {
-            std::string msg = "duplicate procedure '" + s.name + "'";
-            de.emit(il::support::Severity::Error,
-                    "B1004",
-                    s.loc,
-                    static_cast<uint32_t>(s.name.size()),
-                    std::move(msg));
-            return;
-        }
-        ProcSignature sig;
-        sig.kind = ProcSignature::Kind::Sub;
-        sig.retType = std::nullopt;
-        std::unordered_set<std::string> paramNames;
-        for (const auto &p : s.params)
-        {
-            if (!paramNames.insert(p.name).second)
-            {
-                std::string msg = "duplicate parameter '" + p.name + "'";
-                de.emit(il::support::Severity::Error,
-                        "B1005",
-                        p.loc,
-                        static_cast<uint32_t>(p.name.size()),
-                        std::move(msg));
-            }
-            if (p.is_array && p.type != Type::I64 && p.type != Type::Str && p.type != Type::Bool)
-            {
-                std::string msg = "array parameter must be i64 or str";
-                de.emit(il::support::Severity::Error,
-                        "B2004",
-                        p.loc,
-                        static_cast<uint32_t>(p.name.size()),
-                        std::move(msg));
-            }
-            sig.params.push_back({p.type, p.is_array});
-        }
-        procs_.emplace(s.name, std::move(sig));
-    }
+    void registerProc(const SubDecl &s);
 
-    const ProcTable &procs() const
-    {
-        return procs_;
-    }
+    const ProcTable &procs() const;
 
-    const ProcSignature *lookup(const std::string &name) const
-    {
-        auto it = procs_.find(name);
-        return it == procs_.end() ? nullptr : &it->second;
-    }
+    const ProcSignature *lookup(const std::string &name) const;
 
   private:
     SemanticDiagnostics &de;


### PR DESCRIPTION
## Summary
- move ProcRegistry member definitions into a new implementation file
- reduce the header to interface declarations and required includes only
- ensure the basic frontend target compiles the new implementation file

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ce39fb6bc08324bb038b910b6e1764