### PR TITLE
Refactor runtime bridge marshalling helpers

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -502,6 +502,10 @@ add_executable(test_vm_runtime_concurrency unit/test_vm_runtime_concurrency.cpp)
 target_link_libraries(test_vm_runtime_concurrency PRIVATE il_build il_vm support Threads::Threads)
 add_test(NAME test_vm_runtime_concurrency COMMAND test_vm_runtime_concurrency)
 
+add_executable(test_vm_runtime_bridge_marshalling unit/test_vm_runtime_bridge_marshalling.cpp)
+target_link_libraries(test_vm_runtime_bridge_marshalling PRIVATE il_vm)
+add_test(NAME test_vm_runtime_bridge_marshalling COMMAND test_vm_runtime_bridge_marshalling)
+
 add_executable(test_vm_alloca_negative unit/test_vm_alloca_negative.cpp)
 target_link_libraries(test_vm_alloca_negative PRIVATE il_build il_vm support)
 add_test(NAME test_vm_alloca_negative COMMAND test_vm_alloca_negative)

--- a/tests/unit/test_vm_runtime_bridge_marshalling.cpp
+++ b/tests/unit/test_vm_runtime_bridge_marshalling.cpp
@@ -1,0 +1,92 @@
+// File: tests/unit/test_vm_runtime_bridge_marshalling.cpp
+// Purpose: Validate RuntimeBridge argument and result marshalling for supported types.
+// Key invariants: Each IL type kind maps to the correct Slot storage and runtime buffer.
+// Ownership: Uses runtime library helpers; callers release any allocated resources.
+// Links: docs/class-catalog.md
+
+#include "vm/RuntimeBridge.hpp"
+#include "vm/VM.hpp"
+#include "rt_internal.h"
+#include <cassert>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+int main()
+{
+    using il::support::SourceLoc;
+    using il::vm::RuntimeBridge;
+    using il::vm::RuntimeCallContext;
+    using il::vm::Slot;
+
+    RuntimeCallContext ctx{};
+    const SourceLoc loc{};
+    const std::string fn = "runtime.bridge";
+    const std::string block = "entry";
+
+    auto callBridge = [&](const std::string &name, std::vector<Slot> arguments) {
+        return RuntimeBridge::call(ctx, name, arguments, loc, fn, block);
+    };
+
+    Slot intArg{};
+    intArg.i64 = -42;
+    Slot result = callBridge("rt_abs_i64", {intArg});
+    assert(result.i64 == 42);
+
+    Slot fArg{};
+    fArg.f64 = -3.25;
+    result = callBridge("rt_abs_f64", {fArg});
+    assert(result.f64 == 3.25);
+
+    const char *helloLiteral = "hello";
+    Slot ptrArg{};
+    ptrArg.ptr = const_cast<char *>(helloLiteral);
+    result = callBridge("rt_const_cstr", {ptrArg});
+    assert(result.str != nullptr);
+    assert(result.str->data == helloLiteral);
+    rt_string hello = result.str;
+
+    Slot strArg{};
+    strArg.str = hello;
+    Slot lenResult = callBridge("rt_len", {strArg});
+    assert(lenResult.i64 == 5);
+    rt_string_unref(hello);
+
+    Slot numberArg{};
+    numberArg.i64 = 12345;
+    Slot strNumberResult = callBridge("rt_int_to_str", {numberArg});
+    assert(strNumberResult.str != nullptr);
+    rt_string numberStr = strNumberResult.str;
+    std::string numberText(numberStr->data, static_cast<size_t>(numberStr->size));
+    assert(numberText == "12345");
+    rt_string_unref(numberStr);
+
+    const char *abcLiteral = "abc";
+    Slot strPtrArgA{};
+    strPtrArgA.ptr = const_cast<char *>(abcLiteral);
+    Slot strPtrArgB{};
+    strPtrArgB.ptr = const_cast<char *>(abcLiteral);
+    Slot strResA = callBridge("rt_const_cstr", {strPtrArgA});
+    Slot strResB = callBridge("rt_const_cstr", {strPtrArgB});
+    Slot eqArgA{};
+    eqArgA.str = strResA.str;
+    Slot eqArgB{};
+    eqArgB.str = strResB.str;
+    Slot eqResult = callBridge("rt_str_eq", {eqArgA, eqArgB});
+    assert(eqResult.i64 == 1);
+    rt_string_unref(strResA.str);
+    rt_string_unref(strResB.str);
+
+    Slot allocArg{};
+    allocArg.i64 = 16;
+    Slot allocResult = callBridge("rt_alloc", {allocArg});
+    assert(allocResult.ptr != nullptr);
+    free(allocResult.ptr);
+
+    Slot seedArg{};
+    seedArg.i64 = 42;
+    Slot voidResult = callBridge("rt_randomize_i64", {seedArg});
+    assert(voidResult.i64 == 0);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add helpers in `RuntimeBridge.cpp` to convert argument slots and marshal return storage
- call the helpers from `RuntimeBridge::call` so assertions for unsupported kinds live in one place
- add a VM unit test and CMake entries that exercise runtime calls across the supported type kinds

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d0d7eec2e4832481d56f9559adec25