### PR TITLE
refactor(frontends/basic): centralize proc registration helper

### DIFF
--- a/src/frontends/basic/ProcRegistry.hpp
+++ b/src/frontends/basic/ProcRegistry.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <span>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -62,6 +63,10 @@ class ProcRegistry
     };
 
     ProcSignature buildSignature(const ProcDescriptor &descriptor);
+
+    void registerProcImpl(std::string_view name,
+                          const ProcDescriptor &descriptor,
+                          il::support::SourceLoc loc);
 
     SemanticDiagnostics &de;
     ProcTable procs_;


### PR DESCRIPTION
## Summary
- extract registerProcImpl to centralize duplicate checking, diagnostics, and insertion
- route function and sub procedure registration through the shared helper without altering descriptor construction

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d22dc2fa3c8324a407f2d059a008e3