### PR TITLE
refactor(frontends/basic): adopt visitors for semantic and lowering passes

### DIFF
--- a/src/frontends/basic/LowerEmit.hpp
+++ b/src/frontends/basic/LowerEmit.hpp
@@ -116,6 +116,8 @@ RVal ensureF64(RVal v, il::support::SourceLoc loc);
 
 void lowerLet(const LetStmt &stmt);
 void lowerPrint(const PrintStmt &stmt);
+void lowerStmtList(const StmtList &stmt);
+void lowerReturn(const ReturnStmt &stmt);
 /// @brief Emit blocks for an IF/ELSEIF chain.
 /// @param conds Number of conditions (IF + ELSEIFs).
 /// @return Indices for test/then blocks and ELSE/exit blocks.

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -23,6 +23,9 @@
 namespace il::frontends::basic
 {
 
+class LowererExprVisitor;
+class LowererStmtVisitor;
+
 /// @brief Lowers BASIC AST into IL Module.
 /// @invariant Generates deterministic block names per procedure using BlockNamer.
 /// @ownership Owns produced Module; uses IRBuilder for structure emission.
@@ -42,6 +45,9 @@ class Lowerer
     il::core::Module lower(const Program &prog);
 
   private:
+    friend class LowererExprVisitor;
+    friend class LowererStmtVisitor;
+
     using Module = il::core::Module;
     using Function = il::core::Function;
     using BasicBlock = il::core::BasicBlock;

--- a/src/frontends/basic/Parser_Stmt.cpp
+++ b/src/frontends/basic/Parser_Stmt.cpp
@@ -464,18 +464,18 @@ il::support::SourceLoc Parser::parseProcedureBody(TokenKind endKind, std::vector
     {
         while (at(TokenKind::EndOfLine))
             consume();
+        int innerLine = 0;
+        if (at(TokenKind::Number))
+        {
+            innerLine = std::atoi(peek().lexeme.c_str());
+            consume();
+        }
         if (at(TokenKind::KeywordEnd) && peek(1).kind == endKind)
         {
             endLoc = peek().loc;
             consume();
             consume();
             break;
-        }
-        int innerLine = 0;
-        if (at(TokenKind::Number))
-        {
-            innerLine = std::atoi(peek().lexeme.c_str());
-            consume();
         }
         auto stmt = parseStatement(innerLine);
         stmt->line = innerLine;

--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -23,6 +23,9 @@
 namespace il::frontends::basic
 {
 
+class SemanticAnalyzerExprVisitor;
+class SemanticAnalyzerStmtVisitor;
+
 /// @brief Traverses BASIC AST to collect symbols and labels, validate variable
 ///        references, and verify FOR/NEXT nesting.
 /// @invariant Symbol table only contains definitions; unknown uses report
@@ -60,6 +63,9 @@ class SemanticAnalyzer
     const ProcTable &procs() const;
 
   private:
+    friend class SemanticAnalyzerExprVisitor;
+    friend class SemanticAnalyzerStmtVisitor;
+
     /// @brief Record symbols and labels from a statement.
     /// @param s Statement node to analyze.
     void visitStmt(const Stmt &s);

--- a/tests/unit/test_basic_semantic.cpp
+++ b/tests/unit/test_basic_semantic.cpp
@@ -1,10 +1,13 @@
 // File: tests/unit/test_basic_semantic.cpp
-// Purpose: Unit test verifying BASIC semantic analyzer runs without diagnostics.
-// Key invariants: Analyzer collects symbols and labels without emitting messages.
+// Purpose: Unit test verifying BASIC semantic analyzer and lowerer handle a
+//          representative AST without diagnostics.
+// Key invariants: Analyzer collects symbols/labels and lowering produces
+//                 functions for user procedures and main.
 // Ownership/Lifetime: Test owns all objects locally.
 // Links: docs/class-catalog.md
 
 #include "frontends/basic/DiagnosticEmitter.hpp"
+#include "frontends/basic/Lowerer.hpp"
 #include "frontends/basic/Parser.hpp"
 #include "frontends/basic/SemanticAnalyzer.hpp"
 #include "support/source_manager.hpp"
@@ -16,7 +19,34 @@ using namespace il::support;
 
 int main()
 {
-    std::string src = "10 LET X = 1\n20 END\n";
+    std::string src =
+        "100 FUNCTION F(N)\n"
+        "110 RETURN N + 1\n"
+        "120 END FUNCTION\n"
+        "200 SUB P(Q())\n"
+        "210 PRINT LEN(\"SUB\")\n"
+        "220 END SUB\n"
+        "1000 DIM A(5)\n"
+        "1010 DIM FLAG AS BOOLEAN\n"
+        "1020 DIM S$\n"
+        "1030 LET FLAG = TRUE\n"
+        "1035 LET FLAG = NOT FLAG\n"
+        "1040 LET X = 3\n"
+        "1050 LET Y# = 1.5\n"
+        "1060 RANDOMIZE 42: PRINT LEN(\"HI\"), A(X)\n"
+        "1070 IF FLAG THEN LET X = X + 1 ELSEIF X > 1 THEN LET X = X - 1 ELSE PRINT \"ZERO\": PRINT \"TAIL\"\n"
+        "1080 WHILE X > 0\n"
+        "1090 PRINT LEN(\"HI\"), A(X)\n"
+        "1100 LET X = X - 1: PRINT X\n"
+        "1110 WEND\n"
+        "1120 FOR I = 1 TO 3\n"
+        "1130 LET A(I) = I\n"
+        "1140 NEXT I\n"
+        "1150 INPUT \"Value?\", S$\n"
+        "1160 PRINT F(X)\n"
+        "1170 GOTO 2000\n"
+        "1180 END\n"
+        "2000 PRINT \"DONE\";\n";
     SourceManager sm;
     uint32_t fid = sm.addFile("test.bas");
     Parser p(src, fid);
@@ -29,9 +59,46 @@ int main()
     sema.analyze(*prog);
     assert(em.errorCount() == 0);
     assert(em.warningCount() == 0);
+    assert(sema.symbols().count("A") == 1);
+    assert(sema.symbols().count("FLAG") == 1);
+    assert(sema.symbols().count("S$") == 1);
     assert(sema.symbols().count("X") == 1);
-    assert(sema.labels().count(10) == 1);
-    assert(sema.labels().count(20) == 1);
-    assert(sema.labelRefs().empty());
+    assert(sema.symbols().count("Y#") == 1);
+    assert(sema.symbols().count("I") == 1);
+    assert(sema.labels().count(1000) == 1);
+    assert(sema.labels().count(1070) == 1);
+    assert(sema.labels().count(2000) == 1);
+    assert(sema.labelRefs().count(2000) == 1);
+    assert(sema.procs().count("F") == 1);
+    assert(sema.procs().count("P") == 1);
+    assert(sema.procs().at("F").params.size() == 1);
+    assert(sema.procs().at("P").params.size() == 1);
+
+    bool hasStmtList = false;
+    for (const auto &stmt : prog->main)
+    {
+        if (dynamic_cast<const StmtList *>(stmt.get()))
+        {
+            hasStmtList = true;
+            break;
+        }
+    }
+    assert(hasStmtList);
+
+    Lowerer lowerer;
+    il::core::Module module = lowerer.lowerProgram(*prog);
+    bool sawMain = false;
+    bool sawFunction = false;
+    bool sawSub = false;
+    for (const auto &fn : module.functions)
+    {
+        if (fn.name == "main")
+            sawMain = true;
+        else if (fn.name == "F")
+            sawFunction = true;
+        else if (fn.name == "P")
+            sawSub = true;
+    }
+    assert(sawMain && sawFunction && sawSub);
     return 0;
 }


### PR DESCRIPTION
## Summary
- introduce dedicated expression and statement visitors for the BASIC semantic analyzer and lowering so dispatch no longer relies on dynamic_cast chains
- extend Lowerer and SemanticAnalyzer to expose visitor entry points and wire AST accept methods through them, including support helpers for lowering stmt lists and returns
- fix procedure body parsing to consume line numbers before END terminators and expand the BASIC semantic unit test to cover a rich program, verifying both analysis and lowering succeed

## Testing
- cmake --build build --target test_basic_semantic -- -j1
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cf48c0740083249465dad23c41928c