### PR TITLE
refactor(frontends/basic): centralize lowering coercions

### DIFF
--- a/src/frontends/basic/LowerEmit.hpp
+++ b/src/frontends/basic/LowerEmit.hpp
@@ -111,6 +111,9 @@ RVal lowerRnd(const BuiltinCallExpr &expr);
 private:
 // Shared argument helpers
 RVal lowerArg(const BuiltinCallExpr &c, size_t idx);
+RVal coerceToI64(RVal v, il::support::SourceLoc loc);
+RVal coerceToF64(RVal v, il::support::SourceLoc loc);
+RVal coerceToBool(RVal v, il::support::SourceLoc loc);
 RVal ensureI64(RVal v, il::support::SourceLoc loc);
 RVal ensureF64(RVal v, il::support::SourceLoc loc);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -454,6 +454,10 @@ add_executable(test_basic_lowerer_collect unit/test_basic_lowerer_collect.cpp)
 target_link_libraries(test_basic_lowerer_collect PRIVATE fe_basic support)
 add_test(NAME test_basic_lowerer_collect COMMAND test_basic_lowerer_collect)
 
+add_executable(test_basic_lowerer_conversions unit/test_basic_lowerer_conversions.cpp)
+target_link_libraries(test_basic_lowerer_conversions PRIVATE fe_basic support)
+add_test(NAME test_basic_lowerer_conversions COMMAND test_basic_lowerer_conversions)
+
 add_executable(test_basic_semantic_components unit/test_basic_semantic_components.cpp)
 target_link_libraries(test_basic_semantic_components PRIVATE fe_basic support)
 add_test(NAME test_basic_semantic_components COMMAND test_basic_semantic_components)

--- a/tests/unit/test_basic_lowerer_conversions.cpp
+++ b/tests/unit/test_basic_lowerer_conversions.cpp
@@ -1,0 +1,96 @@
+// File: tests/unit/test_basic_lowerer_conversions.cpp
+// Purpose: Verify BASIC lowerer emits conversions for mixed-type statements.
+// Key invariants: Assignments, prints, and inputs coerce values to target types.
+// Ownership/Lifetime: Test owns parser, lowerer, and resulting module.
+// Links: docs/class-catalog.md
+
+#include "frontends/basic/Lowerer.hpp"
+#include "frontends/basic/Parser.hpp"
+#include "support/source_manager.hpp"
+#include <algorithm>
+#include <cassert>
+#include <string>
+#include <vector>
+
+using namespace il::frontends::basic;
+using namespace il::support;
+
+namespace
+{
+
+bool hasLine(const std::vector<int> &lines, int target)
+{
+    return std::find(lines.begin(), lines.end(), target) != lines.end();
+}
+
+} // namespace
+
+int main()
+{
+    const std::string src =
+        "10 DIM FLAG AS BOOLEAN\n"
+        "20 LET I = 3.14\n"
+        "30 LET D# = 1\n"
+        "40 LET I = TRUE\n"
+        "50 PRINT TRUE\n"
+        "70 INPUT \"?\", FLAG\n"
+        "80 INPUT \"?\", D#\n";
+
+    SourceManager sm;
+    uint32_t fid = sm.addFile("conversions.bas");
+    Parser parser(src, fid);
+    auto prog = parser.parseProgram();
+    assert(prog);
+
+    Lowerer lowerer;
+    il::core::Module module = lowerer.lowerProgram(*prog);
+
+    const il::core::Function *mainFn = nullptr;
+    for (const auto &fn : module.functions)
+    {
+        if (fn.name == "main")
+        {
+            mainFn = &fn;
+            break;
+        }
+    }
+    assert(mainFn);
+
+    std::vector<int> fptosiLines;
+    std::vector<int> sitofpLines;
+    std::vector<int> zextLines;
+    std::vector<int> truncLines;
+
+    for (const auto &block : mainFn->blocks)
+    {
+        for (const auto &instr : block.instructions)
+        {
+            switch (instr.op)
+            {
+                case il::core::Opcode::Fptosi:
+                    fptosiLines.push_back(instr.loc.line);
+                    break;
+                case il::core::Opcode::Sitofp:
+                    sitofpLines.push_back(instr.loc.line);
+                    break;
+                case il::core::Opcode::Zext1:
+                    zextLines.push_back(instr.loc.line);
+                    break;
+                case il::core::Opcode::Trunc1:
+                    truncLines.push_back(instr.loc.line);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    assert(hasLine(fptosiLines, 2));  // LET I = 3.14
+    assert(hasLine(sitofpLines, 3));  // LET D# = 1
+    assert(hasLine(sitofpLines, 7));  // INPUT "?", D#
+    assert(hasLine(zextLines, 4));    // LET I = TRUE
+    assert(hasLine(zextLines, 5));    // PRINT TRUE
+    assert(hasLine(truncLines, 6));   // INPUT "?", FLAG
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add coerceToI64, coerceToF64, and coerceToBool helpers on `Lowerer` and use them across expression and statement lowering
- replace manual conversion logic in lowering routines with the new helpers while keeping source locations consistent
- add a unit test for mixed-type assignments, prints, and inputs and wire it into the test suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d16ac8180c832498e26983033fbc1e