### PR TITLE
Refine expected API dependencies

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,8 +33,7 @@ target_include_directories(il_verify PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(il_api STATIC il/api/expected_api.cpp)
 target_link_libraries(il_api
-  PUBLIC support
-  PRIVATE il_io il_verify il_core)
+  PUBLIC support il_io il_verify)
 target_include_directories(il_api PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(il_transform STATIC

--- a/src/il/api/expected_api.cpp
+++ b/src/il/api/expected_api.cpp
@@ -6,6 +6,10 @@
 
 #include "il/api/expected_api.hpp"
 
+#include "il/core/Module.hpp"
+#include "il/io/Parser.hpp"
+#include "il/verify/Verifier.hpp"
+
 namespace il::api::v2
 {
 

--- a/src/il/api/expected_api.hpp
+++ b/src/il/api/expected_api.hpp
@@ -9,9 +9,10 @@
 
 #include "support/diag_expected.hpp"
 
-#include "il/io/Parser.hpp"
-#include "il/verify/Verifier.hpp"
-#include "il/core/Module.hpp"
+namespace il::core
+{
+class Module;
+} // namespace il::core
 
 namespace il::api::v2
 {


### PR DESCRIPTION
## Summary
- forward declare the IL module in `expected_api.hpp` so parser and verifier headers stay out of the public API
- include the parser and verifier headers in `expected_api.cpp` where the wrappers are defined
- make `il_api` link publicly against `support`, `il_io`, and `il_verify` so dependents pick up the right libraries

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ce3efef5548324a291346c84f95046