### PR TITLE
refactor(vm): index frame params by SSA id

### DIFF
--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -71,9 +71,9 @@ struct Frame
     /// @invariant Never exceeds @c stack.size().
     size_t sp = 0;
 
-    /// @brief Pending block parameter values.
-    /// @ownership Owned by the frame; entries cleared when parameters applied.
-    std::unordered_map<unsigned, Slot> params;
+    /// @brief Pending block parameter values indexed by SSA id.
+    /// @ownership Owned by the frame; sized to the register file and reset on use.
+    std::vector<std::optional<Slot>> params;
 };
 
 /// @brief Simple interpreter for the IL.

--- a/src/vm/VMInit.cpp
+++ b/src/vm/VMInit.cpp
@@ -68,6 +68,7 @@ Frame VM::setupFrame(const Function &fn,
     // incremental growth during execution.
     fr.regs.resize(fn.valueNames.size());
     assert(fr.regs.size() == fn.valueNames.size());
+    fr.params.assign(fr.regs.size(), std::nullopt);
     for (const auto &b : fn.blocks)
         blocks[b.label] = &b;
     bb = fn.blocks.empty() ? nullptr : &fn.blocks.front();
@@ -75,7 +76,11 @@ Frame VM::setupFrame(const Function &fn,
     {
         const auto &params = bb->params;
         for (size_t i = 0; i < params.size() && i < args.size(); ++i)
-            fr.params[params[i].id] = args[i];
+        {
+            const auto id = params[i].id;
+            assert(id < fr.params.size());
+            fr.params[id] = args[i];
+        }
     }
     return fr;
 }

--- a/src/vm/control_flow.cpp
+++ b/src/vm/control_flow.cpp
@@ -51,7 +51,11 @@ VM::ExecResult OpHandlers::branchToTarget(VM &vm,
         const auto &args = in.brArgs[idx];
         const size_t limit = std::min(args.size(), target->params.size());
         for (size_t i = 0; i < limit; ++i)
-            fr.params[target->params[i].id] = vm.eval(fr, args[i]);
+        {
+            const auto id = target->params[i].id;
+            assert(id < fr.params.size());
+            fr.params[id] = vm.eval(fr, args[i]);
+        }
     }
 
     bb = target;


### PR DESCRIPTION
## Summary
- replace `Frame::params` with a register-sized optional vector so branch parameters are stored by SSA id
- write branch arguments and entry parameters directly into the indexed slots and reset them after use during debug handling
- keep frame setup and debug break processing aligned with the indexed storage

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1a17bd3c883249a9338d833d42dbd