### PR TITLE
refactor(vm): centralize runtime bridge kind mapping

### DIFF
--- a/src/vm/RuntimeBridge.cpp
+++ b/src/vm/RuntimeBridge.cpp
@@ -8,6 +8,7 @@
 #include "vm/RuntimeBridge.hpp"
 #include "il/runtime/RuntimeSignatures.hpp"
 #include "vm/VM.hpp"
+#include <array>
 #include <cassert>
 #include <sstream>
 
@@ -31,27 +32,131 @@ struct ResultBuffers
     void *ptr = nullptr;   ///< Storage for pointer results.
 };
 
+/// @brief Table entry describing how a particular @ref Type::Kind maps to Slot and
+/// runtime buffer storage.
+struct KindAccessors
+{
+    using SlotAccessor = void *(*)(Slot &);
+    using ResultAccessor = void *(*)(ResultBuffers &);
+    using ResultAssigner = void (*)(Slot &, const ResultBuffers &);
+
+    SlotAccessor slotAccessor = nullptr;       ///< Accessor for VM argument slots.
+    ResultAccessor resultAccessor = nullptr;   ///< Accessor for runtime result buffers.
+    ResultAssigner assignResult = nullptr;     ///< Assignment routine for marshalled results.
+};
+
+constexpr std::array<Type::Kind, 6> kSupportedKinds = {
+    Type::Kind::Void,
+    Type::Kind::I1,
+    Type::Kind::I64,
+    Type::Kind::F64,
+    Type::Kind::Ptr,
+    Type::Kind::Str,
+};
+
+static_assert(kSupportedKinds.size() == 6, "update kind accessors when Type::Kind grows");
+
+constexpr void *nullResultBuffer(ResultBuffers &)
+{
+    return nullptr;
+}
+
+constexpr void assignNoop(Slot &, const ResultBuffers &)
+{
+}
+
+template <auto Member>
+constexpr void *slotMemberAccessor(Slot &slot)
+{
+    return static_cast<void *>(&(slot.*Member));
+}
+
+template <auto Member>
+constexpr void *bufferMemberAccessor(ResultBuffers &buffers)
+{
+    return static_cast<void *>(&(buffers.*Member));
+}
+
+template <auto SlotMember, auto BufferMember>
+constexpr void assignFromBuffer(Slot &slot, const ResultBuffers &buffers)
+{
+    slot.*SlotMember = buffers.*BufferMember;
+}
+
+constexpr KindAccessors makeVoidAccessors()
+{
+    return KindAccessors{nullptr, &nullResultBuffer, &assignNoop};
+}
+
+template <auto SlotMember, auto BufferMember>
+constexpr KindAccessors makeAccessors()
+{
+    return KindAccessors{
+        &slotMemberAccessor<SlotMember>,
+        &bufferMemberAccessor<BufferMember>,
+        &assignFromBuffer<SlotMember, BufferMember>,
+    };
+}
+
+constexpr std::array<KindAccessors, kSupportedKinds.size()> kKindAccessors = [] {
+    std::array<KindAccessors, kSupportedKinds.size()> table{};
+    table[static_cast<size_t>(Type::Kind::Void)] = makeVoidAccessors();
+    table[static_cast<size_t>(Type::Kind::I1)] = makeAccessors<&Slot::i64, &ResultBuffers::i64>();
+    table[static_cast<size_t>(Type::Kind::I64)] = makeAccessors<&Slot::i64, &ResultBuffers::i64>();
+    table[static_cast<size_t>(Type::Kind::F64)] = makeAccessors<&Slot::f64, &ResultBuffers::f64>();
+    table[static_cast<size_t>(Type::Kind::Ptr)] = makeAccessors<&Slot::ptr, &ResultBuffers::ptr>();
+    table[static_cast<size_t>(Type::Kind::Str)] = makeAccessors<&Slot::str, &ResultBuffers::str>();
+    return table;
+}();
+
+static_assert(kKindAccessors[static_cast<size_t>(Type::Kind::Void)].slotAccessor == nullptr,
+              "Void must not expose a slot accessor");
+static_assert(kKindAccessors[static_cast<size_t>(Type::Kind::Void)].resultAccessor == &nullResultBuffer,
+              "Void must map to the null result buffer");
+static_assert(kKindAccessors[static_cast<size_t>(Type::Kind::I1)].slotAccessor ==
+                  &slotMemberAccessor<&Slot::i64>,
+              "I1 slot accessor must target Slot::i64");
+static_assert(kKindAccessors[static_cast<size_t>(Type::Kind::I64)].slotAccessor ==
+                  &slotMemberAccessor<&Slot::i64>,
+              "I64 slot accessor must target Slot::i64");
+static_assert(kKindAccessors[static_cast<size_t>(Type::Kind::F64)].slotAccessor ==
+                  &slotMemberAccessor<&Slot::f64>,
+              "F64 slot accessor must target Slot::f64");
+static_assert(kKindAccessors[static_cast<size_t>(Type::Kind::Ptr)].slotAccessor ==
+                  &slotMemberAccessor<&Slot::ptr>,
+              "Ptr slot accessor must target Slot::ptr");
+static_assert(kKindAccessors[static_cast<size_t>(Type::Kind::Str)].slotAccessor ==
+                  &slotMemberAccessor<&Slot::str>,
+              "Str slot accessor must target Slot::str");
+
+const KindAccessors &dispatchFor(Type::Kind kind)
+{
+    const auto index = static_cast<size_t>(kind);
+    assert(index < kKindAccessors.size() && "invalid type kind");
+    return kKindAccessors[index];
+}
+
+void *reportUnsupportedPointer(const char *msg)
+{
+    assert(false && msg);
+    return nullptr;
+}
+
+void reportUnsupportedAssign(const char *msg)
+{
+    assert(false && msg);
+}
+
 /// @brief Translate a VM slot to the pointer expected by the runtime handler.
 /// @param slot Slot containing the argument value.
 /// @param kind IL type kind describing the slot contents.
 /// @return Pointer to the slot member corresponding to @p kind.
 void *slotToArgPointer(Slot &slot, Type::Kind kind)
 {
-    switch (kind)
-    {
-        case Type::Kind::I1:
-        case Type::Kind::I64:
-            return static_cast<void *>(&slot.i64);
-        case Type::Kind::F64:
-            return static_cast<void *>(&slot.f64);
-        case Type::Kind::Ptr:
-            return static_cast<void *>(&slot.ptr);
-        case Type::Kind::Str:
-            return static_cast<void *>(&slot.str);
-        default:
-            assert(false && "unsupported runtime argument kind");
-            return nullptr;
-    }
+    const auto &entry = dispatchFor(kind);
+    if (!entry.slotAccessor)
+        return reportUnsupportedPointer("unsupported runtime argument kind");
+    return entry.slotAccessor(slot);
 }
 
 /// @brief Obtain the buffer address to receive a runtime result of @p kind.
