### PR TITLE
Refactor terminal input decoding helpers

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -11,6 +11,8 @@ add_library(tui STATIC
   src/term/term_io.cpp
   src/term/session.cpp
   src/term/input.cpp
+  src/term/CsiParser.cpp
+  src/term/Utf8Decoder.cpp
   src/term/clipboard.cpp
   src/input/keymap.cpp
   src/util/unicode.cpp

--- a/tui/include/tui/term/CsiParser.hpp
+++ b/tui/include/tui/term/CsiParser.hpp
@@ -1,0 +1,54 @@
+// tui/include/tui/term/CsiParser.hpp
+// @brief Helpers for parsing Control Sequence Introducer (CSI) input.
+// @invariant Produces key and mouse events for recognized sequences.
+// @ownership Holds references to caller-owned event buffers.
+#pragma once
+
+#include "tui/term/key_event.hpp"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace viper::tui::term
+{
+/// @brief Result of handling a CSI sequence.
+struct CsiResult
+{
+    bool start_paste{false}; ///< True when bracketed paste mode begins.
+    bool handled{false};     ///< True if the sequence mapped to a known action.
+};
+
+/// @brief Parser for terminal CSI escape sequences.
+/// @invariant Reuses caller-provided buffers for decoded events.
+/// @ownership Holds references to event buffers owned by the caller.
+class CsiParser
+{
+  public:
+    /// @brief Construct a parser bound to output event buffers.
+    CsiParser(std::vector<KeyEvent>& keys,
+              std::vector<MouseEvent>& mouse,
+              std::string& paste_buffer);
+
+    /// @brief Handle a CSI sequence with final byte and parameter payload.
+    /// @param final Terminal final byte.
+    /// @param params Parameter bytes preceding the final.
+    /// @return Parsed result indicating produced events and paste state.
+    [[nodiscard]] CsiResult handle(char final, std::string_view params);
+
+    /// @brief Parse a semicolon separated parameter list.
+    [[nodiscard]] std::vector<int> parse_params(std::string_view params) const;
+
+    /// @brief Decode modifier masks from VT-style numeric representation.
+    [[nodiscard]] unsigned decode_mod(int value) const;
+
+  private:
+    void handle_sgr_mouse(char final, std::string_view params);
+
+    std::vector<KeyEvent>& key_events_;
+    std::vector<MouseEvent>& mouse_events_;
+    std::string& paste_buffer_;
+};
+
+} // namespace viper::tui::term
+

--- a/tui/include/tui/term/Utf8Decoder.hpp
+++ b/tui/include/tui/term/Utf8Decoder.hpp
@@ -1,0 +1,43 @@
+// tui/include/tui/term/Utf8Decoder.hpp
+// @brief Incremental UTF-8 decoder producing Unicode codepoints.
+// @invariant Maintains partial multibyte sequences between feed calls.
+// @ownership Owns only the decoder state.
+#pragma once
+
+#include <cstdint>
+
+namespace viper::tui::term
+{
+/// @brief Result of decoding a single byte of UTF-8 data.
+struct Utf8Result
+{
+    bool has_codepoint{false}; ///< True when a complete codepoint was produced.
+    uint32_t codepoint{0};     ///< The decoded Unicode scalar value when available.
+    bool error{false};         ///< Set when an invalid sequence was encountered.
+    bool replay{false};        ///< Request the caller to replay the current byte.
+};
+
+/// @brief Stateful UTF-8 decoder that accepts bytes incrementally.
+/// @invariant Keeps track of remaining continuation bytes for current sequence.
+/// @ownership Does not own external buffers; only internal state.
+class Utf8Decoder
+{
+  public:
+    /// @brief Decode the next byte of UTF-8 data.
+    /// @param byte Next byte from the input stream.
+    /// @return Information about produced codepoints and error handling.
+    [[nodiscard]] Utf8Result feed(unsigned char byte) noexcept;
+
+    /// @brief Whether the decoder is currently idle (no pending continuation).
+    [[nodiscard]] bool idle() const noexcept;
+
+    /// @brief Reset decoder to initial state discarding partial sequence.
+    void reset() noexcept;
+
+  private:
+    uint32_t cp_{0};
+    unsigned expected_{0};
+};
+
+} // namespace viper::tui::term
+

--- a/tui/src/term/CsiParser.cpp
+++ b/tui/src/term/CsiParser.cpp
@@ -1,0 +1,236 @@
+// tui/src/term/CsiParser.cpp
+// @brief Implements parsing of terminal CSI sequences into events.
+// @invariant Produces key and mouse events according to VT conventions.
+// @ownership Writes into caller-supplied event buffers.
+
+#include "tui/term/CsiParser.hpp"
+
+namespace viper::tui::term
+{
+
+CsiParser::CsiParser(std::vector<KeyEvent>& keys,
+                     std::vector<MouseEvent>& mouse,
+                     std::string& paste_buffer)
+    : key_events_(keys)
+    , mouse_events_(mouse)
+    , paste_buffer_(paste_buffer)
+{
+}
+
+std::vector<int> CsiParser::parse_params(std::string_view params) const
+{
+    std::vector<int> out;
+    int val = 0;
+    bool have = false;
+    for (char c : params)
+    {
+        if (c >= '0' && c <= '9')
+        {
+            val = val * 10 + (c - '0');
+            have = true;
+        }
+        else if (c == ';')
+        {
+            out.push_back(have ? val : 0);
+            val = 0;
+            have = false;
+        }
+    }
+    if (have)
+    {
+        out.push_back(val);
+    }
+    return out;
+}
+
+unsigned CsiParser::decode_mod(int value) const
+{
+    if (value < 2)
+    {
+        return 0;
+    }
+    return static_cast<unsigned>(value - 1);
+}
+
+void CsiParser::handle_sgr_mouse(char final, std::string_view params)
+{
+    auto nums = parse_params(params);
+    if (nums.size() < 3)
+    {
+        return;
+    }
+    int b = nums[0];
+    MouseEvent ev{};
+    ev.x = nums[1] - 1;
+    ev.y = nums[2] - 1;
+    if (b & 4)
+    {
+        ev.mods |= KeyEvent::Shift;
+    }
+    if (b & 8)
+    {
+        ev.mods |= KeyEvent::Alt;
+    }
+    if (b & 16)
+    {
+        ev.mods |= KeyEvent::Ctrl;
+    }
+
+    if ((b >= 64 && b <= 65) || (b >= 96 && b <= 97))
+    {
+        ev.type = MouseEvent::Type::Wheel;
+        ev.buttons = (b & 1) ? 2u : 1u;
+    }
+    else if (final == 'm')
+    {
+        ev.type = MouseEvent::Type::Up;
+        ev.buttons = 1u << (b & 3);
+    }
+    else if (b & 32)
+    {
+        ev.type = MouseEvent::Type::Move;
+        ev.buttons = 1u << (b & 3);
+    }
+    else
+    {
+        ev.type = MouseEvent::Type::Down;
+        ev.buttons = 1u << (b & 3);
+    }
+    mouse_events_.push_back(ev);
+}
+
+CsiResult CsiParser::handle(char final, std::string_view params)
+{
+    CsiResult result{};
+    if ((final == 'M' || final == 'm') && !params.empty() && params.front() == '<')
+    {
+        handle_sgr_mouse(final, params.substr(1));
+        result.handled = true;
+        return result;
+    }
+
+    auto nums = parse_params(params);
+    unsigned mods = 0;
+    if (final == '~')
+    {
+        if (nums.size() >= 2)
+        {
+            mods = decode_mod(nums[1]);
+        }
+        if (!nums.empty())
+        {
+            if (nums[0] == 200)
+            {
+                paste_buffer_.clear();
+                result.start_paste = true;
+                result.handled = true;
+                return result;
+            }
+        }
+        if (nums.empty())
+        {
+            return result;
+        }
+        KeyEvent ev{};
+        ev.mods = mods;
+        switch (nums[0])
+        {
+            case 1:
+                ev.code = KeyEvent::Code::Home;
+                break;
+            case 2:
+                ev.code = KeyEvent::Code::Insert;
+                break;
+            case 3:
+                ev.code = KeyEvent::Code::Delete;
+                break;
+            case 4:
+                ev.code = KeyEvent::Code::End;
+                break;
+            case 5:
+                ev.code = KeyEvent::Code::PageUp;
+                break;
+            case 6:
+                ev.code = KeyEvent::Code::PageDown;
+                break;
+            case 11:
+                ev.code = KeyEvent::Code::F1;
+                break;
+            case 12:
+                ev.code = KeyEvent::Code::F2;
+                break;
+            case 13:
+                ev.code = KeyEvent::Code::F3;
+                break;
+            case 14:
+                ev.code = KeyEvent::Code::F4;
+                break;
+            case 15:
+                ev.code = KeyEvent::Code::F5;
+                break;
+            case 17:
+                ev.code = KeyEvent::Code::F6;
+                break;
+            case 18:
+                ev.code = KeyEvent::Code::F7;
+                break;
+            case 19:
+                ev.code = KeyEvent::Code::F8;
+                break;
+            case 20:
+                ev.code = KeyEvent::Code::F9;
+                break;
+            case 21:
+                ev.code = KeyEvent::Code::F10;
+                break;
+            case 23:
+                ev.code = KeyEvent::Code::F11;
+                break;
+            case 24:
+                ev.code = KeyEvent::Code::F12;
+                break;
+            default:
+                return result;
+        }
+        key_events_.push_back(ev);
+        result.handled = true;
+        return result;
+    }
+
+    if (nums.size() >= 2)
+    {
+        mods = decode_mod(nums[1]);
+    }
+
+    KeyEvent ev{};
+    ev.mods = mods;
+    switch (final)
+    {
+        case 'A':
+            ev.code = KeyEvent::Code::Up;
+            break;
+        case 'B':
+            ev.code = KeyEvent::Code::Down;
+            break;
+        case 'C':
+            ev.code = KeyEvent::Code::Right;
+            break;
+        case 'D':
+            ev.code = KeyEvent::Code::Left;
+            break;
+        case 'H':
+            ev.code = KeyEvent::Code::Home;
+            break;
+        case 'F':
+            ev.code = KeyEvent::Code::End;
+            break;
+        default:
+            return result;
+    }
+    key_events_.push_back(ev);
+    result.handled = true;
+    return result;
+}
+
+} // namespace viper::tui::term
+

--- a/tui/src/term/Utf8Decoder.cpp
+++ b/tui/src/term/Utf8Decoder.cpp
@@ -1,0 +1,73 @@
+// tui/src/term/Utf8Decoder.cpp
+// @brief Implements incremental UTF-8 decoding utilities.
+// @invariant Maintains continuation expectations across bytes.
+// @ownership Owns decoder state only.
+
+#include "tui/term/Utf8Decoder.hpp"
+
+namespace viper::tui::term
+{
+
+Utf8Result Utf8Decoder::feed(unsigned char byte) noexcept
+{
+    Utf8Result result{};
+    if (expected_ == 0)
+    {
+        if (byte < 0x80)
+        {
+            result.has_codepoint = true;
+            result.codepoint = byte;
+        }
+        else if ((byte & 0xE0) == 0xC0)
+        {
+            cp_ = byte & 0x1F;
+            expected_ = 1;
+        }
+        else if ((byte & 0xF0) == 0xE0)
+        {
+            cp_ = byte & 0x0F;
+            expected_ = 2;
+        }
+        else if ((byte & 0xF8) == 0xF0)
+        {
+            cp_ = byte & 0x07;
+            expected_ = 3;
+        }
+        else
+        {
+            result.error = true;
+            reset();
+        }
+    }
+    else if ((byte & 0xC0) == 0x80)
+    {
+        cp_ = (cp_ << 6) | (byte & 0x3F);
+        if (--expected_ == 0)
+        {
+            result.has_codepoint = true;
+            result.codepoint = cp_;
+            cp_ = 0;
+        }
+    }
+    else
+    {
+        result.error = true;
+        result.replay = true;
+        reset();
+    }
+    return result;
+}
+
+bool Utf8Decoder::idle() const noexcept
+{
+    return expected_ == 0;
+}
+
+void Utf8Decoder::reset() noexcept
+{
+    cp_ = 0;
+    expected_ = 0;
+}
+
+} // namespace viper::tui::term
+

--- a/tui/tests/test_input_mouse_paste.cpp
+++ b/tui/tests/test_input_mouse_paste.cpp
@@ -10,6 +10,7 @@
 using viper::tui::term::InputDecoder;
 using viper::tui::term::MouseEvent;
 using viper::tui::term::PasteEvent;
+using viper::tui::term::KeyEvent;
 
 int main()
 {
@@ -43,6 +44,13 @@ int main()
     auto pe = d.drain_paste();
     assert(pe.size() == 1);
     assert(pe[0].text == "hello\nworld");
+
+    d.feed("\x1b[A");
+    auto ke = d.drain();
+    assert(ke.size() == 1);
+    assert(ke[0].code == KeyEvent::Code::Up);
+    me = d.drain_mouse();
+    assert(me.empty());
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- add dedicated CsiParser and Utf8Decoder helpers to encapsulate CSI parsing, modifier decoding, UTF-8 decoding, and mouse synthesis
- refactor InputDecoder to delegate CSI and UTF-8 handling to the new helpers while keeping the public queue API intact
- extend the mouse/paste test to cover a key sequence and wire new sources into the TUI build

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1fbf0cb508324ba32d67820ce787e