### PR TITLE
docs: expand CODEMAP coverage for critical C++ files

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -33,18 +33,34 @@ Paths to notable documentation and tests.
 
   Coordinates the BASIC parser's top-level loop, priming the token stream, wiring statement handlers, and splitting procedures from main-line statements as it walks the source. It groups colon-separated statements into `StmtList` nodes and records whether the parser has entered the executable portion of the program so procedures stay at the top. Control flow and diagnostics are delegated to specialized handlers such as `parseIf`, `parseWhile`, and `parseFunction`, which are registered at construction time. The implementation depends on the lexer/token infrastructure, the AST node hierarchy (`Program`, `FunctionDecl`, `SubDecl`, `StmtList`), and `DiagnosticEmitter`/`il::support::SourceLoc` to surface parse errors.
 
+- **src/frontends/basic/Parser.hpp**
+
+  Declares the BASIC parser facade that coordinates token buffering and statement dispatch. It exposes `parseProgram` along with specialized helpers for each statement form, wiring a table of `StmtHandler` entries to member function pointers. Expression parsing utilities, loop body helpers, and DIM bookkeeping are declared here so front-end phases understand how control flow and arrays are surfaced before lowering. Dependencies include the BASIC AST model, lexer, diagnostic emitter, token helper headers, and standard containers such as `<array>`, `<vector>`, and `<unordered_set>`.
+
 - **src/frontends/basic/SemanticAnalyzer.cpp**
 
   Implements symbol, label, and type checking for BASIC programs by visiting the AST after parsing. It snapshots and restores scope state as it enters each procedure, tracks variable declarations, array usage, and procedure signatures, and enforces rules like “FUNCTION must return on every path.” Helper routines compute edit distances for better diagnostics, infer return guarantees, and propagate symbol bindings through nested scopes. The analyzer leans on `ProcRegistry`, `ScopeTracker`, AST statement/expr classes, the builtin registry, and the `DiagnosticEmitter` utilities to register procedures and emit targeted error codes.
+
+- **src/frontends/basic/SemanticAnalyzer.hpp**
+
+  Defines the semantic analyzer interface that walks the BASIC AST to record symbols, labels, and procedure signatures. It exposes diagnostic codes as constants and getters so later passes can inspect the collected scopes, label sets, and procedure registry. RAII helpers such as `ProcedureScope` snapshot symbol state across procedures while nested type-enum utilities describe inference results for expressions and builtin calls. Dependencies include `ProcRegistry`, `ScopeTracker`, `SemanticDiagnostics`, the BASIC AST classes, and standard containers used for symbol tables.
 
 ## IL Analysis
 - **src/il/analysis/CFG.cpp**
 
   Builds lightweight control-flow graph queries for IL functions without materializing persistent graph objects. The utilities collect successor and predecessor blocks by inspecting branch terminators, enabling passes to traverse edges by label resolution against the active module. They also compute post-order, reverse post-order, and topological orders while skipping unreachable blocks, providing canonical iteration sequences for analyses. Dependencies include `CFG.hpp`, IL core containers (`Module`, `Function`, `Block`, `Instr`, `Opcode`), the module registration shim in this file, and standard `<queue>`, `<stack>`, and unordered container types.
 
+- **src/il/analysis/CFG.hpp**
+
+  Introduces lightweight control-flow graph queries that operate directly on IL modules without constructing persistent graph structures. Callers first set the active module and can then ask for successor, predecessor, post-order, or reverse-post-order traversals to drive analyses and transforms. The header also exposes acyclicity and topological ordering helpers so passes share consistent traversal contracts. Dependencies include IL core forward declarations for modules, functions, and blocks alongside the `<vector>` container.
+
 - **src/il/analysis/Dominators.cpp**
 
   Implements dominator tree construction atop the CFG helpers using the Cooper–Harvey–Kennedy algorithm. The builder walks reverse post-order sequences, intersects dominance paths for each block, and records immediate dominators along with child lists for tree traversal. Query helpers like `immediateDominator` and `dominates` then provide inexpensive dominance checks for optimization and verification passes. It relies on `Dominators.hpp`, the CFG API (`reversePostOrder`, `predecessors`), IL block objects, and the standard library's unordered maps.
