### PR TITLE
refactor(frontends/basic): track procedure scope deltas

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -124,14 +124,35 @@ class SemanticAnalyzer
 
         ~ProcedureScope() noexcept;
 
+        void noteSymbolInserted(const std::string &name);
+        void noteVarTypeMutation(const std::string &name, std::optional<Type> previous);
+        void noteArrayMutation(const std::string &name, std::optional<long long> previous);
+        void noteLabelInserted(int label);
+        void noteLabelRefInserted(int label);
+
       private:
+        struct VarTypeDelta
+        {
+            std::string name;
+            std::optional<Type> previous;
+        };
+
+        struct ArrayDelta
+        {
+            std::string name;
+            std::optional<long long> previous;
+        };
+
         SemanticAnalyzer &analyzer_;
-        std::unordered_set<std::string> savedSymbols_;
-        std::unordered_map<std::string, Type> savedVarTypes_;
-        std::unordered_map<std::string, long long> savedArrays_;
-        std::unordered_set<int> savedLabels_;
-        std::unordered_set<int> savedLabelRefs_;
-        std::vector<std::string> savedForStack_;
+        ProcedureScope *previous_{nullptr};
+        size_t forStackDepth_{0};
+        std::vector<std::string> newSymbols_;
+        std::vector<int> newLabels_;
+        std::vector<int> newLabelRefs_;
+        std::vector<VarTypeDelta> varTypeDeltas_;
+        std::vector<ArrayDelta> arrayDeltas_;
+        std::unordered_set<std::string> trackedVarTypes_;
+        std::unordered_set<std::string> trackedArrays_;
     };
 
     /// @brief Classify how a symbol should be tracked during resolution.
@@ -266,6 +287,7 @@ class SemanticAnalyzer
     std::unordered_set<int> labels_;
     std::unordered_set<int> labelRefs_;
     std::vector<std::string> forStack_; ///< Active FOR loop variables.
+    ProcedureScope *activeProcScope_{nullptr};
 };
 
 } // namespace il::frontends::basic

--- a/tests/unit/test_basic_semantic.cpp
+++ b/tests/unit/test_basic_semantic.cpp
@@ -11,7 +11,11 @@
 #include "frontends/basic/Parser.hpp"
 #include "frontends/basic/SemanticAnalyzer.hpp"
 #include "support/source_manager.hpp"
+#include <array>
 #include <cassert>
+#include <memory>
+#include <sstream>
+#include <string_view>
 #include <string>
 
 using namespace il::frontends::basic;
