### PR TITLE
refactor(tui): move all TUI code to namespace viper::tui (no alias; no external dependents)

### DIFF
--- a/tui/apps/tui_demo.cpp
+++ b/tui/apps/tui_demo.cpp
@@ -32,8 +32,8 @@ int main()
         headless = (v[0] == '1');
     }
 
-    tui::TerminalSession session;
-    tui::term::RealTermIO tio;
+    viper::tui::TerminalSession session;
+    viper::tui::term::RealTermIO tio;
 
     viper::tui::style::Theme theme;
     viper::tui::text::TextBuffer buf;

--- a/tui/include/tui/app.hpp
+++ b/tui/include/tui/app.hpp
@@ -21,7 +21,7 @@ class App
   public:
     /// @brief Construct app with root widget and terminal I/O.
     App(std::unique_ptr<ui::Widget> root,
-        ::tui::term::TermIO &tio,
+        ::viper::tui::term::TermIO &tio,
         int rows,
         int cols,
         bool truecolor = false);

--- a/tui/include/tui/render/renderer.hpp
+++ b/tui/include/tui/render/renderer.hpp
@@ -17,7 +17,7 @@ class Renderer
     /// @brief Construct renderer targeting a TermIO.
     /// @param tio Terminal I/O sink used for writes and flushes.
     /// @param truecolor Emit 24-bit color codes when true; otherwise 256-color.
-    explicit Renderer(::tui::term::TermIO &tio, bool truecolor = false);
+    explicit Renderer(::viper::tui::term::TermIO &tio, bool truecolor = false);
 
     /// @brief Draw changed spans from screen buffer to terminal.
     /// @param sb Screen buffer with current and previous state for diffing.
@@ -33,7 +33,7 @@ class Renderer
     void moveCursor(int y, int x);
 
   private:
-    ::tui::term::TermIO &tio_;
+    ::viper::tui::term::TermIO &tio_;
     Style currentStyle_{};
     int cursorY_{-1};
     int cursorX_{-1};

--- a/tui/include/tui/term/clipboard.hpp
+++ b/tui/include/tui/term/clipboard.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <string_view>
 
-namespace tui::term
+namespace viper::tui::term
 {
 class TermIO;
 
@@ -44,4 +44,4 @@ class MockClipboard : public Clipboard
     std::string last_{};
 };
 
-} // namespace tui::term
+} // namespace viper::tui::term

--- a/tui/include/tui/term/session.hpp
+++ b/tui/include/tui/term/session.hpp
@@ -13,7 +13,7 @@
 #include <windows.h>
 #endif
 
-namespace tui
+namespace viper::tui
 {
 
 class TerminalSession
@@ -37,4 +37,4 @@ class TerminalSession
 #endif
 };
 
-} // namespace tui
+} // namespace viper::tui

--- a/tui/include/tui/term/term_io.hpp
+++ b/tui/include/tui/term/term_io.hpp
@@ -2,7 +2,7 @@
 #include <string>
 #include <string_view>
 
-namespace tui::term
+namespace viper::tui::term
 {
 
 class TermIO
@@ -35,4 +35,4 @@ class StringTermIO : public TermIO
     std::string buf_;
 };
 
-} // namespace tui::term
+} // namespace viper::tui::term

