### PR TITLE
fix(vm): trap unknown runtime helpers

### DIFF
--- a/src/vm/RuntimeBridge.cpp
+++ b/src/vm/RuntimeBridge.cpp
@@ -268,7 +268,7 @@ Slot RuntimeBridge::call(RuntimeCallContext &ctx,
     if (!desc)
     {
         std::ostringstream os;
-        os << "unknown runtime helper '" << name << "'";
+        os << "attempted to call unknown runtime helper '" << name << '\'';
         RuntimeBridge::trap(os.str(), loc, fn, block);
         return res;
     }

--- a/tests/unit/test_vm_rt_unknown_helper.cpp
+++ b/tests/unit/test_vm_rt_unknown_helper.cpp
@@ -47,8 +47,14 @@ int main()
         buf[0] = '\0';
     int status = 0;
     waitpid(pid, &status, 0);
+    assert(WIFEXITED(status) && WEXITSTATUS(status) == 1);
     std::string out(buf);
-    bool ok = out.find("unknown runtime helper 'rt_missing'") != std::string::npos;
-    assert(ok);
+    bool messageOk =
+        out.find("runtime trap: attempted to call unknown runtime helper 'rt_missing'") != std::string::npos;
+    bool functionOk = out.find("main: entry") != std::string::npos;
+    bool locationOk = out.find("(1:1:1)") != std::string::npos;
+    assert(messageOk && "expected runtime trap diagnostic for unknown runtime helper");
+    assert(functionOk && "expected function and block context in runtime diagnostic");
+    assert(locationOk && "expected source location in runtime diagnostic");
     return 0;
 }


### PR DESCRIPTION
## Summary
- raise a fatal trap when the runtime bridge cannot find a helper descriptor
- update the unknown helper test to assert the full diagnostic and non-zero exit status

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1c4b3d84883249569d140b63f591a