### PR TITLE
refactor(fe/basic): move semantic diagnostics impl

### DIFF
--- a/src/frontends/basic/SemanticDiagnostics.cpp
+++ b/src/frontends/basic/SemanticDiagnostics.cpp
@@ -7,9 +7,31 @@
 #include "frontends/basic/SemanticDiagnostics.hpp"
 
 #include <string>
+#include <utility>
 
 namespace il::frontends::basic
 {
+
+SemanticDiagnostics::SemanticDiagnostics(DiagnosticEmitter &emitter) : emitter_(emitter) {}
+
+void SemanticDiagnostics::emit(il::support::Severity sev,
+                               std::string code,
+                               il::support::SourceLoc loc,
+                               uint32_t length,
+                               std::string message)
+{
+    emitter_.emit(sev, std::move(code), loc, length, std::move(message));
+}
+
+size_t SemanticDiagnostics::errorCount() const
+{
+    return emitter_.errorCount();
+}
+
+size_t SemanticDiagnostics::warningCount() const
+{
+    return emitter_.warningCount();
+}
 
 std::string SemanticDiagnostics::formatNonBooleanCondition(std::string_view typeName,
                                                            std::string_view exprText)
@@ -39,6 +61,11 @@ void SemanticDiagnostics::emitNonBooleanCondition(std::string code,
          loc,
          length,
          formatNonBooleanCondition(typeName, exprText));
+}
+
+DiagnosticEmitter &SemanticDiagnostics::emitter()
+{
+    return emitter_;
 }
 
 } // namespace il::frontends::basic

--- a/src/frontends/basic/SemanticDiagnostics.hpp
+++ b/src/frontends/basic/SemanticDiagnostics.hpp
@@ -6,8 +6,8 @@
 #pragma once
 
 #include "frontends/basic/DiagnosticEmitter.hpp"
+#include <string>
 #include <string_view>
-#include <utility>
 
 namespace il::frontends::basic
 {
@@ -15,7 +15,7 @@ namespace il::frontends::basic
 class SemanticDiagnostics
 {
   public:
-    explicit SemanticDiagnostics(DiagnosticEmitter &emitter) : emitter_(emitter) {}
+    explicit SemanticDiagnostics(DiagnosticEmitter &emitter);
 
     /// @brief Message template for non-boolean conditions.
     static constexpr std::string_view NonBooleanConditionMessage =
@@ -25,20 +25,11 @@ class SemanticDiagnostics
               std::string code,
               il::support::SourceLoc loc,
               uint32_t length,
-              std::string message)
-    {
-        emitter_.emit(sev, std::move(code), loc, length, std::move(message));
-    }
+              std::string message);
 
-    size_t errorCount() const
-    {
-        return emitter_.errorCount();
-    }
+    [[nodiscard]] size_t errorCount() const;
 
-    size_t warningCount() const
-    {
-        return emitter_.warningCount();
-    }
+    [[nodiscard]] size_t warningCount() const;
 
     /// @brief Format the NonBooleanCondition diagnostic message.
     /// @param typeName Describes the inferred BASIC type.
@@ -59,10 +50,7 @@ class SemanticDiagnostics
                                  std::string_view typeName,
                                  std::string_view exprText);
 
-    DiagnosticEmitter &emitter()
-    {
-        return emitter_;
-    }
+    [[nodiscard]] DiagnosticEmitter &emitter();
 
   private:
     DiagnosticEmitter &emitter_;


### PR DESCRIPTION
## Summary
- move SemanticDiagnostics constructor and helpers out of the header into the implementation file
- update the header to keep declarations only while including the necessary standard headers

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ce3eca82cc8324bd18c1a713bc952b