### PR TITLE
fix: allow zero-byte rt_alloc requests

### DIFF
--- a/runtime/rt_memory.c
+++ b/runtime/rt_memory.c
@@ -11,6 +11,8 @@
  * Allocate a block of memory for runtime usage.
  *
  * @param bytes Number of bytes to allocate. Must be non-negative.
+ *              A zero-byte request yields a one-byte allocation to ensure a
+ *              non-null result.
  * @return Pointer to allocated memory, or traps on invalid input or failure.
  */
 void *rt_alloc(int64_t bytes)
@@ -22,7 +24,10 @@ void *rt_alloc(int64_t bytes)
         rt_trap("allocation too large");
         return NULL;
     }
-    void *p = malloc((size_t)bytes);
+    size_t request = (size_t)bytes;
+    if (request == 0)
+        request = 1;
+    void *p = malloc(request);
     if (!p)
         rt_trap("out of memory");
     return p;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -217,6 +217,10 @@ add_executable(test_rt_alloc runtime/RTAllocTests.cpp)
 target_link_libraries(test_rt_alloc PRIVATE rt)
 add_test(NAME test_rt_alloc COMMAND test_rt_alloc)
 
+add_executable(test_rt_alloc_zero runtime/RTAllocZeroTests.cpp)
+target_link_libraries(test_rt_alloc_zero PRIVATE rt)
+add_test(NAME test_rt_alloc_zero COMMAND test_rt_alloc_zero)
+
 add_executable(test_rt_input_line runtime/RTInputLineTests.cpp)
 target_link_libraries(test_rt_input_line PRIVATE rt)
 add_test(NAME test_rt_input_line COMMAND test_rt_input_line)

--- a/tests/runtime/RTAllocZeroTests.cpp
+++ b/tests/runtime/RTAllocZeroTests.cpp
@@ -1,0 +1,30 @@
+// File: tests/runtime/RTAllocZeroTests.cpp
+// Purpose: Verify rt_alloc handles zero-byte requests without trapping.
+// Key invariants: Under glibc, malloc(0) is forced to return NULL so legacy
+//                 behavior would trap. The test asserts the new logic treats
+//                 zero as a valid allocation size.
+// Ownership: Uses runtime library.
+// Links: docs/runtime-abi.md
+#include "rt.hpp"
+#include <assert.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+#if defined(__GLIBC__)
+extern "C" void *__libc_malloc(size_t size);
+
+extern "C" void *malloc(size_t size)
+{
+    if (size == 0)
+        return NULL;
+    return __libc_malloc(size);
+}
+#endif
+
+int main()
+{
+    void *ptr = rt_alloc(0);
+    assert(ptr != NULL);
+    free(ptr);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ensure rt_alloc rounds zero-byte requests up to a single byte so malloc never reports failure
- add a runtime regression test that forces malloc(0) to return NULL under glibc and verifies rt_alloc(0) succeeds
- register the new runtime test with the test suite

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1afe11d948324ab50f41d9ac43e87