### PR TITLE
refactor(verify): expose expected helpers and unify callers

### DIFF
--- a/src/il/verify/InstructionChecker.cpp
+++ b/src/il/verify/InstructionChecker.cpp
@@ -71,9 +71,9 @@ void emitWarning(const Function &fn,
 /// @param instr Instruction whose signature is being checked.
 /// @return Empty on success; otherwise an error diagnostic describing the
 ///         structural mismatch.
-Expected<void> verifyOpcodeSignature_E(const Function &fn,
-                                        const BasicBlock &bb,
-                                        const Instr &instr)
+Expected<void> verifyOpcodeSignature_impl(const Function &fn,
+                                          const BasicBlock &bb,
+                                          const Instr &instr)
 {
     const auto &info = getOpcodeInfo(instr.op);
 
@@ -461,13 +461,13 @@ Expected<void> checkDefault_E(const Instr &instr, TypeInference &types)
 /// @param warnings Accumulates warning diagnostics emitted during validation.
 /// @return Empty on success; otherwise an error diagnostic describing the
 ///         violated rule.
-Expected<void> verifyInstruction_E(const Function &fn,
-                                    const BasicBlock &bb,
-                                    const Instr &instr,
-                                    const std::unordered_map<std::string, const Extern *> &externs,
-                                    const std::unordered_map<std::string, const Function *> &funcs,
-                                    TypeInference &types,
-                                    std::vector<Diag> &warnings)
+Expected<void> verifyInstruction_impl(const Function &fn,
+                                      const BasicBlock &bb,
+                                      const Instr &instr,
+                                      const std::unordered_map<std::string, const Extern *> &externs,
+                                      const std::unordered_map<std::string, const Function *> &funcs,
+                                      TypeInference &types,
+                                      std::vector<Diag> &warnings)
 {
     switch (instr.op)
     {
@@ -538,6 +538,24 @@ Expected<void> verifyInstruction_E(const Function &fn,
 }
 
 } // namespace
+
+Expected<void> verifyOpcodeSignature_E(const Function &fn,
+                                        const BasicBlock &bb,
+                                        const Instr &instr)
+{
+    return verifyOpcodeSignature_impl(fn, bb, instr);
+}
+
+Expected<void> verifyInstruction_E(const Function &fn,
+                                    const BasicBlock &bb,
+                                    const Instr &instr,
+                                    const std::unordered_map<std::string, const Extern *> &externs,
+                                    const std::unordered_map<std::string, const Function *> &funcs,
+                                    TypeInference &types,
+                                    std::vector<Diag> &warnings)
+{
+    return verifyInstruction_impl(fn, bb, instr, externs, funcs, types, warnings);
+}
 
 bool verifyOpcodeSignature(const Function &fn,
                            const BasicBlock &bb,

--- a/src/il/verify/Verifier.hpp
+++ b/src/il/verify/Verifier.hpp
@@ -5,27 +5,15 @@
 // Links: docs/il-spec.md
 #pragma once
 
-#include <ostream>
-#include <string>
-#include <unordered_map>
-
 #include "support/diag_expected.hpp"
 
 namespace il::core
 {
-struct Extern;
-struct Global;
 struct Module;
-struct Function;
-struct BasicBlock;
-struct Instr;
-struct Type;
 }
 
 namespace il::verify
 {
-
-class TypeInference;
 
 /// @brief Verifies structural and type rules for a module.
 class Verifier
@@ -35,77 +23,6 @@ class Verifier
     /// @param m Module to verify.
     /// @return Expected success or diagnostic on failure.
     static il::support::Expected<void> verify(const il::core::Module &m);
-
-
-  private:
-    /// @brief Validate extern declarations for uniqueness and known signatures.
-    /// @param m Module providing externs.
-    /// @param err Stream receiving diagnostic messages.
-    /// @param externs Map populated with externs by name for later lookups.
-    /// @return True if all externs are well-formed; false otherwise.
-    static bool verifyExterns(const il::core::Module &m,
-                              std::ostream &err,
-                              std::unordered_map<std::string, const il::core::Extern *> &externs);
-
-    /// @brief Check global variables for duplicate definitions.
-    /// @param m Module containing globals.
-    /// @param err Stream receiving diagnostic messages.
-    /// @param globals Map populated with globals by name for later lookups.
-    /// @return True when all globals are unique; false otherwise.
-    static bool verifyGlobals(const il::core::Module &m,
-                              std::ostream &err,
-                              std::unordered_map<std::string, const il::core::Global *> &globals);
-
-    /// @brief Verify a function's signature and internal structure.
-    /// @param fn Function to verify.
-    /// @param externs Previously gathered extern signatures for calls.
-    /// @param funcs Map of all functions for resolving references.
-    /// @param err Stream receiving diagnostic messages.
-    /// @return True if the function passes all checks; false otherwise.
-    static bool verifyFunction(
-        const il::core::Function &fn,
-        const std::unordered_map<std::string, const il::core::Extern *> &externs,
-        const std::unordered_map<std::string, const il::core::Function *> &funcs,
-        std::ostream &err);
-
-    /// @brief Validate a basic block's instructions and terminator.
-    /// @param fn Enclosing function.
-    /// @param bb Block under inspection.
-    /// @param blockMap Map of labels to blocks for branch targets.
-    /// @param externs Extern signatures for call checking.
-    /// @param funcs Function map for call checking.
-    /// @param temps Map of temporary ids to their inferred types.
-    /// @param err Stream receiving diagnostic messages.
-    /// @return True if the block is well-formed; false otherwise.
-    static bool verifyBlock(
-        const il::core::Function &fn,
-        const il::core::BasicBlock &bb,
-        const std::unordered_map<std::string, const il::core::BasicBlock *> &blockMap,
-        const std::unordered_map<std::string, const il::core::Extern *> &externs,
-        const std::unordered_map<std::string, const il::core::Function *> &funcs,
-        std::unordered_map<unsigned, il::core::Type> &temps,
-        std::ostream &err);
-
-    /// @brief Validate a single instruction within a block.
-    /// @param fn Enclosing function.
-    /// @param bb Block containing the instruction.
-    /// @param in Instruction to verify.
-    /// @param blockMap Map of labels to blocks for branch targets.
-    /// @param externs Extern signatures for call checking.
-    /// @param funcs Function map for call checking.
-    /// @param temps Map tracking temporary types.
-    /// @param defined Set of temporaries defined so far.
-    /// @param err Stream receiving diagnostic messages.
-    /// @return True if the instruction is valid; false otherwise.
-    static bool verifyInstr(
-        const il::core::Function &fn,
-        const il::core::BasicBlock &bb,
-        const il::core::Instr &in,
-        const std::unordered_map<std::string, const il::core::BasicBlock *> &blockMap,
-        const std::unordered_map<std::string, const il::core::Extern *> &externs,
-        const std::unordered_map<std::string, const il::core::Function *> &funcs,
-        TypeInference &types,
-        std::ostream &err);
 };
 
 } // namespace il::verify

--- a/src/tools/il-verify/il-verify.cpp
+++ b/src/tools/il-verify/il-verify.cpp
@@ -7,6 +7,7 @@
 
 #include "il/api/expected_api.hpp"
 #include "il/core/Module.hpp"
+#include "il/verify/Verifier.hpp"
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -46,7 +47,7 @@ int main(int argc, char **argv)
         il::support::printDiag(pe.error(), std::cerr);
         return 1;
     }
-    auto ve = il::api::v2::verify_module_expected(m);
+    auto ve = il::verify::Verifier::verify(m);
     if (!ve)
     {
         il::support::printDiag(ve.error(), std::cerr);

--- a/src/tools/ilc/cmd_front_basic.cpp
+++ b/src/tools/ilc/cmd_front_basic.cpp
@@ -12,8 +12,9 @@
 #include "frontends/basic/Lowerer.hpp"
 #include "frontends/basic/Parser.hpp"
 #include "frontends/basic/SemanticAnalyzer.hpp"
-#include "il/api/expected_api.hpp"
 #include "il/io/Serializer.hpp"
+#include "il/api/expected_api.hpp"
+#include "il/verify/Verifier.hpp"
 #include "support/source_manager.hpp"
 #include "vm/VM.hpp"
 #include <cstdint>
@@ -133,7 +134,7 @@ int cmdFrontBasic(int argc, char **argv)
         io::Serializer::write(m, std::cout);
         return 0;
     }
-    auto ve = il::api::v2::verify_module_expected(m);
+    auto ve = il::verify::Verifier::verify(m);
     if (!ve)
     {
         il::support::printDiag(ve.error(), std::cerr);

--- a/src/tools/ilc/cmd_run_il.cpp
+++ b/src/tools/ilc/cmd_run_il.cpp
@@ -13,6 +13,7 @@
 #include "il/api/expected_api.hpp"
 #include "il/core/Function.hpp"
 #include "il/core/Module.hpp"
+#include "il/verify/Verifier.hpp"
 #include "support/source_manager.hpp"
 #include "vm/VM.hpp"
 #include <algorithm>
@@ -210,7 +211,7 @@ int cmdRunIL(int argc, char **argv)
         il::support::printDiag(pe.error(), std::cerr);
         return 1;
     }
-    auto ve = il::api::v2::verify_module_expected(m);
+    auto ve = il::verify::Verifier::verify(m);
     if (!ve)
     {
         il::support::printDiag(ve.error(), std::cerr);

--- a/tests/unit/test_il_verify_forward_call.cpp
+++ b/tests/unit/test_il_verify_forward_call.cpp
@@ -4,12 +4,12 @@
 // Ownership/Lifetime: Modules and functions are local to the test.
 // Links: docs/il-spec.md
 
-#include "il/api/expected_api.hpp"
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Function.hpp"
 #include "il/core/Instr.hpp"
 #include "il/core/Module.hpp"
 #include "il/core/Opcode.hpp"
+#include "il/verify/Verifier.hpp"
 #include "il/core/Type.hpp"
 
 #include <cassert>
@@ -61,7 +61,7 @@ int main()
         module.functions.push_back(caller);
         module.functions.push_back(callee);
 
-        auto forwardResult = il::api::v2::verify_module_expected(module);
+        auto forwardResult = il::verify::Verifier::verify(module);
         assert(forwardResult && "verifier should allow calls to later functions");
     }
 
@@ -89,7 +89,7 @@ int main()
         module.functions.push_back(makeVoidFunction("dup"));
         module.functions.push_back(makeVoidFunction("dup"));
 
-        auto duplicateResult = il::api::v2::verify_module_expected(module);
+        auto duplicateResult = il::verify::Verifier::verify(module);
         assert(!duplicateResult && "duplicate function names must still be rejected");
         assert(duplicateResult.error().message.find("duplicate function @dup") != std::string::npos);
     }

--- a/tests/unit/test_il_verify_trap.cpp
+++ b/tests/unit/test_il_verify_trap.cpp
@@ -4,12 +4,13 @@
 // Ownership/Lifetime: Constructs module locally for verification.
 // Links: docs/il-spec.md
 
-#include "il/api/expected_api.hpp"
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Function.hpp"
 #include "il/core/Instr.hpp"
 #include "il/core/Module.hpp"
 #include "il/core/Opcode.hpp"
+#include "il/verify/Verifier.hpp"
+#include "support/diag_expected.hpp"
 #include <cassert>
 #include <sstream>
 
@@ -34,7 +35,7 @@ int main()
     m.functions.push_back(fn);
 
     std::ostringstream diag;
-    auto ve = il::api::v2::verify_module_expected(m);
+    auto ve = il::verify::Verifier::verify(m);
     if (!ve)
     {
         il::support::printDiag(ve.error(), diag);


### PR DESCRIPTION
## Summary
- expose the Expected-returning control-flow helper entry points and drop the redundant `_expected` wrappers
- remove the bool-based verifier helpers so the implementation relies on the Expected flow end-to-end and simplify the header
- update il-verify, ilc front/run commands, and the verifier unit tests to call `Verifier::verify` directly

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1d7d62f2c83249aa3933dffc4ae4f