### PR TITLE
Refactor TextBuffer to use PieceTable, LineIndex, and EditHistory

### DIFF
--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -30,6 +30,9 @@ add_library(tui STATIC
   src/widgets/list_view.cpp
   src/widgets/tree_view.cpp
   src/syntax/rules.cpp
+  src/text/EditHistory.cpp
+  src/text/LineIndex.cpp
+  src/text/PieceTable.cpp
   src/text/text_buffer.cpp
   src/text/search.cpp
   src/views/text_view.cpp

--- a/tui/include/tui/text/EditHistory.hpp
+++ b/tui/include/tui/text/EditHistory.hpp
@@ -1,0 +1,68 @@
+// tui/include/tui/text/EditHistory.hpp
+// @brief Tracks grouped edit operations supporting undo/redo replay.
+// @invariant Transactions replay in recorded order with preserved payloads.
+// @ownership EditHistory owns stored operation payload strings.
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace viper::tui::text
+{
+/// @brief Stores edit transactions for undo/redo sequencing.
+class EditHistory
+{
+  public:
+    /// @brief Operation kind stored per edit.
+    enum class OpType
+    {
+        Insert,
+        Erase
+    };
+
+    /// @brief Single edit operation payload.
+    struct Op
+    {
+        OpType type{};
+        std::size_t pos{};
+        std::string text{};
+    };
+
+    /// @brief Grouped edits forming a transaction.
+    using Txn = std::vector<Op>;
+
+    /// @brief Callback executed for each operation during replay.
+    using Replay = std::function<void(const Op &)>;
+
+    /// @brief Begin aggregating operations into a transaction.
+    void beginTxn();
+
+    /// @brief Commit current transaction when non-empty.
+    void endTxn();
+
+    /// @brief Record an insert operation (clears redo stack).
+    void recordInsert(std::size_t pos, std::string text);
+
+    /// @brief Record an erase operation (clears redo stack).
+    void recordErase(std::size_t pos, std::string text);
+
+    /// @brief Undo last transaction via replay callback.
+    [[nodiscard]] bool undo(const Replay &replay);
+
+    /// @brief Redo last undone transaction via replay callback.
+    [[nodiscard]] bool redo(const Replay &replay);
+
+    /// @brief Reset stacks and cancel active transaction.
+    void clear();
+
+  private:
+    void append(Op op);
+
+    std::vector<Txn> undo_stack_{};
+    std::vector<Txn> redo_stack_{};
+    Txn current_{};
+    bool in_txn_{};
+};
+} // namespace viper::tui::text

--- a/tui/include/tui/text/LineIndex.hpp
+++ b/tui/include/tui/text/LineIndex.hpp
@@ -1,0 +1,35 @@
+// tui/include/tui/text/LineIndex.hpp
+// @brief Maintains line start offsets reacting to span change notifications.
+// @invariant line_starts_ always begins with zero and remains sorted ascending.
+// @ownership LineIndex owns offset vector; callers retain referenced text buffers.
+#pragma once
+
+#include <cstddef>
+#include <string_view>
+#include <vector>
+
+namespace viper::tui::text
+{
+/// @brief Tracks line boundaries in a text buffer.
+class LineIndex
+{
+  public:
+    /// @brief Reset to a fresh text snapshot.
+    void reset(std::string_view text);
+
+    /// @brief Apply insertion notification at byte position.
+    void onInsert(std::size_t pos, std::string_view text);
+
+    /// @brief Apply erase notification at byte position.
+    void onErase(std::size_t pos, std::string_view text);
+
+    /// @brief Number of indexed lines.
+    [[nodiscard]] std::size_t count() const;
+
+    /// @brief Starting offset of a line.
+    [[nodiscard]] std::size_t start(std::size_t line) const;
+
+  private:
+    std::vector<std::size_t> line_starts_{0};
+};
+} // namespace viper::tui::text

--- a/tui/include/tui/text/PieceTable.hpp
+++ b/tui/include/tui/text/PieceTable.hpp
@@ -1,0 +1,104 @@
+// tui/include/tui/text/PieceTable.hpp
+// @brief Piece table storage for text buffers emitting span change callbacks.
+// @invariant Edits only mutate piece metadata while buffers remain stable.
+// @ownership PieceTable owns original/add buffers and change payload copies.
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <list>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace viper::tui::text
+{
+/// @brief Piece table implementation powering TextBuffer storage.
+class PieceTable
+{
+  public:
+    /// @brief Change payload returned from mutating operations.
+    struct Change
+    {
+        /// @brief Callback signature receiving span position and text view.
+        using Callback = std::function<void(std::size_t pos, std::string_view text)>;
+
+        /// @brief Record inserted span metadata and payload.
+        void recordInsert(std::size_t pos, std::string text);
+
+        /// @brief Record erased span metadata and payload.
+        void recordErase(std::size_t pos, std::string text);
+
+        /// @brief Notify listener about inserted span, if any.
+        void notifyInsert(const Callback &cb) const;
+
+        /// @brief Notify listener about erased span, if any.
+        void notifyErase(const Callback &cb) const;
+
+        /// @brief True if an insert span is present.
+        [[nodiscard]] bool hasInsert() const;
+
+        /// @brief True if an erase span is present.
+        [[nodiscard]] bool hasErase() const;
+
+        /// @brief Position of inserted span (undefined if !hasInsert()).
+        [[nodiscard]] std::size_t insertPos() const;
+
+        /// @brief Position of erased span (undefined if !hasErase()).
+        [[nodiscard]] std::size_t erasePos() const;
+
+        /// @brief Inserted text view (empty if !hasInsert()).
+        [[nodiscard]] std::string_view insertedText() const;
+
+        /// @brief Erased text view (empty if !hasErase()).
+        [[nodiscard]] std::string_view erasedText() const;
+
+      private:
+        struct Span
+        {
+            std::size_t pos{};
+            std::string text{};
+        };
+
+        std::optional<Span> insert_span_{};
+        std::optional<Span> erase_span_{};
+    };
+
+    /// @brief Load fresh content, replacing current buffers.
+    Change load(std::string text);
+
+    /// @brief Current byte size.
+    [[nodiscard]] std::size_t size() const;
+
+    /// @brief Extract text within [pos, pos + len).
+    [[nodiscard]] std::string getText(std::size_t pos, std::size_t len) const;
+
+    /// @brief Insert text at position returning span callbacks.
+    Change insertInternal(std::size_t pos, std::string_view text);
+
+    /// @brief Erase length bytes at position returning span callbacks.
+    Change eraseInternal(std::size_t pos, std::size_t len);
+
+  private:
+    enum class BufferKind
+    {
+        Original,
+        Add
+    };
+
+    struct Piece
+    {
+        BufferKind buf{};
+        std::size_t start{};
+        std::size_t length{};
+    };
+
+    std::list<Piece>::iterator findPiece(std::size_t pos, std::size_t &offset);
+    std::list<Piece>::const_iterator findPiece(std::size_t pos, std::size_t &offset) const;
+
+    std::list<Piece> pieces_{};
+    std::string original_{};
+    std::string add_{};
+    std::size_t size_{};
+};
+} // namespace viper::tui::text

--- a/tui/src/text/EditHistory.cpp
+++ b/tui/src/text/EditHistory.cpp
@@ -1,0 +1,111 @@
+// tui/src/text/EditHistory.cpp
+// @brief EditHistory implementation managing grouped undo/redo operations.
+// @invariant Replay order mirrors stack semantics with preserved payload text.
+// @ownership Stores operation payload copies for deterministic playback.
+
+#include "tui/text/EditHistory.hpp"
+
+#include <utility>
+
+namespace viper::tui::text
+{
+void EditHistory::beginTxn()
+{
+    if (in_txn_)
+    {
+        return;
+    }
+    in_txn_ = true;
+    current_.clear();
+}
+
+void EditHistory::endTxn()
+{
+    if (!in_txn_)
+    {
+        return;
+    }
+    in_txn_ = false;
+    if (!current_.empty())
+    {
+        undo_stack_.push_back(std::move(current_));
+        current_ = Txn{};
+        redo_stack_.clear();
+    }
+    else
+    {
+        current_.clear();
+    }
+}
+
+void EditHistory::recordInsert(std::size_t pos, std::string text)
+{
+    append(Op{OpType::Insert, pos, std::move(text)});
+}
+
+void EditHistory::recordErase(std::size_t pos, std::string text)
+{
+    append(Op{OpType::Erase, pos, std::move(text)});
+}
+
+bool EditHistory::undo(const Replay &replay)
+{
+    if (undo_stack_.empty())
+    {
+        return false;
+    }
+
+    Txn txn = std::move(undo_stack_.back());
+    undo_stack_.pop_back();
+    for (auto it = txn.rbegin(); it != txn.rend(); ++it)
+    {
+        replay(*it);
+    }
+    redo_stack_.push_back(std::move(txn));
+    return true;
+}
+
+bool EditHistory::redo(const Replay &replay)
+{
+    if (redo_stack_.empty())
+    {
+        return false;
+    }
+
+    Txn txn = std::move(redo_stack_.back());
+    redo_stack_.pop_back();
+    for (const auto &op : txn)
+    {
+        replay(op);
+    }
+    undo_stack_.push_back(std::move(txn));
+    return true;
+}
+
+void EditHistory::clear()
+{
+    undo_stack_.clear();
+    redo_stack_.clear();
+    current_.clear();
+    in_txn_ = false;
+}
+
+void EditHistory::append(Op op)
+{
+    if (op.text.empty())
+    {
+        return;
+    }
+
+    redo_stack_.clear();
+    if (in_txn_)
+    {
+        current_.push_back(std::move(op));
+        return;
+    }
+
+    Txn txn;
+    txn.push_back(std::move(op));
+    undo_stack_.push_back(std::move(txn));
+}
+} // namespace viper::tui::text

--- a/tui/src/text/LineIndex.cpp
+++ b/tui/src/text/LineIndex.cpp
@@ -1,0 +1,78 @@
+// tui/src/text/LineIndex.cpp
+// @brief LineIndex implementation reacting to piece table span callbacks.
+// @invariant Offsets remain sorted with sentinel zero entry.
+// @ownership Stores offsets only; text lifetimes managed by callers.
+
+#include "tui/text/LineIndex.hpp"
+
+#include <algorithm>
+
+namespace viper::tui::text
+{
+void LineIndex::reset(std::string_view text)
+{
+    line_starts_.clear();
+    line_starts_.push_back(0);
+    for (std::size_t i = 0; i < text.size(); ++i)
+    {
+        if (text[i] == '\n')
+        {
+            line_starts_.push_back(i + 1);
+        }
+    }
+}
+
+void LineIndex::onInsert(std::size_t pos, std::string_view text)
+{
+    if (text.empty())
+    {
+        return;
+    }
+
+    auto it = std::upper_bound(line_starts_.begin(), line_starts_.end(), pos);
+    std::size_t idx = static_cast<std::size_t>(it - line_starts_.begin());
+    for (std::size_t i = idx; i < line_starts_.size(); ++i)
+    {
+        line_starts_[i] += text.size();
+    }
+
+    std::size_t insert_idx = idx;
+    for (std::size_t i = 0; i < text.size(); ++i)
+    {
+        if (text[i] == '\n')
+        {
+            line_starts_.insert(line_starts_.begin() + insert_idx, pos + i + 1);
+            ++insert_idx;
+        }
+    }
+}
+
+void LineIndex::onErase(std::size_t pos, std::string_view text)
+{
+    if (text.empty())
+    {
+        return;
+    }
+
+    std::size_t len = text.size();
+    auto start_it = std::lower_bound(line_starts_.begin() + 1, line_starts_.end(), pos);
+    auto end_it = std::lower_bound(start_it, line_starts_.end(), pos + len);
+    std::size_t start_idx = static_cast<std::size_t>(start_it - line_starts_.begin());
+    std::size_t end_idx = static_cast<std::size_t>(end_it - line_starts_.begin());
+    line_starts_.erase(line_starts_.begin() + start_idx, line_starts_.begin() + end_idx);
+    for (std::size_t i = start_idx; i < line_starts_.size(); ++i)
+    {
+        line_starts_[i] -= len;
+    }
+}
+
+std::size_t LineIndex::count() const
+{
+    return line_starts_.size();
+}
+
+std::size_t LineIndex::start(std::size_t line) const
+{
+    return line_starts_.at(line);
+}
+} // namespace viper::tui::text

--- a/tui/src/text/PieceTable.cpp
+++ b/tui/src/text/PieceTable.cpp
@@ -1,0 +1,259 @@
+// tui/src/text/PieceTable.cpp
+// @brief PieceTable implementation providing span change callbacks.
+// @invariant Piece metadata splits only when necessary; buffers hold actual bytes.
+// @ownership Change instances own copied span payloads for safe callbacks.
+
+#include "tui/text/PieceTable.hpp"
+
+#include <algorithm>
+#include <utility>
+
+namespace viper::tui::text
+{
+void PieceTable::Change::recordInsert(std::size_t pos, std::string text)
+{
+    if (text.empty())
+    {
+        insert_span_.reset();
+        return;
+    }
+    insert_span_ = Span{pos, std::move(text)};
+}
+
+void PieceTable::Change::recordErase(std::size_t pos, std::string text)
+{
+    if (text.empty())
+    {
+        erase_span_.reset();
+        return;
+    }
+    erase_span_ = Span{pos, std::move(text)};
+}
+
+void PieceTable::Change::notifyInsert(const Callback &cb) const
+{
+    if (cb && insert_span_)
+    {
+        cb(insert_span_->pos, insert_span_->text);
+    }
+}
+
+void PieceTable::Change::notifyErase(const Callback &cb) const
+{
+    if (cb && erase_span_)
+    {
+        cb(erase_span_->pos, erase_span_->text);
+    }
+}
+
+bool PieceTable::Change::hasInsert() const
+{
+    return insert_span_.has_value();
+}
+
+bool PieceTable::Change::hasErase() const
+{
+    return erase_span_.has_value();
+}
+
+std::size_t PieceTable::Change::insertPos() const
+{
+    return insert_span_ ? insert_span_->pos : 0U;
+}
+
+std::size_t PieceTable::Change::erasePos() const
+{
+    return erase_span_ ? erase_span_->pos : 0U;
+}
+
+std::string_view PieceTable::Change::insertedText() const
+{
+    return insert_span_ ? std::string_view(insert_span_->text) : std::string_view{};
+}
+
+std::string_view PieceTable::Change::erasedText() const
+{
+    return erase_span_ ? std::string_view(erase_span_->text) : std::string_view{};
+}
+
+PieceTable::Change PieceTable::load(std::string text)
+{
+    Change change;
+    if (size_ > 0)
+    {
+        change.recordErase(0, getText(0, size_));
+    }
+
+    original_ = std::move(text);
+    add_.clear();
+    pieces_.clear();
+    size_ = original_.size();
+
+    if (!original_.empty())
+    {
+        pieces_.push_back(Piece{BufferKind::Original, 0, original_.size()});
+        change.recordInsert(0, original_);
+    }
+
+    return change;
+}
+
+std::size_t PieceTable::size() const
+{
+    return size_;
+}
+
+PieceTable::Change PieceTable::insertInternal(std::size_t pos, std::string_view text)
+{
+    Change change;
+    if (text.empty())
+    {
+        return change;
+    }
+
+    std::size_t offset = 0;
+    auto it = findPiece(pos, offset);
+    Piece newPiece{BufferKind::Add, add_.size(), text.size()};
+    add_.append(text);
+
+    if (it == pieces_.end())
+    {
+        pieces_.push_back(newPiece);
+    }
+    else if (offset == 0)
+    {
+        pieces_.insert(it, newPiece);
+    }
+    else if (offset == it->length)
+    {
+        ++it;
+        pieces_.insert(it, newPiece);
+    }
+    else
+    {
+        Piece tail = *it;
+        tail.start += offset;
+        tail.length -= offset;
+        it->length = offset;
+        ++it;
+        pieces_.insert(it, newPiece);
+        pieces_.insert(it, tail);
+    }
+
+    size_ += text.size();
+    change.recordInsert(pos, std::string(text));
+    return change;
+}
+
+PieceTable::Change PieceTable::eraseInternal(std::size_t pos, std::size_t len)
+{
+    Change change;
+    if (len == 0)
+    {
+        return change;
+    }
+
+    std::string removed = getText(pos, len);
+    if (removed.empty())
+    {
+        return change;
+    }
+
+    std::size_t offset = 0;
+    auto it = findPiece(pos, offset);
+    if (it == pieces_.end())
+    {
+        return change;
+    }
+
+    std::size_t remaining = removed.size();
+
+    if (offset > 0)
+    {
+        Piece tail = *it;
+        tail.start += offset;
+        tail.length -= offset;
+        it->length = offset;
+        ++it;
+        if (tail.length > 0)
+        {
+            it = pieces_.insert(it, tail);
+        }
+    }
+
+    while (it != pieces_.end() && remaining > 0)
+    {
+        if (remaining < it->length)
+        {
+            it->start += remaining;
+            it->length -= remaining;
+            remaining = 0;
+            break;
+        }
+        else
+        {
+            remaining -= it->length;
+            it = pieces_.erase(it);
+        }
+    }
+
+    size_ -= removed.size();
+    change.recordErase(pos, std::move(removed));
+    return change;
+}
+
+std::string PieceTable::getText(std::size_t pos, std::size_t len) const
+{
+    std::string out;
+    out.reserve(len);
+    std::size_t idx = 0;
+    for (auto it = pieces_.cbegin(); it != pieces_.cend() && len > 0; ++it)
+    {
+        if (pos >= idx + it->length)
+        {
+            idx += it->length;
+            continue;
+        }
+        std::size_t start_in_piece = pos > idx ? pos - idx : 0U;
+        std::size_t take = std::min(it->length - start_in_piece, len);
+        const std::string &buf = it->buf == BufferKind::Add ? add_ : original_;
+        out.append(buf.substr(it->start + start_in_piece, take));
+        pos += take;
+        len -= take;
+        idx += it->length;
+    }
+    return out;
+}
+
+std::list<PieceTable::Piece>::iterator PieceTable::findPiece(std::size_t pos, std::size_t &offset)
+{
+    std::size_t idx = 0;
+    for (auto it = pieces_.begin(); it != pieces_.end(); ++it)
+    {
+        if (pos <= idx + it->length)
+        {
+            offset = pos - idx;
+            return it;
+        }
+        idx += it->length;
+    }
+    offset = 0;
+    return pieces_.end();
+}
+
+std::list<PieceTable::Piece>::const_iterator PieceTable::findPiece(std::size_t pos, std::size_t &offset) const
+{
+    std::size_t idx = 0;
+    for (auto it = pieces_.cbegin(); it != pieces_.cend(); ++it)
+    {
+        if (pos <= idx + it->length)
+        {
+            offset = pos - idx;
+            return it;
+        }
+        idx += it->length;
+    }
+    offset = 0;
+    return pieces_.cend();
+}
+} // namespace viper::tui::text

--- a/tui/src/text/text_buffer.cpp
+++ b/tui/src/text/text_buffer.cpp
@@ -1,318 +1,117 @@
 // tui/src/text/text_buffer.cpp
-// @brief Piece table text buffer implementation with undo/redo and line index.
-// @invariant Edits modify piece metadata only; original text is never copied.
-// @ownership TextBuffer owns buffers; undo/redo stacks own their stored text.
+// @brief TextBuffer orchestration of PieceTable, LineIndex, and EditHistory helpers.
+// @invariant Helper state stays synchronized through span change callbacks.
+// @ownership TextBuffer owns helpers and returns copied strings to callers.
 
 #include "tui/text/text_buffer.hpp"
 
-#include <algorithm>
-#include <cassert>
+#include <utility>
 
 namespace viper::tui::text
 {
 void TextBuffer::load(std::string text)
 {
-    original_ = std::move(text);
-    add_.clear();
-    pieces_.clear();
-    if (!original_.empty())
-    {
-        pieces_.push_back(Piece{BufferKind::Original, 0, original_.size()});
-        size_ = original_.size();
-    }
-    else
-    {
-        size_ = 0;
-    }
-    line_starts_.clear();
-    line_starts_.push_back(0);
-    for (size_t i = 0; i < original_.size(); ++i)
-    {
-        if (original_[i] == '\n')
-        {
-            line_starts_.push_back(i + 1);
-        }
-    }
-    undo_stack_.clear();
-    redo_stack_.clear();
+    auto change = table_.load(std::move(text));
+    line_index_.reset(change.insertedText());
+    history_.clear();
 }
 
-/// @brief Report the current number of bytes stored in the buffer.
 std::size_t TextBuffer::size() const
 {
-    return size_;
+    return table_.size();
 }
 
 void TextBuffer::beginTxn()
 {
-    in_txn_ = true;
-    txn_ops_.clear();
+    history_.beginTxn();
 }
 
 void TextBuffer::endTxn()
 {
-    in_txn_ = false;
-    if (!txn_ops_.empty())
+    history_.endTxn();
+}
+
+void TextBuffer::insert(std::size_t pos, std::string_view text)
+{
+    auto change = table_.insertInternal(pos, text);
+    change.notifyInsert([this](std::size_t changePos, std::string_view inserted) {
+        line_index_.onInsert(changePos, inserted);
+    });
+    if (change.hasInsert())
     {
-        undo_stack_.push_back(txn_ops_);
-        redo_stack_.clear();
-        txn_ops_.clear();
+        history_.recordInsert(change.insertPos(), std::string(change.insertedText()));
     }
 }
 
-std::list<TextBuffer::Piece>::iterator TextBuffer::findPiece(size_t pos, size_t &offset)
+void TextBuffer::erase(std::size_t pos, std::size_t len)
 {
-    size_t idx = 0;
-    for (auto it = pieces_.begin(); it != pieces_.end(); ++it)
+    auto change = table_.eraseInternal(pos, len);
+    change.notifyErase([this](std::size_t changePos, std::string_view removed) {
+        line_index_.onErase(changePos, removed);
+    });
+    if (change.hasErase())
     {
-        if (pos <= idx + it->length)
-        {
-            offset = pos - idx;
-            return it;
-        }
-        idx += it->length;
-    }
-    offset = 0;
-    return pieces_.end();
-}
-
-void TextBuffer::insertInternal(size_t pos, std::string_view text)
-{
-    if (text.empty())
-    {
-        return;
-    }
-    size_t offset = 0;
-    auto it = findPiece(pos, offset);
-    Piece newPiece{BufferKind::Add, add_.size(), text.size()};
-    add_.append(text);
-
-    if (it == pieces_.end())
-    {
-        pieces_.push_back(newPiece);
-    }
-    else if (offset == 0)
-    {
-        pieces_.insert(it, newPiece);
-    }
-    else if (offset == it->length)
-    {
-        ++it;
-        pieces_.insert(it, newPiece);
-    }
-    else
-    {
-        Piece tail = *it;
-        tail.start += offset;
-        tail.length -= offset;
-        it->length = offset;
-        ++it;
-        pieces_.insert(it, newPiece);
-        pieces_.insert(it, tail);
-    }
-    size_ += text.size();
-    updateLinesInsert(pos, text);
-}
-
-void TextBuffer::insert(size_t pos, std::string_view text)
-{
-    insertInternal(pos, text);
-    if (in_txn_)
-    {
-        txn_ops_.push_back(Op{OpType::Insert, pos, std::string(text)});
-    }
-    else
-    {
-        undo_stack_.push_back(Txn{Op{OpType::Insert, pos, std::string(text)}});
-        redo_stack_.clear();
-    }
-}
-
-std::string TextBuffer::getText(size_t pos, size_t len) const
-{
-    std::string out;
-    out.reserve(len);
-    size_t idx = 0;
-    for (auto it = pieces_.begin(); it != pieces_.end() && len > 0; ++it)
-    {
-        if (pos >= idx + it->length)
-        {
-            idx += it->length;
-            continue;
-        }
-        size_t start_in_piece = pos > idx ? pos - idx : 0;
-        size_t take = std::min(it->length - start_in_piece, len);
-        const std::string &buf = it->buf == BufferKind::Add ? add_ : original_;
-        out.append(buf.substr(it->start + start_in_piece, take));
-        pos += take;
-        len -= take;
-        idx += it->length;
-    }
-    return out;
-}
-
-void TextBuffer::eraseInternal(size_t pos, size_t len)
-{
-    if (len == 0)
-    {
-        return;
-    }
-    size_t offset = 0;
-    auto it = findPiece(pos, offset);
-    size_t remaining = len;
-
-    if (it == pieces_.end())
-    {
-        return;
-    }
-
-    if (offset > 0)
-    {
-        Piece tail = *it;
-        tail.start += offset;
-        tail.length -= offset;
-        it->length = offset;
-        ++it;
-        if (tail.length > 0)
-        {
-            it = pieces_.insert(it, tail);
-        }
-    }
-
-    while (it != pieces_.end() && remaining > 0)
-    {
-        if (remaining < it->length)
-        {
-            it->start += remaining;
-            it->length -= remaining;
-            remaining = 0;
-            break;
-        }
-        else
-        {
-            remaining -= it->length;
-            it = pieces_.erase(it);
-        }
-    }
-    size_ -= len - remaining;
-    updateLinesErase(pos, len - remaining);
-}
-
-void TextBuffer::erase(size_t pos, size_t len)
-{
-    if (len == 0)
-    {
-        return;
-    }
-    std::string removed = getText(pos, len);
-    eraseInternal(pos, len);
-    if (in_txn_)
-    {
-        txn_ops_.push_back(Op{OpType::Erase, pos, removed});
-    }
-    else
-    {
-        undo_stack_.push_back(Txn{Op{OpType::Erase, pos, removed}});
-        redo_stack_.clear();
+        history_.recordErase(change.erasePos(), std::string(change.erasedText()));
     }
 }
 
 bool TextBuffer::undo()
 {
-    if (undo_stack_.empty())
-    {
-        return false;
-    }
-    Txn txn = undo_stack_.back();
-    undo_stack_.pop_back();
-    for (auto it = txn.rbegin(); it != txn.rend(); ++it)
-    {
-        if (it->type == OpType::Insert)
+    return history_.undo([this](const EditHistory::Op &op) {
+        if (op.type == EditHistory::OpType::Insert)
         {
-            eraseInternal(it->pos, it->text.size());
+            auto change = table_.eraseInternal(op.pos, op.text.size());
+            change.notifyErase([this](std::size_t changePos, std::string_view removed) {
+                line_index_.onErase(changePos, removed);
+            });
         }
         else
         {
-            insertInternal(it->pos, it->text);
+            auto change = table_.insertInternal(op.pos, op.text);
+            change.notifyInsert([this](std::size_t changePos, std::string_view inserted) {
+                line_index_.onInsert(changePos, inserted);
+            });
         }
-    }
-    redo_stack_.push_back(std::move(txn));
-    return true;
+    });
 }
 
 bool TextBuffer::redo()
 {
-    if (redo_stack_.empty())
-    {
-        return false;
-    }
-    Txn txn = redo_stack_.back();
-    redo_stack_.pop_back();
-    for (const auto &op : txn)
-    {
-        if (op.type == OpType::Insert)
+    return history_.redo([this](const EditHistory::Op &op) {
+        if (op.type == EditHistory::OpType::Insert)
         {
-            insertInternal(op.pos, op.text);
+            auto change = table_.insertInternal(op.pos, op.text);
+            change.notifyInsert([this](std::size_t changePos, std::string_view inserted) {
+                line_index_.onInsert(changePos, inserted);
+            });
         }
         else
         {
-            eraseInternal(op.pos, op.text.size());
+            auto change = table_.eraseInternal(op.pos, op.text.size());
+            change.notifyErase([this](std::size_t changePos, std::string_view removed) {
+                line_index_.onErase(changePos, removed);
+            });
         }
-    }
-    undo_stack_.push_back(std::move(txn));
-    return true;
+    });
 }
 
 std::string TextBuffer::str() const
 {
-    return getText(0, size_);
+    return table_.getText(0, table_.size());
 }
 
-std::string TextBuffer::getLine(size_t lineNo) const
+std::string TextBuffer::getLine(std::size_t lineNo) const
 {
-    if (lineNo >= line_starts_.size())
+    if (lineNo >= line_index_.count())
     {
         return {};
     }
-    size_t start = line_starts_[lineNo];
-    size_t end = (lineNo + 1 < line_starts_.size()) ? line_starts_[lineNo + 1] - 1 : size_;
+    std::size_t start = line_index_.start(lineNo);
+    std::size_t end = (lineNo + 1 < line_index_.count()) ? line_index_.start(lineNo + 1) - 1 : table_.size();
     if (end < start)
     {
         end = start;
     }
-    return getText(start, end - start);
+    return table_.getText(start, end - start);
 }
-
-void TextBuffer::updateLinesInsert(size_t pos, std::string_view text)
-{
-    auto it = std::upper_bound(line_starts_.begin(), line_starts_.end(), pos);
-    size_t idx = it - line_starts_.begin();
-    for (size_t i = idx; i < line_starts_.size(); ++i)
-    {
-        line_starts_[i] += text.size();
-    }
-    size_t insert_idx = idx;
-    for (size_t i = 0; i < text.size(); ++i)
-    {
-        if (text[i] == '\n')
-        {
-            line_starts_.insert(line_starts_.begin() + insert_idx, pos + i + 1);
-            ++insert_idx;
-        }
-    }
-}
-
-void TextBuffer::updateLinesErase(size_t pos, size_t len)
-{
-    auto start_it = std::lower_bound(line_starts_.begin() + 1, line_starts_.end(), pos);
-    auto end_it = std::lower_bound(start_it, line_starts_.end(), pos + len);
-    size_t start_idx = start_it - line_starts_.begin();
-    size_t end_idx = end_it - line_starts_.begin();
-    line_starts_.erase(line_starts_.begin() + start_idx, line_starts_.begin() + end_idx);
-    for (size_t i = start_idx; i < line_starts_.size(); ++i)
-    {
-        line_starts_[i] -= len;
-    }
-}
-
 } // namespace viper::tui::text


### PR DESCRIPTION
## Summary
- add dedicated PieceTable, LineIndex, and EditHistory helpers to own storage, line tracking, and undo/redo state
- refactor TextBuffer to delegate to the new helpers and route span-change callbacks
- include the new helper sources in the TUI build

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1fbfea81c8324ba439881ffbf9860