### PR TITLE
fix: zero-fill rt_alloc allocations

### DIFF
--- a/runtime/rt_memory.c
+++ b/runtime/rt_memory.c
@@ -27,7 +27,7 @@ void *rt_alloc(int64_t bytes)
     size_t request = (size_t)bytes;
     if (request == 0)
         request = 1;
-    void *p = malloc(request);
+    void *p = calloc(1, request);
     if (!p)
         rt_trap("out of memory");
     return p;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -247,6 +247,10 @@ add_executable(test_rt_alloc_zero runtime/RTAllocZeroTests.cpp)
 target_link_libraries(test_rt_alloc_zero PRIVATE rt)
 add_test(NAME test_rt_alloc_zero COMMAND test_rt_alloc_zero)
 
+add_executable(test_rt_alloc_zero_fill runtime/RTAllocZeroFillTests.cpp)
+target_link_libraries(test_rt_alloc_zero_fill PRIVATE rt)
+add_test(NAME test_rt_alloc_zero_fill COMMAND test_rt_alloc_zero_fill)
+
 add_executable(test_rt_input_line runtime/RTInputLineTests.cpp)
 target_link_libraries(test_rt_input_line PRIVATE rt)
 add_test(NAME test_rt_input_line COMMAND test_rt_input_line)

--- a/tests/runtime/RTAllocZeroFillTests.cpp
+++ b/tests/runtime/RTAllocZeroFillTests.cpp
@@ -1,0 +1,34 @@
+// File: tests/runtime/RTAllocZeroFillTests.cpp
+// Purpose: Verify rt_alloc returns zero-initialized memory.
+// Key invariants: Memory returned from rt_alloc must contain only zero bytes.
+// Ownership: Uses runtime library and frees allocated memory.
+// Links: docs/runtime-abi.md
+#include "rt.hpp"
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(__GLIBC__)
+extern "C" void *__libc_malloc(size_t size);
+
+extern "C" void *malloc(size_t size)
+{
+    void *ptr = __libc_malloc(size);
+    if (ptr)
+        memset(ptr, 0xAB, size);
+    return ptr;
+}
+#endif
+
+int main()
+{
+    const size_t size = 64;
+    uint8_t *bytes = (uint8_t *)rt_alloc((int64_t)size);
+    assert(bytes != NULL);
+    for (size_t i = 0; i < size; ++i)
+        assert(bytes[i] == 0);
+    free(bytes);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- update `rt_alloc` to zero-initialize allocations so runtime clients receive cleared memory
- add a regression test that overrides glibc malloc to ensure the allocation path returns zeroed bytes
- register the new runtime test with the CMake test suite

## Testing
- cmake -S . -B build
- cmake --build build --target rt
- cmake --build build
- ctest --test-dir build --output-on-failure -R "^test_rt_"


------
https://chatgpt.com/codex/tasks/task_e_68d1f15ad3dc83249cf3b81d83f4d2ef