@@ -60,23 +165,10 @@ void *slotToArgPointer(Slot &slot, Type::Kind kind)
 /// @return Pointer handed to the runtime handler for writing the result.
 void *resultBufferFor(Type::Kind kind, ResultBuffers &buffers)
 {
-    switch (kind)
-    {
-        case Type::Kind::Void:
-            return nullptr;
-        case Type::Kind::I1:
-        case Type::Kind::I64:
-            return static_cast<void *>(&buffers.i64);
-        case Type::Kind::F64:
-            return static_cast<void *>(&buffers.f64);
-        case Type::Kind::Str:
-            return static_cast<void *>(&buffers.str);
-        case Type::Kind::Ptr:
-            return static_cast<void *>(&buffers.ptr);
-        default:
-            assert(false && "unsupported runtime return kind");
-            return nullptr;
-    }
+    const auto &entry = dispatchFor(kind);
+    if (!entry.resultAccessor)
+        return reportUnsupportedPointer("unsupported runtime return kind");
+    return entry.resultAccessor(buffers);
 }
 
 /// @brief Store the marshalled runtime result back into VM slot @p slot.
@@ -85,27 +177,13 @@ void *resultBufferFor(Type::Kind kind, ResultBuffers &buffers)
 /// @param buffers Temporary storage containing the runtime result.
 void assignResult(Slot &slot, Type::Kind kind, const ResultBuffers &buffers)
 {
-    switch (kind)
+    const auto &entry = dispatchFor(kind);
+    if (!entry.assignResult)
     {
-        case Type::Kind::Void:
-            break;
-        case Type::Kind::I1:
-        case Type::Kind::I64:
-            slot.i64 = buffers.i64;
-            break;
-        case Type::Kind::F64:
-            slot.f64 = buffers.f64;
-            break;
-        case Type::Kind::Str:
-            slot.str = buffers.str;
-            break;
-        case Type::Kind::Ptr:
-            slot.ptr = buffers.ptr;
-            break;
-        default:
-            assert(false && "unsupported runtime return kind");
-            break;
+        reportUnsupportedAssign("unsupported runtime return kind");
+        return;
     }
+    entry.assignResult(slot, buffers);
 }
 
 struct ContextGuard

--- a/tests/unit/test_vm_runtime_bridge_marshalling.cpp
+++ b/tests/unit/test_vm_runtime_bridge_marshalling.cpp
@@ -6,7 +6,10 @@
 
 #include "vm/RuntimeBridge.hpp"
 #include "vm/VM.hpp"
+#include "il/core/Type.hpp"
 #include "rt_internal.h"
+#include <array>
+#include <initializer_list>
 #include <cassert>
 #include <cstdlib>
 #include <string>
