### PR TITLE
Refactor BASIC lowerer helpers

### DIFF
--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -154,6 +154,30 @@ class Lowerer
 
     std::unique_ptr<BlockNamer> blockNamer;
 
+    struct ProcedureConfig;
+
+    struct ProcedureMetadata
+    {
+        std::vector<const Stmt *> bodyStmts;
+        std::unordered_set<std::string> paramNames;
+        std::vector<il::core::Param> irParams;
+        size_t paramCount{0};
+    };
+
+    ProcedureMetadata collectProcedureMetadata(const std::vector<Param> &params,
+                                               const std::vector<StmtPtr> &body,
+                                               const ProcedureConfig &config);
+
+    void buildProcedureSkeleton(Function &f,
+                                const std::string &name,
+                                const ProcedureMetadata &metadata);
+
+    void allocateLocals(const std::unordered_set<std::string> &paramNames);
+
+    void lowerStatementSequence(const std::vector<const Stmt *> &stmts,
+                                bool stopOnTerminated,
+                                const std::function<void(const Stmt &)> &beforeBranch = {});
+
 #include "frontends/basic/LowerEmit.hpp"
 
     build::IRBuilder *builder{nullptr};


### PR DESCRIPTION
## Summary
- add dedicated helpers in the BASIC lowerer for collecting procedure metadata, building block skeletons, allocating locals, and lowering statement sequences
- switch procedure lowering to invoke the new helpers instead of inlined logic for better structure reuse
- reuse the new allocation and sequencing helpers when emitting the main program to eliminate duplicated logic

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d09c9975c883249cb08a247192e562