--- a/tui/src/app.cpp
+++ b/tui/src/app.cpp
@@ -8,7 +8,7 @@
 namespace viper::tui
 {
 App::App(
-    std::unique_ptr<ui::Widget> root, ::tui::term::TermIO &tio, int rows, int cols, bool truecolor)
+    std::unique_ptr<ui::Widget> root, ::viper::tui::term::TermIO &tio, int rows, int cols, bool truecolor)
     : root_(std::move(root)), renderer_(tio, truecolor), rows_(rows), cols_(cols)
 {
     screen_.resize(rows, cols);

--- a/tui/src/render/renderer.cpp
+++ b/tui/src/render/renderer.cpp
@@ -12,7 +12,7 @@
 namespace viper::tui::render
 {
 
-Renderer::Renderer(::tui::term::TermIO &tio, bool truecolor) : tio_(tio), truecolor_(truecolor) {}
+Renderer::Renderer(::viper::tui::term::TermIO &tio, bool truecolor) : tio_(tio), truecolor_(truecolor) {}
 
 namespace
 {

--- a/tui/src/term/clipboard.cpp
+++ b/tui/src/term/clipboard.cpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <string_view>
 
-namespace tui::term
+namespace viper::tui::term
 {
 namespace
 {
@@ -176,4 +176,4 @@ void MockClipboard::clear()
     last_.clear();
 }
 
-} // namespace tui::term
+} // namespace viper::tui::term

--- a/tui/src/term/session.cpp
+++ b/tui/src/term/session.cpp
@@ -1,7 +1,7 @@
 #include "tui/term/session.hpp"
 #include "tui/term/term_io.hpp"
 
-namespace tui
+namespace viper::tui
 {
 
 static inline bool env_no_tty()
@@ -69,7 +69,7 @@ TerminalSession::TerminalSession()
 
     if (!env_no_tty() && env_true("VIPERTUI_MOUSE"))
     {
-        ::tui::term::RealTermIO io;
+        ::viper::tui::term::RealTermIO io;
         io.write("\x1b[?1000h\x1b[?1002h\x1b[?1006h"); // enable mouse + SGR
         io.flush();
     }
@@ -84,7 +84,7 @@ TerminalSession::~TerminalSession()
 
     if (!env_no_tty() && env_true("VIPERTUI_MOUSE"))
     {
-        ::tui::term::RealTermIO io;
+        ::viper::tui::term::RealTermIO io;
         io.write("\x1b[?1006l\x1b[?1002l\x1b[?1000l"); // disable SGR + motion + mouse
         io.flush();
     }
@@ -112,4 +112,4 @@ bool TerminalSession::active() const
     return active_;
 }
 
-} // namespace tui
+} // namespace viper::tui

--- a/tui/src/term/term_io.cpp
+++ b/tui/src/term/term_io.cpp
@@ -1,7 +1,7 @@
 #include "tui/term/term_io.hpp"
 #include <cstdio>
 
-namespace tui::term
+namespace viper::tui::term
 {
 
 void RealTermIO::write(std::string_view s)
@@ -40,4 +40,4 @@ void StringTermIO::clear()
     buf_.clear();
 }
 
-} // namespace tui::term
+} // namespace viper::tui::term

--- a/tui/tests/test_app_layout.cpp
+++ b/tui/tests/test_app_layout.cpp
@@ -12,7 +12,7 @@
 #include <memory>
 #include <string>
 
-using tui::term::StringTermIO;
+using viper::tui::term::StringTermIO;
 using viper::tui::App;
 using viper::tui::render::ScreenBuffer;
 using viper::tui::ui::VStack;

--- a/tui/tests/test_app_resize.cpp
+++ b/tui/tests/test_app_resize.cpp
@@ -11,7 +11,7 @@
 #include <cassert>
 #include <memory>
 
-using tui::term::StringTermIO;
+using viper::tui::term::StringTermIO;
 using viper::tui::App;
 using viper::tui::render::ScreenBuffer;
 using viper::tui::ui::Widget;

