### PR TITLE
Refactor runtime bridge context handling

### DIFF
--- a/src/vm/RuntimeBridge.hpp
+++ b/src/vm/RuntimeBridge.hpp
@@ -15,6 +15,14 @@ namespace il::vm
 
 union Slot; // defined in VM.hpp
 
+/// @brief Stores runtime call metadata for trap diagnostics.
+struct RuntimeCallContext
+{
+    il::support::SourceLoc loc{}; ///< Source location of the active runtime call.
+    std::string function;         ///< Name of the calling function.
+    std::string block;            ///< Label of the calling basic block.
+};
+
 /// @brief Provides entry points from the VM into the C runtime library.
 class RuntimeBridge
 {
@@ -26,7 +34,8 @@ class RuntimeBridge
     /// @param fn Calling function name.
     /// @param block Calling block label.
     /// @return Result slot from runtime call.
-    static Slot call(const std::string &name,
+    static Slot call(RuntimeCallContext &ctx,
+                     const std::string &name,
                      const std::vector<Slot> &args,
                      const il::support::SourceLoc &loc,
                      const std::string &fn,
@@ -38,6 +47,10 @@ class RuntimeBridge
                      const il::support::SourceLoc &loc,
                      const std::string &fn,
                      const std::string &block);
+
+    /// @brief Access the runtime call context active on the current thread.
+    /// @return Pointer to the call context when a runtime call is executing; nullptr otherwise.
+    static const RuntimeCallContext *activeContext();
 };
 
 } // namespace il::vm

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "vm/Debug.hpp"
+#include "vm/RuntimeBridge.hpp"
 #include "vm/Trace.hpp"
 #include "il/core/fwd.hpp"
 #include "il/core/Opcode.hpp"
@@ -155,6 +156,9 @@ class VM
     /// @brief Interned runtime strings.
     /// @ownership Owned by the VM; manages @c rt_string handles.
     std::unordered_map<std::string, rt_string> strMap;
+
+    /// @brief Trap metadata for the currently executing runtime call.
+    RuntimeCallContext runtimeContext;
 
     /// @brief Execute function @p fn with optional arguments.
     /// @param fn Function to execute.

