### PR TITLE
feat(tui): expose safe text buffer line boundary accessors

### DIFF
--- a/tui/include/tui/text/text_buffer.hpp
+++ b/tui/include/tui/text/text_buffer.hpp
@@ -84,6 +84,15 @@ class TextBuffer
         }
     }
 
+    /// @brief Number of indexed lines tracked by the line index.
+    [[nodiscard]] std::size_t lineCount() const;
+
+    /// @brief Starting byte offset for a line; returns buffer size when out of range.
+    [[nodiscard]] std::size_t lineStart(std::size_t lineNo) const;
+
+    /// @brief Exclusive ending byte offset excluding trailing newline; clamps to buffer size.
+    [[nodiscard]] std::size_t lineEnd(std::size_t lineNo) const;
+
     /// @brief Retrieve starting offset for a line, clamped to buffer end.
     [[nodiscard]] std::size_t lineOffset(std::size_t lineNo) const;
 
@@ -92,9 +101,6 @@ class TextBuffer
 
     /// @brief Retrieve line metadata and segment iterator for a line.
     [[nodiscard]] LineView lineView(std::size_t lineNo) const;
-
-    /// @brief Number of indexed lines.
-    [[nodiscard]] std::size_t lineCount() const;
 
     /// @brief Get full buffer content.
     [[nodiscard]] std::string str() const;

--- a/tui/src/text/text_buffer.cpp
+++ b/tui/src/text/text_buffer.cpp
@@ -41,7 +41,7 @@ std::size_t TextBuffer::lineCount() const
     return line_index_.count();
 }
 
-std::size_t TextBuffer::lineOffset(std::size_t lineNo) const
+std::size_t TextBuffer::lineStart(std::size_t lineNo) const
 {
     if (lineNo >= line_index_.count())
     {
@@ -50,11 +50,11 @@ std::size_t TextBuffer::lineOffset(std::size_t lineNo) const
     return line_index_.start(lineNo);
 }
 
-std::size_t TextBuffer::lineLength(std::size_t lineNo) const
+std::size_t TextBuffer::lineEnd(std::size_t lineNo) const
 {
     if (lineNo >= line_index_.count())
     {
-        return 0;
+        return table_.size();
     }
 
     const std::size_t start = line_index_.start(lineNo);
@@ -64,11 +64,27 @@ std::size_t TextBuffer::lineLength(std::size_t lineNo) const
         const std::size_t nextStart = line_index_.start(nextLine);
         if (nextStart > start)
         {
-            return nextStart - start - 1;
+            return nextStart - 1;
         }
+        return start;
+    }
+    return table_.size();
+}
+
+std::size_t TextBuffer::lineOffset(std::size_t lineNo) const
+{
+    return lineStart(lineNo);
+}
+
+std::size_t TextBuffer::lineLength(std::size_t lineNo) const
+{
+    const std::size_t start = lineStart(lineNo);
+    const std::size_t end = lineEnd(lineNo);
+    if (end <= start)
+    {
         return 0;
     }
-    return table_.size() > start ? table_.size() - start : 0U;
+    return end - start;
 }
 
 TextBuffer::LineView TextBuffer::lineView(std::size_t lineNo) const

--- a/tui/tests/test_text_buffer.cpp
+++ b/tui/tests/test_text_buffer.cpp
@@ -16,11 +16,24 @@ int main()
     buf.load("hello\nworld");
     assert(buf.getLine(0) == "hello");
     assert(buf.getLine(1) == "world");
+    assert(buf.lineCount() == 2);
+    assert(buf.lineStart(0) == 0);
+    assert(buf.lineEnd(0) == buf.lineStart(0) + buf.getLine(0).size());
+    assert(buf.lineStart(1) == 6);
+    assert(buf.lineEnd(1) == buf.size());
+    assert(buf.lineStart(5) == buf.size());
+    assert(buf.lineEnd(5) == buf.size());
 
     buf.insert(5, ", there\nbeautiful");
     assert(buf.getLine(0) == "hello, there");
     assert(buf.getLine(1) == "beautiful");
     assert(buf.getLine(2) == "world");
+    assert(buf.lineCount() == 3);
+    assert(buf.lineEnd(0) == buf.lineStart(0) + buf.getLine(0).size());
+    assert(buf.lineEnd(1) == buf.lineStart(1) + buf.getLine(1).size());
+    assert(buf.lineEnd(2) == buf.lineStart(2) + buf.getLine(2).size());
+    assert(buf.lineStart(99) == buf.size());
+    assert(buf.lineEnd(99) == buf.size());
 
     buf.beginTxn();
     buf.erase(0, 5); // remove 'hello'

--- a/tui/tests/views/test_text_view_large_buffer.cpp
+++ b/tui/tests/views/test_text_view_large_buffer.cpp
@@ -43,8 +43,13 @@ int main()
     const std::size_t sample = kLines / 2;
     assert(buf.lineOffset(sample) == sample * (kWidth + 1));
     assert(buf.lineLength(sample) == kWidth);
+    assert(buf.lineStart(sample) == buf.lineOffset(sample));
+    assert(buf.lineEnd(sample) == buf.lineStart(sample) + kWidth);
     assert(buf.lineOffset(kLines - 1) == (kLines - 1) * (kWidth + 1));
     assert(buf.lineLength(kLines - 1) == kWidth);
+    assert(buf.lineEnd(kLines - 1) == buf.size());
+    assert(buf.lineStart(kLines) == buf.size());
+    assert(buf.lineEnd(kLines) == buf.size());
 
     Theme theme;
     TextView view(buf, theme, false);


### PR DESCRIPTION
## Summary
- add documented const TextBuffer accessors for line count, start, and end backed by the line index
- reuse the new helpers to clamp existing offset/length queries to the buffer size
- extend text buffer regression tests to cover the new APIs and out-of-range cases

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d221d2b1708324a859106e1c1d42c7