### PR TITLE
refactor(frontends/basic): inline Lowerer helper declarations

### DIFF
--- a/src/frontends/basic/LowerEmit.cpp
+++ b/src/frontends/basic/LowerEmit.cpp
@@ -5,6 +5,7 @@
 // Ownership/Lifetime: Operates on Lowerer state without owning AST or module.
 // Links: docs/class-catalog.md
 
+// Requires the consolidated Lowerer interface for emission helpers.
 #include "frontends/basic/Lowerer.hpp"
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Function.hpp"

--- a/src/frontends/basic/LowerExpr.cpp
+++ b/src/frontends/basic/LowerExpr.cpp
@@ -6,6 +6,7 @@
 // Ownership/Lifetime: Operates on Lowerer state without owning AST or module.
 // Links: docs/class-catalog.md
 
+// Requires the consolidated Lowerer interface for expression lowering helpers.
 #include "frontends/basic/Lowerer.hpp"
 #include "frontends/basic/BuiltinRegistry.hpp"
 #include "il/core/BasicBlock.hpp"

--- a/src/frontends/basic/LowerRuntime.cpp
+++ b/src/frontends/basic/LowerRuntime.cpp
@@ -6,6 +6,7 @@
 // Ownership/Lifetime: Operates on Lowerer state without owning AST or module.
 // Links: docs/class-catalog.md
 
+// Requires the consolidated Lowerer interface for runtime tracking declarations.
 #include "frontends/basic/Lowerer.hpp"
 #include "il/runtime/RuntimeSignatures.hpp"
 #include <cassert>

--- a/src/frontends/basic/LowerStmt.cpp
+++ b/src/frontends/basic/LowerStmt.cpp
@@ -6,6 +6,7 @@
 // Ownership/Lifetime: Operates on Lowerer state without owning AST or module.
 // Links: docs/class-catalog.md
 
+// Requires the consolidated Lowerer interface for statement lowering helpers.
 #include "frontends/basic/Lowerer.hpp"
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Function.hpp"

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -200,7 +200,215 @@ class Lowerer
                                 bool stopOnTerminated,
                                 const std::function<void(const Stmt &)> &beforeBranch = {});
 
