### PR TITLE
Fix verifier forward call handling

### DIFF
--- a/src/il/verify/Verifier.cpp
+++ b/src/il/verify/Verifier.cpp
@@ -358,10 +358,11 @@ Expected<void> verifyModule_E(const Module &m, std::vector<Diag> &warnings)
     {
         if (!funcs.emplace(fn.name, &fn).second)
             return Expected<void>{makeError({}, "duplicate function @" + fn.name)};
+    }
 
+    for (const auto &fn : m.functions)
         if (auto result = verifyFunction_E(fn, externs, funcs, warnings); !result)
             return result;
-    }
 
     return {};
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -93,6 +93,10 @@ add_executable(test_il_verify_trap unit/test_il_verify_trap.cpp)
 target_link_libraries(test_il_verify_trap PRIVATE il_core il_verify il_api)
 add_test(NAME test_il_verify_trap COMMAND test_il_verify_trap)
 
+add_executable(test_il_verify_forward_call unit/test_il_verify_forward_call.cpp)
+target_link_libraries(test_il_verify_forward_call PRIVATE il_core il_verify il_api)
+add_test(NAME test_il_verify_forward_call COMMAND test_il_verify_forward_call)
+
 add_executable(test_il_type_inference unit/test_il_type_inference.cpp)
 target_link_libraries(test_il_type_inference PRIVATE il_core il_verify support)
 add_test(NAME test_il_type_inference COMMAND test_il_type_inference)

--- a/tests/unit/test_il_verify_forward_call.cpp
+++ b/tests/unit/test_il_verify_forward_call.cpp
@@ -1,0 +1,98 @@
+// File: tests/unit/test_il_verify_forward_call.cpp
+// Purpose: Ensure the verifier resolves forward callee lookups and rejects duplicates.
+// Key invariants: Forward calls verify successfully; duplicate function names still fail.
+// Ownership/Lifetime: Modules and functions are local to the test.
+// Links: docs/il-spec.md
+
+#include "il/api/expected_api.hpp"
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Module.hpp"
+#include "il/core/Opcode.hpp"
+#include "il/core/Type.hpp"
+
+#include <cassert>
+#include <string>
+
+int main()
+{
+    using namespace il::core;
+
+    {
+        Module module;
+
+        Function caller;
+        caller.name = "caller";
+        caller.retType = Type(Type::Kind::Void);
+
+        BasicBlock callerEntry;
+        callerEntry.label = "entry";
+
+        Instr callInstr;
+        callInstr.op = Opcode::Call;
+        callInstr.type = Type(Type::Kind::Void);
+        callInstr.callee = "callee";
+        callerEntry.instructions.push_back(callInstr);
+
+        Instr callerRet;
+        callerRet.op = Opcode::Ret;
+        callerRet.type = Type(Type::Kind::Void);
+        callerEntry.instructions.push_back(callerRet);
+        callerEntry.terminated = true;
+
+        caller.blocks.push_back(callerEntry);
+
+        Function callee;
+        callee.name = "callee";
+        callee.retType = Type(Type::Kind::Void);
+
+        BasicBlock calleeEntry;
+        calleeEntry.label = "entry";
+
+        Instr calleeRet;
+        calleeRet.op = Opcode::Ret;
+        calleeRet.type = Type(Type::Kind::Void);
+        calleeEntry.instructions.push_back(calleeRet);
+        calleeEntry.terminated = true;
+
+        callee.blocks.push_back(calleeEntry);
+
+        module.functions.push_back(caller);
+        module.functions.push_back(callee);
+
+        auto forwardResult = il::api::v2::verify_module_expected(module);
+        assert(forwardResult && "verifier should allow calls to later functions");
+    }
+
+    {
+        Module module;
+
+        auto makeVoidFunction = [](const std::string &name) {
+            Function fn;
+            fn.name = name;
+            fn.retType = Type(Type::Kind::Void);
+
+            BasicBlock entry;
+            entry.label = "entry";
+
+            Instr ret;
+            ret.op = Opcode::Ret;
+            ret.type = Type(Type::Kind::Void);
+            entry.instructions.push_back(ret);
+            entry.terminated = true;
+
+            fn.blocks.push_back(entry);
+            return fn;
+        };
+
+        module.functions.push_back(makeVoidFunction("dup"));
+        module.functions.push_back(makeVoidFunction("dup"));
+
+        auto duplicateResult = il::api::v2::verify_module_expected(module);
+        assert(!duplicateResult && "duplicate function names must still be rejected");
+        assert(duplicateResult.error().message.find("duplicate function @dup") != std::string::npos);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- preload the module function lookup map before verifying to unblock forward call validation while keeping duplicate checks
- add a unit test that covers forward calls and duplicate detection

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d1cc0e86dc83249c3527efa3e60d26