### PR TITLE
refactor(frontends/basic): encapsulate runtime feature tracking

### DIFF
--- a/src/frontends/basic/BuiltinRegistry.hpp
+++ b/src/frontends/basic/BuiltinRegistry.hpp
@@ -51,8 +51,8 @@ struct BuiltinScanRule
         /// @brief Which Lowerer helper should be invoked for the feature.
         enum class Action
         {
-            Request, ///< Call Lowerer::requestHelper.
-            Track,   ///< Call Lowerer::trackRuntime.
+            Request, ///< Call Lowerer::RuntimeFeatureTracker::requestHelper.
+            Track,   ///< Call Lowerer::RuntimeFeatureTracker::trackRuntime.
         } action{Action::Request};
 
         /// @brief Conditional guard controlling whether the feature fires.
@@ -99,8 +99,8 @@ struct BuiltinLoweringRule
         /// @brief Which runtime tracking API to invoke.
         enum class Action
         {
-            Request, ///< Call @ref Lowerer::requestHelper.
-            Track,   ///< Call @ref Lowerer::trackRuntime.
+            Request, ///< Call @ref Lowerer::RuntimeFeatureTracker::requestHelper.
+            Track,   ///< Call @ref Lowerer::RuntimeFeatureTracker::trackRuntime.
         } action{Action::Request};
 
         il::runtime::RuntimeFeature feature{il::runtime::RuntimeFeature::Count}; ///< Runtime feature identifier.

--- a/src/frontends/basic/LowerExpr.cpp
+++ b/src/frontends/basic/LowerExpr.cpp
@@ -762,10 +762,10 @@ Lowerer::RVal Lowerer::lowerBuiltinCall(const BuiltinCallExpr &c)
         switch (feature.action)
         {
             case BuiltinLoweringRule::Feature::Action::Request:
-                requestHelper(feature.feature);
+                runtimeTracker.requestHelper(feature.feature);
                 break;
             case BuiltinLoweringRule::Feature::Action::Track:
-                trackRuntime(feature.feature);
+                runtimeTracker.trackRuntime(feature.feature);
                 break;
         }
     }

--- a/src/frontends/basic/LowerRuntime.hpp
+++ b/src/frontends/basic/LowerRuntime.hpp
@@ -5,15 +5,26 @@
 // Links: docs/class-catalog.md
 #pragma once
 
-struct RuntimeFeatureHash
+class RuntimeFeatureTracker
 {
-    size_t operator()(RuntimeFeature f) const;
+  public:
+    void reset();
+
+    void requestHelper(RuntimeFeature feature);
+    bool isHelperNeeded(RuntimeFeature feature) const;
+    void trackRuntime(RuntimeFeature feature);
+    void declareRequiredRuntime(build::IRBuilder &b, bool boundsChecks) const;
+
+  private:
+    struct RuntimeFeatureHash
+    {
+        std::size_t operator()(RuntimeFeature f) const;
+    };
+
+    static constexpr std::size_t kRuntimeFeatureCount =
+        static_cast<std::size_t>(RuntimeFeature::Count);
+
+    std::bitset<kRuntimeFeatureCount> features_{};
+    std::vector<RuntimeFeature> ordered_{};
+    std::unordered_set<RuntimeFeature, RuntimeFeatureHash> seen_{};
 };
-
-std::vector<RuntimeFeature> runtimeOrder;
-std::unordered_set<RuntimeFeature, RuntimeFeatureHash> runtimeSet;
-
-void requestHelper(RuntimeFeature feature);
-bool isHelperNeeded(RuntimeFeature feature) const;
-void trackRuntime(RuntimeFeature feature);
-void declareRequiredRuntime(build::IRBuilder &b);

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -228,13 +228,12 @@ class Lowerer
     // runtime requirement tracking
     using RuntimeFeature = il::runtime::RuntimeFeature;
 
-    static constexpr size_t kRuntimeFeatureCount =
-        static_cast<size_t>(RuntimeFeature::Count);
-
-    std::bitset<kRuntimeFeatureCount> runtimeFeatures;
-
 #include "frontends/basic/LowerRuntime.hpp"
 #include "frontends/basic/LowerScan.hpp"
+
+    RuntimeFeatureTracker runtimeTracker;
+
+    void declareRequiredRuntime(build::IRBuilder &b);
 
     SlotType getSlotType(std::string_view name) const;
 

--- a/src/frontends/basic/LoweringPipeline.cpp
+++ b/src/frontends/basic/LoweringPipeline.cpp
@@ -268,9 +268,7 @@ void ProgramLowering::run(const Program &prog, il::core::Module &module)
     lowerer.procSignatures.clear();
     lowerer.boundsCheckId = 0;
 
-    lowerer.runtimeFeatures.reset();
-    lowerer.runtimeOrder.clear();
-    lowerer.runtimeSet.clear();
+    lowerer.runtimeTracker.reset();
 
     lowerer.scanProgram(prog);
     lowerer.declareRequiredRuntime(builder);


### PR DESCRIPTION
## Summary
- introduce a `RuntimeFeatureTracker` that owns the runtime helper bitset, ordered list, and declaration logic
- switch lowering and scanning flows to use the tracker, resetting it through the pipeline
- refresh builtin runtime metadata comments to reference the tracker interface

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure -R lowerer


------
https://chatgpt.com/codex/tasks/task_e_68d2aca7e34c8324978a6336e94518f2