### PR TITLE
refactor(frontends/basic): separate scope tracker implementation

### DIFF
--- a/src/frontends/basic/CMakeLists.txt
+++ b/src/frontends/basic/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(fe_basic STATIC
   LowerScan.cpp
   LowerEmit.cpp
   SemanticAnalyzer.cpp
+  ScopeTracker.cpp
   ConstFolder.cpp
   Intrinsics.cpp
   DiagnosticEmitter.cpp

--- a/src/frontends/basic/ScopeTracker.cpp
+++ b/src/frontends/basic/ScopeTracker.cpp
@@ -1,0 +1,74 @@
+// File: src/frontends/basic/ScopeTracker.cpp
+// Purpose: Implements lexical scope tracking with name mangling for the BASIC front end.
+// Key invariants: Scopes form a stack; resolving searches innermost to outermost.
+// Ownership/Lifetime: Owned by SemanticAnalyzer; no AST ownership.
+// Links: docs/class-catalog.md
+
+#include "frontends/basic/ScopeTracker.hpp"
+
+namespace il::frontends::basic
+{
+
+ScopeTracker::ScopedScope::ScopedScope(ScopeTracker &st) : st_(st)
+{
+    st_.pushScope();
+}
+
+ScopeTracker::ScopedScope::~ScopedScope()
+{
+    st_.popScope();
+}
+
+void ScopeTracker::reset()
+{
+    stack_.clear();
+    nextId_ = 0;
+}
+
+void ScopeTracker::pushScope()
+{
+    stack_.emplace_back();
+}
+
+void ScopeTracker::popScope()
+{
+    if (!stack_.empty())
+        stack_.pop_back();
+}
+
+void ScopeTracker::bind(const std::string &name, const std::string &mapped)
+{
+    if (!stack_.empty())
+        stack_.back()[name] = mapped;
+}
+
+bool ScopeTracker::isDeclaredInCurrentScope(const std::string &name) const
+{
+    return !stack_.empty() && stack_.back().count(name);
+}
+
+std::string ScopeTracker::declareLocal(const std::string &name)
+{
+    std::string unique = name + "_" + std::to_string(nextId_++);
+    if (!stack_.empty())
+        stack_.back()[name] = unique;
+    return unique;
+}
+
+std::optional<std::string> ScopeTracker::resolve(const std::string &name) const
+{
+    for (auto it = stack_.rbegin(); it != stack_.rend(); ++it)
+    {
+        auto found = it->find(name);
+        if (found != it->end())
+            return found->second;
+    }
+    return std::nullopt;
+}
+
+bool ScopeTracker::hasScope() const
+{
+    return !stack_.empty();
+}
+
+} // namespace il::frontends::basic

--- a/src/frontends/basic/ScopeTracker.hpp
+++ b/src/frontends/basic/ScopeTracker.hpp
@@ -19,71 +19,29 @@ class ScopeTracker
     class ScopedScope
     {
       public:
-        explicit ScopedScope(ScopeTracker &st) : st_(st)
-        {
-            st_.pushScope();
-        }
+        explicit ScopedScope(ScopeTracker &st);
 
-        ~ScopedScope()
-        {
-            st_.popScope();
-        }
+        ~ScopedScope();
 
       private:
         ScopeTracker &st_;
     };
 
-    void reset()
-    {
-        stack_.clear();
-        nextId_ = 0;
-    }
+    void reset();
 
-    void pushScope()
-    {
-        stack_.emplace_back();
-    }
+    void pushScope();
 
-    void popScope()
-    {
-        if (!stack_.empty())
-            stack_.pop_back();
-    }
+    void popScope();
 
-    void bind(const std::string &name, const std::string &mapped)
-    {
-        if (!stack_.empty())
-            stack_.back()[name] = mapped;
-    }
+    void bind(const std::string &name, const std::string &mapped);
 
-    bool isDeclaredInCurrentScope(const std::string &name) const
-    {
-        return !stack_.empty() && stack_.back().count(name);
-    }
+    bool isDeclaredInCurrentScope(const std::string &name) const;
 
-    std::string declareLocal(const std::string &name)
-    {
-        std::string unique = name + "_" + std::to_string(nextId_++);
-        if (!stack_.empty())
-            stack_.back()[name] = unique;
-        return unique;
-    }
+    std::string declareLocal(const std::string &name);
 
-    std::optional<std::string> resolve(const std::string &name) const
-    {
-        for (auto it = stack_.rbegin(); it != stack_.rend(); ++it)
-        {
-            auto found = it->find(name);
-            if (found != it->end())
-                return found->second;
-        }
-        return std::nullopt;
-    }
+    std::optional<std::string> resolve(const std::string &name) const;
 
-    bool hasScope() const
-    {
-        return !stack_.empty();
-    }
+    bool hasScope() const;
 
   private:
     std::vector<std::unordered_map<std::string, std::string>> stack_;


### PR DESCRIPTION
## Summary
- move ScopeTracker member definitions from the header into a new implementation file
- register the new implementation unit with the BASIC frontend library build

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ce3ed2bacc83248598d979cfd33883