### PR TITLE
Pass active block context to TraceSink onStep

### DIFF
--- a/src/vm/Trace.hpp
+++ b/src/vm/Trace.hpp
@@ -5,9 +5,12 @@
 // Links: docs/dev/vm.md
 #pragma once
 
+#include <cstddef>
+
 namespace il::core
 {
 struct Instr;
+struct BasicBlock;
 } // namespace il::core
 
 namespace il::support
@@ -46,7 +49,14 @@ class TraceSink
     explicit TraceSink(TraceConfig cfg = {});
 
     /// @brief Record execution of instruction @p in within frame @p fr.
-    void onStep(const il::core::Instr &in, const Frame &fr);
+    /// @param blk Optional basic block containing @p in. When null, the sink
+    ///            will locate the instruction by scanning the function.
+    /// @param ip  Instruction index within @p blk. Ignored when @p blk is
+    ///            omitted and recomputed via the fallback scan.
+    void onStep(const il::core::Instr &in,
+                const Frame &fr,
+                const il::core::BasicBlock *blk = nullptr,
+                size_t ip = 0);
 
   private:
     TraceConfig cfg; ///< Active configuration

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -138,7 +138,7 @@ Slot VM::runFunctionLoop(ExecState &st)
         const Instr &in = st.bb->instructions[st.ip];
         if (auto br = processDebugControl(st, &in, false))
             return *br;
-        tracer.onStep(in, st.fr);
+        tracer.onStep(in, st.fr, st.bb, st.ip);
         ++instrCount;
         auto res = executeOpcode(st.fr, in, st.blocks, st.bb, st.ip);
         if (res.returned)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -119,7 +119,11 @@ target_include_directories(test_tools_break_parsing PRIVATE ${CMAKE_SOURCE_DIR}/
 add_test(NAME test_tools_break_parsing COMMAND test_tools_break_parsing)
 
 add_executable(test_vm_trace_il vm/TraceILTests.cpp)
-add_test(NAME test_vm_trace_il COMMAND test_vm_trace_il $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/trace_min.il ${CMAKE_SOURCE_DIR}/tests/vm/trace_min.trace)
+add_test(NAME test_vm_trace_il COMMAND test_vm_trace_il
+  $<TARGET_FILE:ilc>
+  ${CMAKE_SOURCE_DIR}/examples/il/trace_min.il
+  ${CMAKE_SOURCE_DIR}/tests/vm/trace_min.trace
+  ${CMAKE_SOURCE_DIR}/tests/vm/trace_min_src.trace)
 add_executable(test_vm_break_label vm/BreakLabelTests.cpp)
 add_test(NAME test_vm_break_label COMMAND test_vm_break_label $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/break_label.il)
 add_executable(test_vm_debug_script vm/DebugScriptTests.cpp)

--- a/tests/vm/trace_min_src.trace
+++ b/tests/vm/trace_min_src.trace
@@ -1,0 +1,4 @@
+[SRC] <unknown>  (fn=@main blk=entry ip=#0)
+[SRC] <unknown>  (fn=@main blk=entry ip=#1)
+[SRC] <unknown>  (fn=@main blk=entry ip=#2)
+[SRC] <unknown>  (fn=@main blk=entry ip=#3)


### PR DESCRIPTION
## Summary
- pass the active basic block pointer and instruction index from the VM loop into `TraceSink::onStep`
- update `TraceSink` to consume the supplied context while retaining the legacy scan fallback
- extend the trace test harness to check both IL and SRC modes with a new SRC golden file

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1a1b5242483249884920f6379427d