### PR TITLE
perf(vm): cache trace instruction lookup

### DIFF
--- a/src/vm/VMInit.cpp
+++ b/src/vm/VMInit.cpp
@@ -97,6 +97,7 @@ VM::ExecState VM::prepareExecution(const Function &fn, const std::vector<Slot> &
 {
     ExecState st;
     st.fr = setupFrame(fn, args, st.blocks, st.bb);
+    tracer.onFramePrepared(st.fr);
     debug.resetLastHit();
     st.ip = 0;
     st.skipBreakOnce = false;


### PR DESCRIPTION
## Summary
- precompute per-function instruction location maps when preparing a frame
- use the cached lookup in TraceSink::onStep to avoid nested scans while preserving output

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d221831f3c8324ac36e5475f268803