### PR TITLE
docs(lowering): move lowering reference and update IL reference links.

### DIFF
--- a/docs/il-reference.md
+++ b/docs/il-reference.md
@@ -15,7 +15,7 @@ Viper IL is the project’s "thin waist" intermediate language designed to sit b
 * **Explicit control flow** – each basic block ends with exactly one terminator; no fallthrough.
 * **Static types** – a minimal set of primitive types (`i1`, `i64`, `f64`, `ptr`, `str`, `void`).
 
-Execution is organized as functions consisting of labelled basic blocks.  Modules may execute either under the IL virtual machine interpreter or after lowering to native code through a C runtime.  Front ends such as BASIC first lower into IL patterns described in [BASIC lowering](../archive/docs/references/lowering.md).
+Execution is organized as functions consisting of labelled basic blocks.  Modules may execute either under the IL virtual machine interpreter or after lowering to native code through a C runtime.  Front ends such as BASIC first lower into IL patterns described in [BASIC lowering](lowering/basic-to-il.md).
 
 ## Module & Function Syntax
 An IL module is a set of declarations and function definitions.  It starts with a version line:

--- a/docs/lowering/basic-to-il.md
+++ b/docs/lowering/basic-to-il.md
@@ -1,10 +1,10 @@
 <!--
 SPDX-License-Identifier: MIT
-File: archive/docs/references/lowering.md
+File: docs/lowering/basic-to-il.md
 Purpose: Mapping BASIC constructs to IL.
 -->
 
-#Lowering Reference
+# Lowering Reference
 
 | BASIC         | IL runtime call |
 |---------------|-----------------|


### PR DESCRIPTION
## Summary
- move the BASIC lowering reference into docs/lowering/basic-to-il.md with refreshed front matter
- update the IL reference to link to the relocated lowering guide

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1b7fca3e8832497ce53fbc3f34fac