### PR TITLE
perf(vm): cache trace locations and reuse source lines

### DIFF
--- a/src/vm/Trace.cpp
+++ b/src/vm/Trace.cpp
@@ -17,8 +17,12 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <list>
 #include <locale>
 #include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
 
 #ifdef _WIN32
 #include <fcntl.h>
@@ -35,8 +39,78 @@ bool TraceConfig::enabled() const
     return mode != Off;
 }
 
+struct TraceSink::SourceCache
+{
+    struct Key
+    {
+        uint32_t file = 0;
+        uint32_t line = 0;
+
+        bool operator==(const Key &other) const noexcept
+        {
+            return file == other.file && line == other.line;
+        }
+    };
+
+    struct KeyHash
+    {
+        size_t operator()(const Key &key) const noexcept
+        {
+            return (static_cast<size_t>(key.file) << 32) ^ static_cast<size_t>(key.line);
+        }
+    };
+
+    struct Entry
+    {
+        std::string text;
+        std::list<Key>::iterator orderIt;
+    };
+
+    explicit SourceCache(size_t cap) : capacity(cap) {}
+
+    const std::string *get(uint32_t file, uint32_t line)
+    {
+        Key key{file, line};
+        auto it = map.find(key);
+        if (it == map.end())
+            return nullptr;
+        order.splice(order.begin(), order, it->second.orderIt);
+        return &it->second.text;
+    }
+
+    const std::string *put(uint32_t file, uint32_t line, std::string value)
+    {
+        Key key{file, line};
+        auto it = map.find(key);
+        if (it != map.end())
+        {
+            it->second.text = std::move(value);
+            order.splice(order.begin(), order, it->second.orderIt);
+            return &it->second.text;
+        }
+        order.push_front(key);
+        auto inserted = map.emplace(key, Entry{std::move(value), order.begin()});
+        if (!inserted.second)
+            return &inserted.first->second.text;
+        if (map.size() > capacity)
+        {
+            const Key &oldKey = order.back();
+            map.erase(oldKey);
+            order.pop_back();
+        }
+        return &inserted.first->second.text;
+    }
+
+  private:
+    size_t capacity;
+    std::list<Key> order;
+    std::unordered_map<Key, Entry, KeyHash> map;
+};
+
 namespace
 {
+constexpr size_t kDefaultSourceCacheSize = 16;
+
 /// @brief Temporarily force the C locale for numeric formatting.
 class LocaleGuard
 {
@@ -97,7 +171,11 @@ TraceSink::TraceSink(TraceConfig cfg) : cfg(cfg)
 #ifdef _WIN32
     _setmode(_fileno(stderr), _O_BINARY);
 #endif
+    if (cfg.mode == TraceConfig::SRC)
+        srcCache = std::make_unique<SourceCache>(kDefaultSourceCacheSize);
 }
+
+TraceSink::~TraceSink() = default;
 
 void TraceSink::onStep(const il::core::Instr &in, const Frame &fr)
 {
@@ -106,22 +184,13 @@ void TraceSink::onStep(const il::core::Instr &in, const Frame &fr)
     LocaleGuard lg(std::cerr);
     std::cerr << std::noboolalpha << std::dec;
     const auto *fn = fr.func;
-    const il::core::BasicBlock *blk = nullptr;
-    size_t ip = 0;
-    for (const auto &b : fn->blocks)
-    {
-        for (size_t i = 0; i < b.instructions.size(); ++i)
-        {
-            if (&b.instructions[i] == &in)
-            {
-                blk = &b;
-                ip = i;
-                break;
-            }
-        }
-        if (blk)
-            break;
-    }
+    if (!fn)
+        return;
+    auto locIt = fr.instrLocations.find(&in);
+    if (locIt == fr.instrLocations.end())
+        return;
+    const auto *blk = locIt->second.block;
+    size_t ip = locIt->second.index;
     if (!blk)
         return;
     if (cfg.mode == TraceConfig::IL)
@@ -146,34 +215,41 @@ void TraceSink::onStep(const il::core::Instr &in, const Frame &fr)
     if (cfg.mode == TraceConfig::SRC)
     {
         std::string locStr = "<unknown>";
-        std::string srcLine;
+        std::string_view srcView;
         if (cfg.sm && in.loc.isValid())
         {
             std::string path(cfg.sm->getPath(in.loc.file_id));
             std::filesystem::path p(path);
             locStr = p.filename().string() + ':' + std::to_string(in.loc.line) + ':' +
                      std::to_string(in.loc.column);
-            std::ifstream f(path);
-            if (f)
+            if (!srcCache)
+                srcCache = std::make_unique<SourceCache>(kDefaultSourceCacheSize);
+            const std::string *cachedLine = srcCache->get(in.loc.file_id, in.loc.line);
+            if (!cachedLine)
             {
-                std::string line;
-                for (uint32_t i = 0; i < in.loc.line && std::getline(f, line); ++i)
-                    ;
-                if (!line.empty())
+                std::ifstream f(path);
+                if (f)
                 {
-                    if (in.loc.column > 0 && in.loc.column - 1 < line.size())
-                        srcLine = line.substr(in.loc.column - 1);
-                    else
-                        srcLine = line;
-                    while (!srcLine.empty() && (srcLine.back() == '\n' || srcLine.back() == '\r'))
-                        srcLine.pop_back();
+                    std::string line;
+                    for (uint32_t i = 0; i < in.loc.line && std::getline(f, line); ++i)
+                        ;
+                    while (!line.empty() && (line.back() == '\r' || line.back() == '\n'))
+                        line.pop_back();
+                    cachedLine = srcCache->put(in.loc.file_id, in.loc.line, std::move(line));
                 }
+            }
+            if (cachedLine && !cachedLine->empty())
+            {
+                if (in.loc.column > 0 && static_cast<size_t>(in.loc.column - 1) < cachedLine->size())
+                    srcView = std::string_view(*cachedLine).substr(in.loc.column - 1);
+                else
+                    srcView = std::string_view(*cachedLine);
             }
         }
         std::cerr << "[SRC] " << locStr << "  (fn=@" << fn->name << " blk=" << blk->label << " ip=#"
                   << ip << ')';
-        if (!srcLine.empty())
-            std::cerr << "  " << srcLine;
+        if (!srcView.empty())
+            std::cerr << "  " << srcView;
         std::cerr << '\n' << std::flush;
     }
 }

--- a/src/vm/Trace.hpp
+++ b/src/vm/Trace.hpp
@@ -5,6 +5,8 @@
 // Links: docs/dev/vm.md
 #pragma once
 
+#include <memory>
+
 namespace il::core
 {
 struct Instr;
@@ -45,11 +47,20 @@ class TraceSink
     /// @brief Create sink with configuration @p cfg.
     explicit TraceSink(TraceConfig cfg = {});
 
+    /// @brief Destroy sink and release cached resources.
+    ~TraceSink();
+
     /// @brief Record execution of instruction @p in within frame @p fr.
     void onStep(const il::core::Instr &in, const Frame &fr);
 
   private:
     TraceConfig cfg; ///< Active configuration
+
+    /// @brief Internal LRU cache for source lines when tracing in SRC mode.
+    struct SourceCache;
+
+    /// @brief Lazily constructed source line cache storage.
+    std::unique_ptr<SourceCache> srcCache;
 };
 
 } // namespace il::vm

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -70,6 +70,17 @@ struct Frame
     /// @brief Pending block parameter values.
     /// @ownership Owned by the frame; entries cleared when parameters applied.
     std::unordered_map<unsigned, Slot> params;
