### PR TITLE
Handle interacting allocas in mem2reg

### DIFF
--- a/tests/golden/il_opt/mem2reg_diamond.opt.il
+++ b/tests/golden/il_opt/mem2reg_diamond.opt.il
@@ -7,6 +7,6 @@ T:
   br Join(2)
 F:
   br Join(3)
-Join(%a0:i64):
+Join(%t3:i64):
   ret %t3
 }

--- a/tests/golden/il_opt/mem2reg_loop.opt.il
+++ b/tests/golden/il_opt/mem2reg_loop.opt.il
@@ -2,10 +2,10 @@ il 0.1.2
 func @main() -> i64 {
 entry:
   br L1(0)
-L1(%a0:i64):
+L1(%t5:i64):
   %t2 = add %t5, 1
   %t3 = scmp_lt %t2, 10
   cbr %t3, L1(%t2), Exit(%t2)
-Exit(%a0:i64):
+Exit(%t6:i64):
   ret %t6
 }

--- a/tests/golden/il_opt/mem2reg_nested.opt.il
+++ b/tests/golden/il_opt/mem2reg_nested.opt.il
@@ -12,6 +12,6 @@ T2:
   br Join(3)
 F2:
   br Join(4)
-Join(%a0:i64):
+Join(%t4:i64):
   ret %t4
 }


### PR DESCRIPTION
## Summary
- collect all promotable allocas per function and invoke the SSA renamer once so mutually recursive stores/loads are promoted together
- assign block parameter names based on their SSA id so serialized IL can be re-parsed without type mismatches
- refresh the mem2reg golden outputs to match the new block parameter naming

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d1b6e7c90c8324bdff7c94ee633f9b