### PR TITLE
refactor(frontends/basic): centralize runtime helper tracking

### DIFF
--- a/src/frontends/basic/LowerRuntime.cpp
+++ b/src/frontends/basic/LowerRuntime.cpp
@@ -47,8 +47,8 @@ void declareRuntimeExtern(build::IRBuilder &b, std::string_view name)
 
 /// @brief Declare every runtime helper required by the current lowering run.
 /// @details Emits baseline helpers unconditionally and consults lowering
-///          toggles such as needRtConcat, boundsChecks, and similar feature
-///          flags to decide which additional helpers are necessary. Runtime
+///          toggles recorded through requestHelper/isHelperNeeded along with
+///          boundsChecks to decide which additional helpers are necessary. Runtime
 ///          math helpers requested dynamically are iterated in the order
 ///          recorded by trackRuntime so declaration emission remains
 ///          deterministic. Each declaration delegates to declareRuntimeExtern,
@@ -57,6 +57,16 @@ void declareRuntimeExtern(build::IRBuilder &b, std::string_view name)
 /// @note Assumes runtimeOrder has been populated through trackRuntime calls;
 ///       missing signatures are enforced by the assertion in
 ///       declareRuntimeExtern.
+void Lowerer::requestHelper(RuntimeHelper helper)
+{
+    runtimeHelpers.set(static_cast<size_t>(helper));
+}
+
+bool Lowerer::isHelperNeeded(RuntimeHelper helper) const
+{
+    return runtimeHelpers.test(static_cast<size_t>(helper));
+}
+
 void Lowerer::declareRequiredRuntime(build::IRBuilder &b)
 {
     declareRuntimeExtern(b, "rt_print_str");
@@ -64,45 +74,45 @@ void Lowerer::declareRequiredRuntime(build::IRBuilder &b)
     declareRuntimeExtern(b, "rt_print_f64");
     declareRuntimeExtern(b, "rt_len");
     declareRuntimeExtern(b, "rt_substr");
-    if (needRtConcat)
+    if (isHelperNeeded(RuntimeHelper::Concat))
         declareRuntimeExtern(b, "rt_concat");
     if (boundsChecks)
         declareRuntimeExtern(b, "rt_trap");
-    if (needInputLine)
+    if (isHelperNeeded(RuntimeHelper::InputLine))
         declareRuntimeExtern(b, "rt_input_line");
-    if (needRtToInt)
+    if (isHelperNeeded(RuntimeHelper::ToInt))
         declareRuntimeExtern(b, "rt_to_int");
-    if (needRtIntToStr)
+    if (isHelperNeeded(RuntimeHelper::IntToStr))
         declareRuntimeExtern(b, "rt_int_to_str");
-    if (needRtF64ToStr)
+    if (isHelperNeeded(RuntimeHelper::F64ToStr))
         declareRuntimeExtern(b, "rt_f64_to_str");
-    if (needAlloc)
+    if (isHelperNeeded(RuntimeHelper::Alloc))
         declareRuntimeExtern(b, "rt_alloc");
-    if (needRtLeft)
+    if (isHelperNeeded(RuntimeHelper::Left))
         declareRuntimeExtern(b, "rt_left");
-    if (needRtRight)
+    if (isHelperNeeded(RuntimeHelper::Right))
         declareRuntimeExtern(b, "rt_right");
-    if (needRtMid2)
+    if (isHelperNeeded(RuntimeHelper::Mid2))
         declareRuntimeExtern(b, "rt_mid2");
-    if (needRtMid3)
+    if (isHelperNeeded(RuntimeHelper::Mid3))
         declareRuntimeExtern(b, "rt_mid3");
-    if (needRtInstr2)
+    if (isHelperNeeded(RuntimeHelper::Instr2))
         declareRuntimeExtern(b, "rt_instr2");
-    if (needRtInstr3)
+    if (isHelperNeeded(RuntimeHelper::Instr3))
         declareRuntimeExtern(b, "rt_instr3");
-    if (needRtLtrim)
+    if (isHelperNeeded(RuntimeHelper::Ltrim))
         declareRuntimeExtern(b, "rt_ltrim");
-    if (needRtRtrim)
+    if (isHelperNeeded(RuntimeHelper::Rtrim))
         declareRuntimeExtern(b, "rt_rtrim");
-    if (needRtTrim)
+    if (isHelperNeeded(RuntimeHelper::Trim))
         declareRuntimeExtern(b, "rt_trim");
-    if (needRtUcase)
+    if (isHelperNeeded(RuntimeHelper::Ucase))
         declareRuntimeExtern(b, "rt_ucase");
-    if (needRtLcase)
+    if (isHelperNeeded(RuntimeHelper::Lcase))
         declareRuntimeExtern(b, "rt_lcase");
-    if (needRtChr)
+    if (isHelperNeeded(RuntimeHelper::Chr))
         declareRuntimeExtern(b, "rt_chr");
-    if (needRtAsc)
+    if (isHelperNeeded(RuntimeHelper::Asc))
         declareRuntimeExtern(b, "rt_asc");
 
     for (RuntimeFn fn : runtimeOrder)
@@ -142,7 +152,7 @@ void Lowerer::declareRequiredRuntime(build::IRBuilder &b)
         }
     }
 