@@ -19,38 +23,125 @@ using namespace il::support;
 
 int main()
 {
-    std::string src =
-        "100 FUNCTION F(N)\n"
-        "110 RETURN N + 1\n"
-        "120 END FUNCTION\n"
-        "200 SUB P(Q())\n"
-        "210 PRINT LEN(\"SUB\")\n"
-        "220 END SUB\n"
-        "1000 DIM A(5)\n"
-        "1010 DIM FLAG AS BOOLEAN\n"
-        "1020 DIM S$\n"
-        "1030 LET FLAG = TRUE\n"
-        "1035 LET FLAG = NOT FLAG\n"
-        "1040 LET X = 3\n"
-        "1050 LET Y# = 1.5\n"
-        "1060 RANDOMIZE 42: PRINT LEN(\"HI\"), A(X)\n"
-        "1070 IF FLAG THEN LET X = X + 1 ELSEIF X > 1 THEN LET X = X - 1 ELSE PRINT \"ZERO\": PRINT \"TAIL\"\n"
-        "1080 WHILE X > 0\n"
-        "1090 PRINT LEN(\"HI\"), A(X)\n"
-        "1100 LET X = X - 1: PRINT X\n"
-        "1110 WEND\n"
-        "1120 FOR I = 1 TO 3\n"
-        "1130 LET A(I) = I\n"
-        "1140 NEXT I\n"
-        "1150 INPUT \"Value?\", S$\n"
-        "1160 PRINT F(X)\n"
-        "1170 GOTO 2000\n"
-        "1180 END\n"
-        "2000 PRINT \"DONE\";\n";
+    std::ostringstream srcBuilder;
+    srcBuilder << "100 FUNCTION F(N)\n"
+               << "110 RETURN N + 1\n"
+               << "120 END FUNCTION\n"
+               << "200 SUB P(Q())\n"
+               << "210 PRINT LEN(\"SUB\")\n"
+               << "220 END SUB\n";
+
+    constexpr int kExtraProcedures = 16;
+
+    srcBuilder << "1000 DIM A(5)\n"
+               << "1010 DIM FLAG AS BOOLEAN\n"
+               << "1020 DIM S$\n"
+               << "1030 LET FLAG = TRUE\n"
+               << "1035 LET FLAG = NOT FLAG\n"
+               << "1040 LET X = 3\n"
+               << "1050 LET Y# = 1.5\n"
+               << "1060 RANDOMIZE 42: PRINT LEN(\"HI\"), A(X)\n"
+               << "1070 IF FLAG THEN LET X = X + 1 ELSEIF X > 1 THEN LET X = X - 1 ELSE PRINT \"ZERO\": PRINT \"TAIL\"\n"
+               << "1080 WHILE X > 0\n"
+               << "1090 PRINT LEN(\"HI\"), A(X)\n"
+               << "1100 LET X = X - 1: PRINT X\n"
+               << "1110 WEND\n"
+               << "1120 FOR I = 1 TO 3\n"
+               << "1130 LET A(I) = I\n"
+               << "1140 NEXT I\n"
+               << "1150 INPUT \"Value?\", S$\n"
+               << "1160 PRINT F(X)\n"
+               << "1170 GOTO 2000\n"
+               << "1180 END\n"
+               << "2000 PRINT \"DONE\";\n";
+
+    std::string src = srcBuilder.str();
     SourceManager sm;
     uint32_t fid = sm.addFile("test.bas");
     Parser p(src, fid);
     auto prog = p.parseProgram();
+
+    for (int i = 0; i < kExtraProcedures; ++i)
+    {
+        auto fn = std::make_unique<FunctionDecl>();
+        fn->line = 3000 + i * 10;
+        fn->name = "EXTRA_FN" + std::to_string(i);
+        Param param;
+        param.name = "LARGE_FN_ARG_" + std::to_string(i);
+        fn->params.push_back(param);
+
+        auto fnDim = std::make_unique<DimStmt>();
+        fnDim->line = fn->line + 1;
+        fnDim->name = "LARGE_FN_DIM_" + std::to_string(i);
+        auto fnDimSize = std::make_unique<IntExpr>();
+        fnDimSize->value = 5;
+        fnDim->size = std::move(fnDimSize);
+        fn->body.push_back(std::move(fnDim));
+
+        auto fnLet = std::make_unique<LetStmt>();
+        fnLet->line = fn->line + 2;
+        auto fnTarget = std::make_unique<VarExpr>();
+        fnTarget->name = "LARGE_FN_LOCAL_" + std::to_string(i);
+        fnLet->target = std::move(fnTarget);
+        auto fnExpr = std::make_unique<VarExpr>();
+        fnExpr->name = param.name;
+        fnLet->expr = std::move(fnExpr);
+        fn->body.push_back(std::move(fnLet));
+
+        auto fnInput = std::make_unique<InputStmt>();
+        fnInput->line = fn->line + 3;
+        auto fnPrompt = std::make_unique<StringExpr>();
+        fnPrompt->value = "?";
+        fnInput->prompt = std::move(fnPrompt);
+        fnInput->var = "LARGE_FN_INPUT_" + std::to_string(i) + "$";
+        fn->body.push_back(std::move(fnInput));
+
+        auto fnReturn = std::make_unique<ReturnStmt>();
+        fnReturn->line = fn->line + 4;
+        auto retExpr = std::make_unique<VarExpr>();
+        retExpr->name = param.name;
+        fnReturn->value = std::move(retExpr);
+        fn->body.push_back(std::move(fnReturn));
+
+        prog->procs.push_back(std::move(fn));
+    }
+    for (int i = 0; i < kExtraProcedures; ++i)
+    {
+        auto sub = std::make_unique<SubDecl>();
+        sub->line = 4000 + i * 10;
+        sub->name = "EXTRA_SUB" + std::to_string(i);
+        Param param;
+        param.name = "LARGE_SUB_ARG_" + std::to_string(i);
+        sub->params.push_back(param);
+
+        auto subDim = std::make_unique<DimStmt>();
+        subDim->line = sub->line + 1;
+        subDim->name = "LARGE_SUB_DIM_" + std::to_string(i);
+        auto subDimSize = std::make_unique<IntExpr>();
+        subDimSize->value = 3;
+        subDim->size = std::move(subDimSize);
+        sub->body.push_back(std::move(subDim));
+
+        auto subLet = std::make_unique<LetStmt>();
+        subLet->line = sub->line + 2;
+        auto subTarget = std::make_unique<VarExpr>();
+        subTarget->name = "LARGE_SUB_LOCAL_" + std::to_string(i);
+        subLet->target = std::move(subTarget);
+        auto subExpr = std::make_unique<VarExpr>();
+        subExpr->name = param.name;
+        subLet->expr = std::move(subExpr);
+        sub->body.push_back(std::move(subLet));
+
+        auto subInput = std::make_unique<InputStmt>();
+        subInput->line = sub->line + 3;
+        auto subPrompt = std::make_unique<StringExpr>();
+        subPrompt->value = "!";
+        subInput->prompt = std::move(subPrompt);
+        subInput->var = "LARGE_SUB_INPUT_" + std::to_string(i) + "$";
+        sub->body.push_back(std::move(subInput));
+
+        prog->procs.push_back(std::move(sub));
+    }
 
     DiagnosticEngine de;
     DiagnosticEmitter em(de, sm);
@@ -100,5 +191,20 @@ int main()
             sawSub = true;
     }
     assert(sawMain && sawFunction && sawSub);
+
+    const std::array<std::string_view, 8> forbiddenPrefixes = {
+        "LARGE_FN_DIM_",
+        "LARGE_FN_LOCAL_",
+        "LARGE_FN_INPUT_",
+        "LARGE_FN_ARG_",
+        "LARGE_SUB_DIM_",
+        "LARGE_SUB_LOCAL_",
+        "LARGE_SUB_INPUT_",
+        "LARGE_SUB_ARG_"};
+    for (const auto &name : sema.symbols())
+    {
+        for (auto prefix : forbiddenPrefixes)
+            assert(name.rfind(prefix, 0) != 0);
+    }
     return 0;
 }


### PR DESCRIPTION
## Summary
- replace ProcedureScope's full-state snapshots with delta tracking hooks
- update semantic analyzer to record per-scope symbol, type, array, and label mutations
- extend the basic semantic unit test with many synthetic procedures to ensure scope-local names are reclaimed

## Testing
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68d1641235408324a42070132f027efc