### PR TITLE
Handle invalid break line numbers in ilc run command

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -131,6 +131,15 @@ target_include_directories(test_cli_run_missing_main PRIVATE ${CMAKE_SOURCE_DIR}
 target_link_libraries(test_cli_run_missing_main PRIVATE il_vm il_api support)
 add_test(NAME test_cli_run_missing_main COMMAND test_cli_run_missing_main)
 
+add_executable(test_cli_run_invalid_break_line
+  unit/test_cli_run_invalid_break_line.cpp
+  ${CMAKE_SOURCE_DIR}/src/tools/ilc/cli.cpp
+  ${CMAKE_SOURCE_DIR}/src/tools/ilc/cmd_run_il.cpp
+  ${CMAKE_SOURCE_DIR}/src/tools/ilc/break_spec.cpp)
+target_include_directories(test_cli_run_invalid_break_line PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(test_cli_run_invalid_break_line PRIVATE il_vm il_api support)
+add_test(NAME test_cli_run_invalid_break_line COMMAND test_cli_run_invalid_break_line)
+
 add_executable(test_vm_trace_il vm/TraceILTests.cpp)
 add_test(NAME test_vm_trace_il COMMAND test_vm_trace_il $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/trace_min.il ${CMAKE_SOURCE_DIR}/tests/vm/trace_min.trace)
 add_executable(test_vm_break_label vm/BreakLabelTests.cpp)

--- a/tests/unit/test_cli_run_invalid_break_line.cpp
+++ b/tests/unit/test_cli_run_invalid_break_line.cpp
@@ -1,0 +1,63 @@
+// File: tests/unit/test_cli_run_invalid_break_line.cpp
+// Purpose: Ensure cmdRunIL gracefully rejects malformed break line numbers.
+// Key invariants: Invalid --break/--break-src arguments must report usage and fail.
+// Ownership/Lifetime: N/A.
+// Links: src/tools/ilc/cmd_run_il.cpp
+
+#include "tools/ilc/cli.hpp"
+
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+int invokeWithFlag(const std::string &flag, const std::string &spec, std::string &stderrText)
+{
+    std::string fileArg = "placeholder.il";
+    std::vector<std::string> argStorage = { fileArg, flag, spec };
+    std::vector<char *> argv = { argStorage[0].data(), argStorage[1].data(), argStorage[2].data() };
+
+    std::ostringstream errStream;
+    auto *oldBuf = std::cerr.rdbuf(errStream.rdbuf());
+    int rc = cmdRunIL(static_cast<int>(argv.size()), argv.data());
+    std::cerr.flush();
+    std::cerr.rdbuf(oldBuf);
+
+    stderrText = errStream.str();
+    return rc;
+}
+
+} // namespace
+
+static bool gUsageCalled = false;
+
+void usage()
+{
+    gUsageCalled = true;
+}
+
+int main()
+{
+    std::string err;
+
+    gUsageCalled = false;
+    int rc = invokeWithFlag("--break-src", "tests/e2e/BreakSrcExact.bas:not-a-number", err);
+    assert(rc != 0);
+    assert(gUsageCalled);
+    assert(err.find("invalid line number") != std::string::npos);
+    assert(err.find("--break-src") != std::string::npos);
+
+    gUsageCalled = false;
+    err.clear();
+    rc = invokeWithFlag("--break", "tests/e2e/BreakSrcExact.bas:99999999999999999999", err);
+    assert(rc != 0);
+    assert(gUsageCalled);
+    assert(err.find("invalid line number") != std::string::npos);
+    assert(err.find("--break") != std::string::npos);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- validate source line break specifications before adding debugger breakpoints
- emit a clear usage error and exit when `--break`/`--break-src` receive malformed or oversized line numbers
- add a CLI regression test that exercises the invalid break line handling and registers it with CTest

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1cbe98238832493aa887d136dcb95