### PR TITLE
Refactor PassManager liveness to reuse CFG helpers

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -589,6 +589,10 @@ add_executable(test_vm_opcode_dispatch unit/test_vm_opcode_dispatch.cpp)
 target_link_libraries(test_vm_opcode_dispatch PRIVATE il_io il_vm il_api)
 add_test(NAME test_vm_opcode_dispatch COMMAND test_vm_opcode_dispatch)
 
+add_executable(test_il_liveness unit/test_il_liveness.cpp)
+target_link_libraries(test_il_liveness PRIVATE il_io il_transform il_api)
+add_test(NAME test_il_liveness COMMAND test_il_liveness)
+
 add_executable(test_il_pass_manager unit/test_il_pass_manager.cpp)
 target_link_libraries(test_il_pass_manager PRIVATE il_io il_transform il_api)
 add_test(NAME test_il_pass_manager COMMAND test_il_pass_manager)

--- a/tests/unit/test_il_liveness.cpp
+++ b/tests/unit/test_il_liveness.cpp
@@ -1,0 +1,114 @@
+// File: tests/unit/test_il_liveness.cpp
+// Purpose: Regression tests for liveness analysis on complex control flow.
+// Key invariants: Live-in/out sets reflect required SSA values across branches.
+// Ownership/Lifetime: Test constructs modules locally and discards on exit.
+// Links: docs/class-catalog.md
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "il/transform/PassManager.hpp"
+
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+using namespace il;
+
+namespace
+{
+const char *kProgram = R"(il 0.1.2
+
+func @complex(%flag:i1) -> i64 {
+entry(%flag:i1):
+  %base = add 0, 1
+  %incr = add %base, 1
+  cbr %flag, left(%incr), right(%base)
+left(%lv:i64):
+  %left = add %lv, %incr
+  br join(%left, %lv)
+right(%rv:i64):
+  %right = add %rv, %base
+  br join(%right, %rv)
+join(%x:i64, %y:i64):
+  %sum = add %x, %y
+  ret %sum
+}
+)";
+
+unsigned findValueId(const core::Function &fn, std::string_view name)
+{
+    for (std::size_t idx = fn.valueNames.size(); idx-- > 0;)
+    {
+        if (fn.valueNames[idx] == name)
+            return static_cast<unsigned>(idx);
+    }
+    assert(false && "value not found");
+    return 0;
+}
+
+const core::BasicBlock *findBlock(const core::Function &fn, std::string_view label)
+{
+    for (const auto &block : fn.blocks)
+    {
+        if (block.label == label)
+            return &block;
+    }
+    assert(false && "block not found");
+    return nullptr;
+}
+} // namespace
+
+int main()
+{
+    core::Module module;
+    std::istringstream input(kProgram);
+    auto parsed = il::api::v2::parse_text_expected(input, module);
+    if (!parsed)
+    {
+        il::support::printDiag(parsed.error(), std::cerr);
+        return 1;
+    }
+
+    assert(module.functions.size() == 1);
+    core::Function &fn = module.functions[0];
+
+    transform::LivenessInfo liveness = transform::computeLiveness(module, fn);
+
+    const unsigned flagId = findValueId(fn, "flag");
+    const unsigned baseId = findValueId(fn, "base");
+    const unsigned incrId = findValueId(fn, "incr");
+
+    const core::BasicBlock *entry = findBlock(fn, "entry");
+    const core::BasicBlock *left = findBlock(fn, "left");
+    const core::BasicBlock *right = findBlock(fn, "right");
+    const core::BasicBlock *join = findBlock(fn, "join");
+
+    auto entryIn = liveness.liveIn(entry);
+    assert(entryIn.empty());
+
+    auto entryOut = liveness.liveOut(entry);
+    assert(entryOut.contains(baseId));
+    assert(entryOut.contains(incrId));
+    assert(!entryOut.contains(flagId));
+
+    auto leftIn = liveness.liveIn(left);
+    assert(leftIn.contains(incrId));
+    assert(!leftIn.contains(baseId));
+    auto leftOut = liveness.liveOut(left);
+    assert(leftOut.empty());
+
+    auto rightIn = liveness.liveIn(right);
+    assert(rightIn.contains(baseId));
+    assert(!rightIn.contains(incrId));
+    auto rightOut = liveness.liveOut(right);
+    assert(rightOut.empty());
+
+    auto joinIn = liveness.liveIn(join);
+    assert(joinIn.empty());
+    auto joinOut = liveness.liveOut(join);
+    assert(joinOut.empty());
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- reuse the CFG analysis helpers inside `buildCFG` and rework the liveness computation to operate on the shared adjacency data
- add a unit test that exercises liveness on branched control flow and wire it into the test build

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d1d7df03cc8324ab7da18a0bf852bb