### PR TITLE
fix(il/io): diagnose unresolved temporaries

### DIFF
--- a/src/il/io/InstrParser.cpp
+++ b/src/il/io/InstrParser.cpp
@@ -86,7 +86,9 @@ Expected<Value> parseValue_E(const std::string &tok, ParserState &st)
                 }
             }
         }
-        return Value::temp(0);
+        std::ostringstream oss;
+        oss << "Line " << st.lineNo << ": unknown temp '" << tok << "'";
+        return Expected<Value>{makeError(st.curLoc, oss.str())};
     }
     if (tok[0] == '@')
         return Value::global(tok.substr(1));

--- a/tests/unit/test_il_parse_unknown_temp.cpp
+++ b/tests/unit/test_il_parse_unknown_temp.cpp
@@ -1,0 +1,35 @@
+// File: tests/unit/test_il_parse_unknown_temp.cpp
+// Purpose: Ensure IL parser reports an error when encountering an unknown SSA name.
+// Key invariants: Parser surfaces diagnostics for unresolved temporary references.
+// Ownership/Lifetime: Test constructs modules and diagnostic buffers locally.
+// Links: docs/il-spec.md
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    const char *src = R"(il 0.1.2
+func @main() -> i64 {
+entry:
+  %t0 = add %undef, 1
+  ret 0
+}
+)";
+
+    std::istringstream in(src);
+    il::core::Module m;
+    std::ostringstream diag;
+    auto parse = il::api::v2::parse_text_expected(in, m);
+    if (!parse)
+    {
+        il::support::printDiag(parse.error(), diag);
+    }
+    assert(!parse);
+    std::string msg = diag.str();
+    assert(msg.find("unknown temp '%undef'") != std::string::npos);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- report an error diagnostic when parsing a % operand that does not resolve to a known SSA value
- add a parser regression test that asserts the diagnostic for an unknown temporary name

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1c19ea96c8324bc9e9db20711688c