### PR TITLE
fix(vm): trap runtime calls with excess operands

### DIFF
--- a/src/vm/RuntimeBridge.cpp
+++ b/src/vm/RuntimeBridge.cpp
@@ -253,10 +253,12 @@ Slot RuntimeBridge::call(RuntimeCallContext &ctx,
     Slot res{};
     auto checkArgs = [&](size_t count)
     {
-        if (args.size() < count)
+        if (args.size() != count)
         {
             std::ostringstream os;
             os << name << ": expected " << count << " argument(s), got " << args.size();
+            if (args.size() > count)
+                os << " (excess runtime operands)";
             RuntimeBridge::trap(os.str(), loc, fn, block);
             return false;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -524,6 +524,10 @@ add_executable(test_vm_rt_missing_arg unit/test_vm_rt_missing_arg.cpp)
 target_link_libraries(test_vm_rt_missing_arg PRIVATE il_build il_vm support)
 add_test(NAME test_vm_rt_missing_arg COMMAND test_vm_rt_missing_arg)
 
+add_executable(test_vm_rt_extra_arg unit/test_vm_rt_extra_arg.cpp)
+target_link_libraries(test_vm_rt_extra_arg PRIVATE il_build il_vm support)
+add_test(NAME test_vm_rt_extra_arg COMMAND test_vm_rt_extra_arg)
+
 add_executable(test_vm_rt_concat_missing_args unit/test_vm_rt_concat_missing_args.cpp)
 target_link_libraries(test_vm_rt_concat_missing_args PRIVATE il_build il_vm support)
 add_test(NAME test_vm_rt_concat_missing_args COMMAND test_vm_rt_concat_missing_args)

--- a/tests/unit/test_vm_rt_extra_arg.cpp
+++ b/tests/unit/test_vm_rt_extra_arg.cpp
@@ -1,0 +1,55 @@
+// File: tests/unit/test_vm_rt_extra_arg.cpp
+// Purpose: Ensure runtime bridge traps when rt_print_str is called with too many arguments.
+// Key invariants: Calls with excess args should emit descriptive trap rather than crash.
+// Ownership: Test constructs IL module and executes VM.
+// Links: docs/class-catalog.md
+
+#include "il/build/IRBuilder.hpp"
+#include "vm/VM.hpp"
+#include <cassert>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main()
+{
+    using namespace il::core;
+    Module m;
+    il::build::IRBuilder b(m);
+    b.addExtern("rt_print_str", Type(Type::Kind::Void), {Type(Type::Kind::Str)});
+    b.addGlobalStr("g", "hi");
+    auto &fn = b.startFunction("main", Type(Type::Kind::Void), {});
+    auto &bb = b.addBlock(fn, "entry");
+    b.setInsertPoint(bb);
+    Value s = b.emitConstStr("g", {1, 1, 1});
+    // Deliberately provide an extra argument beyond the signature.
+    b.emitCall("rt_print_str", {s, s}, std::optional<Value>{}, {1, 1, 1});
+    b.emitRet(std::optional<Value>{}, {1, 1, 1});
+
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        il::vm::VM vm(m);
+        vm.run();
+        _exit(0);
+    }
+    close(fds[1]);
+    char buf[256];
+    ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
+    if (n > 0)
+        buf[n] = '\0';
+    else
+        buf[0] = '\0';
+    int status = 0;
+    waitpid(pid, &status, 0);
+    std::string out(buf);
+    bool ok = out.find("rt_print_str: expected 1 argument") != std::string::npos &&
+              out.find("excess runtime operands") != std::string::npos;
+    assert(ok);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ensure `RuntimeBridge::call` traps when runtime helpers receive the wrong number of operands and annotate the excess-operand diagnostic
- add a VM unit test that calls a helper with too many arguments and register it with the test suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1ba2e475c832480eb3420595bacde