### PR TITLE
fix(frontends/basic): sync temp ids with builder

### DIFF
--- a/src/frontends/basic/Lowerer.cpp
+++ b/src/frontends/basic/Lowerer.cpp
@@ -463,6 +463,7 @@ Module Lowerer::lowerProgram(const Program &prog)
     builder = &b;
 
     mangler = NameMangler();
+    nextTemp = 0;
     lineBlocks.clear();
     varSlots.clear();
     arrayLenSlots.clear();
@@ -577,9 +578,6 @@ void Lowerer::buildProcedureSkeleton(Function &f,
     blockNamer = std::make_unique<BlockNamer>(name);
 
     builder->addBlock(f, blockNamer->entry());
-
-    for (size_t i = 0; i < metadata.paramCount; ++i)
-        mangler.nextTemp();
 
     size_t blockIndex = 1;
     for (const auto *stmt : metadata.bodyStmts)
@@ -702,6 +700,7 @@ void Lowerer::lowerProcedure(const std::string &name,
 
     Function &f = builder->startFunction(name, config.retType, metadata.irParams);
     func = &f;
+    nextTemp = func->valueNames.size();
 
     buildProcedureSkeleton(f, name, metadata);
 
@@ -786,6 +785,7 @@ void Lowerer::resetLoweringState()
     varTypes.clear();
     lineBlocks.clear();
     boundsCheckId = 0;
+    nextTemp = 0;
 }
 
 /// @brief Allocate stack storage for incoming parameters and record their types.

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -194,6 +194,7 @@ class Lowerer
     BasicBlock *cur{nullptr};
     size_t fnExit{0};
     NameMangler mangler;
+    unsigned nextTemp{0};
     std::unordered_map<int, size_t> lineBlocks;
     std::unordered_map<std::string, unsigned> varSlots;
     std::unordered_map<std::string, unsigned> arrayLenSlots;

--- a/src/il/build/IRBuilder.cpp
+++ b/src/il/build/IRBuilder.cpp
@@ -261,4 +261,15 @@ void IRBuilder::emitRet(const std::optional<Value> &v, il::support::SourceLoc lo
     append(std::move(instr));
 }
 
+/// @brief Reserve the next SSA temporary identifier for the currently active function.
+/// @return Identifier assigned to the new temporary.
+unsigned IRBuilder::reserveTempId()
+{
+    assert(curFunc && "reserveTempId requires an active function");
+    unsigned id = nextTemp++;
+    if (curFunc->valueNames.size() <= id)
+        curFunc->valueNames.resize(id + 1);
+    return id;
+}
+
 } // namespace il::build

--- a/src/il/build/IRBuilder.hpp
+++ b/src/il/build/IRBuilder.hpp
@@ -95,6 +95,10 @@ class IRBuilder
     /// @param v Optional return value.
     void emitRet(const std::optional<Value> &v, il::support::SourceLoc loc);
 
+    /// @brief Reserve the next SSA temporary identifier for the active function.
+    /// @return Newly assigned temporary id.
+    unsigned reserveTempId();
+
   private:
     Module &mod;                   ///< Module being constructed
     Function *curFunc{nullptr};    ///< Current function

--- a/tests/basic/goldens/ReturnNest.il
+++ b/tests/basic/goldens/ReturnNest.il
@@ -31,13 +31,13 @@ entry:
   br L0
 L0:
   .loc 1 4 7
-  %t1 = call @F()
+  %t0 = call @F()
   .loc 1 4 1
-  call @rt_print_i64(%t1)
+  call @rt_print_i64(%t0)
   .loc 1 4 1
-  %t2 = const_str @.L0
+  %t1 = const_str @.L0
   .loc 1 4 1
-  call @rt_print_str(%t2)
+  call @rt_print_str(%t1)
   .loc 1 4 1
   br exit
 exit:

--- a/tests/golden/basic_to_il/calls_lowering.il
+++ b/tests/golden/basic_to_il/calls_lowering.il
@@ -23,44 +23,44 @@ ret_F#:
 }
 func @ID$(str %S$) -> str {
 entry_ID$:
-  %t4 = alloca 8
-  store str, %t4, %t0
+  %t1 = alloca 8
+  store str, %t1, %t0
   br L0_ID$
 L0_ID$:
   .loc 1 5 8
-  %t5 = load str, %t4
+  %t2 = load str, %t1
   .loc 1 5 8
-  ret %t5
+  ret %t2
 ret_ID$:
-  %t6 = const_str @.L0
-  ret %t6
+  %t3 = const_str @.L0
+  ret %t3
 }
 func @FIRST#(i64 %N) -> f64 {
 entry_FIRST#:
-  %t8 = alloca 8
-  store i64, %t8, %t0
+  %t1 = alloca 8
+  store i64, %t1, %t0
   br L0_FIRST#
 L0_FIRST#:
 L0_FIRST#:
   .loc 1 8 1
   br if_test_0_FIRST#
   .loc 1 9 16
-  %t11 = load i64, %t8
+  %t4 = load i64, %t1
   .loc 1 9 8
-  %t12 = sitofp %t11
+  %t5 = sitofp %t4
   .loc 1 9 8
-  %t13 = call @SECOND#(%t12)
+  %t6 = call @SECOND#(%t5)
   .loc 1 9 8
-  ret %t13
+  ret %t6
 ret_FIRST#:
   ret 0.0
 if_test_0_FIRST#:
   .loc 1 8 4
