### PR TITLE
fix(vm): trap on alloca overflow

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -573,6 +573,10 @@ add_executable(test_vm_alloca_missing_size unit/test_vm_alloca_missing_size.cpp)
 target_link_libraries(test_vm_alloca_missing_size PRIVATE il_build il_vm support)
 add_test(NAME test_vm_alloca_missing_size COMMAND test_vm_alloca_missing_size)
 
+add_executable(test_vm_alloca_overflow unit/test_vm_alloca_overflow.cpp)
+target_link_libraries(test_vm_alloca_overflow PRIVATE il_build il_vm support)
+add_test(NAME test_vm_alloca_overflow COMMAND test_vm_alloca_overflow)
+
 add_executable(test_vm_unknown_global unit/test_vm_unknown_global.cpp)
 target_link_libraries(test_vm_unknown_global PRIVATE il_build il_vm support)
 add_test(NAME test_vm_unknown_global COMMAND test_vm_unknown_global)

--- a/tests/unit/test_vm_alloca_overflow.cpp
+++ b/tests/unit/test_vm_alloca_overflow.cpp
@@ -1,0 +1,52 @@
+// File: tests/unit/test_vm_alloca_overflow.cpp
+// Purpose: Ensure VM traps when alloca exceeds frame stack capacity.
+// Key invariants: Alloca larger than stack size must emit "stack overflow in alloca" trap.
+// Ownership: Test constructs IL module and executes VM.
+// Links: docs/class-catalog.md
+
+#include "il/build/IRBuilder.hpp"
+#include "vm/VM.hpp"
+#include <cassert>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main()
+{
+    il::core::Module m;
+    il::build::IRBuilder b(m);
+    auto &fn = b.startFunction("main", il::core::Type(il::core::Type::Kind::I64), {});
+    auto &bb = b.addBlock(fn, "entry");
+    il::core::Instr in;
+    in.op = il::core::Opcode::Alloca;
+    in.type = il::core::Type(il::core::Type::Kind::Ptr);
+    in.operands.push_back(il::core::Value::constInt(2048));
+    in.loc = {1, 1, 1};
+    bb.instructions.push_back(in);
+
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        il::vm::VM vm(m);
+        vm.run();
+        _exit(0);
+    }
+    close(fds[1]);
+    char buf[256];
+    ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
+    if (n > 0)
+        buf[n] = '\0';
+    else
+        buf[0] = '\0';
+    int status = 0;
+    waitpid(pid, &status, 0);
+    std::string out(buf);
+    bool ok = out.find("stack overflow in alloca") != std::string::npos;
+    assert(ok);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- replace the debug-only alloca stack check with a runtime trap and guard the remaining-capacity calculation against wraparound before zeroing the stack slice
- mark the exec result as returned when trapping on overflow to mirror other alloca errors
- add a VM regression test that emits an oversized alloca and assert the trap message, wiring it into the test suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d1f16350048324b70ba2dbee3809ea