### PR TITLE
Normalize debug path handling with std::filesystem

### DIFF
--- a/src/vm/Debug.hpp
+++ b/src/vm/Debug.hpp
@@ -69,8 +69,8 @@ class DebugCtrl
     const il::support::SourceManager *getSourceManager() const;
 
     /// @brief Normalize @p p by canonicalizing separators and dot segments.
-    /// Replaces backslashes with forward slashes, removes redundant "./", and
-    /// collapses "dir/../" without resolving symlinks.
+    /// Uses std::filesystem::path::lexically_normal() after converting
+    /// backslashes to forward slashes to ensure stable breakpoint comparisons.
     static std::string normalizePath(std::string p);
 
     /// @brief Register a watch on variable @p name.

--- a/tests/unit/test_vm_normalize_path.cpp
+++ b/tests/unit/test_vm_normalize_path.cpp
@@ -11,8 +11,11 @@ int main()
 {
     using il::vm::DebugCtrl;
     assert(DebugCtrl::normalizePath(R"(a\b\c)") == "a/b/c");
+    assert(DebugCtrl::normalizePath(R"(C:\project\src\..\main.bas)") == "C:/project/main.bas");
     assert(DebugCtrl::normalizePath("./a/./b") == "a/b");
+    assert(DebugCtrl::normalizePath("../foo/../bar") == "../bar");
     assert(DebugCtrl::normalizePath("dir/../file") == "file");
     assert(DebugCtrl::normalizePath("/foo/../") == "/");
+    assert(DebugCtrl::normalizePath("") == ".");
     return 0;
 }


### PR DESCRIPTION
## Summary
- replace the manual stack-based normalization logic with `std::filesystem::path::lexically_normal()` while keeping forward slash comparisons
- expand the VM path normalization unit test with Windows drive, relative `..`, and empty-string cases
- document the filesystem-based normalization strategy in `DebugCtrl`

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d19f5c7de883248c2798ac53b990ce