### PR TITLE
refactor(frontends/basic): share literal zero helper

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.Exprs.cpp
+++ b/src/frontends/basic/SemanticAnalyzer.Exprs.cpp
@@ -289,6 +289,12 @@ void SemanticAnalyzer::emitDivideByZero(const BinaryExpr &expr)
     de.emit(il::support::Severity::Error, "B2002", expr.loc, 1, std::move(msg));
 }
 
+bool SemanticAnalyzer::rhsIsLiteralZero(const BinaryExpr &expr) const
+{
+    const auto *ri = dynamic_cast<const IntExpr *>(expr.rhs.get());
+    return ri != nullptr && ri->value == 0;
+}
+
 void SemanticAnalyzer::validateNumericOperands(const BinaryExpr &expr,
                                                Type lhs,
                                                Type rhs,
@@ -307,12 +313,9 @@ void SemanticAnalyzer::validateDivisionOperands(const BinaryExpr &expr,
                                                 std::string_view diagId)
 {
     validateNumericOperands(expr, lhs, rhs, diagId);
-    if (dynamic_cast<const IntExpr *>(expr.lhs.get()) &&
-        dynamic_cast<const IntExpr *>(expr.rhs.get()))
+    if (dynamic_cast<const IntExpr *>(expr.lhs.get()) && rhsIsLiteralZero(expr))
     {
-        const auto *ri = static_cast<const IntExpr *>(expr.rhs.get());
-        if (ri->value == 0)
-            emitDivideByZero(expr);
+        emitDivideByZero(expr);
     }
 }
 
@@ -326,12 +329,9 @@ void SemanticAnalyzer::validateIntegerOperands(const BinaryExpr &expr,
     {
         emitOperandTypeMismatch(expr, diagId);
     }
-    if (dynamic_cast<const IntExpr *>(expr.lhs.get()) &&
-        dynamic_cast<const IntExpr *>(expr.rhs.get()))
+    if (dynamic_cast<const IntExpr *>(expr.lhs.get()) && rhsIsLiteralZero(expr))
     {
-        const auto *ri = static_cast<const IntExpr *>(expr.rhs.get());
-        if (ri->value == 0)
-            emitDivideByZero(expr);
+        emitDivideByZero(expr);
     }
 }
 

--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -195,6 +195,8 @@ class SemanticAnalyzer
     void emitOperandTypeMismatch(const BinaryExpr &expr, std::string_view diagId);
     /// @brief Emit divide-by-zero diagnostic when appropriate.
     void emitDivideByZero(const BinaryExpr &expr);
+    /// @brief Determine whether the RHS of @p expr is the integer literal 0.
+    bool rhsIsLiteralZero(const BinaryExpr &expr) const;
     /// @brief Ensure operands are numeric (INT or FLOAT) when required.
     void validateNumericOperands(const BinaryExpr &expr,
                                  Type lhs,


### PR DESCRIPTION
## Summary
- add a private SemanticAnalyzer helper to detect integer literal zero RHS operands
- reuse the helper for division and integer operator validation to keep diagnostics consistent

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d22dd35b0c8324898de63f3f4f624d