### PR TITLE
Refactor BASIC semantic analyzer symbol resolution helper

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -134,6 +134,19 @@ class SemanticAnalyzer
         std::vector<std::string> savedForStack_;
     };
 
+    /// @brief Classify how a symbol should be tracked during resolution.
+    enum class SymbolKind
+    {
+        Reference,      ///< Existing symbol use; do not declare or type.
+        Definition,     ///< Implicit definition; apply suffix defaults if unset.
+        InputTarget     ///< INPUT destination; force suffix-based defaults.
+    };
+
+    /// @brief Resolve @p name in current scope and update symbol/type tables.
+    /// @param name Symbol to resolve; updated when a scoped alias exists.
+    /// @param kind Handling strategy indicating whether defaults should apply.
+    void resolveAndTrackSymbol(std::string &name, SymbolKind kind);
+
     /// @brief Validate variable references in @p e and recurse into subtrees.
     /// @param e Expression node to analyze.
     /// @return Inferred type of the expression.


### PR DESCRIPTION
## Summary
- add a resolveAndTrackSymbol helper to centralize scope resolution and suffix defaults
- replace duplicated symbol handling in assignments, loops, input, and array lookups

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d0b74647d0832482596b12b381e1c0