### PR TITLE
refactor(il/analysis): add CFG context object

### DIFF
--- a/archive/docs/dev/analysis.md
+++ b/archive/docs/dev/analysis.md
@@ -7,8 +7,9 @@ constructing an explicit graph.
 
 ```cpp
 using namespace viper::analysis;
-auto succ = successors(block);
-auto pred = predecessors(func, block);
+CFGContext ctx(module);
+auto succ = successors(ctx, block);
+auto pred = predecessors(ctx, block);
 ```
 
 ## Orders
@@ -16,8 +17,8 @@ auto pred = predecessors(func, block);
 Standard depth-first orders are available without materializing a graph.
 
 ```cpp
-auto po = postOrder(fn);      // entry last
-auto rpo = reversePostOrder(fn); // entry first
+auto po = postOrder(ctx, fn);      // entry last
+auto rpo = reversePostOrder(ctx, fn); // entry first
 ```
 
 ## Acyclicity & Topological Order
@@ -26,8 +27,8 @@ Cycle detection and topological sorting are available for DAG-restricted
 analyses.
 
 ```cpp
-bool ok = isAcyclic(fn);      // false if any cycle exists
-auto topo = topoOrder(fn);    // empty if cyclic
+bool ok = isAcyclic(ctx, fn);      // false if any cycle exists
+auto topo = topoOrder(ctx, fn);    // empty if cyclic
 ```
 
 These helpers gate passes like the mem2reg v2 prototype, which operates only

--- a/src/il/analysis/CFG.hpp
+++ b/src/il/analysis/CFG.hpp
@@ -5,6 +5,7 @@
 // Links: docs/dev/analysis.md
 #pragma once
 
+#include <unordered_map>
 #include <vector>
 
 namespace il::core
@@ -18,39 +19,50 @@ using Block = BasicBlock;
 namespace viper::analysis
 {
 
-/// @brief Set the current module for CFG queries.
-/// @param M IL module providing function/block context.
-void setModule(const il::core::Module &M);
+/// @brief Lightweight context bundling module information for CFG queries.
+///
+/// Stores a reference to the active module alongside a lookup table mapping
+/// basic blocks to their owning functions. The mapping is computed eagerly on
+/// construction so subsequent CFG utilities can resolve block parents without
+/// global state. The caller is responsible for rebuilding the context if the
+/// module's function/block layout changes.
+struct CFGContext
+{
+    explicit CFGContext(il::core::Module &module);
+
+    il::core::Module *module{nullptr};
+    std::unordered_map<const il::core::Block *, il::core::Function *> blockToFunction;
+};
 
 /// @brief Return successors of block @p B by inspecting its terminator.
 /// @param B Block whose outgoing edges are requested.
 /// @return List of successor blocks (may be empty).
-std::vector<il::core::Block *> successors(const il::core::Block &B);
+std::vector<il::core::Block *> successors(const CFGContext &ctx, const il::core::Block &B);
 
 /// @brief Return predecessors of block @p B within function @p F.
 /// @param F Function containing blocks to scan.
 /// @param B Target block whose incoming edges are requested.
 /// @return List of predecessor blocks (may be empty).
-std::vector<il::core::Block *> predecessors(const il::core::Function &F, const il::core::Block &B);
+std::vector<il::core::Block *> predecessors(const CFGContext &ctx, const il::core::Block &B);
 
 /// @brief Compute DFS post-order of blocks in @p F starting from the entry block.
 /// @param F Function whose blocks are traversed.
 /// @return Blocks in post-order; the entry block is last.
-std::vector<il::core::Block *> postOrder(il::core::Function &F);
+std::vector<il::core::Block *> postOrder(const CFGContext &ctx, il::core::Function &F);
 
 /// @brief Compute reverse post-order (RPO) of blocks in @p F.
 /// @param F Function whose blocks are traversed.
 /// @return Blocks in RPO; the entry block is first.
-std::vector<il::core::Block *> reversePostOrder(il::core::Function &F);
+std::vector<il::core::Block *> reversePostOrder(const CFGContext &ctx, il::core::Function &F);
 
 /// @brief Check whether the control-flow graph of @p F has no cycles.
 /// @param F Function whose CFG is inspected.
 /// @return True if the CFG is acyclic; false otherwise.
-bool isAcyclic(il::core::Function &F);
+bool isAcyclic(const CFGContext &ctx, il::core::Function &F);
 
 /// @brief Compute a topological order of blocks in @p F.
 /// @param F Function whose blocks are ordered.
 /// @return Blocks in topological order; empty if @p F contains cycles.
-std::vector<il::core::Block *> topoOrder(il::core::Function &F);
+std::vector<il::core::Block *> topoOrder(const CFGContext &ctx, il::core::Function &F);
 
 } // namespace viper::analysis

