### PR TITLE
Refactor BASIC procedure signature collection to use AST helpers

### DIFF
--- a/src/frontends/basic/AST.cpp
+++ b/src/frontends/basic/AST.cpp
@@ -274,6 +274,13 @@ void ReturnStmt::accept(MutStmtVisitor &visitor)
     visitor.visit(*this);
 }
 
+/// @brief Returns no signature information for statements that are not procedures.
+/// @return Empty optional indicating the statement does not declare a procedure.
+std::optional<ProcSignatureView> Stmt::declaredSignature() const
+{
+    return std::nullopt;
+}
+
 /// @brief Forwards this function declaration node to the visitor for double dispatch.
 /// @param visitor Receives the node; ownership remains with the AST.
 void FunctionDecl::accept(StmtVisitor &visitor) const
@@ -286,6 +293,12 @@ void FunctionDecl::accept(MutStmtVisitor &visitor)
     visitor.visit(*this);
 }
 
+std::optional<ProcSignatureView> FunctionDecl::declaredSignature() const
+{
+    return ProcSignatureView{std::string_view{name}, std::optional<Type>{ret},
+                             std::span<const Param>{params}};
+}
+
 /// @brief Forwards this subroutine declaration node to the visitor for double dispatch.
 /// @param visitor Receives the node; ownership remains with the AST.
 void SubDecl::accept(StmtVisitor &visitor) const
@@ -296,6 +309,12 @@ void SubDecl::accept(StmtVisitor &visitor) const
 void SubDecl::accept(MutStmtVisitor &visitor)
 {
     visitor.visit(*this);
+}
+
+std::optional<ProcSignatureView> SubDecl::declaredSignature() const
+{
+    return ProcSignatureView{std::string_view{name}, std::nullopt,
+                             std::span<const Param>{params}};
 }
 
 /// @brief Forwards this statement list node to the visitor for double dispatch.

--- a/tests/unit/test_basic_lowerer_collect.cpp
+++ b/tests/unit/test_basic_lowerer_collect.cpp
@@ -57,6 +57,9 @@ int main()
         "20 RANDOMIZE SEED\n"
         "30 RETURN SEED\n"
         "40 END FUNCTION\n"
+        "50 SUB SHOW(A())\n"
+        "60 PRINT A(0)\n"
+        "70 END SUB\n"
         "100 RANDOMIZE MAINSEED\n"
         "110 PRINT MAINSEED\n";
 
@@ -81,5 +84,16 @@ int main()
     assert(entryHasAlloca(*funcF));
     assert(tempsHaveNames(*mainFn));
     assert(tempsHaveNames(*funcF));
+
+    const auto *sigF = lowerer.findProcSignature("F");
+    assert(sigF);
+    assert(sigF->retType.kind == il::core::Type::Kind::I64);
+    assert(sigF->paramTypes.empty());
+
+    const auto *sigShow = lowerer.findProcSignature("SHOW");
+    assert(sigShow);
+    assert(sigShow->retType.kind == il::core::Type::Kind::Void);
+    assert(sigShow->paramTypes.size() == 1);
+    assert(sigShow->paramTypes.front().kind == il::core::Type::Kind::Ptr);
     return 0;
 }


### PR DESCRIPTION
## Summary
- add ProcSignatureView plus declaredSignature overrides so BASIC procedure nodes expose their signature data directly
- refactor ProcedureLowering::collectProcedureSignatures to rely on the new AST helpers instead of dynamic casts
- extend the lowering collection unit test to assert function return typing and array parameter pointer lowering

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d221b1ef408324bb34b70b53a4c347