-    if (needRtStrEq)
+    if (isHelperNeeded(RuntimeHelper::StrEq))
         declareRuntimeExtern(b, "rt_str_eq");
 }
 

--- a/src/frontends/basic/LowerRuntime.hpp
+++ b/src/frontends/basic/LowerRuntime.hpp
@@ -27,5 +27,7 @@ struct RuntimeFnHash
 std::vector<RuntimeFn> runtimeOrder;
 std::unordered_set<RuntimeFn, RuntimeFnHash> runtimeSet;
 
+void requestHelper(RuntimeHelper helper);
+bool isHelperNeeded(RuntimeHelper helper) const;
 void trackRuntime(RuntimeFn fn);
 void declareRequiredRuntime(build::IRBuilder &b);

--- a/src/frontends/basic/Lowerer.cpp
+++ b/src/frontends/basic/Lowerer.cpp
@@ -192,26 +192,7 @@ Module Lowerer::lowerProgram(const Program &prog)
     arrays.clear();
     boundsCheckId = 0;
 
-    needInputLine = false;
-    needRtToInt = false;
-    needRtIntToStr = false;
-    needRtF64ToStr = false;
-    needAlloc = false;
-    needRtStrEq = false;
-    needRtConcat = false;
-    needRtLeft = false;
-    needRtRight = false;
-    needRtMid2 = false;
-    needRtMid3 = false;
-    needRtInstr2 = false;
-    needRtInstr3 = false;
-    needRtLtrim = false;
-    needRtRtrim = false;
-    needRtTrim = false;
-    needRtUcase = false;
-    needRtLcase = false;
-    needRtChr = false;
-    needRtAsc = false;
+    runtimeHelpers.reset();
     runtimeOrder.clear();
     runtimeSet.clear();
 

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -10,6 +10,7 @@
 #include "frontends/basic/NameMangler.hpp"
 #include "il/build/IRBuilder.hpp"
 #include "il/core/Module.hpp"
+#include <bitset>
 #include <functional>
 #include <memory>
 #include <string>
@@ -158,26 +159,35 @@ class Lowerer
     unsigned boundsCheckId{0};
 
     // runtime requirement tracking
-    bool needInputLine{false};
-    bool needRtToInt{false};
-    bool needRtIntToStr{false};
-    bool needRtF64ToStr{false};
-    bool needAlloc{false};
-    bool needRtStrEq{false};
-    bool needRtConcat{false};
-    bool needRtLeft{false};
-    bool needRtRight{false};
-    bool needRtMid2{false};
-    bool needRtMid3{false};
-    bool needRtInstr2{false};
-    bool needRtInstr3{false};
-    bool needRtLtrim{false};
-    bool needRtRtrim{false};
-    bool needRtTrim{false};
-    bool needRtUcase{false};
-    bool needRtLcase{false};
-    bool needRtChr{false};
-    bool needRtAsc{false};
+    enum class RuntimeHelper
+    {
+        InputLine,
+        ToInt,
+        IntToStr,
+        F64ToStr,
+        Alloc,
+        StrEq,
+        Concat,
+        Left,
+        Right,
+        Mid2,
+        Mid3,
+        Instr2,
+        Instr3,
+        Ltrim,
+        Rtrim,
+        Trim,
+        Ucase,
+        Lcase,
+        Chr,
+        Asc,
+        Count,
+    };
+
+    static constexpr size_t kRuntimeHelperCount =
+        static_cast<size_t>(RuntimeHelper::Count);
+
+    std::bitset<kRuntimeHelperCount> runtimeHelpers;
 
 #include "frontends/basic/LowerRuntime.hpp"
 #include "frontends/basic/LowerScan.hpp"


### PR DESCRIPTION
## Summary
- add a RuntimeHelper enum plus bitset tracking so helper requests flow through requestHelper/isHelperNeeded
- reset helper state in one call and update runtime declarations to query the new container
- switch scanning and lowering code paths to request runtime helpers through the centralized API

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cf20b61a348324a1ce69a3aeb10ed2