### PR TITLE
refactor(fe/basic): centralize type suffix inference

### DIFF
--- a/src/frontends/basic/CMakeLists.txt
+++ b/src/frontends/basic/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(fe_basic STATIC
   Parser_Expr.cpp
   Parser_Token.cpp
   NameMangler.cpp
+  TypeSuffix.cpp
   LoweringContext.cpp
   LoweringPipeline.cpp
   BuiltinRegistry.cpp

--- a/src/frontends/basic/LowerScan.cpp
+++ b/src/frontends/basic/LowerScan.cpp
@@ -7,8 +7,8 @@
 
 #include "frontends/basic/BuiltinRegistry.hpp"
 #include "frontends/basic/Lowerer.hpp"
+#include "frontends/basic/TypeSuffix.hpp"
 #include <optional>
-#include <string_view>
 #include <vector>
 
 namespace il::frontends::basic
@@ -32,20 +32,6 @@ Lowerer::ExprType exprTypeFromAstType(::il::frontends::basic::Type ty)
         default:
             return Lowerer::ExprType::I64;
     }
-}
-
-::il::frontends::basic::Type inferAstTypeFromName(std::string_view name)
-{
-    using AstType = ::il::frontends::basic::Type;
-    if (!name.empty())
-    {
-        char suffix = name.back();
-        if (suffix == '$')
-            return AstType::Str;
-        if (suffix == '#')
-            return AstType::F64;
-    }
-    return AstType::I64;
 }
 
 } // namespace

--- a/src/frontends/basic/Lowerer.cpp
+++ b/src/frontends/basic/Lowerer.cpp
@@ -8,6 +8,7 @@
 // Links: docs/class-catalog.md
 
 #include "frontends/basic/Lowerer.hpp"
+#include "frontends/basic/TypeSuffix.hpp"
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Function.hpp"
 #include "il/core/Instr.hpp"
@@ -21,7 +22,6 @@ using namespace il::core;
 namespace il::frontends::basic
 {
 
-using pipeline_detail::astTypeFromName;
 using pipeline_detail::coreTypeForAstType;
 
 Lowerer::BlockNamer::BlockNamer(std::string p) : proc(std::move(p)) {}
@@ -139,7 +139,7 @@ Lowerer::SlotType Lowerer::getSlotType(std::string_view name) const
     std::string key(name);
     using AstType = ::il::frontends::basic::Type;
     auto it = varTypes.find(key);
-    AstType astTy = (it != varTypes.end()) ? it->second : astTypeFromName(name);
+    AstType astTy = (it != varTypes.end()) ? it->second : inferAstTypeFromName(name);
     info.isArray = arrays.find(key) != arrays.end();
     info.isBoolean = !info.isArray && astTy == AstType::Bool;
     info.type = info.isArray ? Type(Type::Kind::Ptr) : coreTypeForAstType(astTy);

--- a/src/frontends/basic/LoweringPipeline.cpp
+++ b/src/frontends/basic/LoweringPipeline.cpp
@@ -7,6 +7,7 @@
 
 #include "frontends/basic/Lowerer.hpp"
 #include "frontends/basic/LoweringPipeline.hpp"
+#include "frontends/basic/TypeSuffix.hpp"
 #include "il/build/IRBuilder.hpp"
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Function.hpp"
@@ -17,7 +18,6 @@
 namespace il::frontends::basic
 {
 
-using pipeline_detail::astTypeFromName;
 using pipeline_detail::coreTypeForAstType;
 
 namespace
@@ -93,7 +93,7 @@ class VarCollectExprVisitor final : public ExprVisitor
             return;
         if (varTypes_.find(name) != varTypes_.end())
             return;
-        varTypes_[name] = astTypeFromName(name);
+        varTypes_[name] = inferAstTypeFromName(name);
     }
 
     std::unordered_set<std::string> &vars_;
@@ -178,7 +178,7 @@ class VarCollectStmtVisitor final : public StmtVisitor
         {
             vars_.insert(stmt.var);
             if (varTypes_.find(stmt.var) == varTypes_.end())
-                varTypes_[stmt.var] = astTypeFromName(stmt.var);
+                varTypes_[stmt.var] = inferAstTypeFromName(stmt.var);
         }
         if (stmt.start)
             stmt.start->accept(exprVisitor_);
@@ -209,7 +209,7 @@ class VarCollectStmtVisitor final : public StmtVisitor
         {
             vars_.insert(stmt.var);
             if (varTypes_.find(stmt.var) == varTypes_.end())
-                varTypes_[stmt.var] = astTypeFromName(stmt.var);
+                varTypes_[stmt.var] = inferAstTypeFromName(stmt.var);
         }
     }
 

