### PR TITLE
Refactor BASIC IF parser branch helpers

### DIFF
--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -11,6 +11,7 @@
 #include "frontends/basic/Lexer.hpp"
 #include <array>
 #include <functional>
+#include <initializer_list>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -87,6 +88,19 @@ class Parser
     /// @brief Create a statement context bound to this parser instance.
     /// @return StatementContext referencing the parser's token stream.
     StatementContext statementContext();
+
+    /// @brief Consume optional line labels that follow a line break.
+    /// @param ctx Statement context providing newline skipping helpers.
+    /// @param followerKinds When non-empty, only consume the label when the
+    ///        subsequent token is one of the specified kinds.
+    void skipOptionalLineLabelAfterBreak(StatementContext &ctx,
+                                         std::initializer_list<TokenKind> followerKinds = {});
+
+    /// @brief Parse the body of a single IF-related branch.
+    /// @param line Line number propagated to the branch statement.
+    /// @param ctx Statement context for separator management.
+    /// @return Parsed statement belonging to the branch body.
+    StmtPtr parseIfBranchBody(int line, StatementContext &ctx);
 
     mutable Lexer lexer_;                    ///< Provides tokens from the source buffer.
     mutable std::vector<Token> tokens_;      ///< Lookahead token buffer.

--- a/tests/frontends/basic/ParserStatementContextTests.cpp
+++ b/tests/frontends/basic/ParserStatementContextTests.cpp
@@ -77,5 +77,72 @@ int main()
         assert(dynamic_cast<PrintStmt *>(ifStmt->else_branch.get()));
     }
 
+    {
+        std::string src =
+            "10 IF FLAG THEN\n"
+            "20 PRINT 1\n"
+            "30 ELSEIF OTHER THEN\n"
+            "40 PRINT 2\n"
+            "50 ELSE\n"
+            "60 PRINT 3\n"
+            "70 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("ifelseif.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        assert(prog);
+        assert(prog->main.size() == 2);
+        auto *ifStmt = dynamic_cast<IfStmt *>(prog->main[0].get());
+        assert(ifStmt);
+        assert(ifStmt->then_branch);
+        assert(ifStmt->then_branch->line == 10);
+        assert(dynamic_cast<PrintStmt *>(ifStmt->then_branch.get()));
+        assert(ifStmt->elseifs.size() == 1);
+        assert(ifStmt->elseifs[0].then_branch);
+        assert(ifStmt->elseifs[0].then_branch->line == 10);
+        assert(dynamic_cast<PrintStmt *>(ifStmt->elseifs[0].then_branch.get()));
+        assert(ifStmt->else_branch);
+        assert(ifStmt->else_branch->line == 10);
+        assert(dynamic_cast<PrintStmt *>(ifStmt->else_branch.get()));
+    }
+
+    {
+        std::string src =
+            "10 IF FLAG THEN PRINT 1 ELSEIF OTHER THEN PRINT 2 ELSE PRINT 3\n"
+            "20 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("ifinline.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        assert(prog);
+        assert(prog->main.size() == 2);
+        auto *ifStmt = dynamic_cast<IfStmt *>(prog->main[0].get());
+        assert(ifStmt);
+        assert(ifStmt->then_branch);
+        assert(dynamic_cast<PrintStmt *>(ifStmt->then_branch.get()));
+        assert(ifStmt->elseifs.size() == 1);
+        assert(dynamic_cast<PrintStmt *>(ifStmt->elseifs[0].then_branch.get()));
+        assert(ifStmt->else_branch);
+        assert(dynamic_cast<PrintStmt *>(ifStmt->else_branch.get()));
+    }
+
+    {
+        std::string src =
+            "10 IF FLAG THEN PRINT 1: PRINT 2\n"
+            "20 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("ifcolon.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        assert(prog);
+        assert(prog->main.size() == 2);
+        auto *list = dynamic_cast<StmtList *>(prog->main[0].get());
+        assert(list);
+        assert(list->stmts.size() == 2);
+        auto *ifStmt = dynamic_cast<IfStmt *>(list->stmts[0].get());
+        assert(ifStmt);
+        assert(dynamic_cast<PrintStmt *>(list->stmts[1].get()));
+    }
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- add helpers for skipping optional line labels and parsing IF branch bodies
- refactor parseIf to share the helper logic across THEN/ELSEIF/ELSE
- extend BASIC parser tests to cover multi-line and inline IF/ELSE variants

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d229cf086c8324bf874493b2fc25e4