### PR TITLE
fix(vm): transfer block params before break gating

### DIFF
--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -187,7 +187,7 @@ class VM
                      std::unordered_map<std::string, const il::core::BasicBlock *> &blocks,
                      const il::core::BasicBlock *&bb);
 
-    /// @brief Handle pending debug breaks and parameter transfers.
+    /// @brief Handle pending debug breaks at block entry or instruction boundaries.
     /// @param fr Current frame.
     /// @param bb Current basic block.
     /// @param ip Instruction index within @p bb.
@@ -199,6 +199,11 @@ class VM
                                          size_t ip,
                                          bool &skipBreakOnce,
                                          const il::core::Instr *in);
+
+    /// @brief Transfer pending parameters for @p bb into @p fr.
+    /// @param fr Frame whose registers receive parameter values.
+    /// @param bb Basic block whose parameters are being populated.
+    void transferBlockParams(Frame &fr, const il::core::BasicBlock &bb);
 
     /// @brief Execute instruction @p in updating control flow state.
     /// @param fr Current frame.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,6 +152,8 @@ add_executable(test_vm_debug_script vm/DebugScriptTests.cpp)
 add_test(NAME test_vm_debug_script COMMAND test_vm_debug_script $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/debug_script.il ${CMAKE_SOURCE_DIR}/examples/il/debug_script.txt)
 add_executable(test_vm_watch vm/WatchTests.cpp)
 add_test(NAME test_vm_watch COMMAND test_vm_watch $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/tests/vm/WatchTests.il)
+add_executable(test_vm_block_param_step vm/BlockParamStepTests.cpp)
+add_test(NAME test_vm_block_param_step COMMAND test_vm_block_param_step $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/tests/vm/BlockParamStep.il ${CMAKE_SOURCE_DIR}/tests/vm/BlockParamStep.txt)
 
 add_executable(test_vm_summary vm/SummaryTests.cpp)
 add_test(NAME test_vm_summary COMMAND test_vm_summary $<TARGET_FILE:ilc> ${CMAKE_SOURCE_DIR}/examples/il/summary.il)

--- a/tests/vm/BlockParamStep.il
+++ b/tests/vm/BlockParamStep.il
@@ -1,0 +1,9 @@
+il 0.1.2 ; // File: tests/vm/BlockParamStep.il // Purpose: Validate block parameter transfer while stepping. // Links: docs/il-spec.md#control-flow-terminators
+
+func @main() -> i64 {
+entry:
+  br callee(7)
+
+callee(%x: i64):
+  ret %x
+}

--- a/tests/vm/BlockParamStep.txt
+++ b/tests/vm/BlockParamStep.txt
@@ -1,0 +1,2 @@
+step
+continue

--- a/tests/vm/BlockParamStepTests.cpp
+++ b/tests/vm/BlockParamStepTests.cpp
@@ -1,0 +1,50 @@
+// File: tests/vm/BlockParamStepTests.cpp
+// Purpose: Ensure block parameters transfer correctly while stepping through a call.
+// Key invariants: Scripted stepping still yields callee arguments and prints a step break.
+// Ownership/Lifetime: Test creates temporary stderr capture file and deletes it.
+// Links: docs/testing.md
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+int main(int argc, char **argv)
+{
+    if (argc != 4)
+    {
+        std::cerr << "usage: BlockParamStepTests <ilc> <il file> <script>\n";
+        return 1;
+    }
+    std::string ilc = argv[1];
+    std::string ilFile = argv[2];
+    std::string script = argv[3];
+    std::string errFile = "block_param_step.err";
+    std::string cmd = ilc + " -run " + ilFile + " --break entry --debug-cmds " + script +
+                      " 2>" + errFile;
+    int rc = std::system(cmd.c_str());
+    if (rc != 7 * 256)
+    {
+        std::cerr << "unexpected exit status: " << rc << "\n";
+        std::remove(errFile.c_str());
+        return 1;
+    }
+    std::ifstream err(errFile);
+    std::string line;
+    bool sawStep = false;
+    while (std::getline(err, line))
+    {
+        if (line.rfind("[BREAK]", 0) == 0 && line.find("reason=step") != std::string::npos)
+        {
+            sawStep = true;
+            break;
+        }
+    }
+    std::remove(errFile.c_str());
+    if (!sawStep)
+    {
+        std::cerr << "missing step break output\n";
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- move block parameter transfer logic into a helper invoked on every block entry before breakpoint suppression logic
- declare the helper in the VM interface so block arguments are always materialized when stepping
- add a regression test (plus IL/script fixtures) that steps into a block with parameters to ensure the callee observes the argument while stepping

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1f16783ac83248d40b11bb270cd69