### PR TITLE
refactor(il/io): switch function parser to Expected

### DIFF
--- a/src/il/io/FunctionParser.hpp
+++ b/src/il/io/FunctionParser.hpp
@@ -6,21 +6,24 @@
 #pragma once
 
 #include "il/io/ParserState.hpp"
+#include "support/diag_expected.hpp"
 
 #include <istream>
-#include <ostream>
 #include <string>
 
 namespace il::io::detail
 {
 
 /// @brief Parse a function header introducing parameters and return type.
-bool parseFunctionHeader(const std::string &header, ParserState &st, std::ostream &err);
+il::support::Expected<void> parseFunctionHeader(const std::string &header,
+                                                ParserState &st);
 
 /// @brief Parse a basic block label and its optional parameter list.
-bool parseBlockHeader(const std::string &header, ParserState &st, std::ostream &err);
+il::support::Expected<void> parseBlockHeader(const std::string &header,
+                                             ParserState &st);
 
 /// @brief Parse an entire function body following its header line.
-bool parseFunction(std::istream &is, std::string &header, ParserState &st, std::ostream &err);
+il::support::Expected<void> parseFunction(std::istream &is, std::string &header,
+                                          ParserState &st);
 
 } // namespace il::io::detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,10 @@ add_executable(test_il_parse_invalid_type unit/test_il_parse_invalid_type.cpp)
 target_link_libraries(test_il_parse_invalid_type PRIVATE il_core il_io il_api)
 add_test(NAME test_il_parse_invalid_type COMMAND test_il_parse_invalid_type)
 
+add_executable(test_il_function_parser_errors unit/test_il_function_parser_errors.cpp)
+target_link_libraries(test_il_function_parser_errors PRIVATE il_core il_io support)
+add_test(NAME test_il_function_parser_errors COMMAND test_il_function_parser_errors)
+
 add_executable(test_expected_api_build unit/test_expected_api_build.cpp)
 target_link_libraries(test_expected_api_build PRIVATE il_core il_io il_api)
 add_test(NAME test_expected_api_build COMMAND test_expected_api_build)

--- a/tests/unit/test_il_function_parser_errors.cpp
+++ b/tests/unit/test_il_function_parser_errors.cpp
@@ -1,0 +1,61 @@
+// File: tests/unit/test_il_function_parser_errors.cpp
+// Purpose: Exercise Expected-returning function parser helpers on failure paths.
+// Key invariants: Helpers surface structured diagnostics for malformed headers and bodies.
+// Ownership/Lifetime: Tests construct modules and parser states locally.
+// Links: docs/il-spec.md
+
+#include "il/io/FunctionParser.hpp"
+#include "il/io/ParserState.hpp"
+#include "il/core/Module.hpp"
+
+#include <cassert>
+#include <sstream>
+#include <string>
+
+int main()
+{
+    using il::io::detail::parseBlockHeader;
+    using il::io::detail::parseFunction;
+    using il::io::detail::parseFunctionHeader;
+    using il::io::detail::ParserState;
+
+    // Malformed function header should report a diagnostic.
+    {
+        il::core::Module m;
+        ParserState st{m};
+        st.lineNo = 3;
+        auto result = parseFunctionHeader("func @broken() i32 {", st);
+        assert(!result);
+        const std::string &msg = result.error().message;
+        assert(msg.find("malformed function header") != std::string::npos);
+    }
+
+    // Block parameter missing a colon should trigger the "bad param" diagnostic.
+    {
+        il::core::Module m;
+        ParserState st{m};
+        st.lineNo = 5;
+        auto headerOk = parseFunctionHeader("func @ok(i32 %x) -> i32 {", st);
+        assert(headerOk);
+        st.lineNo = 6;
+        auto blockErr = parseBlockHeader("entry(%x i32)", st);
+        assert(!blockErr);
+        const std::string &msg = blockErr.error().message;
+        assert(msg.find("bad param") != std::string::npos);
+    }
+
+    // Body without an opening block should surface an instruction-placement error.
+    {
+        il::core::Module m;
+        ParserState st{m};
+        st.lineNo = 10;
+        std::string header = "func @body() -> i32 {";
+        std::istringstream body("  ret 0\n}\n");
+        auto parseResult = parseFunction(body, header, st);
+        assert(!parseResult);
+        const std::string &msg = parseResult.error().message;
+        assert(msg.find("instruction outside block") != std::string::npos);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- update the function parser helpers to return `il::support::Expected` results with structured diagnostics
- remove the module-level shim and adjust call sites for the new interface
- add a regression test exercising failure diagnostics from the function parser

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1748649c08324a435b02c717a45a3