### PR TITLE
fix(vm): trap on unknown runtime helper

### DIFF
--- a/src/vm/RuntimeBridge.cpp
+++ b/src/vm/RuntimeBridge.cpp
@@ -267,9 +267,12 @@ Slot RuntimeBridge::call(RuntimeCallContext &ctx,
     const auto *desc = il::runtime::findRuntimeDescriptor(name);
     if (!desc)
     {
-        assert(false && "unknown runtime call");
+        std::ostringstream os;
+        os << "unknown runtime helper '" << name << "'";
+        RuntimeBridge::trap(os.str(), loc, fn, block);
+        return res;
     }
-    else if (checkArgs(desc->signature.paramTypes.size()))
+    if (checkArgs(desc->signature.paramTypes.size()))
     {
         const auto &sig = desc->signature;
         std::vector<void *> rawArgs(sig.paramTypes.size());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -532,6 +532,10 @@ add_executable(test_vm_rt_concat_missing_args unit/test_vm_rt_concat_missing_arg
 target_link_libraries(test_vm_rt_concat_missing_args PRIVATE il_build il_vm support)
 add_test(NAME test_vm_rt_concat_missing_args COMMAND test_vm_rt_concat_missing_args)
 
+add_executable(test_vm_rt_unknown_helper unit/test_vm_rt_unknown_helper.cpp)
+target_link_libraries(test_vm_rt_unknown_helper PRIVATE il_build il_vm support)
+add_test(NAME test_vm_rt_unknown_helper COMMAND test_vm_rt_unknown_helper)
+
 add_executable(test_vm_runtime_concurrency unit/test_vm_runtime_concurrency.cpp)
 target_link_libraries(test_vm_runtime_concurrency PRIVATE il_build il_vm support Threads::Threads)
 add_test(NAME test_vm_runtime_concurrency COMMAND test_vm_runtime_concurrency)

--- a/tests/unit/test_vm_rt_unknown_helper.cpp
+++ b/tests/unit/test_vm_rt_unknown_helper.cpp
@@ -1,0 +1,54 @@
+// File: tests/unit/test_vm_rt_unknown_helper.cpp
+// Purpose: Ensure runtime bridge traps when unknown runtime helpers are invoked.
+// Key invariants: Calls to helpers absent from the runtime registry must produce traps in all build modes.
+// Ownership: Test constructs IL module and executes the VM in a child to capture diagnostics.
+// Links: docs/class-catalog.md
+
+#include "il/build/IRBuilder.hpp"
+#include "vm/VM.hpp"
+#include <cassert>
+#include <optional>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main()
+{
+    using namespace il::core;
+    Module module;
+    il::build::IRBuilder builder(module);
+    builder.addExtern("rt_missing", Type(Type::Kind::Void), {});
+
+    auto &fn = builder.startFunction("main", Type(Type::Kind::Void), {});
+    auto &bb = builder.addBlock(fn, "entry");
+    builder.setInsertPoint(bb);
+    builder.emitCall("rt_missing", {}, std::optional<Value>{}, {1, 1, 1});
+    builder.emitRet(std::optional<Value>{}, {1, 1, 1});
+
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        il::vm::VM vm(module);
+        vm.run();
+        _exit(0);
+    }
+
+    close(fds[1]);
+    char buf[256];
+    ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
+    if (n > 0)
+        buf[n] = '\0';
+    else
+        buf[0] = '\0';
+    int status = 0;
+    waitpid(pid, &status, 0);
+    std::string out(buf);
+    bool ok = out.find("unknown runtime helper 'rt_missing'") != std::string::npos;
+    assert(ok);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- replace the debug-only assert in `RuntimeBridge::call` with a runtime trap so release builds report missing helpers
- add a regression test that calls an unknown runtime helper and verifies the trap message
- register the new test with the test suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1bdc7addc8324965a0cfefd267110