--- a/src/il/analysis/Dominators.cpp
+++ b/src/il/analysis/Dominators.cpp
@@ -56,14 +56,15 @@ bool DomTree::dominates(il::core::Block *A, il::core::Block *B) const
 ///
 /// Implements the Cooper–Harvey–Kennedy algorithm to derive immediate
 /// dominators for every block in the function.
+/// @param ctx CFG context used to access traversal helpers.
 /// @param F Function whose dominator relationships are computed.
 /// @return A fully populated dominator tree with parent and child links.
 /// @invariant The function must have a valid control-flow graph with a
 /// single entry block.
-DomTree computeDominatorTree(il::core::Function &F)
+DomTree computeDominatorTree(const CFGContext &ctx, il::core::Function &F)
 {
     DomTree DT;
-    auto rpo = reversePostOrder(F);
+    auto rpo = reversePostOrder(ctx, F);
     if (rpo.empty())
         return DT;
 
@@ -81,7 +82,7 @@ DomTree computeDominatorTree(il::core::Function &F)
         for (std::size_t i = 1; i < rpo.size(); ++i)
         {
             il::core::Block *b = rpo[i];
-            auto preds = predecessors(F, *b);
+            auto preds = predecessors(ctx, *b);
 
             il::core::Block *newIdom = nullptr;
             for (auto *p : preds)

--- a/src/il/analysis/Dominators.hpp
+++ b/src/il/analysis/Dominators.hpp
@@ -17,6 +17,7 @@ using Block = BasicBlock;
 
 namespace viper::analysis
 {
+struct CFGContext;
 /// @brief Dominator tree for a function.
 /// Stores immediate dominator relationships and tree children for each block.
 struct DomTree
@@ -39,8 +40,9 @@ struct DomTree
 };
 
 /// @brief Compute dominator tree for function @p F.
+/// @param ctx CFG context providing traversal utilities.
 /// @param F Function to analyze.
 /// @return Dominator tree with immediate dominators and child map.
-DomTree computeDominatorTree(il::core::Function &F);
+DomTree computeDominatorTree(const CFGContext &ctx, il::core::Function &F);
 
 } // namespace viper::analysis

--- a/src/il/transform/PassManager.cpp
+++ b/src/il/transform/PassManager.cpp
@@ -585,8 +585,8 @@ PassManager::PassManager()
         "dominators",
         [](core::Module &module, core::Function &fn)
         {
-            viper::analysis::setModule(module);
-            return viper::analysis::computeDominatorTree(fn);
+            viper::analysis::CFGContext ctx(module);
+            return viper::analysis::computeDominatorTree(ctx, fn);
         });
     registerFunctionAnalysis<LivenessInfo>("liveness",
                                            [](core::Module &module, core::Function &fn)

--- a/tests/analysis/AcyclicTests.cpp
+++ b/tests/analysis/AcyclicTests.cpp
@@ -14,7 +14,6 @@ using namespace viper::analysis;
 int main()
 {
     Module m;
-    setModule(m);
     il::build::IRBuilder b(m);
 
     // Linear chain: A -> B -> C
@@ -31,10 +30,14 @@ int main()
     b.br(C, {});
     b.setInsertPoint(C);
     b.emitRet(std::nullopt, {});
-    assert(isAcyclic(chain));
-    auto chainOrder = topoOrder(chain);
-    assert(chainOrder.size() == 3);
-    assert(chainOrder[0] == &A && chainOrder[1] == &B && chainOrder[2] == &C);
+
+    {
+        CFGContext ctx(m);
+        assert(isAcyclic(ctx, chain));
+        auto chainOrder = topoOrder(ctx, chain);
+        assert(chainOrder.size() == 3);
+        assert(chainOrder[0] == &A && chainOrder[1] == &B && chainOrder[2] == &C);
+    }
 
     // Diamond: entry -> {t, f} -> join
     Function &diamond = b.startFunction("diamond", Type(Type::Kind::Void), {});
@@ -54,11 +57,15 @@ int main()
     b.br(dJoin, {});
     b.setInsertPoint(dJoin);
     b.emitRet(std::nullopt, {});
-    assert(isAcyclic(diamond));
-    auto diamondOrder = topoOrder(diamond);
-    assert(diamondOrder.size() == 4);
-    assert(diamondOrder.front() == &dEntry);
-    assert(diamondOrder.back() == &dJoin);
+
+    {
+        CFGContext ctx(m);
+        assert(isAcyclic(ctx, diamond));
+        auto diamondOrder = topoOrder(ctx, diamond);
+        assert(diamondOrder.size() == 4);
+        assert(diamondOrder.front() == &dEntry);
+        assert(diamondOrder.back() == &dJoin);
+    }
 
     // Loop: entry -> loop -> loop (cycle)
     Function &loopFn = b.startFunction("loop", Type(Type::Kind::Void), {});
@@ -70,9 +77,12 @@ int main()
     b.br(lLoop, {});
     b.setInsertPoint(lLoop);
     b.br(lLoop, {});
-    assert(!isAcyclic(loopFn));
-    auto loopOrder = topoOrder(loopFn);
-    assert(loopOrder.empty());
+    {
+        CFGContext ctx(m);
+        assert(!isAcyclic(ctx, loopFn));
+        auto loopOrder = topoOrder(ctx, loopFn);
+        assert(loopOrder.empty());
+    }
 
     return 0;
 }

--- a/tests/analysis/CFGTests.cpp
+++ b/tests/analysis/CFGTests.cpp
@@ -13,11 +13,9 @@ int main()
 {
     using namespace il::core;
     using viper::analysis::predecessors;
-    using viper::analysis::setModule;
     using viper::analysis::successors;
 
     Module m;
-    setModule(m);
     il::build::IRBuilder b(m);
     Function &fn = b.startFunction("f", Type(Type::Kind::Void), {});
     b.createBlock(fn, "entry");
@@ -41,18 +39,20 @@ int main()
     b.setInsertPoint(join);
     b.emitRet(std::nullopt, {});
 
-    auto sEntry = successors(entry);
+    viper::analysis::CFGContext ctx(m);
+
+    auto sEntry = successors(ctx, entry);
     assert(sEntry.size() == 2);
     assert((sEntry[0] == &t && sEntry[1] == &f) || (sEntry[0] == &f && sEntry[1] == &t));
 
-    auto sT = successors(t);
+    auto sT = successors(ctx, t);
     assert(sT.size() == 1 && sT[0] == &join);
-    auto sF = successors(f);
+    auto sF = successors(ctx, f);
     assert(sF.size() == 1 && sF[0] == &join);
-    auto sJoin = successors(join);
+    auto sJoin = successors(ctx, join);
     assert(sJoin.empty());
 
-    auto pJoin = predecessors(fn, join);
+    auto pJoin = predecessors(ctx, join);
     assert(pJoin.size() == 2);
     assert((pJoin[0] == &t && pJoin[1] == &f) || (pJoin[0] == &f && pJoin[1] == &t));
 

--- a/tests/analysis/DominatorsTests.cpp
+++ b/tests/analysis/DominatorsTests.cpp
@@ -15,7 +15,6 @@ int main()
     using namespace viper::analysis;
 
     Module m;
-    setModule(m);
     il::build::IRBuilder b(m);
 
     // Diamond graph: entry -> {t, f} -> join
@@ -38,15 +37,18 @@ int main()
     b.setInsertPoint(dJoin);
     b.emitRet(std::nullopt, {});
 
-    DomTree dtDiamond = computeDominatorTree(diamond);
-    assert(dtDiamond.immediateDominator(&dEntry) == nullptr);
-    assert(dtDiamond.immediateDominator(&dT) == &dEntry);
-    assert(dtDiamond.immediateDominator(&dF) == &dEntry);
-    assert(dtDiamond.immediateDominator(&dJoin) == &dEntry);
-    assert(dtDiamond.dominates(&dEntry, &dT));
-    assert(dtDiamond.dominates(&dEntry, &dF));
-    assert(dtDiamond.dominates(&dEntry, &dJoin));
-    assert(!dtDiamond.dominates(&dT, &dF));
+    {
+        CFGContext ctx(m);
+        DomTree dtDiamond = computeDominatorTree(ctx, diamond);
+        assert(dtDiamond.immediateDominator(&dEntry) == nullptr);
+        assert(dtDiamond.immediateDominator(&dT) == &dEntry);
+        assert(dtDiamond.immediateDominator(&dF) == &dEntry);
+        assert(dtDiamond.immediateDominator(&dJoin) == &dEntry);
+        assert(dtDiamond.dominates(&dEntry, &dT));
+        assert(dtDiamond.dominates(&dEntry, &dF));
+        assert(dtDiamond.dominates(&dEntry, &dJoin));
+        assert(!dtDiamond.dominates(&dT, &dF));
+    }
 
     // Linear chain: A -> B -> C
     Function &chain = b.startFunction("chain", Type(Type::Kind::Void), {});
@@ -64,12 +66,15 @@ int main()
     b.setInsertPoint(C);
     b.emitRet(std::nullopt, {});
 
-    DomTree dtChain = computeDominatorTree(chain);
-    assert(dtChain.immediateDominator(&A) == nullptr);
-    assert(dtChain.immediateDominator(&B) == &A);
-    assert(dtChain.immediateDominator(&C) == &B);
-    assert(dtChain.dominates(&A, &B));
-    assert(dtChain.dominates(&A, &C));
+    {
+        CFGContext ctx(m);
+        DomTree dtChain = computeDominatorTree(ctx, chain);
+        assert(dtChain.immediateDominator(&A) == nullptr);
+        assert(dtChain.immediateDominator(&B) == &A);
+        assert(dtChain.immediateDominator(&C) == &B);
+        assert(dtChain.dominates(&A, &B));
+        assert(dtChain.dominates(&A, &C));
+    }
 
     return 0;
 }

--- a/tests/analysis/GraphOrderTests.cpp
+++ b/tests/analysis/GraphOrderTests.cpp
@@ -13,10 +13,10 @@
 using namespace il::core;
 using namespace viper::analysis;
 
-static void checkOrders(Function &fn)
+static void checkOrders(const CFGContext &ctx, Function &fn)
 {
-    auto po = postOrder(fn);
-    auto rpo = reversePostOrder(fn);
+    auto po = postOrder(ctx, fn);
+    auto rpo = reversePostOrder(ctx, fn);
 
     assert(po.size() == fn.blocks.size());
     assert(rpo.size() == fn.blocks.size());
@@ -33,7 +33,6 @@ static void checkOrders(Function &fn)
 int main()
 {
     Module m;
-    setModule(m);
     il::build::IRBuilder b(m);
 
     // Diamond: entry -> {t,f} -> join
@@ -56,7 +55,10 @@ int main()
     b.setInsertPoint(dJoin);
     b.emitRet(std::nullopt, {});
 
-    checkOrders(diamond);
+    {
+        CFGContext ctx(m);
+        checkOrders(ctx, diamond);
+    }
 
     // Linear chain: A -> B -> C
     Function &chain = b.startFunction("chain", Type(Type::Kind::Void), {});
@@ -74,7 +76,10 @@ int main()
     b.setInsertPoint(C);
     b.emitRet(std::nullopt, {});
 
-    checkOrders(chain);
+    {
+        CFGContext ctx(m);
+        checkOrders(ctx, chain);
+    }
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a CFGContext that stores module ownership to support CFG queries without globals
- update CFG traversals, the dominator builder, Mem2Reg, and PassManager to thread the context
- refresh tests and docs to construct contexts per module before invoking CFG utilities

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1afc2c3108324b9b522ad147c0ad1