### PR TITLE
feat: add TextBuffer line iteration helpers

### DIFF
--- a/tui/include/tui/text/text_buffer.hpp
+++ b/tui/include/tui/text/text_buffer.hpp
@@ -9,8 +9,10 @@
 #include "tui/text/PieceTable.hpp"
 
 #include <cstddef>
+#include <functional>
 #include <string>
 #include <string_view>
+#include <utility>
 
 namespace viper::tui::text
 {
@@ -18,6 +20,31 @@ namespace viper::tui::text
 class TextBuffer
 {
   public:
+    /// @brief Lightweight view over a single line.
+    class LineView
+    {
+      public:
+        LineView(const PieceTable &table, std::size_t offset, std::size_t length);
+
+        /// @brief Starting byte offset of the line.
+        [[nodiscard]] std::size_t offset() const;
+
+        /// @brief Length in bytes excluding trailing newline.
+        [[nodiscard]] std::size_t length() const;
+
+        /// @brief Iterate contiguous string_view segments composing the line.
+        template <typename Fn>
+        void forEachSegment(Fn &&fn) const
+        {
+            table_.forEachSegment(offset_, length_, std::forward<Fn>(fn));
+        }
+
+      private:
+        const PieceTable &table_;
+        std::size_t offset_{};
+        std::size_t length_{};
+    };
+
     /// @brief Load initial content, replacing current buffer.
     void load(std::string text);
 
@@ -41,6 +68,33 @@ class TextBuffer
 
     /// @brief Get line content without trailing newline.
     [[nodiscard]] std::string getLine(std::size_t lineNo) const;
+
+    /// @brief Visit each indexed line with a lightweight view.
+    template <typename Fn>
+    void forEachLine(Fn &&fn) const
+    {
+        const std::size_t lines = line_index_.count();
+        for (std::size_t line = 0; line < lines; ++line)
+        {
+            LineView view(table_, lineOffset(line), lineLength(line));
+            if (!std::invoke(fn, line, view))
+            {
+                break;
+            }
+        }
+    }
+
+    /// @brief Retrieve starting offset for a line, clamped to buffer end.
+    [[nodiscard]] std::size_t lineOffset(std::size_t lineNo) const;
+
+    /// @brief Retrieve byte length of a line excluding trailing newline.
+    [[nodiscard]] std::size_t lineLength(std::size_t lineNo) const;
+
+    /// @brief Retrieve line metadata and segment iterator for a line.
+    [[nodiscard]] LineView lineView(std::size_t lineNo) const;
+
+    /// @brief Number of indexed lines.
+    [[nodiscard]] std::size_t lineCount() const;
 
     /// @brief Get full buffer content.
     [[nodiscard]] std::string str() const;

--- a/tui/include/tui/views/text_view.hpp
+++ b/tui/include/tui/views/text_view.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -75,9 +76,9 @@ class TextView : public ui::Widget
     std::vector<std::pair<std::size_t, std::size_t>> highlights_{};
 
     // helpers
-    static std::pair<char32_t, std::size_t> decodeChar(const std::string &s, std::size_t off);
-    static std::size_t lineWidth(const std::string &line);
-    static std::size_t columnToOffset(const std::string &line, std::size_t col);
+    static std::pair<char32_t, std::size_t> decodeChar(std::string_view s, std::size_t off);
+    static std::size_t lineWidth(std::string_view line);
+    static std::size_t columnToOffset(std::string_view line, std::size_t col);
     std::size_t offsetFromRowCol(std::size_t row, std::size_t col) const;
     std::size_t totalLines() const;
     void setCursor(std::size_t row, std::size_t col, bool shift, bool updateTarget);

--- a/tui/src/text/text_buffer.cpp
+++ b/tui/src/text/text_buffer.cpp
@@ -9,6 +9,21 @@
 
 namespace viper::tui::text
 {
+TextBuffer::LineView::LineView(const PieceTable &table, std::size_t offset, std::size_t length)
+    : table_(table), offset_(offset), length_(length)
+{
+}
+
+std::size_t TextBuffer::LineView::offset() const
+{
+    return offset_;
+}
+
+std::size_t TextBuffer::LineView::length() const
+{
+    return length_;
+}
+
 void TextBuffer::load(std::string text)
 {
     auto change = table_.load(std::move(text));
@@ -19,6 +34,46 @@ void TextBuffer::load(std::string text)
 std::size_t TextBuffer::size() const
 {
     return table_.size();
+}
+
+std::size_t TextBuffer::lineCount() const
+{
+    return line_index_.count();
+}
+
+std::size_t TextBuffer::lineOffset(std::size_t lineNo) const
+{
+    if (lineNo >= line_index_.count())
+    {
+        return table_.size();
+    }
+    return line_index_.start(lineNo);
+}
+
+std::size_t TextBuffer::lineLength(std::size_t lineNo) const
+{
+    if (lineNo >= line_index_.count())
+    {
+        return 0;
+    }
+
+    const std::size_t start = line_index_.start(lineNo);
+    const std::size_t nextLine = lineNo + 1;
+    if (nextLine < line_index_.count())
+    {
+        const std::size_t nextStart = line_index_.start(nextLine);
+        if (nextStart > start)
+        {
+            return nextStart - start - 1;
+        }
+        return 0;
+    }
+    return table_.size() > start ? table_.size() - start : 0U;
+}
+
+TextBuffer::LineView TextBuffer::lineView(std::size_t lineNo) const
+{
+    return LineView(table_, lineOffset(lineNo), lineLength(lineNo));
 }
 
 void TextBuffer::beginTxn()

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -74,6 +74,10 @@ add_executable(tui_test_text_view test_text_view.cpp)
 target_link_libraries(tui_test_text_view PRIVATE tui)
 add_test(NAME tui_test_text_view COMMAND tui_test_text_view)
 
+add_executable(tui_test_text_view_large views/test_text_view_large_buffer.cpp)
+target_link_libraries(tui_test_text_view_large PRIVATE tui)
+add_test(NAME tui_test_text_view_large COMMAND tui_test_text_view_large)
+
 add_executable(tui_test_search test_search.cpp)
 target_link_libraries(tui_test_search PRIVATE tui)
 add_test(NAME tui_test_search COMMAND tui_test_search)

--- a/tui/tests/views/test_text_view_large_buffer.cpp
+++ b/tui/tests/views/test_text_view_large_buffer.cpp
@@ -1,0 +1,74 @@
+// tui/tests/views/test_text_view_large_buffer.cpp
+// @brief Regression test stressing TextView cursor movement over large buffers.
+// @invariant Cursor offsets map to expected rows/columns without copying entire buffer.
+// @ownership Test owns buffer, theme, and view instances.
+
+#include "tui/style/theme.hpp"
+#include "tui/views/text_view.hpp"
+
+#include <cassert>
+#include <string>
+
+using viper::tui::style::Theme;
+using viper::tui::text::TextBuffer;
+using viper::tui::views::TextView;
+
+namespace
+{
+std::string makeLargeBuffer(std::size_t lines, std::size_t width)
+{
+    std::string text;
+    text.reserve(lines * (width + 1));
+    for (std::size_t i = 0; i < lines; ++i)
+    {
+        text.append(width, static_cast<char>('a' + static_cast<char>(i % 26))); // ASCII payload
+        if (i + 1 < lines)
+        {
+            text.push_back('\n');
+        }
+    }
+    return text;
+}
+} // namespace
+
+int main()
+{
+    constexpr std::size_t kLines = 2048;
+    constexpr std::size_t kWidth = 96;
+
+    TextBuffer buf;
+    buf.load(makeLargeBuffer(kLines, kWidth));
+
+    assert(buf.lineCount() == kLines);
+    const std::size_t sample = kLines / 2;
+    assert(buf.lineOffset(sample) == sample * (kWidth + 1));
+    assert(buf.lineLength(sample) == kWidth);
+    assert(buf.lineOffset(kLines - 1) == (kLines - 1) * (kWidth + 1));
+    assert(buf.lineLength(kLines - 1) == kWidth);
+
+    Theme theme;
+    TextView view(buf, theme, false);
+    view.layout({0, 0, 80, 24});
+
+    const std::size_t targetLine = kLines - 5;
+    const std::size_t targetStart = buf.lineOffset(targetLine);
+
+    view.moveCursorToOffset(targetStart);
+    assert(view.cursorRow() == targetLine);
+    assert(view.cursorCol() == 0);
+
+    const std::size_t midOffset = targetStart + kWidth / 2;
+    view.moveCursorToOffset(midOffset);
+    assert(view.cursorRow() == targetLine);
+    assert(view.cursorCol() == kWidth / 2);
+
+    view.moveCursorToOffset(targetStart + kWidth);
+    assert(view.cursorRow() == targetLine + 1);
+    assert(view.cursorCol() == 0);
+
+    view.moveCursorToOffset(buf.size());
+    assert(view.cursorRow() == kLines - 1);
+    assert(view.cursorCol() == kWidth);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extend TextBuffer and PieceTable with segment-aware line iteration helpers
- rework TextView offset helpers to use lightweight iteration
- add a large-buffer regression test for TextView cursor movement

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d219d06b6c8324a3504b5b73135ef5