### PR TITLE
fix(il/io): validate global string quotes

### DIFF
--- a/src/il/io/ModuleParser.cpp
+++ b/src/il/io/ModuleParser.cpp
@@ -101,7 +101,19 @@ Expected<void> parseGlobal_E(const std::string &line, ParserState &st)
         return Expected<void>{makeError({}, oss.str())};
     }
     size_t q1 = line.find('"', eq);
+    if (q1 == std::string::npos)
+    {
+        std::ostringstream oss;
+        oss << "line " << st.lineNo << ": missing opening '\"'";
+        return Expected<void>{makeError({}, oss.str())};
+    }
     size_t q2 = line.rfind('"');
+    if (q2 == std::string::npos || q2 <= q1)
+    {
+        std::ostringstream oss;
+        oss << "line " << st.lineNo << ": missing closing '\"'";
+        return Expected<void>{makeError({}, oss.str())};
+    }
     std::string name = trim(line.substr(at + 1, eq - at - 1));
     std::string init = line.substr(q1 + 1, q2 - q1 - 1);
     st.m.globals.push_back({name, Type(Type::Kind::Str), init});

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,10 @@ add_executable(test_il_parse_first_error unit/test_il_parse_first_error.cpp)
 target_link_libraries(test_il_parse_first_error PRIVATE il_core il_io il_api)
 add_test(NAME test_il_parse_first_error COMMAND test_il_parse_first_error)
 
+add_executable(test_il_parse_global_missing_quotes unit/test_il_parse_global_missing_quotes.cpp)
+target_link_libraries(test_il_parse_global_missing_quotes PRIVATE il_core il_io il_api)
+add_test(NAME test_il_parse_global_missing_quotes COMMAND test_il_parse_global_missing_quotes)
+
 add_executable(test_il_parse_invalid_type unit/test_il_parse_invalid_type.cpp)
 target_link_libraries(test_il_parse_invalid_type PRIVATE il_core il_io il_api)
 add_test(NAME test_il_parse_invalid_type COMMAND test_il_parse_invalid_type)

--- a/tests/unit/test_il_parse_global_missing_quotes.cpp
+++ b/tests/unit/test_il_parse_global_missing_quotes.cpp
@@ -1,0 +1,31 @@
+// File: tests/unit/test_il_parse_global_missing_quotes.cpp
+// Purpose: Ensure IL parser reports diagnostics when global string quotes are missing.
+// Key invariants: Parser surfaces a single diagnostic instead of crashing on malformed globals.
+// Ownership/Lifetime: Test owns parsing streams and module instance.
+// Links: docs/il-spec.md
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    const char *src = R"(il 0.1.2
+global @greeting = hello
+)";
+    std::istringstream in(src);
+    il::core::Module m;
+    std::ostringstream diag;
+    auto parse = il::api::v2::parse_text_expected(in, m);
+    if (!parse)
+    {
+        il::support::printDiag(parse.error(), diag);
+    }
+    assert(!parse);
+    const std::string message = diag.str();
+    assert(message.find("missing opening '\"'") != std::string::npos ||
+           message.find("missing closing '\"'") != std::string::npos);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- guard `parseGlobal_E` against missing quotes so malformed globals return diagnostics instead of slicing invalid substrings
- add a parser regression test for globals lacking quotes and register it with the unit test suite

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d1bd76a2a083248763f3aefa90308e