### PR TITLE
fix(vm): handle missing main gracefully

### DIFF
--- a/src/tools/ilc/cli.hpp
+++ b/src/tools/ilc/cli.hpp
@@ -74,7 +74,8 @@ int cmdFrontBasic(int argc, char **argv);
 ///
 /// @param argc Number of arguments following `-run`.
 /// @param argv Argument vector beginning with the IL file path.
-/// @return Exit code of the executed program or `1` when validation fails.
+/// @return Exit code of the executed program or `1` when validation fails or the
+///         module lacks `func @main()` (emitting "missing main").
 ///
 /// @note May modify `stdin`, emit trace/debug information to `stderr`, and
 /// collect execution statistics.

--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -30,6 +30,8 @@ void usage()
         << "       ilc front basic -run <file.bas> [--trace=il|src] [--stdin-from <file>] "
            "[--max-steps N] [--break label|file:line]* [--break-src file:line]* [--bounds-checks]\n"
         << "       ilc il-opt <in.il> -o <out.il> --passes p1,p2\n"
+        << "\nIL notes:\n"
+        << "  IL modules executed with -run must define func @main().\n"
         << "\nBASIC notes:\n"
         << "  FUNCTION must RETURN a value on all paths.\n"
         << "  SUB cannot be used as an expression.\n"

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -13,6 +13,7 @@
 #include "il/core/Value.hpp"
 #include "vm/RuntimeBridge.hpp"
 #include <cassert>
+#include <iostream>
 
 using namespace il::core;
 
@@ -25,14 +26,20 @@ namespace il::vm
 /// executed via @c execFunction. Any tracing or debugging configured on the VM
 /// applies to the entire run.
 ///
-/// Workflow: look up @c main in @c fnMap, assert it exists, then call
-/// @c execFunction with an empty argument list and forward its return value.
+/// Workflow: look up @c main in @c fnMap, report a diagnostic when absent, and
+/// otherwise call @c execFunction with an empty argument list before forwarding
+/// its return value.
 ///
 /// @returns Signed 64-bit exit code produced by the program's @c main function.
+/// @retval 1 When the module lacks an entry point, after printing "missing main".
 int64_t VM::run()
 {
     auto it = fnMap.find("main");
-    assert(it != fnMap.end());
+    if (it == fnMap.end())
+    {
+        std::cerr << "missing main" << std::endl;
+        return 1;
+    }
     return execFunction(*it->second, {}).i64;
 }
 

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -110,7 +110,7 @@ class VM
        DebugScript *script = nullptr);
 
     /// @brief Execute the module's entry function.
-    /// @return Exit code from main function.
+    /// @return Exit code from @c main or `1` when the entry point is missing.
     int64_t run();
 
     /// @brief Function signature for opcode handlers.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -118,6 +118,15 @@ add_executable(test_tools_break_parsing tools/BreakParsingTests.cpp
 target_include_directories(test_tools_break_parsing PRIVATE ${CMAKE_SOURCE_DIR}/src)
 add_test(NAME test_tools_break_parsing COMMAND test_tools_break_parsing)
 
+add_executable(test_cli_run_missing_main
+  unit/test_cli_run_missing_main.cpp
+  ${CMAKE_SOURCE_DIR}/src/tools/ilc/cli.cpp
+  ${CMAKE_SOURCE_DIR}/src/tools/ilc/cmd_run_il.cpp
+  ${CMAKE_SOURCE_DIR}/src/tools/ilc/break_spec.cpp)
+target_include_directories(test_cli_run_missing_main PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(test_cli_run_missing_main PRIVATE il_vm il_api support)
+add_test(NAME test_cli_run_missing_main COMMAND test_cli_run_missing_main)
+
 add_executable(test_vm_trace_il vm/TraceILTests.cpp)
 add_test(NAME test_vm_trace_il COMMAND test_vm_trace_il $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/trace_min.il ${CMAKE_SOURCE_DIR}/tests/vm/trace_min.trace)
 add_executable(test_vm_break_label vm/BreakLabelTests.cpp)

--- a/tests/unit/test_cli_run_missing_main.cpp
+++ b/tests/unit/test_cli_run_missing_main.cpp
@@ -1,0 +1,59 @@
+// File: tests/unit/test_cli_run_missing_main.cpp
+// Purpose: Validate that cmdRunIL reports missing main without aborting.
+// Key invariants: CLI must emit "missing main" and return non-zero.
+// Ownership/Lifetime: Test owns temporary IL file it writes.
+// Links: src/tools/ilc/cmd_run_il.cpp
+
+#include "tools/ilc/cli.hpp"
+
+#include <cassert>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+const char kModuleSource[] = "il 0.1\n\nfunc @helper() -> i64 {\nentry:\n  ret 0\n}\n";
+}
+
+// Stubbed usage() to satisfy linkage when embedding cmd_run_il.cpp in the test.
+void usage()
+{
+}
+
+int main()
+{
+    namespace fs = std::filesystem;
+
+    const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+    fs::path tmpPath = fs::temp_directory_path();
+    tmpPath /= "viper-ilc-missing-main-" + std::to_string(stamp) + ".il";
+    {
+        std::ofstream ofs(tmpPath);
+        ofs << kModuleSource;
+    }
+
+    std::string pathStr = tmpPath.string();
+    std::vector<char> argStorage(pathStr.begin(), pathStr.end());
+    argStorage.push_back('\0');
+    char *argv[] = { argStorage.data() };
+
+    std::ostringstream errStream;
+    auto *oldBuf = std::cerr.rdbuf(errStream.rdbuf());
+    int rc = cmdRunIL(1, argv);
+    std::cerr.flush();
+    std::cerr.rdbuf(oldBuf);
+
+    fs::remove(tmpPath);
+
+    const std::string errText = errStream.str();
+    const bool hasMessage = errText.find("missing main") != std::string::npos;
+
+    assert(rc != 0);
+    assert(hasMessage);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- report a "missing main" runtime error in `VM::run` instead of asserting
- document the entry-point requirement in `ilc` usage text and add a CLI regression test

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d1b5c6feac8324a860653e6ae4c199