-#include "frontends/basic/LowerEmit.hpp"
+    void collectProcedureSignatures(const Program &prog);
+
+    void collectVars(const Program &prog);
+
+    void collectVars(const std::vector<const Stmt *> &stmts);
+
+    void lowerFunctionDecl(const FunctionDecl &decl);
+
+    void lowerSubDecl(const SubDecl &decl);
+
+  public:
+    /// @brief Configuration shared by FUNCTION and SUB lowering.
+    struct ProcedureConfig
+    {
+        Type retType{Type(Type::Kind::Void)};          ///< IL return type for the procedure.
+        std::function<void()> postCollect;             ///< Hook after variable discovery.
+        std::function<void()> emitEmptyBody;           ///< Emit return path for empty bodies.
+        std::function<void()> emitFinalReturn;         ///< Emit return in the synthetic exit block.
+    };
+
+  private:
+    /// @brief Lower shared procedure scaffolding for FUNCTION/SUB declarations.
+    void lowerProcedure(const std::string &name,
+                        const std::vector<Param> &params,
+                        const std::vector<StmtPtr> &body,
+                        const ProcedureConfig &config);
+
+    /// @brief Stack-allocate parameters and seed local map.
+    void materializeParams(const std::vector<Param> &params);
+
+    /// @brief Reset procedure-level lowering state.
+    void resetLoweringState();
+
+    void lowerStmt(const Stmt &stmt);
+
+    RVal lowerExpr(const Expr &expr);
+
+    /// @brief Lower a variable reference expression.
+    /// @param expr Variable expression node.
+    /// @return Loaded value and its type.
+    RVal lowerVarExpr(const VarExpr &expr);
+
+    /// @brief Lower a unary expression (e.g. NOT).
+    /// @param expr Unary expression node.
+    /// @return Resulting value and type.
+    RVal lowerUnaryExpr(const UnaryExpr &expr);
+
+    /// @brief Lower a binary expression.
+    /// @param expr Binary expression node.
+    /// @return Resulting value and type.
+    RVal lowerBinaryExpr(const BinaryExpr &expr);
+
+    /// @brief Lower a boolean expression using explicit branch bodies.
+    /// @param cond Boolean condition selecting THEN branch.
+    /// @param loc Source location to attribute to control flow.
+    /// @param emitThen Lambda emitting THEN branch body, storing into result slot.
+    /// @param emitElse Lambda emitting ELSE branch body, storing into result slot.
+    /// @param thenLabelBase Optional label base for THEN block naming.
+    /// @param elseLabelBase Optional label base for ELSE block naming.
+    /// @param joinLabelBase Optional label base for join block naming.
+    /// @return Resulting value and type.
+    RVal lowerBoolBranchExpr(Value cond,
+                             il::support::SourceLoc loc,
+                             const std::function<void(Value)> &emitThen,
+                             const std::function<void(Value)> &emitElse,
+                             std::string_view thenLabelBase = {},
+                             std::string_view elseLabelBase = {},
+                             std::string_view joinLabelBase = {});
+
+    /// @brief Lower logical (`AND`/`OR`) expressions with short-circuiting.
+    /// @param expr Binary expression node.
+    /// @return Resulting value and type.
+    RVal lowerLogicalBinary(const BinaryExpr &expr);
+
+    /// @brief Lower integer division and modulo with divide-by-zero check.
+    /// @param expr Binary expression node.
+    /// @return Resulting value and type.
+    RVal lowerDivOrMod(const BinaryExpr &expr);
+
+    /// @brief Lower string concatenation and equality/inequality comparisons.
+    /// @param expr Binary expression node.
+    /// @param lhs Pre-lowered left-hand side.
+    /// @param rhs Pre-lowered right-hand side.
+    /// @return Resulting value and type.
+    RVal lowerStringBinary(const BinaryExpr &expr, RVal lhs, RVal rhs);
+
+    /// @brief Lower numeric arithmetic and comparisons.
+    /// @param expr Binary expression node.
+    /// @param lhs Pre-lowered left-hand side.
+    /// @param rhs Pre-lowered right-hand side.
+    /// @return Resulting value and type.
+    RVal lowerNumericBinary(const BinaryExpr &expr, RVal lhs, RVal rhs);
+
+    /// @brief Lower a built-in call expression.
+    /// @param expr Built-in call expression node.
+    /// @return Resulting value and type.
+    RVal lowerBuiltinCall(const BuiltinCallExpr &expr);
+
+    // Shared argument helpers
+    RVal coerceToI64(RVal v, il::support::SourceLoc loc);
+
+    RVal coerceToF64(RVal v, il::support::SourceLoc loc);
+
+    RVal coerceToBool(RVal v, il::support::SourceLoc loc);
+
+    RVal ensureI64(RVal v, il::support::SourceLoc loc);
+
+    RVal ensureF64(RVal v, il::support::SourceLoc loc);
+
+    void lowerLet(const LetStmt &stmt);
+
+    void lowerPrint(const PrintStmt &stmt);
+
+    void lowerStmtList(const StmtList &stmt);
+
+    void lowerReturn(const ReturnStmt &stmt);
+
+    /// @brief Emit blocks for an IF/ELSEIF chain.
+    /// @param conds Number of conditions (IF + ELSEIFs).
+    /// @return Indices for test/then blocks and ELSE/exit blocks.
+    IfBlocks emitIfBlocks(size_t conds);
+
+    /// @brief Evaluate @p cond and branch to @p thenBlk or @p falseBlk.
+    void lowerIfCondition(const Expr &cond,
+                          BasicBlock *testBlk,
+                          BasicBlock *thenBlk,
+                          BasicBlock *falseBlk,
+                          il::support::SourceLoc loc);
+
+    /// @brief Lower a THEN/ELSE branch and link to exit.
+    /// @return True if branch falls through to @p exitBlk.
+    bool lowerIfBranch(const Stmt *stmt,
+                       BasicBlock *thenBlk,
+                       BasicBlock *exitBlk,
+                       il::support::SourceLoc loc);
+
+    void lowerIf(const IfStmt &stmt);
+
+    void lowerWhile(const WhileStmt &stmt);
+
+    void lowerLoopBody(const std::vector<StmtPtr> &body);
+
+    void lowerFor(const ForStmt &stmt);
+
+    void lowerForConstStep(const ForStmt &stmt, Value slot, RVal end, RVal step, int64_t stepConst);
+
+    void lowerForVarStep(const ForStmt &stmt, Value slot, RVal end, RVal step);
+
+    ForBlocks setupForBlocks(bool varStep);
+
+    void emitForStep(Value slot, Value step);
+
+    void lowerNext(const NextStmt &stmt);
+
+    void lowerGoto(const GotoStmt &stmt);
+
+    void lowerEnd(const EndStmt &stmt);
+
+    void lowerInput(const InputStmt &stmt);
+
+    void lowerDim(const DimStmt &stmt);
+
+    void lowerRandomize(const RandomizeStmt &stmt);
+
+    // helpers
+    IlType ilBoolTy();
+
+    IlValue emitBoolConst(bool v);
+
+    IlValue emitBoolFromBranches(const std::function<void(Value)> &emitThen,
+                                 const std::function<void(Value)> &emitElse,
+                                 std::string_view thenLabelBase = "bool_then",
+                                 std::string_view elseLabelBase = "bool_else",
+                                 std::string_view joinLabelBase = "bool_join");
+
+    Value emitAlloca(int bytes);
+
+    Value emitLoad(Type ty, Value addr);
+
+    void emitStore(Type ty, Value addr, Value val);
+
+    Value emitBinary(Opcode op, Type ty, Value lhs, Value rhs);
+
+    /// @brief Emit unary instruction of @p op on @p val producing @p ty.
+    Value emitUnary(Opcode op, Type ty, Value val);
+
+    void emitBr(BasicBlock *target);
+
+    void emitCBr(Value cond, BasicBlock *t, BasicBlock *f);
+
+    Value emitCallRet(Type ty, const std::string &callee, const std::vector<Value> &args);
+
+    void emitCall(const std::string &callee, const std::vector<Value> &args);
+
+    Value emitConstStr(const std::string &globalName);
+
+    void emitTrap();
+
+    void emitRet(Value v);
+
+    void emitRetVoid();
+
+    std::string getStringLabel(const std::string &s);
+
+    unsigned nextTempId();
+
+    Value lowerArrayAddr(const ArrayExpr &expr);
+
+    void emitProgram(const Program &prog);
 
     std::unique_ptr<ProgramLowering> programLowering;
     std::unique_ptr<ProcedureLowering> procedureLowering;
@@ -233,7 +441,22 @@ class Lowerer
 
     std::bitset<kRuntimeFeatureCount> runtimeFeatures;
 
-#include "frontends/basic/LowerRuntime.hpp"
+    struct RuntimeFeatureHash
+    {
+        size_t operator()(RuntimeFeature f) const;
+    };
+
+    std::vector<RuntimeFeature> runtimeOrder;
+
+    std::unordered_set<RuntimeFeature, RuntimeFeatureHash> runtimeSet;
+
+    void requestHelper(RuntimeFeature feature);
+
+    bool isHelperNeeded(RuntimeFeature feature) const;
+
+    void trackRuntime(RuntimeFeature feature);
+
+    void declareRequiredRuntime(build::IRBuilder &b);
 #include "frontends/basic/LowerScan.hpp"
 
     SlotType getSlotType(std::string_view name) const;


### PR DESCRIPTION
## Summary
- inline the LowerEmit and LowerRuntime helper declarations directly into `Lowerer.hpp`
- document the consolidated header usage in the BASIC lowering implementation files

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d2ac567e0c8324848922a34c9d9370