+
+- **src/il/analysis/Dominators.hpp**
+
+  Declares the `DomTree` structure that stores immediate dominator and child relationships for each block in an IL function. It provides convenience queries such as `dominates` and `immediateDominator` so optimization passes and verifiers can reason about control flow quickly. A standalone `computeDominatorTree` entry point promises a complete computation that the implementation backs with the Cooper–Harvey–Kennedy algorithm. Dependencies include IL core block/function types plus `<unordered_map>` and `<vector>` containers, and it pairs with `Dominators.cpp` which pulls in the CFG utilities.
 
 ## IL Build
 - **src/il/build/IRBuilder.cpp**
@@ -65,6 +81,14 @@ Paths to notable documentation and tests.
   Provides constructors and formatting helpers for IL SSA values including temporaries, numeric literals, globals, and null pointers. The `toString` routine canonicalizes floating-point output by trimming trailing zeroes and ensuring deterministic formatting for the serializer, while helpers like `constInt` and `global` package values with the right tag. These utilities are widely used when building IR, pretty-printing modules, and interpreting values in the VM. The file depends on `il/core/Value.hpp` and the C++ standard library (`<sstream>`, `<iomanip>`, `<limits>`, `<utility>`) for string conversion.
 
 ## IL I/O
+- **src/il/io/Parser.cpp**
+
+  Implements the façade for parsing textual IL modules from an input stream. It seeds a `ParserState`, normalizes each line while skipping comments or blanks, and then hands structural decisions to the detail `parseModuleHeader_E` helper. Errors from that helper propagate unchanged so callers receive consistent diagnostics with precise line numbers. Dependencies include `Parser.hpp`, `ModuleParser.hpp`, `ParserUtil.hpp`, the parser-state helpers, IL core `Module` definitions, and the diagnostics `Expected` wrapper.
+
+- **src/il/io/Parser.hpp**
+
+  Declares the IL parser entry point that orchestrates module, function, and instruction sub-parsers. The class exposes a single static `parse` routine, signaling that parsing is a stateless operation layered over a supplied module instance. Its includes reveal the composition of specialized parsers and parser-state bookkeeping while documenting the diagnostic channel used for reporting errors. Dependencies include IL core forward declarations, the function/instruction/module parser headers, `ParserState.hpp`, and the `il::support::Expected` utility.
+
 - **src/il/io/Serializer.cpp**
 
   Emits IL modules into textual form by traversing externs, globals, and function bodies with deterministic ordering when canonical mode is requested. It prints `.loc` metadata, rewrites operands using `Value::toString`, and honors opcode-specific formatting rules for calls, branches, loads/stores, and returns. Extern declarations can be sorted lexicographically to support diff-friendly output, and functions render their block parameters alongside instructions. Dependencies include the serializer interface, IL core containers (`Extern`, `Global`, `Function`, `BasicBlock`, `Instr`, `Module`, `Opcode`, `Value`), and the standard `<algorithm>`/`<sstream>` utilities.
@@ -73,6 +97,10 @@ Paths to notable documentation and tests.
 - **src/il/runtime/RuntimeSignatures.cpp**
 
   Defines the shared registry mapping runtime helper names to IL signatures so frontends, verifiers, and the VM agree on the C ABI. A lazily initialized table enumerates every exported helper and wraps each return/parameter kind in `il::core::Type` objects, exposing lookup helpers for consumers. The data ensures extern declarations carry the right arity and type tags while giving the runtime bridge enough metadata to validate calls. Dependencies include `RuntimeSignatures.hpp`, IL core type definitions, and standard containers such as `<initializer_list>` and `<unordered_map>`.
+
+- **src/il/runtime/RuntimeSignatures.hpp**
+
+  Describes the metadata schema for runtime helper signatures shared across the toolchain. It defines the `RuntimeSignature` struct capturing return and parameter types using IL type objects and documents how parameter order mirrors the C ABI. Accessor functions expose the registry map and an optional lookup helper so consumers can fetch signatures lazily without copying data. Dependencies include `il/core/Type.hpp`, `<string_view>`, `<vector>`, and `<unordered_map>`.
 
 ## IL Transform
 - **src/il/transform/Mem2Reg.cpp**