-  %t9 = load i64, %t8
+  %t2 = load i64, %t1
   .loc 1 8 6
-  %t10 = scmp_le %t9, 0
+  %t3 = scmp_le %t2, 0
   .loc 1 8 6
-  cbr %t10, if_then_0_FIRST#, if_else_0_FIRST#
+  cbr %t3, if_then_0_FIRST#, if_else_0_FIRST#
 if_then_0_FIRST#:
   .loc 1 8 23
   ret 0.0
@@ -73,36 +73,36 @@ if_end_0_FIRST#:
 }
 func @SECOND#(f64 %N#) -> f64 {
 entry_SECOND#:
-  %t15 = alloca 8
-  store f64, %t15, %t0
+  %t1 = alloca 8
+  store f64, %t1, %t0
   br L0_SECOND#
 L0_SECOND#:
 L0_SECOND#:
   .loc 1 12 1
   br if_test_0_SECOND#
   .loc 1 13 15
-  %t19 = load f64, %t15
+  %t5 = load f64, %t1
   .loc 1 13 18
-  %t20 = sitofp 1
+  %t6 = sitofp 1
   .loc 1 13 18
-  %t21 = fsub %t19, %t20
+  %t7 = fsub %t5, %t6
   .loc 1 13 8
-  %t22 = fptosi %t21
+  %t8 = fptosi %t7
   .loc 1 13 8
-  %t23 = call @FIRST#(%t22)
+  %t9 = call @FIRST#(%t8)
   .loc 1 13 8
-  ret %t23
+  ret %t9
 ret_SECOND#:
   ret 0.0
 if_test_0_SECOND#:
   .loc 1 12 4
-  %t16 = load f64, %t15
+  %t2 = load f64, %t1
   .loc 1 12 7
-  %t17 = sitofp 0
+  %t3 = sitofp 0
   .loc 1 12 7
-  %t18 = fcmp_le %t16, %t17
+  %t4 = fcmp_le %t2, %t3
   .loc 1 12 7
-  cbr %t18, if_then_0_SECOND#, if_else_0_SECOND#
+  cbr %t4, if_then_0_SECOND#, if_else_0_SECOND#
 if_then_0_SECOND#:
   .loc 1 12 24
   ret 0.0
@@ -118,39 +118,39 @@ entry:
   br L10
 L10:
   .loc 1 15 10
-  %t24 = sitofp 1
+  %t0 = sitofp 1
   .loc 1 15 10
-  %t25 = call @F#(%t24)
+  %t1 = call @F#(%t0)
   .loc 1 15 4
-  call @rt_print_f64(%t25)
+  call @rt_print_f64(%t1)
   .loc 1 15 4
-  %t26 = const_str @.L1
+  %t2 = const_str @.L1
   .loc 1 15 4
-  call @rt_print_str(%t26)
+  call @rt_print_str(%t2)
   .loc 1 15 4
   br L20
 L20:
   .loc 1 16 14
-  %t27 = const_str @.L2
+  %t3 = const_str @.L2
   .loc 1 16 10
-  %t28 = call @ID$(%t27)
+  %t4 = call @ID$(%t3)
   .loc 1 16 4
-  call @rt_print_str(%t28)
+  call @rt_print_str(%t4)
   .loc 1 16 4
-  %t29 = const_str @.L1
+  %t5 = const_str @.L1
   .loc 1 16 4
-  call @rt_print_str(%t29)
+  call @rt_print_str(%t5)
   .loc 1 16 4
   br L30
 L30:
   .loc 1 17 10
-  %t30 = call @FIRST#(2)
+  %t6 = call @FIRST#(2)
   .loc 1 17 4
-  call @rt_print_f64(%t30)
+  call @rt_print_f64(%t6)
   .loc 1 17 4
-  %t31 = const_str @.L1
+  %t7 = const_str @.L1
   .loc 1 17 4
-  call @rt_print_str(%t31)
+  call @rt_print_str(%t7)
   .loc 1 17 4
   br L40
 L40:

--- a/tests/unit/test_basic_lowerer_collect.cpp
+++ b/tests/unit/test_basic_lowerer_collect.cpp
@@ -28,6 +28,24 @@ bool entryHasAlloca(const il::core::Function &fn)
     return false;
 }
 
+bool tempsHaveNames(const il::core::Function &fn)
+{
+    for (const auto &bb : fn.blocks)
+    {
+        for (const auto &instr : bb.instructions)
+        {
+            if (!instr.result)
+                continue;
+            unsigned id = *instr.result;
+            if (fn.valueNames.size() <= id)
+                return false;
+            if (fn.valueNames[id].empty())
+                return false;
+        }
+    }
+    return true;
+}
+
 } // namespace
 
 int main()
@@ -61,5 +79,7 @@ int main()
     assert(mainFn && funcF);
     assert(entryHasAlloca(*mainFn));
     assert(entryHasAlloca(*funcF));
+    assert(tempsHaveNames(*mainFn));
+    assert(tempsHaveNames(*funcF));
     return 0;
 }


### PR DESCRIPTION
## Summary
- add IRBuilder::reserveTempId so Lowerer can share the SSA counter and reset it per function
- populate valueNames placeholders when emitting temporaries to keep VM register sizing consistent
- update lowering tests and golden IL outputs to match the new numbering scheme

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1cc2638348324a1963a33b39654f6