### PR TITLE
refactor(fe/basic): share loop body lowering helper

### DIFF
--- a/src/frontends/basic/LowerEmit.hpp
+++ b/src/frontends/basic/LowerEmit.hpp
@@ -136,6 +136,7 @@ bool lowerIfBranch(const Stmt *stmt,
                    il::support::SourceLoc loc);
 void lowerIf(const IfStmt &stmt);
 void lowerWhile(const WhileStmt &stmt);
+void lowerLoopBody(const std::vector<StmtPtr> &body);
 void lowerFor(const ForStmt &stmt);
 void lowerForConstStep(const ForStmt &stmt, Value slot, RVal end, RVal step, int64_t stepConst);
 void lowerForVarStep(const ForStmt &stmt, Value slot, RVal end, RVal step);


### PR DESCRIPTION
## Summary
- add a shared `lowerLoopBody` helper to encapsulate loop body lowering with termination checks
- call the helper from `lowerWhile`, `lowerForConstStep`, and `lowerForVarStep` to reduce duplication

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d0d55a40088324aa7a12667fec6e39