### PR TITLE
Refactor serializer formatting and extend opcode coverage

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,11 @@ target_link_libraries(test_il_serialize PRIVATE il_core il_build il_io support)
 target_compile_definitions(test_il_serialize PRIVATE TESTS_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 add_test(NAME test_il_serialize COMMAND test_il_serialize)
 
+add_executable(test_il_serialize_opcodes unit/test_il_serialize_opcodes.cpp)
+target_link_libraries(test_il_serialize_opcodes PRIVATE il_core il_io support)
+target_compile_definitions(test_il_serialize_opcodes PRIVATE TESTS_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+add_test(NAME test_il_serialize_opcodes COMMAND test_il_serialize_opcodes)
+
 add_executable(test_il_malformed_cbr unit/test_il_malformed_cbr.cpp)
 target_link_libraries(test_il_malformed_cbr PRIVATE il_core il_io support)
 add_test(NAME test_il_malformed_cbr COMMAND test_il_malformed_cbr)

--- a/tests/golden/il/serializer_all_opcodes.il
+++ b/tests/golden/il/serializer_all_opcodes.il
@@ -1,0 +1,58 @@
+il 0.1.2
+extern @do_work(i64, i64) -> i64
+global const str @.Lstr = "ops"
+func @all_ops() -> i64 {
+entry:
+  %t0 = add 1, 2
+  %t1 = sub %t0, 3
+  %t2 = mul %t0, %t1
+  %t3 = sdiv %t2, 5
+  %t4 = udiv 10, 2
+  %t5 = srem 7, 3
+  %t6 = urem 9, 4
+  %t7 = and 240, 15
+  %t8 = or %t7, 1
+  %t9 = xor %t8, 3
+  %t10 = shl %t9, 1
+  %t11 = lshr %t10, 2
+  %t12 = ashr -8, 1
+  %t13 = fadd 1, 2.5
+  %t14 = fsub %t13, 1.25
+  %t15 = fmul %t14, 4
+  %t16 = fdiv %t15, 2
+  %t17 = icmp_eq 1, 1
+  %t18 = icmp_ne 1, 0
+  %t19 = scmp_lt -1, 0
+  %t20 = scmp_le 0, 0
+  %t21 = scmp_gt 2, 1
+  %t22 = scmp_ge 2, 2
+  %t23 = ucmp_lt 1, 2
+  %t24 = ucmp_le 2, 2
+  %t25 = ucmp_gt 3, 2
+  %t26 = ucmp_ge 3, 3
+  %t27 = fcmp_eq 1, 1
+  %t28 = fcmp_ne 1, 2
+  %t29 = fcmp_lt 1, 2
+  %t30 = fcmp_le 2, 2
+  %t31 = fcmp_gt 3, 2
+  %t32 = fcmp_ge 3, 3
+  %t33 = sitofp 42
+  %t34 = fptosi 5.5
+  %t35 = zext1 %t18
+  %t36 = trunc1 255
+  %t37 = alloca 8
+  %t38 = gep %t37, 1
+  store i64, %t37, 64
+  %t39 = load i64, %t37
+  %t40 = addr_of @.Lstr
+  %t41 = const_str @.Lstr
+  %t42 = const_null
+  %t43 = call @do_work(%t40, 5)
+  cbr %t18, compute(%t35, %t39), abort(%t42)
+compute(%wide:i64, %loaded:i64):
+  br join(%t43, %t35)
+abort:
+  trap
+join(%lhs:i64, %rhs:i64):
+  ret %t43
+}

--- a/tests/unit/test_il_serialize_opcodes.cpp
+++ b/tests/unit/test_il_serialize_opcodes.cpp
@@ -1,0 +1,178 @@
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Extern.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Global.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Module.hpp"
+#include "il/core/Param.hpp"
+#include "il/core/Type.hpp"
+#include "il/core/Value.hpp"
+#include "il/io/Serializer.hpp"
+#include <cassert>
+#include <fstream>
+#include <initializer_list>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+int main()
+{
+    using namespace il::core;
+
+    Module m;
+
+    Extern ext;
+    ext.name = "do_work";
+    ext.retType = Type(Type::Kind::I64);
+    ext.params = {Type(Type::Kind::I64), Type(Type::Kind::I64)};
+    m.externs.push_back(ext);
+
+    Global g;
+    g.name = ".Lstr";
+    g.type = Type(Type::Kind::Str);
+    g.init = "ops";
+    m.globals.push_back(g);
+
+    Function f;
+    f.name = "all_ops";
+    f.retType = Type(Type::Kind::I64);
+
+    BasicBlock entry;
+    entry.label = "entry";
+
+    unsigned nextTemp = 0;
+
+    auto emitValue = [&](Opcode op, Type type, std::initializer_list<Value> operands) -> Value {
+        Instr instr;
+        instr.result = nextTemp;
+        instr.op = op;
+        instr.type = type;
+        instr.operands = std::vector<Value>(operands);
+        entry.instructions.push_back(std::move(instr));
+        return Value::temp(nextTemp++);
+    };
+
+    auto emitVoid = [&](Opcode op, Type type, std::initializer_list<Value> operands) {
+        Instr instr;
+        instr.op = op;
+        instr.type = type;
+        instr.operands = std::vector<Value>(operands);
+        entry.instructions.push_back(std::move(instr));
+    };
+
+    auto emitCall = [&](const std::string &callee, Type type, std::initializer_list<Value> operands) -> Value {
+        Instr instr;
+        instr.result = nextTemp;
+        instr.op = Opcode::Call;
+        instr.type = type;
+        instr.callee = callee;
+        instr.operands = std::vector<Value>(operands);
+        entry.instructions.push_back(std::move(instr));
+        return Value::temp(nextTemp++);
+    };
+
+    Value addRes = emitValue(Opcode::Add, Type(Type::Kind::I64), {Value::constInt(1), Value::constInt(2)});
+    Value subRes = emitValue(Opcode::Sub, Type(Type::Kind::I64), {addRes, Value::constInt(3)});
+    Value mulRes = emitValue(Opcode::Mul, Type(Type::Kind::I64), {addRes, subRes});
+    [[maybe_unused]] Value sdivRes = emitValue(Opcode::SDiv, Type(Type::Kind::I64), {mulRes, Value::constInt(5)});
+    [[maybe_unused]] Value udivRes = emitValue(Opcode::UDiv, Type(Type::Kind::I64), {Value::constInt(10), Value::constInt(2)});
+    [[maybe_unused]] Value sremRes = emitValue(Opcode::SRem, Type(Type::Kind::I64), {Value::constInt(7), Value::constInt(3)});
+    [[maybe_unused]] Value uremRes = emitValue(Opcode::URem, Type(Type::Kind::I64), {Value::constInt(9), Value::constInt(4)});
+    Value andRes = emitValue(Opcode::And, Type(Type::Kind::I64), {Value::constInt(0xF0), Value::constInt(0x0F)});
+    Value orRes = emitValue(Opcode::Or, Type(Type::Kind::I64), {andRes, Value::constInt(1)});
+    Value xorRes = emitValue(Opcode::Xor, Type(Type::Kind::I64), {orRes, Value::constInt(3)});
+    Value shlRes = emitValue(Opcode::Shl, Type(Type::Kind::I64), {xorRes, Value::constInt(1)});
+    [[maybe_unused]] Value lshrRes = emitValue(Opcode::LShr, Type(Type::Kind::I64), {shlRes, Value::constInt(2)});
+    [[maybe_unused]] Value ashrRes = emitValue(Opcode::AShr, Type(Type::Kind::I64), {Value::constInt(-8), Value::constInt(1)});
+    Value faddRes = emitValue(Opcode::FAdd, Type(Type::Kind::F64), {Value::constFloat(1.0), Value::constFloat(2.5)});
+    Value fsubRes = emitValue(Opcode::FSub, Type(Type::Kind::F64), {faddRes, Value::constFloat(1.25)});
+    Value fmulRes = emitValue(Opcode::FMul, Type(Type::Kind::F64), {fsubRes, Value::constFloat(4.0)});
+    [[maybe_unused]] Value fdivRes = emitValue(Opcode::FDiv, Type(Type::Kind::F64), {fmulRes, Value::constFloat(2.0)});
+    [[maybe_unused]] Value icmpEqRes = emitValue(Opcode::ICmpEq, Type(Type::Kind::I1), {Value::constInt(1), Value::constInt(1)});
+    Value icmpNeRes = emitValue(Opcode::ICmpNe, Type(Type::Kind::I1), {Value::constInt(1), Value::constInt(0)});
+    [[maybe_unused]] Value scmpLtRes = emitValue(Opcode::SCmpLT, Type(Type::Kind::I1), {Value::constInt(-1), Value::constInt(0)});
+    [[maybe_unused]] Value scmpLeRes = emitValue(Opcode::SCmpLE, Type(Type::Kind::I1), {Value::constInt(0), Value::constInt(0)});
+    [[maybe_unused]] Value scmpGtRes = emitValue(Opcode::SCmpGT, Type(Type::Kind::I1), {Value::constInt(2), Value::constInt(1)});
+    [[maybe_unused]] Value scmpGeRes = emitValue(Opcode::SCmpGE, Type(Type::Kind::I1), {Value::constInt(2), Value::constInt(2)});
+    [[maybe_unused]] Value ucmpLtRes = emitValue(Opcode::UCmpLT, Type(Type::Kind::I1), {Value::constInt(1), Value::constInt(2)});
+    [[maybe_unused]] Value ucmpLeRes = emitValue(Opcode::UCmpLE, Type(Type::Kind::I1), {Value::constInt(2), Value::constInt(2)});
+    [[maybe_unused]] Value ucmpGtRes = emitValue(Opcode::UCmpGT, Type(Type::Kind::I1), {Value::constInt(3), Value::constInt(2)});
+    [[maybe_unused]] Value ucmpGeRes = emitValue(Opcode::UCmpGE, Type(Type::Kind::I1), {Value::constInt(3), Value::constInt(3)});
+    [[maybe_unused]] Value fcmpEqRes = emitValue(Opcode::FCmpEQ, Type(Type::Kind::I1), {Value::constFloat(1.0), Value::constFloat(1.0)});
+    [[maybe_unused]] Value fcmpNeRes = emitValue(Opcode::FCmpNE, Type(Type::Kind::I1), {Value::constFloat(1.0), Value::constFloat(2.0)});
+    [[maybe_unused]] Value fcmpLtRes = emitValue(Opcode::FCmpLT, Type(Type::Kind::I1), {Value::constFloat(1.0), Value::constFloat(2.0)});
+    [[maybe_unused]] Value fcmpLeRes = emitValue(Opcode::FCmpLE, Type(Type::Kind::I1), {Value::constFloat(2.0), Value::constFloat(2.0)});
+    [[maybe_unused]] Value fcmpGtRes = emitValue(Opcode::FCmpGT, Type(Type::Kind::I1), {Value::constFloat(3.0), Value::constFloat(2.0)});
+    [[maybe_unused]] Value fcmpGeRes = emitValue(Opcode::FCmpGE, Type(Type::Kind::I1), {Value::constFloat(3.0), Value::constFloat(3.0)});
+    [[maybe_unused]] Value sitofpRes = emitValue(Opcode::Sitofp, Type(Type::Kind::F64), {Value::constInt(42)});
+    [[maybe_unused]] Value fptosiRes = emitValue(Opcode::Fptosi, Type(Type::Kind::I64), {Value::constFloat(5.5)});
+    Value zextRes = emitValue(Opcode::Zext1, Type(Type::Kind::I64), {icmpNeRes});
+    [[maybe_unused]] Value truncRes = emitValue(Opcode::Trunc1, Type(Type::Kind::I1), {Value::constInt(255)});
+    Value allocaRes = emitValue(Opcode::Alloca, Type(Type::Kind::Ptr), {Value::constInt(8)});
+    [[maybe_unused]] Value gepRes = emitValue(Opcode::GEP, Type(Type::Kind::Ptr), {allocaRes, Value::constInt(1)});
+    emitVoid(Opcode::Store, Type(Type::Kind::I64), {allocaRes, Value::constInt(64)});
+    Value loadRes = emitValue(Opcode::Load, Type(Type::Kind::I64), {allocaRes});
+    Value addrOfRes = emitValue(Opcode::AddrOf, Type(Type::Kind::Ptr), {Value::global(g.name)});
+    [[maybe_unused]] Value constStrRes = emitValue(Opcode::ConstStr, Type(Type::Kind::Str), {Value::global(g.name)});
+    Value constNullRes = emitValue(Opcode::ConstNull, Type(Type::Kind::Ptr), {});
+    Value callRes = emitCall(ext.name, Type(Type::Kind::I64), {addrOfRes, Value::constInt(5)});
+
+    Instr cbr;
+    cbr.op = Opcode::CBr;
+    cbr.type = Type(Type::Kind::Void);
+    cbr.operands.push_back(icmpNeRes);
+    cbr.labels = {"compute", "abort"};
+    cbr.brArgs = {{zextRes, loadRes}, {constNullRes}};
+    entry.instructions.push_back(std::move(cbr));
+    entry.terminated = true;
+
+    BasicBlock compute;
+    compute.label = "compute";
+    compute.params.push_back(Param{"wide", Type(Type::Kind::I64), 0});
+    compute.params.push_back(Param{"loaded", Type(Type::Kind::I64), 1});
+    Instr br;
+    br.op = Opcode::Br;
+    br.type = Type(Type::Kind::Void);
+    br.labels = {"join"};
+    br.brArgs = {{callRes, zextRes}};
+    compute.instructions.push_back(std::move(br));
+    compute.terminated = true;
+
+    BasicBlock abortBlock;
+    abortBlock.label = "abort";
+    Instr trap;
+    trap.op = Opcode::Trap;
+    trap.type = Type(Type::Kind::Void);
+    abortBlock.instructions.push_back(std::move(trap));
+    abortBlock.terminated = true;
+
+    BasicBlock join;
+    join.label = "join";
+    join.params.push_back(Param{"lhs", Type(Type::Kind::I64), 0});
+    join.params.push_back(Param{"rhs", Type(Type::Kind::I64), 1});
+    Instr ret;
+    ret.op = Opcode::Ret;
+    ret.type = Type(Type::Kind::Void);
+    ret.operands.push_back(callRes);
+    join.instructions.push_back(std::move(ret));
+    join.terminated = true;
+
+    f.blocks.push_back(std::move(entry));
+    f.blocks.push_back(std::move(compute));
+    f.blocks.push_back(std::move(abortBlock));
+    f.blocks.push_back(std::move(join));
+    m.functions.push_back(std::move(f));
+
+    std::string out = il::io::Serializer::toString(m);
+    std::ifstream in(std::string(TESTS_DIR) + "/golden/il/serializer_all_opcodes.il");
+    std::stringstream buf;
+    buf << in.rdbuf();
+    std::string expected = buf.str();
+    if (!out.empty() && out.back() == '\n')
+        out.pop_back();
+    if (!expected.empty() && expected.back() == '\n')
+        expected.pop_back();
+    assert(out == expected);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- replace the serializer operand formatting ladder with a formatter table that shares helpers for calls, branches, loads, and stores
- add a golden IL fixture that covers every opcode and a unit test that checks the serializer output against it
- register the opcode serializer test with CMake so it runs with the rest of the suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d2198213788324a29ad27d69a86037