### PR TITLE
fix(runtime): ensure rt_concat releases consumed references

### DIFF
--- a/runtime/rt_string.c
+++ b/runtime/rt_string.c
@@ -99,6 +99,21 @@ rt_string rt_concat(rt_string a, rt_string b)
         memcpy(buf + asz, b->data, bsz);
     buf[s->size] = '\0';
     s->data = buf;
+
+    int64_t a_refcnt = (a && a->refcnt != INT64_MAX) ? a->refcnt : INT64_MAX;
+    if (a)
+        rt_string_unref(a);
+    if (b)
+    {
+        if (b == a && a_refcnt != INT64_MAX && a_refcnt <= 1)
+        {
+            // The first unref already released the sole reference; avoid double free.
+        }
+        else
+        {
+            rt_string_unref(b);
+        }
+    }
     return s;
 }
 


### PR DESCRIPTION
## Summary
- update `rt_concat` to release each operand after their data is copied, guarding against accidental double frees when both arguments alias
- extend `test_rt_string` to retain inputs across concatenation and assert reference counts drop once concatenated strings are consumed

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d1c13bbdbc832493107c037b402582