### PR TITLE
fix: validate function header type parsing

### DIFF
--- a/tests/golden/invalid_il/bad_types.il
+++ b/tests/golden/invalid_il/bad_types.il
@@ -1,5 +1,5 @@
 il 0.1
-func @bad_types() -> i32 {
+func @bad_types() -> i64 {
 entry:
   %p = const_null
   %r = add %p, 1

--- a/tests/golden/invalid_il/wrong_extern_call.il
+++ b/tests/golden/invalid_il/wrong_extern_call.il
@@ -1,6 +1,6 @@
 il 0.1
 extern @rt_print_str(str) -> void
-func @main() -> i32 {
+func @main() -> i64 {
 entry:
   call @rt_print_str(42)
   ret 0

--- a/tests/golden/invalid_il/wrong_extern_sig.il
+++ b/tests/golden/invalid_il/wrong_extern_sig.il
@@ -1,6 +1,6 @@
 il 0.1
 extern @rt_print_str(i64) -> void
-func @main() -> i32 {
+func @main() -> i64 {
 entry:
   ret 0
 }

--- a/tests/il/parse/alloca_missing_size.il
+++ b/tests/il/parse/alloca_missing_size.il
@@ -1,5 +1,5 @@
 il 0.1.2
-func @f() -> i32 {
+func @f() -> i64 {
 entry:
   %t0 = alloca
   ret 0

--- a/tests/il/parse/bad_arg_count.il
+++ b/tests/il/parse/bad_arg_count.il
@@ -1,5 +1,5 @@
 il 0.1.2
-func @f() -> i32 {
+func @f() -> i64 {
 entry(%x:i64, %y:i64):
   ret 0
 start:

--- a/tests/il/parse/mismatched_paren.il
+++ b/tests/il/parse/mismatched_paren.il
@@ -1,5 +1,5 @@
 il 0.1.2
-func @f() -> i32 {
+func @f() -> i64 {
 entry:
   br next(1
 next(%x:i64):

--- a/tests/il/parse/unknown_param_type.il
+++ b/tests/il/parse/unknown_param_type.il
@@ -1,5 +1,5 @@
 il 0.1.2
-func @f() -> i32 {
+func @f() -> i64 {
 entry(%x:foo):
   ret 0
 }

--- a/tests/il/roundtrip/block-params.il
+++ b/tests/il/roundtrip/block-params.il
@@ -1,6 +1,6 @@
 il 0.1.2
 
-func @main() -> i32 {
+func @main() -> i64 {
 entry:
   br loop(0)
 

--- a/tests/il/roundtrip/zero-args-shorthand.il
+++ b/tests/il/roundtrip/zero-args-shorthand.il
@@ -1,6 +1,6 @@
 il 0.1.2
 
-func @main() -> i32 {
+func @main() -> i64 {
 entry:
   cbr 1, then, else
 

--- a/tests/unit/test_il_comments.cpp
+++ b/tests/unit/test_il_comments.cpp
@@ -14,7 +14,7 @@ int main()
     const char *src = R"(// header line 1
 // header line 2
 il 0.1.2
-func @main() -> i32 {
+func @main() -> i64 {
 entry:
   ret 0
 }

--- a/tests/unit/test_il_function_parser_errors.cpp
+++ b/tests/unit/test_il_function_parser_errors.cpp
@@ -24,10 +24,22 @@ int main()
         il::core::Module m;
         ParserState st{m};
         st.lineNo = 3;
-        auto result = parseFunctionHeader("func @broken() i32 {", st);
+        auto result = parseFunctionHeader("func @broken() i64 {", st);
         assert(!result);
         const std::string &msg = result.error().message;
         assert(msg.find("malformed function header") != std::string::npos);
+    }
+
+    // Unknown parameter type should surface an error and avoid mutating the module.
+    {
+        il::core::Module m;
+        ParserState st{m};
+        st.lineNo = 4;
+        auto result = parseFunctionHeader("func @oops(bad %x) -> i64 {", st);
+        assert(!result);
+        const std::string &msg = result.error().message;
+        assert(msg.find("unknown param type") != std::string::npos);
+        assert(m.functions.empty());
     }
 
     // Block parameter missing a colon should trigger the "bad param" diagnostic.
@@ -35,10 +47,10 @@ int main()
         il::core::Module m;
         ParserState st{m};
         st.lineNo = 5;
-        auto headerOk = parseFunctionHeader("func @ok(i32 %x) -> i32 {", st);
+        auto headerOk = parseFunctionHeader("func @ok(i64 %x) -> i64 {", st);
         assert(headerOk);
         st.lineNo = 6;
-        auto blockErr = parseBlockHeader("entry(%x i32)", st);
+        auto blockErr = parseBlockHeader("entry(%x i64)", st);
         assert(!blockErr);
         const std::string &msg = blockErr.error().message;
         assert(msg.find("bad param") != std::string::npos);
@@ -49,7 +61,7 @@ int main()
         il::core::Module m;
         ParserState st{m};
         st.lineNo = 10;
-        std::string header = "func @body() -> i32 {";
+        std::string header = "func @body() -> i64 {";
         std::istringstream body("  ret 0\n}\n");
         auto parseResult = parseFunction(body, header, st);
         assert(!parseResult);

--- a/tests/unit/test_il_parse_comment.cpp
+++ b/tests/unit/test_il_parse_comment.cpp
@@ -13,7 +13,7 @@ int main()
 {
     const char *src = R"(il 0.1.2
 // comment before function
-func @main() -> i32 {
+func @main() -> i64 {
 entry:
   ret 0
 }

--- a/tests/unit/test_il_parse_extern_missing_arrow.cpp
+++ b/tests/unit/test_il_parse_extern_missing_arrow.cpp
@@ -12,8 +12,8 @@
 int main()
 {
     const char *src = R"(il 0.1.2
-extern @foo(i32)
-func @main() -> i32 {
+extern @foo(i64)
+func @main() -> i64 {
 entry:
   ret 0
 }

--- a/tests/unit/test_il_parse_first_error.cpp
+++ b/tests/unit/test_il_parse_first_error.cpp
@@ -13,7 +13,7 @@
 int main()
 {
     const char *src = R"(il 0.1.2
-func @main() -> i32 {
+func @main() -> i64 {
 entry:
   %0 add 1, 2
   foo %1

--- a/tests/unit/test_il_parse_malformed_func_header.cpp
+++ b/tests/unit/test_il_parse_malformed_func_header.cpp
@@ -12,7 +12,7 @@
 int main()
 {
     const char *src = R"(il 0.1.2
-func @main() -> i32
+func @main() -> i64
 )";
     std::istringstream in(src);
     il::core::Module m;

--- a/tests/unit/test_il_parse_missing_eq.cpp
+++ b/tests/unit/test_il_parse_missing_eq.cpp
@@ -12,7 +12,7 @@
 int main()
 {
     const char *src = R"(il 0.1.2
-func @main() -> i32 {
+func @main() -> i64 {
 entry:
   %0 add 1, 2
 }


### PR DESCRIPTION
## Summary
- ensure `parseFunctionHeader` rejects unknown parameter types and propagates return type parse failures
- update parser unit tests and IL fixtures to use supported type tokens and cover the new diagnostic path

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1cbf2305c83248ecadaf4b6813e07