+
+    /// @brief Cached mapping from instruction pointer to block/index within the function.
+    /// @ownership Owned by the frame; populated during setup for O(1) trace lookups.
+    struct InstrLocation
+    {
+        const il::core::BasicBlock *block = nullptr; ///< Containing basic block
+        size_t index = 0;                             ///< Instruction offset in block
+    };
+
+    /// @brief Lookup table keyed by instruction address for fast tracing metadata.
+    std::unordered_map<const il::core::Instr *, InstrLocation> instrLocations;
 };
 
 /// @brief Simple interpreter for the IL.

--- a/src/vm/VMInit.cpp
+++ b/src/vm/VMInit.cpp
@@ -68,8 +68,21 @@ Frame VM::setupFrame(const Function &fn,
     // incremental growth during execution.
     fr.regs.resize(fn.valueNames.size());
     assert(fr.regs.size() == fn.valueNames.size());
+    size_t totalInstr = 0;
     for (const auto &b : fn.blocks)
+        totalInstr += b.instructions.size();
+    fr.instrLocations.reserve(totalInstr);
+    for (const auto &b : fn.blocks)
+    {
         blocks[b.label] = &b;
+        for (size_t idx = 0; idx < b.instructions.size(); ++idx)
+        {
+            Frame::InstrLocation loc{};
+            loc.block = &b;
+            loc.index = idx;
+            fr.instrLocations.emplace(&b.instructions[idx], loc);
+        }
+    }
     bb = fn.blocks.empty() ? nullptr : &fn.blocks.front();
     if (bb)
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -526,6 +526,10 @@ add_executable(test_vm_opcode_dispatch unit/test_vm_opcode_dispatch.cpp)
 target_link_libraries(test_vm_opcode_dispatch PRIVATE il_io il_vm il_api)
 add_test(NAME test_vm_opcode_dispatch COMMAND test_vm_opcode_dispatch)
 
+add_executable(test_vm_trace_cache unit/test_vm_trace_cache.cpp)
+target_link_libraries(test_vm_trace_cache PRIVATE il_vm)
+add_test(NAME test_vm_trace_cache COMMAND test_vm_trace_cache)
+
 add_executable(test_il_pass_manager unit/test_il_pass_manager.cpp)
 target_link_libraries(test_il_pass_manager PRIVATE il_io il_transform il_api)
 add_test(NAME test_il_pass_manager COMMAND test_il_pass_manager)

--- a/tests/data/trace_cache.txt
+++ b/tests/data/trace_cache.txt
@@ -1,0 +1,3 @@
+# Trace cache data
+  value = add(40, 2) + sub(1)
+return value

--- a/tests/unit/test_vm_trace_cache.cpp
+++ b/tests/unit/test_vm_trace_cache.cpp
@@ -1,0 +1,225 @@
+// File: tests/unit/test_vm_trace_cache.cpp
+// Purpose: Verify VM tracing caches instruction locations and source lines without altering output.
+// Key invariants: Cached tracing must emit identical lines as legacy uncached formatting.
+// Ownership: Test constructs IL module and executes VM twice under different trace modes.
+// Links: docs/dev/vm.md
+
+#include "il/core/Module.hpp"
+#include "il/core/Opcode.hpp"
+#include "il/core/Type.hpp"
+#include "il/core/Value.hpp"
+#include "support/source_manager.hpp"
+#include "vm/VM.hpp"
+
+#include <cassert>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace
+{
+void legacyPrintValue(std::ostream &os, const il::core::Value &v)
+{
+    switch (v.kind)
+    {
+        case il::core::Value::Kind::Temp:
+            os << "%t" << std::dec << v.id;
+            break;
+        case il::core::Value::Kind::ConstInt:
+            os << std::dec << v.i64;
+            break;
+        case il::core::Value::Kind::ConstFloat:
+        {
+            char buf[32];
+            std::snprintf(buf, sizeof(buf), "%.17g", v.f64);
+            os << buf;
+            break;
+        }
+        case il::core::Value::Kind::ConstStr:
+            os << '"' << v.str << '"';
+            break;
+        case il::core::Value::Kind::GlobalAddr:
+            os << '@' << v.str;
+            break;
+        case il::core::Value::Kind::NullPtr:
+            os << "null";
+            break;
+    }
+}
+
+std::string formatLegacyIL(const il::core::Function &fn,
+                           const il::core::BasicBlock &blk,
+                           size_t ip,
+                           const il::core::Instr &in)
+{
+    std::ostringstream os;
+    os << std::noboolalpha << std::dec;
+    os << "[IL] fn=@" << fn.name << " blk=" << blk.label << " ip=#" << ip
+       << " op=" << il::core::toString(in.op);
+    if (!in.operands.empty())
+    {
+        os << ' ';
+        for (size_t idx = 0; idx < in.operands.size(); ++idx)
+        {
+            if (idx)
+                os << ", ";
+            legacyPrintValue(os, in.operands[idx]);
+        }
+    }
+    if (in.result)
+        os << " -> %t" << std::dec << *in.result;
+    os << '\n';
+    return os.str();
+}
+
+std::string formatLegacySRC(const il::core::Function &fn,
+                            const il::core::BasicBlock &blk,
+                            size_t ip,
+                            const il::core::Instr &in,
+                            const il::support::SourceManager &sm)
+{
+    std::ostringstream os;
+    std::string locStr = "<unknown>";
+    std::string srcLine;
+    if (in.loc.isValid())
+    {
+        std::string path(sm.getPath(in.loc.file_id));
+        std::filesystem::path file(path);
+        locStr = file.filename().string() + ':' + std::to_string(in.loc.line) + ':' +
+                 std::to_string(in.loc.column);
+        std::ifstream f(path);
+        if (f)
+        {
+            std::string line;
+            for (uint32_t lineNo = 0; lineNo < in.loc.line && std::getline(f, line); ++lineNo)
+                ;
+            if (!line.empty())
+            {
+                if (in.loc.column > 0 && in.loc.column - 1 < line.size())
+                    srcLine = line.substr(in.loc.column - 1);
+                else
+                    srcLine = line;
+                while (!srcLine.empty() && (srcLine.back() == '\n' || srcLine.back() == '\r'))
+                    srcLine.pop_back();
+            }
+        }
+    }
+    os << "[SRC] " << locStr << "  (fn=@" << fn.name << " blk=" << blk.label << " ip=#" << ip << ')';
+    if (!srcLine.empty())
+        os << "  " << srcLine;
+    os << '\n';
+    return os.str();
+}
+
+class StderrCapture
+{
+    std::streambuf *oldBuf;
+    std::ostringstream buffer;
+
+  public:
+    StderrCapture() : oldBuf(std::cerr.rdbuf(buffer.rdbuf())) {}
+
+    ~StderrCapture()
+    {
+        std::cerr.rdbuf(oldBuf);
+    }
+
+    std::string str() const
+    {
+        return buffer.str();
+    }
+};
+
+std::filesystem::path dataFilePath()
+{
+    std::filesystem::path src(__FILE__);
+    return std::filesystem::absolute(src).parent_path().parent_path() / "data" / "trace_cache.txt";
+}
+} // namespace
+
+int main()
+{
+    using namespace il::core;
+    using il::support::SourceManager;
+
+    SourceManager sm;
+    const auto dataPath = dataFilePath();
+    const uint32_t fileId = sm.addFile(dataPath.string());
+
+    Module m;
+    Function fn;
+    fn.name = "main";
+    fn.retType = Type(Type::Kind::I64);
+    fn.valueNames.resize(2);
+
+    BasicBlock entry;
+    entry.label = "entry";
+    entry.terminated = true;
+
+    Instr add;
+    add.result = 0u;
+    add.op = Opcode::Add;
+    add.type = Type(Type::Kind::I64);
+    add.operands.push_back(Value::constInt(40));
+    add.operands.push_back(Value::constInt(2));
+    add.loc = {fileId, 2, 3};
+    entry.instructions.push_back(add);
+
+    Instr sub;
+    sub.result = 1u;
+    sub.op = Opcode::Sub;
+    sub.type = Type(Type::Kind::I64);
+    sub.operands.push_back(Value::temp(0));
+    sub.operands.push_back(Value::constInt(1));
+    sub.loc = {fileId, 2, 10};
+    entry.instructions.push_back(sub);
+
+    Instr ret;
+    ret.op = Opcode::Ret;
+    ret.type = Type(Type::Kind::Void);
+    ret.operands.push_back(Value::temp(1));
+    ret.loc = {fileId, 3, 1};
+    entry.instructions.push_back(ret);
+
+    fn.blocks.push_back(entry);
+    m.functions.push_back(std::move(fn));
+
+    const auto &storedFn = m.functions.front();
+    std::string expectedIL;
+    std::string expectedSRC;
+    for (const auto &block : storedFn.blocks)
+    {
+        for (size_t idx = 0; idx < block.instructions.size(); ++idx)
+        {
+            expectedIL += formatLegacyIL(storedFn, block, idx, block.instructions[idx]);
+            expectedSRC += formatLegacySRC(storedFn, block, idx, block.instructions[idx], sm);
+        }
+    }
+
+    {
+        il::vm::TraceConfig cfg{};
+        cfg.mode = il::vm::TraceConfig::IL;
+        il::vm::VM vm(m, cfg);
+        StderrCapture cap;
+        int64_t rv = vm.run();
+        assert(rv == 41);
+        std::string actual = cap.str();
+        assert(actual == expectedIL);
+    }
+
+    {
+        il::vm::TraceConfig cfg{};
+        cfg.mode = il::vm::TraceConfig::SRC;
+        cfg.sm = &sm;
+        il::vm::VM vm(m, cfg);
+        StderrCapture cap;
+        vm.run();
+        std::string actual = cap.str();
+        assert(actual == expectedSRC);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- precompute instruction location tables during frame setup to avoid per-step block scans
- extend the trace sink with an LRU source line cache and reuse the precomputed map for lookups
- add a regression test and data fixture that confirm cached tracing matches legacy output

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d0d629b71483248b2d1b357f4539bf