### PR TITLE
refactor(frontends/basic): centralize proc parameter validation

### DIFF
--- a/src/frontends/basic/ProcRegistry.cpp
+++ b/src/frontends/basic/ProcRegistry.cpp
@@ -19,23 +19,14 @@ void ProcRegistry::clear()
     procs_.clear();
 }
 
-void ProcRegistry::registerProc(const FunctionDecl &f)
+ProcSignature ProcRegistry::buildSignature(const ProcDescriptor &descriptor)
 {
-    if (procs_.count(f.name))
-    {
-        std::string msg = "duplicate procedure '" + f.name + "'";
-        de.emit(il::support::Severity::Error,
-                "B1004",
-                f.loc,
-                static_cast<uint32_t>(f.name.size()),
-                std::move(msg));
-        return;
-    }
     ProcSignature sig;
-    sig.kind = ProcSignature::Kind::Function;
-    sig.retType = f.ret;
+    sig.kind = descriptor.kind;
+    sig.retType = descriptor.retType;
+
     std::unordered_set<std::string> paramNames;
-    for (const auto &p : f.params)
+    for (const auto &p : descriptor.params)
     {
         if (!paramNames.insert(p.name).second)
         {
@@ -57,7 +48,27 @@ void ProcRegistry::registerProc(const FunctionDecl &f)
         }
         sig.params.push_back({p.type, p.is_array});
     }
-    procs_.emplace(f.name, std::move(sig));
+
+    return sig;
+}
+
+void ProcRegistry::registerProc(const FunctionDecl &f)
+{
+    if (procs_.count(f.name))
+    {
+        std::string msg = "duplicate procedure '" + f.name + "'";
+        de.emit(il::support::Severity::Error,
+                "B1004",
+                f.loc,
+                static_cast<uint32_t>(f.name.size()),
+                std::move(msg));
+        return;
+    }
+    const ProcDescriptor descriptor{ProcSignature::Kind::Function,
+                                    f.ret,
+                                    std::span<const Param>{f.params},
+                                    f.loc};
+    procs_.emplace(f.name, buildSignature(descriptor));
 }
 
 void ProcRegistry::registerProc(const SubDecl &s)
@@ -72,33 +83,11 @@ void ProcRegistry::registerProc(const SubDecl &s)
                 std::move(msg));
         return;
     }
-    ProcSignature sig;
-    sig.kind = ProcSignature::Kind::Sub;
-    sig.retType = std::nullopt;
-    std::unordered_set<std::string> paramNames;
-    for (const auto &p : s.params)
-    {
-        if (!paramNames.insert(p.name).second)
-        {
-            std::string msg = "duplicate parameter '" + p.name + "'";
-            de.emit(il::support::Severity::Error,
-                    "B1005",
-                    p.loc,
-                    static_cast<uint32_t>(p.name.size()),
-                    std::move(msg));
-        }
-        if (p.is_array && p.type != Type::I64 && p.type != Type::Str && p.type != Type::Bool)
-        {
-            std::string msg = "array parameter must be i64 or str";
-            de.emit(il::support::Severity::Error,
-                    "B2004",
-                    p.loc,
-                    static_cast<uint32_t>(p.name.size()),
-                    std::move(msg));
-        }
-        sig.params.push_back({p.type, p.is_array});
-    }
-    procs_.emplace(s.name, std::move(sig));
+    const ProcDescriptor descriptor{ProcSignature::Kind::Sub,
+                                    std::nullopt,
+                                    std::span<const Param>{s.params},
+                                    s.loc};
+    procs_.emplace(s.name, buildSignature(descriptor));
 }
 
 const ProcTable &ProcRegistry::procs() const

--- a/src/frontends/basic/ProcRegistry.hpp
+++ b/src/frontends/basic/ProcRegistry.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <optional>
+#include <span>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -52,6 +53,16 @@ class ProcRegistry
     const ProcSignature *lookup(const std::string &name) const;
 
   private:
+    struct ProcDescriptor
+    {
+        ProcSignature::Kind kind;
+        std::optional<Type> retType;
+        std::span<const Param> params;
+        il::support::SourceLoc loc;
+    };
+
+    ProcSignature buildSignature(const ProcDescriptor &descriptor);
+
     SemanticDiagnostics &de;
     ProcTable procs_;
 };

--- a/tests/unit/test_basic_semantic_components.cpp
+++ b/tests/unit/test_basic_semantic_components.cpp
@@ -47,5 +47,55 @@ int main()
     reg.registerProc(f); // duplicate
     assert(diag.errorCount() == 1);
 
+    // Duplicate parameter diagnostics for FUNCTION declarations
+    FunctionDecl dupFunc;
+    dupFunc.name = "BAR";
+    Param dupParam;
+    dupParam.name = "X";
+    dupParam.type = Type::I64;
+    dupFunc.params.push_back(dupParam);
+    Param dupParam2 = dupParam;
+    dupFunc.params.push_back(dupParam2);
+    auto prevErrors = diag.errorCount();
+    reg.registerProc(dupFunc);
+    assert(diag.errorCount() == prevErrors + 1);
+
+    // Duplicate parameter diagnostics for SUB declarations
+    SubDecl dupSub;
+    dupSub.name = "BAZ";
+    Param subParam;
+    subParam.name = "Y";
+    subParam.type = Type::I64;
+    dupSub.params.push_back(subParam);
+    Param subParam2 = subParam;
+    dupSub.params.push_back(subParam2);
+    prevErrors = diag.errorCount();
+    reg.registerProc(dupSub);
+    assert(diag.errorCount() == prevErrors + 1);
+
+    // Invalid array parameter diagnostics for FUNCTION declarations
+    FunctionDecl arrayFunc;
+    arrayFunc.name = "ARRFN";
+    Param arrParam;
+    arrParam.name = "ARR";
+    arrParam.type = Type::F64;
+    arrParam.is_array = true;
+    arrayFunc.params.push_back(arrParam);
+    prevErrors = diag.errorCount();
+    reg.registerProc(arrayFunc);
+    assert(diag.errorCount() == prevErrors + 1);
+
+    // Invalid array parameter diagnostics for SUB declarations
+    SubDecl arraySub;
+    arraySub.name = "ARRSUB";
+    Param arrSubParam;
+    arrSubParam.name = "ARRS";
+    arrSubParam.type = Type::F64;
+    arrSubParam.is_array = true;
+    arraySub.params.push_back(arrSubParam);
+    prevErrors = diag.errorCount();
+    reg.registerProc(arraySub);
+    assert(diag.errorCount() == prevErrors + 1);
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- extract a ProcDescriptor-based helper to validate parameters and build procedure signatures
- call the shared helper from both registerProc overloads to keep diagnostics consistent
- extend the semantic component test to cover duplicate and invalid parameters for FUNCTIONs and SUBs

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d18a798a8083249a17804e9dc87faa