### PR TITLE
refactor(analysis): cache CFG label lookups

### DIFF
--- a/src/il/analysis/CFG.hpp
+++ b/src/il/analysis/CFG.hpp
@@ -1,10 +1,11 @@
 // File: src/il/analysis/CFG.hpp
 // Purpose: Minimal control-flow graph utilities for IL blocks and functions.
-// Key invariants: Computes edges on demand without caching.
+// Key invariants: Successor lookups reuse precomputed label maps per function.
 // Ownership/Lifetime: Operates on IL structures owned by caller.
 // Links: docs/dev/analysis.md
 #pragma once
 
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -32,6 +33,9 @@ struct CFGContext
 
     il::core::Module *module{nullptr};
     std::unordered_map<const il::core::Block *, il::core::Function *> blockToFunction;
+    /// @brief Cache mapping function pointers to their blocks indexed by label.
+    std::unordered_map<il::core::Function *, std::unordered_map<std::string, il::core::Block *>>
+        functionLabelToBlock;
 };
 
 /// @brief Return successors of block @p B by inspecting its terminator.

--- a/tests/analysis/CFGTests.cpp
+++ b/tests/analysis/CFGTests.cpp
@@ -39,6 +39,18 @@ int main()
     b.setInsertPoint(join);
     b.emitRet(std::nullopt, {});
 
+    Function &other = b.startFunction("g", Type(Type::Kind::Void), {});
+    b.createBlock(other, "entry");
+    b.createBlock(other, "t");
+    Block &otherEntry = other.blocks[0];
+    Block &otherT = other.blocks[1];
+
+    b.setInsertPoint(otherEntry);
+    b.br(otherT, {});
+
+    b.setInsertPoint(otherT);
+    b.emitRet(std::nullopt, {});
+
     viper::analysis::CFGContext ctx(m);
 
     auto sEntry = successors(ctx, entry);
@@ -51,6 +63,11 @@ int main()
     assert(sF.size() == 1 && sF[0] == &join);
     auto sJoin = successors(ctx, join);
     assert(sJoin.empty());
+
+    auto sOtherEntry = successors(ctx, otherEntry);
+    assert(sOtherEntry.size() == 1 && sOtherEntry[0] == &otherT);
+    auto sOtherT = successors(ctx, otherT);
+    assert(sOtherT.empty());
 
     auto pJoin = predecessors(ctx, join);
     assert(pJoin.size() == 2);


### PR DESCRIPTION
## Summary
- cache per-function label to block mappings alongside block ownership in CFGContext
- rewrite successors() to reuse the cached label lookup instead of scanning blocks
- extend CFG tests to cover modules containing duplicate labels across functions

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d22135eb348324ae2b8dcc36918704