### PR TITLE
refactor(frontends/basic): scan AST via visitors

### DIFF
--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -25,6 +25,8 @@ namespace il::frontends::basic
 
 class LowererExprVisitor;
 class LowererStmtVisitor;
+class ScanExprVisitor;
+class ScanStmtVisitor;
 struct ProgramLowering;
 struct ProcedureLowering;
 struct StatementLowering;
@@ -52,6 +54,8 @@ class Lowerer
   private:
     friend class LowererExprVisitor;
     friend class LowererStmtVisitor;
+    friend class ScanExprVisitor;
+    friend class ScanStmtVisitor;
     friend struct ProgramLowering;
     friend struct ProcedureLowering;
     friend struct StatementLowering;


### PR DESCRIPTION
## Summary
- introduce ScanExprVisitor and ScanStmtVisitor to walk BASIC ASTs while recording scan results
- refactor Lowerer::scanExpr and scanStmt to delegate to the new visitors so helper functions remain reusable
- expose the visitors to Lowerer through friend declarations to access private state during scans

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d22d8896608324bfbd72909934c6e7