### PR TITLE
refactor(frontends/basic): centralize slot allocation

### DIFF
--- a/src/frontends/basic/LowerEmit.cpp
+++ b/src/frontends/basic/LowerEmit.cpp
@@ -69,7 +69,7 @@ void Lowerer::emitProgram(const Program &prog)
     // allocate slots in entry
     BasicBlock *entry = &f.blocks.front();
     cur = entry;
-    allocateLocals(std::unordered_set<std::string>());
+    allocateLocalSlots(std::unordered_set<std::string>(), /*includeParams=*/true);
 
     if (mainStmts.empty())
     {

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -172,7 +172,8 @@ class Lowerer
                                 const std::string &name,
                                 const ProcedureMetadata &metadata);
 
-    void allocateLocals(const std::unordered_set<std::string> &paramNames);
+    void allocateLocalSlots(const std::unordered_set<std::string> &paramNames,
+                            bool includeParams);
 
     void lowerStatementSequence(const std::vector<const Stmt *> &stmts,
                                 bool stopOnTerminated,


### PR DESCRIPTION
## Summary
- introduce an allocateLocalSlots helper to centralize stack slot allocation and bounds-check preparation for BASIC lowering
- invoke the shared helper from lowerProcedure and emitProgram to avoid duplicating local slot emission

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d0b63d3ddc8324b5baf2171fce9322