### PR TITLE
refactor: migrate legacy libs into src tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,10 +103,6 @@ enable_testing()
 
 add_subdirectory(runtime)
 add_subdirectory(src)
-add_subdirectory(lib/Analysis)
-add_subdirectory(lib/IL)
-add_subdirectory(lib/Passes)
-add_subdirectory(lib/VM)
 
 # ---- ViperTUI subproject ----
 option(BUILD_TUI "Build ViperTUI subproject" ON)

--- a/archive/docs/CONTRIBUTING.md
+++ b/archive/docs/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Contributing
 
-- The repository includes a lightweight `Analysis` library in `lib/Analysis`.
+- The repository includes a lightweight `Analysis` library in `src/il/analysis`.
   Run the tests under `tests/analysis` when modifying these utilities.

--- a/archive/docs/dev/analysis.md
+++ b/archive/docs/dev/analysis.md
@@ -43,7 +43,7 @@ children for easy traversal. Complexity is linear in practice and worst-case
 
 ## IL utilities
 
-Helpers in `lib/IL/Utils` provide light-weight queries on basic blocks and
+Helpers in `src/il/utils` provide light-weight queries on basic blocks and
 instructions, such as checking block membership or retrieving a block's
 terminator. They depend only on `il_core`, allowing passes to use them without
 pulling in the Analysis layer.

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -1,3 +1,0 @@
-add_library(Analysis CFG.cpp Dominators.cpp)
-target_link_libraries(Analysis PRIVATE il_core)
-target_include_directories(Analysis PUBLIC ${CMAKE_SOURCE_DIR}/lib)

--- a/lib/IL/CMakeLists.txt
+++ b/lib/IL/CMakeLists.txt
@@ -1,3 +1,0 @@
-add_library(IL Utils.cpp)
-target_link_libraries(IL PUBLIC il_core)
-target_include_directories(IL PUBLIC ${CMAKE_SOURCE_DIR}/lib)

--- a/lib/Passes/CMakeLists.txt
+++ b/lib/Passes/CMakeLists.txt
@@ -1,3 +1,0 @@
-add_library(Passes Mem2Reg.cpp)
-target_link_libraries(Passes PUBLIC Analysis il_core)
-target_include_directories(Passes PUBLIC ${CMAKE_SOURCE_DIR}/lib)

--- a/lib/VM/CMakeLists.txt
+++ b/lib/VM/CMakeLists.txt
@@ -1,3 +1,0 @@
-add_library(VMTrace Trace.cpp Debug.cpp DebugScript.cpp)
-target_link_libraries(VMTrace PUBLIC il_core rt support)
-target_include_directories(VMTrace PUBLIC ${CMAKE_SOURCE_DIR}/lib ${CMAKE_SOURCE_DIR}/src)

