### PR TITLE
feat(fe/basic): collect vars via visitors

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -448,6 +448,10 @@ add_executable(test_basic_semantic unit/test_basic_semantic.cpp)
 target_link_libraries(test_basic_semantic PRIVATE fe_basic support)
 add_test(NAME test_basic_semantic COMMAND test_basic_semantic)
 
+add_executable(test_basic_lowerer_collect unit/test_basic_lowerer_collect.cpp)
+target_link_libraries(test_basic_lowerer_collect PRIVATE fe_basic support)
+add_test(NAME test_basic_lowerer_collect COMMAND test_basic_lowerer_collect)
+
 add_executable(test_basic_semantic_components unit/test_basic_semantic_components.cpp)
 target_link_libraries(test_basic_semantic_components PRIVATE fe_basic support)
 add_test(NAME test_basic_semantic_components COMMAND test_basic_semantic_components)

--- a/tests/unit/test_basic_lowerer_collect.cpp
+++ b/tests/unit/test_basic_lowerer_collect.cpp
@@ -1,0 +1,65 @@
+// File: tests/unit/test_basic_lowerer_collect.cpp
+// Purpose: Ensure BASIC lowerer collects variables from all statement visitors.
+// Key invariants: RANDOMIZE/RETURN statements must allocate referenced variables.
+// Ownership: Test owns constructed AST and module.
+// Links: docs/class-catalog.md
+
+#include "frontends/basic/Lowerer.hpp"
+#include "frontends/basic/Parser.hpp"
+#include "support/source_manager.hpp"
+#include <cassert>
+#include <string>
+
+using namespace il::frontends::basic;
+using namespace il::support;
+
+namespace
+{
+
+bool entryHasAlloca(const il::core::Function &fn)
+{
+    if (fn.blocks.empty())
+        return false;
+    for (const auto &instr : fn.blocks.front().instructions)
+    {
+        if (instr.op == il::core::Opcode::Alloca)
+            return true;
+    }
+    return false;
+}
+
+} // namespace
+
+int main()
+{
+    SourceManager sm;
+    uint32_t fid = sm.addFile("test.bas");
+    std::string src =
+        "10 FUNCTION F()\n"
+        "20 RANDOMIZE SEED\n"
+        "30 RETURN SEED\n"
+        "40 END FUNCTION\n"
+        "100 RANDOMIZE MAINSEED\n"
+        "110 PRINT MAINSEED\n";
+
+    Parser parser(src, fid);
+    auto prog = parser.parseProgram();
+    assert(prog);
+
+    Lowerer lowerer;
+    il::core::Module module = lowerer.lowerProgram(*prog);
+
+    const il::core::Function *mainFn = nullptr;
+    const il::core::Function *funcF = nullptr;
+    for (const auto &fn : module.functions)
+    {
+        if (fn.name == "main")
+            mainFn = &fn;
+        else if (fn.name == "F")
+            funcF = &fn;
+    }
+    assert(mainFn && funcF);
+    assert(entryHasAlloca(*mainFn));
+    assert(entryHasAlloca(*funcF));
+    return 0;
+}


### PR DESCRIPTION
## Summary
- replace dynamic_cast scanning with dedicated expression and statement visitors so every BASIC AST node contributes to variable, array, and type tracking
- update `Lowerer::collectVars` to drive traversal through `accept` calls instead of repeated `dynamic_cast`
- add a BASIC lowering unit test that exercises RANDOMIZE/RETURN variable collection and wire it into the test suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cfaae813c883248976117249e1e395