@@ -15,6 +18,7 @@
 int main()
 {
     using il::support::SourceLoc;
+    using il::core::Type;
     using il::vm::RuntimeBridge;
     using il::vm::RuntimeCallContext;
     using il::vm::Slot;
@@ -24,37 +28,46 @@ int main()
     const std::string fn = "runtime.bridge";
     const std::string block = "entry";
 
-    auto callBridge = [&](const std::string &name, std::vector<Slot> arguments) {
+    constexpr size_t kKindCount = static_cast<size_t>(Type::Kind::Str) + 1;
+    std::array<bool, kKindCount> coveredKinds{};
+    auto markKind = [&](Type::Kind kind) { coveredKinds[static_cast<size_t>(kind)] = true; };
+    auto callBridge = [&](const std::string &name,
+                          std::vector<Slot> arguments,
+                          Type::Kind resultKind,
+                          std::initializer_list<Type::Kind> argKinds) {
+        for (Type::Kind arg : argKinds)
+            markKind(arg);
+        markKind(resultKind);
         return RuntimeBridge::call(ctx, name, arguments, loc, fn, block);
     };
 
     Slot intArg{};
     intArg.i64 = -42;
-    Slot result = callBridge("rt_abs_i64", {intArg});
+    Slot result = callBridge("rt_abs_i64", {intArg}, Type::Kind::I64, {Type::Kind::I64});
     assert(result.i64 == 42);
 
     Slot fArg{};
     fArg.f64 = -3.25;
-    result = callBridge("rt_abs_f64", {fArg});
+    result = callBridge("rt_abs_f64", {fArg}, Type::Kind::F64, {Type::Kind::F64});
     assert(result.f64 == 3.25);
 
     const char *helloLiteral = "hello";
     Slot ptrArg{};
     ptrArg.ptr = const_cast<char *>(helloLiteral);
-    result = callBridge("rt_const_cstr", {ptrArg});
+    result = callBridge("rt_const_cstr", {ptrArg}, Type::Kind::Str, {Type::Kind::Ptr});
     assert(result.str != nullptr);
     assert(result.str->data == helloLiteral);
     rt_string hello = result.str;
 
     Slot strArg{};
     strArg.str = hello;
-    Slot lenResult = callBridge("rt_len", {strArg});
+    Slot lenResult = callBridge("rt_len", {strArg}, Type::Kind::I64, {Type::Kind::Str});
     assert(lenResult.i64 == 5);
     rt_string_unref(hello);
 
     Slot numberArg{};
     numberArg.i64 = 12345;
-    Slot strNumberResult = callBridge("rt_int_to_str", {numberArg});
+    Slot strNumberResult = callBridge("rt_int_to_str", {numberArg}, Type::Kind::Str, {Type::Kind::I64});
     assert(strNumberResult.str != nullptr);
     rt_string numberStr = strNumberResult.str;
     std::string numberText(numberStr->data, static_cast<size_t>(numberStr->size));
@@ -66,27 +79,30 @@ int main()
     strPtrArgA.ptr = const_cast<char *>(abcLiteral);
     Slot strPtrArgB{};
     strPtrArgB.ptr = const_cast<char *>(abcLiteral);
-    Slot strResA = callBridge("rt_const_cstr", {strPtrArgA});
-    Slot strResB = callBridge("rt_const_cstr", {strPtrArgB});
+    Slot strResA = callBridge("rt_const_cstr", {strPtrArgA}, Type::Kind::Str, {Type::Kind::Ptr});
+    Slot strResB = callBridge("rt_const_cstr", {strPtrArgB}, Type::Kind::Str, {Type::Kind::Ptr});
     Slot eqArgA{};
     eqArgA.str = strResA.str;
     Slot eqArgB{};
     eqArgB.str = strResB.str;
-    Slot eqResult = callBridge("rt_str_eq", {eqArgA, eqArgB});
+    Slot eqResult = callBridge("rt_str_eq", {eqArgA, eqArgB}, Type::Kind::I1, {Type::Kind::Str, Type::Kind::Str});
     assert(eqResult.i64 == 1);
     rt_string_unref(strResA.str);
     rt_string_unref(strResB.str);
 
     Slot allocArg{};
     allocArg.i64 = 16;
-    Slot allocResult = callBridge("rt_alloc", {allocArg});
+    Slot allocResult = callBridge("rt_alloc", {allocArg}, Type::Kind::Ptr, {Type::Kind::I64});
     assert(allocResult.ptr != nullptr);
     free(allocResult.ptr);
 
     Slot seedArg{};
     seedArg.i64 = 42;
-    Slot voidResult = callBridge("rt_randomize_i64", {seedArg});
+    Slot voidResult = callBridge("rt_randomize_i64", {seedArg}, Type::Kind::Void, {Type::Kind::I64});
     assert(voidResult.i64 == 0);
+
+    for (bool covered : coveredKinds)
+        assert(covered);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- replace the RuntimeBridge slot/result switches with a shared dispatch table that maps `Type::Kind` to the correct accessors and asserts coverage at compile time
- add a coverage-aware helper in the marshalling unit test to exercise every supported runtime type

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d19e05eb1c832498a5137e0daab92b