--- a/tui/tests/test_clipboard.cpp
+++ b/tui/tests/test_clipboard.cpp
@@ -30,8 +30,8 @@ static void set_disable()
 int main()
 {
     clear_disable();
-    tui::term::StringTermIO tio;
-    tui::term::Osc52Clipboard cb(tio);
+    viper::tui::term::StringTermIO tio;
+    viper::tui::term::Osc52Clipboard cb(tio);
     bool ok = cb.copy("hello");
     assert(ok);
     assert(tio.buffer() == "\x1b]52;c;aGVsbG8=\x07");
@@ -42,7 +42,7 @@ int main()
     assert(tio.buffer() == "\x1b]52;c;aGVsbG8=\x07");
 
     clear_disable();
-    tui::term::MockClipboard mock;
+    viper::tui::term::MockClipboard mock;
     ok = mock.copy("test");
     assert(ok);
     assert(mock.last() == "\x1b]52;c;dGVzdA==\x07");

--- a/tui/tests/test_focus.cpp
+++ b/tui/tests/test_focus.cpp
@@ -11,7 +11,7 @@
 #include <cassert>
 #include <memory>
 
-using tui::term::StringTermIO;
+using viper::tui::term::StringTermIO;
 using viper::tui::App;
 using viper::tui::term::KeyEvent;
 using viper::tui::ui::Event;

--- a/tui/tests/test_keymap_palette.cpp
+++ b/tui/tests/test_keymap_palette.cpp
@@ -13,7 +13,7 @@
 
 #include <cassert>
 
-using tui::term::StringTermIO;
+using viper::tui::term::StringTermIO;
 using viper::tui::input::KeyChord;
 using viper::tui::input::Keymap;
 using viper::tui::render::Renderer;

--- a/tui/tests/test_list_tree.cpp
+++ b/tui/tests/test_list_tree.cpp
@@ -16,7 +16,7 @@
 #include <string>
 #include <vector>
 
-using tui::term::StringTermIO;
+using viper::tui::term::StringTermIO;
 using viper::tui::render::Renderer;
 using viper::tui::render::ScreenBuffer;
 using viper::tui::style::Role;

--- a/tui/tests/test_modal.cpp
+++ b/tui/tests/test_modal.cpp
@@ -10,7 +10,7 @@
 #include <cassert>
 #include <memory>
 
-using tui::term::StringTermIO;
+using viper::tui::term::StringTermIO;
 using viper::tui::App;
 using viper::tui::term::KeyEvent;
 using viper::tui::ui::Event;

--- a/tui/tests/test_renderer_minimal.cpp
+++ b/tui/tests/test_renderer_minimal.cpp
@@ -11,7 +11,7 @@
 #include <cassert>
 #include <string>
 
-using tui::term::StringTermIO;
+using viper::tui::term::StringTermIO;
 using viper::tui::render::Renderer;
 using viper::tui::render::ScreenBuffer;
 using viper::tui::render::Style;

--- a/tui/tests/test_session.cpp
+++ b/tui/tests/test_session.cpp
@@ -13,8 +13,8 @@ static void set_no_tty_env()
 
 int main()
 {
-    set_no_tty_env();       // ensure CI-safe no-op
-    tui::TerminalSession s; // should not throw or exit raw mode paths
-    assert(!s.active());    // in CI/headless we expect inactive
+    set_no_tty_env();                // ensure CI-safe no-op
+    viper::tui::TerminalSession s;   // should not throw or exit raw mode paths
+    assert(!s.active());             // in CI/headless we expect inactive
     return 0;
 }

--- a/tui/tests/test_term_io.cpp
+++ b/tui/tests/test_term_io.cpp
@@ -9,7 +9,7 @@
 
 int main()
 {
-    tui::term::StringTermIO tio;
+    viper::tui::term::StringTermIO tio;
     tio.write("hello");
     tio.flush();
     assert(tio.buffer() == "hello");

--- a/tui/tests/test_widgets_basic.cpp
+++ b/tui/tests/test_widgets_basic.cpp
@@ -13,7 +13,7 @@
 #include <cassert>
 #include <string>
 
-using tui::term::StringTermIO;
+using viper::tui::term::StringTermIO;
 using viper::tui::render::Renderer;
 using viper::tui::render::ScreenBuffer;
 using viper::tui::style::Role;

--- a/tui/tests/test_win_vt.cpp
+++ b/tui/tests/test_win_vt.cpp
@@ -8,7 +8,7 @@
 int main()
 {
 #ifdef _WIN32
-    tui::TerminalSession session;
+    viper::tui::TerminalSession session;
 #endif
     return 0;
 }


### PR DESCRIPTION
## Summary
- move terminal session, term I/O, and clipboard headers/sources into the viper::tui namespace hierarchy
- update App/Renderer signatures and constructors to accept ::viper::tui::term::TermIO and adjust the demo
- migrate TUI tests to reference viper::tui symbols now that the standalone tui namespace is gone

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d2b26a5b8883248abc1dacc3d219a7