### PR TITLE
Refactor Lowerer per-procedure state

### DIFF
--- a/src/frontends/basic/LowerExpr.cpp
+++ b/src/frontends/basic/LowerExpr.cpp
@@ -134,8 +134,8 @@ class LowererExprVisitor final : public ExprVisitor
 Lowerer::RVal Lowerer::lowerVarExpr(const VarExpr &v)
 {
     curLoc = v.loc;
-    auto it = varSlots.find(v.name);
-    assert(it != varSlots.end());
+    auto it = procState.varSlots.find(v.name);
+    assert(it != procState.varSlots.end());
     Value ptr = Value::temp(it->second);
     SlotType info = getSlotType(v.name);
     Type ty = info.type;

--- a/src/frontends/basic/LowerRuntime.cpp
+++ b/src/frontends/basic/LowerRuntime.cpp
@@ -54,12 +54,12 @@ void declareRuntimeExtern(build::IRBuilder &b, const il::runtime::RuntimeDescrip
 ///       declareRuntimeExtern.
 void Lowerer::requestHelper(RuntimeFeature feature)
 {
-    runtimeFeatures.set(static_cast<size_t>(feature));
+    procState.runtimeFeatures.set(static_cast<size_t>(feature));
 }
 
 bool Lowerer::isHelperNeeded(RuntimeFeature feature) const
 {
-    return runtimeFeatures.test(static_cast<size_t>(feature));
+    return procState.runtimeFeatures.test(static_cast<size_t>(feature));
 }
 
 void Lowerer::declareRequiredRuntime(build::IRBuilder &b)
@@ -85,7 +85,7 @@ void Lowerer::declareRequiredRuntime(build::IRBuilder &b)
         }
     }
 
-    for (RuntimeFeature feature : runtimeOrder)
+    for (RuntimeFeature feature : procState.runtimeOrder)
     {
         const auto *desc = il::runtime::findRuntimeDescriptor(feature);
         assert(desc && "requested runtime feature missing from registry");
@@ -103,9 +103,9 @@ void Lowerer::declareRequiredRuntime(build::IRBuilder &b)
 ///       was not previously tracked.
 void Lowerer::trackRuntime(RuntimeFeature feature)
 {
-    runtimeFeatures.set(static_cast<size_t>(feature));
-    if (runtimeSet.insert(feature).second)
-        runtimeOrder.push_back(feature);
+    procState.runtimeFeatures.set(static_cast<size_t>(feature));
+    if (procState.runtimeSet.insert(feature).second)
+        procState.runtimeOrder.push_back(feature);
 }
 
 } // namespace il::frontends::basic

--- a/src/frontends/basic/LowerRuntime.hpp
+++ b/src/frontends/basic/LowerRuntime.hpp
@@ -5,14 +5,6 @@
 // Links: docs/class-catalog.md
 #pragma once
 
-struct RuntimeFeatureHash
-{
-    size_t operator()(RuntimeFeature f) const;
-};
-
-std::vector<RuntimeFeature> runtimeOrder;
-std::unordered_set<RuntimeFeature, RuntimeFeatureHash> runtimeSet;
-
 void requestHelper(RuntimeFeature feature);
 bool isHelperNeeded(RuntimeFeature feature) const;
 void trackRuntime(RuntimeFeature feature);


### PR DESCRIPTION
## Summary
- introduce a ProcedureState struct so Lowerer can manage transient per-procedure maps and counters in one place
- update lowering, scanning, and runtime helpers to read and write through the new state container for procedures and the main program
- route runtime feature tracking through ProcedureState while keeping module-level declarations unchanged

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68d2ac8bfb1c83249ae4f463fedc53cc