--- a/src/vm/control_flow.cpp
+++ b/src/vm/control_flow.cpp
@@ -164,7 +164,7 @@ VM::ExecResult OpHandlers::handleCall(VM &vm,
     if (it != vm.fnMap.end())
         out = vm.execFunction(*it->second, args);
     else
-        out = RuntimeBridge::call(in.callee, args, in.loc, fr.func->name, bb->label);
+        out = RuntimeBridge::call(vm.runtimeContext, in.callee, args, in.loc, fr.func->name, bb->label);
     ops::storeResult(fr, in, out);
     return {};
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 option(IL_ENABLE_DOCS_LINT "Run header/Doxygen docs check (scripts/check_comments.py)" OFF)
 
+find_package(Threads REQUIRED)
+
 if(IL_ENABLE_DOCS_LINT)
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
   execute_process(COMMAND git rev-parse --is-inside-work-tree
@@ -495,6 +497,10 @@ add_test(NAME test_vm_rt_missing_arg COMMAND test_vm_rt_missing_arg)
 add_executable(test_vm_rt_concat_missing_args unit/test_vm_rt_concat_missing_args.cpp)
 target_link_libraries(test_vm_rt_concat_missing_args PRIVATE il_build il_vm support)
 add_test(NAME test_vm_rt_concat_missing_args COMMAND test_vm_rt_concat_missing_args)
+
+add_executable(test_vm_runtime_concurrency unit/test_vm_runtime_concurrency.cpp)
+target_link_libraries(test_vm_runtime_concurrency PRIVATE il_build il_vm support Threads::Threads)
+add_test(NAME test_vm_runtime_concurrency COMMAND test_vm_runtime_concurrency)
 
 add_executable(test_vm_alloca_negative unit/test_vm_alloca_negative.cpp)
 target_link_libraries(test_vm_alloca_negative PRIVATE il_build il_vm support)

--- a/tests/unit/test_vm_runtime_concurrency.cpp
+++ b/tests/unit/test_vm_runtime_concurrency.cpp
@@ -1,0 +1,93 @@
+// File: tests/unit/test_vm_runtime_concurrency.cpp
+// Purpose: Verify runtime trap metadata remains isolated per VM under concurrency.
+// Key invariants: Concurrent runtime calls must preserve distinct trap context.
+// Ownership: Constructs independent modules per thread and overrides vm_trap.
+// Links: docs/class-catalog.md
+
+#include "il/build/IRBuilder.hpp"
+#include "support/source_location.hpp"
+#include "vm/RuntimeBridge.hpp"
+#include "vm/VM.hpp"
+#include <array>
+#include <barrier>
+#include <cassert>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+std::barrier<> trapBarrier(2);
+std::mutex trapMutex;
+std::vector<std::string> trapMessages;
+}
+
+extern "C" void vm_trap(const char *msg)
+{
+    trapBarrier.arrive_and_wait();
+    const auto *ctx = il::vm::RuntimeBridge::activeContext();
+    std::ostringstream os;
+    os << (msg ? msg : "trap");
+    if (ctx)
+    {
+        os << ' ' << ctx->function << ": " << ctx->block;
+        if (ctx->loc.isValid())
+            os << " (" << ctx->loc.file_id << ':' << ctx->loc.line << ':' << ctx->loc.column << ')';
+    }
+    std::lock_guard<std::mutex> lock(trapMutex);
+    trapMessages.push_back(os.str());
+}
+
+int main()
+{
+    trapMessages.clear();
+
+    const std::array<std::string, 2> globals = {"g_msg_a", "g_msg_b"};
+    const std::array<std::string, 2> messages = {"trap-A", "trap-B"};
+    const std::array<std::string, 2> blocks = {"blockA", "blockB"};
+    const std::array<il::support::SourceLoc, 2> locs = {
+        il::support::SourceLoc{1, 10, 4},
+        il::support::SourceLoc{2, 20, 8},
+    };
+
+    auto worker = [&](int idx)
+    {
+        il::core::Module module;
+        il::build::IRBuilder builder(module);
+        builder.addExtern("rt_trap",
+                          il::core::Type(il::core::Type::Kind::Void),
+                          {il::core::Type(il::core::Type::Kind::Str)});
+        builder.addGlobalStr(globals[idx], messages[idx]);
+        auto &fn = builder.startFunction("main", il::core::Type(il::core::Type::Kind::I64), {});
+        auto &bb = builder.addBlock(fn, blocks[idx]);
+        builder.setInsertPoint(bb);
+        auto strVal = builder.emitConstStr(globals[idx], locs[idx]);
+        builder.emitCall("rt_trap", {strVal}, std::nullopt, locs[idx]);
+        std::optional<il::core::Value> ret = il::core::Value::constInt(0);
+        builder.emitRet(ret, locs[idx]);
+
+        il::vm::VM vm(module);
+        vm.run();
+    };
+
+    std::thread t0(worker, 0);
+    std::thread t1(worker, 1);
+    t0.join();
+    t1.join();
+
+    assert(trapMessages.size() == 2);
+    bool seenA = false;
+    bool seenB = false;
+    for (const auto &entry : trapMessages)
+    {
+        if (entry.find("trap-A") != std::string::npos)
+            seenA = entry.find("blockA") != std::string::npos && entry.find("(1:10:4)") != std::string::npos;
+        if (entry.find("trap-B") != std::string::npos)
+            seenB = entry.find("blockB") != std::string::npos && entry.find("(2:20:8)") != std::string::npos;
+    }
+    assert(seenA && seenB);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- capture runtime trap metadata in a per-VM RuntimeCallContext guarded by thread-local state and expose it via RuntimeBridge
- update vm_trap to use the active context and fall back gracefully while making the default handler weak for test overrides
- add a concurrency-focused VM runtime test and link it with libpthread support

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d0b7822cac8324a7c53d67d2c55970