--- a/scripts/run_iwyu.sh
+++ b/scripts/run_iwyu.sh
@@ -25,7 +25,7 @@ declare -a units=(
   "src/il/io/FunctionParser.cpp"
   "src/il/io/InstrParser.cpp"
   "src/il/io/ModuleParser.cpp"
-  "lib/VM/Debug.cpp"
+  "src/vm/Debug.cpp"
 )
 
 for unit in "${units[@]}"; do

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,13 +36,24 @@ target_link_libraries(il_api
   PUBLIC support il_io il_verify)
 target_include_directories(il_api PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_library(il_analysis STATIC
+  il/analysis/CFG.cpp
+  il/analysis/Dominators.cpp)
+target_link_libraries(il_analysis PUBLIC il_core)
+target_include_directories(il_analysis PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_library(il_transform STATIC
   il/transform/PassManager.cpp
   il/transform/Peephole.cpp
   il/transform/ConstFold.cpp
-  il/transform/DCE.cpp)
-target_link_libraries(il_transform PUBLIC il_core il_verify Analysis)
+  il/transform/DCE.cpp
+  il/transform/Mem2Reg.cpp)
+target_link_libraries(il_transform PUBLIC il_core il_verify il_analysis)
 target_include_directories(il_transform PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(il_utils STATIC il/utils/Utils.cpp)
+target_link_libraries(il_utils PUBLIC il_core)
+target_include_directories(il_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(il_vm STATIC
   vm/VM.cpp
@@ -51,12 +62,15 @@ add_library(il_vm STATIC
   vm/RuntimeBridge.cpp
   vm/OpHandlers.cpp
   vm/OpHandlerUtils.cpp
+  vm/Debug.cpp
+  vm/DebugScript.cpp
+  vm/Trace.cpp
   vm/mem_ops.cpp
   vm/int_ops.cpp
   vm/fp_ops.cpp
   vm/control_flow.cpp)
 target_include_directories(il_vm PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(il_vm PUBLIC il_core rt support VMTrace)
+target_link_libraries(il_vm PUBLIC il_core rt support)
 
 add_library(il_codegen_x86_64 STATIC codegen/x86_64/placeholder.cpp)
 set_target_properties(il_codegen_x86_64 PROPERTIES LINKER_LANGUAGE CXX)
@@ -69,7 +83,7 @@ add_executable(ilc
   tools/ilc/cli.cpp
   tools/ilc/break_spec.cpp)
 set_target_properties(ilc PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/ilc)
-target_link_libraries(ilc PRIVATE il_core il_io il_vm il_verify il_transform fe_basic il_api support Passes)
+target_link_libraries(ilc PRIVATE il_core il_io il_vm il_verify il_transform fe_basic il_api support)
 
 add_executable(il-verify tools/il-verify/il-verify.cpp)
 set_target_properties(il-verify PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/il-verify)

--- a/src/il/analysis/CFG.cpp
+++ b/src/il/analysis/CFG.cpp
@@ -1,10 +1,10 @@
-// File: lib/Analysis/CFG.cpp
+// File: src/il/analysis/CFG.cpp
 // Purpose: Implements minimal CFG utilities for IL blocks and functions.
 // Key invariants: Results are computed on demand; no caches or global graphs.
 // Ownership/Lifetime: Uses IL objects owned by the caller.
 // Links: docs/dev/analysis.md
 
-#include "Analysis/CFG.h"
+#include "il/analysis/CFG.hpp"
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Function.hpp"
 #include "il/core/Instr.hpp"

--- a/src/il/analysis/CFG.hpp
+++ b/src/il/analysis/CFG.hpp
@@ -1,4 +1,4 @@
-// File: lib/Analysis/CFG.h
+// File: src/il/analysis/CFG.hpp
 // Purpose: Minimal control-flow graph utilities for IL blocks and functions.
 // Key invariants: Computes edges on demand without caching.
 // Ownership/Lifetime: Operates on IL structures owned by caller.

--- a/src/il/analysis/Dominators.cpp
+++ b/src/il/analysis/Dominators.cpp
@@ -1,11 +1,11 @@
-// File: lib/Analysis/Dominators.cpp
+// File: src/il/analysis/Dominators.cpp
 // Purpose: Implement dominator tree construction using the Cooper et al. algorithm.
 // Key invariants: Tree is built once per function; no incremental updates or caches.
 // Ownership/Lifetime: Relies on IL blocks owned by the caller.
 // Links: docs/dev/analysis.md
 
-#include "Analysis/Dominators.h"
-#include "Analysis/CFG.h"
+#include "il/analysis/Dominators.hpp"
+#include "il/analysis/CFG.hpp"
 #include <cstddef>
 
 namespace viper::analysis

--- a/src/il/analysis/Dominators.hpp
+++ b/src/il/analysis/Dominators.hpp
@@ -1,4 +1,4 @@
-// File: lib/Analysis/Dominators.h
+// File: src/il/analysis/Dominators.hpp
 // Purpose: Dominator tree computation and queries.
 // Key invariants: Dominator tree is computed eagerly and remains constant; no incremental updates.
 // Ownership/Lifetime: Operates on IL blocks owned by the caller.

--- a/src/il/transform/Mem2Reg.cpp
+++ b/src/il/transform/Mem2Reg.cpp
@@ -1,4 +1,4 @@
-// File: lib/Passes/Mem2Reg.cpp
+// File: src/il/transform/Mem2Reg.cpp
 // Purpose: Implement alloca promotion to SSA using block parameters with the
 // seal-and-rename algorithm (mem2reg v3).
 // Key invariants: Handles i64/f64/i1 allocas whose addresses do not escape,
@@ -7,8 +7,8 @@
 // removing allocas/loads/stores.
 // Links: docs/passes/mem2reg.md
 
-#include "Passes/Mem2Reg.h"
-#include "Analysis/CFG.h"
+#include "il/transform/Mem2Reg.hpp"
+#include "il/analysis/CFG.hpp"
 #include <algorithm>
 #include <functional>
 #include <optional>

--- a/src/il/transform/Mem2Reg.hpp
+++ b/src/il/transform/Mem2Reg.hpp
@@ -1,4 +1,4 @@
-// File: lib/Passes/Mem2Reg.h
+// File: src/il/transform/Mem2Reg.hpp
 // Purpose: Promote eligible stack slots to SSA registers.
 // Key invariants: Promotes i64/f64/i1 allocas with no escaped addresses using
 // sealed SSA construction with block parameters, handling loops. Ownership/

--- a/src/il/transform/PassManager.cpp
+++ b/src/il/transform/PassManager.cpp
@@ -15,8 +15,8 @@
 
 #include "il/transform/PassManager.hpp"
 
-#include "Analysis/CFG.h"
-#include "Analysis/Dominators.h"
+#include "il/analysis/CFG.hpp"
+#include "il/analysis/Dominators.hpp"
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Function.hpp"
 #include "il/core/Instr.hpp"

--- a/src/il/utils/Utils.cpp
+++ b/src/il/utils/Utils.cpp
@@ -1,9 +1,9 @@
-// File: lib/IL/Utils.cpp
+// File: src/il/utils/Utils.cpp
 // Purpose: Implement small IL helper utilities for blocks and instructions.
 // Key invariants: Operates on il_core structures without additional dependencies.
 // Ownership/Lifetime: Non-owning views; caller manages lifetimes.
 // Links: docs/dev/analysis.md
-#include "IL/Utils.h"
+#include "il/utils/Utils.hpp"
 
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Instr.hpp"

--- a/src/il/utils/Utils.hpp
+++ b/src/il/utils/Utils.hpp
@@ -1,4 +1,4 @@
-// File: lib/IL/Utils.h
+// File: src/il/utils/Utils.hpp
 // Purpose: Provide small helper utilities for IL blocks and instructions.
 // Key invariants: Non-owning queries that depend only on il_core types.
 // Ownership/Lifetime: Callers retain ownership of IL structures.

--- a/src/tools/ilc/cli.hpp
+++ b/src/tools/ilc/cli.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "VM/Trace.h"
+#include "vm/Trace.hpp"
 #include <cstdint>
 #include <string>
 

--- a/src/tools/ilc/cmd_front_basic.cpp
+++ b/src/tools/ilc/cmd_front_basic.cpp
@@ -5,7 +5,7 @@
 // Ownership/Lifetime: Tool owns loaded modules.
 // Links: docs/class-catalog.md
 
-#include "VM/Trace.h"
+#include "vm/Trace.hpp"
 #include "cli.hpp"
 #include "frontends/basic/ConstFolder.hpp"
 #include "frontends/basic/DiagnosticEmitter.hpp"

--- a/src/tools/ilc/cmd_il_opt.cpp
+++ b/src/tools/ilc/cmd_il_opt.cpp
@@ -5,7 +5,7 @@
 // Links: docs/class-catalog.md
 // License: MIT.
 
-#include "Passes/Mem2Reg.h"
+#include "il/transform/Mem2Reg.hpp"
 #include "cli.hpp"
 #include "il/api/expected_api.hpp"
 #include "il/io/Serializer.hpp"

--- a/src/tools/ilc/cmd_run_il.cpp
+++ b/src/tools/ilc/cmd_run_il.cpp
@@ -5,9 +5,9 @@
 // Ownership/Lifetime: Tool owns loaded modules.
 // Links: docs/class-catalog.md
 
-#include "VM/Debug.h"
-#include "VM/DebugScript.h"
-#include "VM/Trace.h"
+#include "vm/Debug.hpp"
+#include "vm/DebugScript.hpp"
+#include "vm/Trace.hpp"
 #include "break_spec.hpp"
 #include "cli.hpp"
 #include "il/api/expected_api.hpp"

--- a/src/vm/Debug.cpp
+++ b/src/vm/Debug.cpp
@@ -1,11 +1,11 @@
-// File: lib/VM/Debug.cpp
+// File: src/vm/Debug.cpp
 // Purpose: Implement breakpoint control and path normalization for the VM.
 // Key invariants: Interned labels identify block breakpoints; source line
 // breakpoints match when either the normalized file path and line or the
 // basename and line coincide. Ownership/Lifetime: DebugCtrl owns its interner,
 // breakpoint set, and source line list.
 // Links: docs/dev/vm.md
-#include "VM/Debug.h"
+#include "vm/Debug.hpp"
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Instr.hpp"
 #include "support/source_location.hpp"

--- a/src/vm/Debug.hpp
+++ b/src/vm/Debug.hpp
@@ -1,4 +1,4 @@
-// File: lib/VM/Debug.h
+// File: src/vm/Debug.hpp
 // Purpose: Declare breakpoint control and path normalization utilities for the VM.
 // Key invariants: Block breakpoints use interned labels. Source line breakpoints
 // match when both the line number and either the normalized path or basename are

--- a/src/vm/DebugScript.cpp
+++ b/src/vm/DebugScript.cpp
@@ -1,9 +1,9 @@
-// File: lib/VM/DebugScript.cpp
+// File: src/vm/DebugScript.cpp
 // Purpose: Implement parsing of debug command scripts for the VM.
 // Key invariants: Unknown lines emit [DEBUG] messages and are skipped.
 // Ownership/Lifetime: Reads from filesystem at construction; no further I/O.
 // Links: docs/dev/vm.md
-#include "VM/DebugScript.h"
+#include "vm/DebugScript.hpp"
 
 #include <fstream>
 #include <iostream>

--- a/src/vm/DebugScript.hpp
+++ b/src/vm/DebugScript.hpp
@@ -1,4 +1,4 @@
-// File: lib/VM/DebugScript.h
+// File: src/vm/DebugScript.hpp
 // Purpose: Parse debug command scripts for automated VM break handling.
 // Key invariants: Unknown commands are ignored; actions returned in FIFO order.
 // Ownership/Lifetime: Holds parsed actions only; does not own external resources.

--- a/src/vm/Trace.cpp
+++ b/src/vm/Trace.cpp
@@ -1,9 +1,9 @@
-// File: lib/VM/Trace.cpp
+// File: src/vm/Trace.cpp
 // Purpose: Implement deterministic tracing for IL VM steps.
 // Key invariants: Each executed instruction produces at most one flushed line.
 // Ownership/Lifetime: Uses external streams; no resource ownership.
 // Links: docs/dev/vm.md
-#include "VM/Trace.h"
+#include "vm/Trace.hpp"
 
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Function.hpp"

--- a/src/vm/Trace.hpp
+++ b/src/vm/Trace.hpp
@@ -1,4 +1,4 @@
-// File: lib/VM/Trace.h
+// File: src/vm/Trace.hpp
 // Purpose: Declare tracing configuration and sink for VM instruction steps.
 // Key invariants: Trace output is deterministic and line-oriented.
 // Ownership/Lifetime: Sink holds configuration by value; no dynamic state.

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -5,8 +5,8 @@
 // Links: docs/il-spec.md
 #pragma once
 
-#include "VM/Debug.h"
-#include "VM/Trace.h"
+#include "vm/Debug.hpp"
+#include "vm/Trace.hpp"
 #include "il/core/fwd.hpp"
 #include "il/core/Opcode.hpp"
 #include "rt.hpp"

--- a/src/vm/VMDebug.cpp
+++ b/src/vm/VMDebug.cpp
@@ -9,7 +9,7 @@
 #include "il/core/Function.hpp"
 #include "il/core/Instr.hpp"
 #include "support/source_manager.hpp"
-#include "VM/DebugScript.h"
+#include "vm/DebugScript.hpp"
 
 #include <filesystem>
 #include <iostream>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,7 +95,7 @@ target_link_libraries(test_basic_lexer_high_bit PRIVATE fe_basic support)
 add_test(NAME test_basic_lexer_high_bit COMMAND test_basic_lexer_high_bit)
 
 add_executable(test_il_utils il/UtilsTests.cpp)
-target_link_libraries(test_il_utils PRIVATE IL)
+target_link_libraries(test_il_utils PRIVATE il_utils)
 add_test(NAME test_il_utils COMMAND test_il_utils)
 
 add_executable(test_tools_break_parsing tools/BreakParsingTests.cpp
@@ -117,19 +117,19 @@ add_test(NAME test_vm_summary COMMAND test_vm_summary $<TARGET_FILE:ilc> ${CMAKE
 
 
 add_executable(test_analysis_cfg analysis/CFGTests.cpp)
-target_link_libraries(test_analysis_cfg PRIVATE Analysis il_build)
+target_link_libraries(test_analysis_cfg PRIVATE il_analysis il_build)
 add_test(NAME test_analysis_cfg COMMAND test_analysis_cfg)
 
 add_executable(test_analysis_graph_order analysis/GraphOrderTests.cpp)
-target_link_libraries(test_analysis_graph_order PRIVATE Analysis il_build)
+target_link_libraries(test_analysis_graph_order PRIVATE il_analysis il_build)
 add_test(NAME test_analysis_graph_order COMMAND test_analysis_graph_order)
 
 add_executable(test_analysis_dominators analysis/DominatorsTests.cpp)
-target_link_libraries(test_analysis_dominators PRIVATE Analysis il_build)
+target_link_libraries(test_analysis_dominators PRIVATE il_analysis il_build)
 add_test(NAME test_analysis_dominators COMMAND test_analysis_dominators)
 
 add_executable(test_analysis_acyclic analysis/AcyclicTests.cpp)
-target_link_libraries(test_analysis_acyclic PRIVATE Analysis il_build)
+target_link_libraries(test_analysis_acyclic PRIVATE il_analysis il_build)
 add_test(NAME test_analysis_acyclic COMMAND test_analysis_acyclic)
 
 add_test(NAME il_verify_ex1 COMMAND $<TARGET_FILE:il-verify> ${CMAKE_SOURCE_DIR}/examples/il/ex1_hello_cond.il)
@@ -517,11 +517,11 @@ target_link_libraries(test_il_pass_manager PRIVATE il_io il_transform il_api)
 add_test(NAME test_il_pass_manager COMMAND test_il_pass_manager)
 
 add_executable(test_vm_normalize_path unit/test_vm_normalize_path.cpp)
-target_link_libraries(test_vm_normalize_path PRIVATE VMTrace)
+target_link_libraries(test_vm_normalize_path PRIVATE il_vm)
 add_test(NAME test_vm_normalize_path COMMAND test_vm_normalize_path)
 
 add_executable(test_path_normalize unit/PathNormalizeTests.cpp)
-target_link_libraries(test_path_normalize PRIVATE VMTrace)
+target_link_libraries(test_path_normalize PRIVATE il_vm)
 add_test(NAME test_path_normalize COMMAND test_path_normalize)
 
 

--- a/tests/analysis/AcyclicTests.cpp
+++ b/tests/analysis/AcyclicTests.cpp
@@ -4,7 +4,7 @@
 // Ownership/Lifetime: Builds local modules via IRBuilder.
 // Links: docs/dev/analysis.md
 
-#include "Analysis/CFG.h"
+#include "il/analysis/CFG.hpp"
 #include "il/build/IRBuilder.hpp"
 #include <cassert>
 

--- a/tests/analysis/CFGTests.cpp
+++ b/tests/analysis/CFGTests.cpp
@@ -4,7 +4,7 @@
 // Ownership/Lifetime: Builds a local module via IRBuilder.
 // Links: docs/dev/analysis.md
 
-#include "Analysis/CFG.h"
+#include "il/analysis/CFG.hpp"
 #include "il/build/IRBuilder.hpp"
 #include <algorithm>
 #include <cassert>

--- a/tests/analysis/DominatorsTests.cpp
+++ b/tests/analysis/DominatorsTests.cpp
@@ -4,8 +4,8 @@
 // Ownership/Lifetime: Builds local modules via IRBuilder.
 // Links: docs/dev/analysis.md
 
-#include "Analysis/CFG.h"
-#include "Analysis/Dominators.h"
+#include "il/analysis/CFG.hpp"
+#include "il/analysis/Dominators.hpp"
 #include "il/build/IRBuilder.hpp"
 #include <cassert>
 

--- a/tests/analysis/GraphOrderTests.cpp
+++ b/tests/analysis/GraphOrderTests.cpp
@@ -4,7 +4,7 @@
 // Ownership/Lifetime: Builds local modules via IRBuilder.
 // Links: docs/dev/analysis.md
 
-#include "Analysis/CFG.h"
+#include "il/analysis/CFG.hpp"
 #include "il/build/IRBuilder.hpp"
 #include <algorithm>
 #include <cassert>

--- a/tests/il/UtilsTests.cpp
+++ b/tests/il/UtilsTests.cpp
@@ -4,7 +4,7 @@
 // Ownership/Lifetime: Constructs local IL blocks and instructions.
 // Links: docs/dev/analysis.md
 
-#include "IL/Utils.h"
+#include "il/utils/Utils.hpp"
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Instr.hpp"
 #include "il/core/Opcode.hpp"

--- a/tests/unit/PathNormalizeTests.cpp
+++ b/tests/unit/PathNormalizeTests.cpp
@@ -4,7 +4,7 @@
 // basename extracted from normalized path.
 // Ownership: Standalone executable.
 // Links: docs/class-catalog.md
-#include "VM/Debug.h"
+#include "vm/Debug.hpp"
 #include <cassert>
 
 int main()

--- a/tests/unit/test_vm_normalize_path.cpp
+++ b/tests/unit/test_vm_normalize_path.cpp
@@ -3,7 +3,7 @@
 // Key invariants: Backslashes become slashes; './' removed; 'dir/../' collapsed.
 // Ownership: Standalone executable.
 // Links: docs/class-catalog.md
-#include "VM/Debug.h"
+#include "vm/Debug.hpp"
 #include <cassert>
 #include <string>
 


### PR DESCRIPTION
## Summary
- move the former lib/Analysis, lib/IL, lib/Passes, and lib/VM sources under src/
- add dedicated il_analysis and il_utils targets, fold VM debug/trace code into il_vm, and extend il_transform with Mem2Reg
- update build logic, includes, tests, scripts, and docs to match the new layout

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ce46eac9b08324bc0cb6650a5dffc8