@@ -105,6 +133,10 @@ Paths to notable documentation and tests.
 
   Implements the diagnostic engine that collects, counts, and prints errors and warnings emitted across the toolchain. It records severity information, formats messages with source locations when a `SourceManager` is provided, and exposes counters so clients can bail out after fatal issues. The printing helper maps enum severities to lowercase strings to keep output consistent between front-end and backend consumers. Dependencies cover the diagnostics interfaces, source management utilities, and standard stream facilities.
 
+- **src/support/diagnostics.hpp**
+
+  Advertises the diagnostics subsystem responsible for collecting, counting, and printing compiler messages. The header enumerates severity levels, the `Diagnostic` record, and the `DiagnosticEngine` API so callers can report events and later flush them to a stream. Counter accessors make it easy for front ends to guard execution on accumulated errors while preserving the order of recorded messages. Dependencies include the shared `source_location.hpp` definitions and standard library facilities such as `<ostream>`, `<string>`, and `<vector>`.
+
 - **src/support/source_manager.cpp**
 
   Maintains canonical source-file identifiers and paths for diagnostics through the `SourceManager`. New files are normalized with `std::filesystem` so relative paths collapse to stable, platform-independent strings before being assigned incrementing IDs. Consumers such as the lexer, diagnostics engine, and tracing facilities call back into the manager to resolve `SourceLoc` instances into filenames. Dependencies include `source_manager.hpp` and the C++ `<filesystem>` library.
@@ -130,9 +162,17 @@ Paths to notable documentation and tests.
 
   Implements deterministic tracing facilities for the VM, emitting IL-level or source-level logs depending on the configured mode. Each step event walks the owning function's blocks to locate the instruction pointer, formats operands with locale-stable helpers, and optionally loads source snippets using the `SourceManager`. It supports Windows console quirks, writes to `stderr` with flush control, and ensures floating-point text matches serializer output. Dependencies include `Trace.hpp`, IL core instruction/value types, `support/source_manager.hpp`, `<locale>`, and `<filesystem>/<fstream>`.
 
+- **src/vm/Trace.hpp**
+
+  Declares the tracing configuration and sink used by the VM to emit execution logs. `TraceConfig` models the available modes and can carry a `SourceManager` pointer to support source-aware traces. `TraceSink` exposes an `onStep` callback that the interpreter invokes with each instruction and active frame so the implementation can render deterministic text. Dependencies include IL instruction forward declarations, `il::support::SourceManager`, the VM `Frame` type, and the standard headers consumed by `Trace.cpp`.
+
 - **src/vm/VM.cpp**
 
   Drives execution of IL modules by locating `main`, preparing frames, and stepping through instructions with debug and tracing hooks. The interpreter evaluates SSA values into runtime slots, routes opcodes through the handler table, and manages control-flow transitions within the execution loop. It coordinates with the runtime bridge for traps/globals and with debug controls to pause or resume execution as needed. Dependencies include `vm/VM.hpp`, IL core types (`Module`, `Function`, `BasicBlock`, `Instr`, `Value`, `Opcode`), the opcode handler table, tracing/debug infrastructure, and the `RuntimeBridge` C ABI.
+
+- **src/vm/VM.hpp**
+
+  Defines the VM's public interface, including the slot union, execution frame container, and the interpreter class itself. The header documents how `VM` wires together tracing, debugging, and opcode dispatch, exposing the `ExecResult` structure and handler table typedefs that drive the interpreter loop. It also details constructor knobs like step limits and debug scripts so embedding tools understand lifecycle expectations. Nested data members describe ownership semantics for modules, runtime strings, and per-function lookup tables. Dependencies include the VM debug and trace headers, IL opcode/type forward declarations, the runtime `rt.hpp` bridge, and standard containers such as `<vector>`, `<array>`, and `<unordered_map>`.
 
 - **src/vm/VMInit.cpp**
 


### PR DESCRIPTION
## Summary
- document BASIC front-end headers for the parser and semantic analyzer in CODEMAP
- add CODEMAP coverage for IL analysis/runtime, support diagnostics, and VM interfaces that lacked entries

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cf213df6048324a2976737ee2e0348