--- a/src/frontends/basic/LoweringPipeline.hpp
+++ b/src/frontends/basic/LoweringPipeline.hpp
@@ -10,7 +10,6 @@
 #include "il/core/Type.hpp"
 #include <functional>
 #include <string>
-#include <string_view>
 #include <vector>
 
 namespace il::frontends::basic
@@ -40,26 +39,6 @@ inline il::core::Type coreTypeForAstType(::il::frontends::basic::Type ty)
     return Type(Type::Kind::I64);
 }
 
-/// @brief Infer the BASIC AST type for an identifier by inspecting its suffix.
-/// @param name Identifier to analyze.
-/// @return BASIC type derived from the suffix; defaults to integer for suffix-free names.
-inline ::il::frontends::basic::Type astTypeFromName(std::string_view name)
-{
-    using AstType = ::il::frontends::basic::Type;
-    if (!name.empty())
-    {
-        switch (name.back())
-        {
-            case '$':
-                return AstType::Str;
-            case '#':
-                return AstType::F64;
-            default:
-                break;
-        }
-    }
-    return AstType::I64;
-}
 } // namespace pipeline_detail
 
 /// @brief Coordinates program-level lowering by seeding module state and driving emission.

--- a/src/frontends/basic/TypeSuffix.cpp
+++ b/src/frontends/basic/TypeSuffix.cpp
@@ -1,0 +1,30 @@
+// File: src/frontends/basic/TypeSuffix.cpp
+// License: MIT License. See LICENSE in the project root for full license information.
+// Purpose: Implements helpers for inferring BASIC semantic types from identifier suffixes.
+// Key invariants: BASIC suffix characters map deterministically to AST scalar types.
+// Ownership/Lifetime: Stateless utility functions.
+// Links: docs/class-catalog.md
+
+#include "frontends/basic/TypeSuffix.hpp"
+
+namespace il::frontends::basic
+{
+
+Type inferAstTypeFromName(std::string_view name)
+{
+    if (!name.empty())
+    {
+        switch (name.back())
+        {
+            case '$':
+                return Type::Str;
+            case '#':
+                return Type::F64;
+            default:
+                break;
+        }
+    }
+    return Type::I64;
+}
+
+} // namespace il::frontends::basic

--- a/src/frontends/basic/TypeSuffix.hpp
+++ b/src/frontends/basic/TypeSuffix.hpp
@@ -1,0 +1,19 @@
+// File: src/frontends/basic/TypeSuffix.hpp
+// Purpose: Declares helpers for inferring BASIC semantic types from identifier suffixes.
+// Key invariants: BASIC suffix characters map to a single AST scalar type.
+// Ownership/Lifetime: Pure utility with no retained state.
+// Links: docs/class-catalog.md
+#pragma once
+
+#include "frontends/basic/AST.hpp"
+#include <string_view>
+
+namespace il::frontends::basic
+{
+
+/// @brief Determine the BASIC AST type implied by an identifier suffix.
+/// @param name BASIC identifier, potentially containing a type suffix character.
+/// @return Semantic type derived from the suffix, defaulting to integer when none matches.
+Type inferAstTypeFromName(std::string_view name);
+
+} // namespace il::frontends::basic


### PR DESCRIPTION
## Summary
- add a TypeSuffix utility that infers BASIC AST types from identifier suffixes
- reuse the shared inference logic in Lowerer and LowerScan and register the new unit with the build

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d21f1e182883248eee1c62f22b3260