### PR TITLE
Refactor BASIC runtime helper tracking into RuntimeHelperTracker

### DIFF
--- a/src/frontends/basic/LowerRuntime.hpp
+++ b/src/frontends/basic/LowerRuntime.hpp
@@ -5,15 +5,54 @@
 // Links: docs/class-catalog.md
 #pragma once
 
-struct RuntimeFeatureHash
+#include "il/runtime/RuntimeSignatures.hpp"
+#include <bitset>
+#include <unordered_set>
+#include <vector>
+
+namespace il::build
 {
-    size_t operator()(RuntimeFeature f) const;
+class IRBuilder;
+} // namespace il::build
+
+namespace il::frontends::basic
+{
+
+/// @brief Tracks runtime helper usage across scanning and lowering.
+/// @invariant Helpers are declared at most once and maintain first-use order.
+/// @ownership Owned by Lowerer; stores transient state per lowering run.
+class RuntimeHelperTracker
+{
+  public:
+    using RuntimeFeature = il::runtime::RuntimeFeature;
+
+    /// @brief Reset helper tracking to an empty state.
+    void reset();
+
+    /// @brief Mark a runtime helper as required.
+    void requestHelper(RuntimeFeature feature);
+
+    /// @brief Query whether a runtime helper has been requested.
+    [[nodiscard]] bool isHelperNeeded(RuntimeFeature feature) const;
+
+    /// @brief Record an ordered runtime helper requirement.
+    void trackRuntime(RuntimeFeature feature);
+
+    /// @brief Declare all helpers requested during the current lowering run.
+    void declareRequiredRuntime(build::IRBuilder &b, bool boundsChecks) const;
+
+  private:
+    struct RuntimeFeatureHash
+    {
+        std::size_t operator()(RuntimeFeature f) const;
+    };
+
+    static constexpr std::size_t kRuntimeFeatureCount =
+        static_cast<std::size_t>(RuntimeFeature::Count);
+
+    std::bitset<kRuntimeFeatureCount> requested_;
+    std::vector<RuntimeFeature> ordered_;
+    std::unordered_set<RuntimeFeature, RuntimeFeatureHash> tracked_;
 };
 
-std::vector<RuntimeFeature> runtimeOrder;
-std::unordered_set<RuntimeFeature, RuntimeFeatureHash> runtimeSet;
-
-void requestHelper(RuntimeFeature feature);
-bool isHelperNeeded(RuntimeFeature feature) const;
-void trackRuntime(RuntimeFeature feature);
-void declareRequiredRuntime(build::IRBuilder &b);
+} // namespace il::frontends::basic

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -7,11 +7,11 @@
 #pragma once
 
 #include "frontends/basic/AST.hpp"
+#include "frontends/basic/LowerRuntime.hpp"
 #include "frontends/basic/NameMangler.hpp"
 #include "il/build/IRBuilder.hpp"
 #include "il/core/Module.hpp"
 #include "il/runtime/RuntimeSignatures.hpp"
-#include <bitset>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -446,19 +446,7 @@ class Lowerer
     // runtime requirement tracking
     using RuntimeFeature = il::runtime::RuntimeFeature;
 
-    static constexpr size_t kRuntimeFeatureCount =
-        static_cast<size_t>(RuntimeFeature::Count);
-
-    std::bitset<kRuntimeFeatureCount> runtimeFeatures;
-
-    struct RuntimeFeatureHash
-    {
-        size_t operator()(RuntimeFeature f) const;
-    };
-
-    std::vector<RuntimeFeature> runtimeOrder;
-
-    std::unordered_set<RuntimeFeature, RuntimeFeatureHash> runtimeSet;
+    RuntimeHelperTracker runtimeTracker;
 
     void requestHelper(RuntimeFeature feature);
 

--- a/src/frontends/basic/LoweringPipeline.cpp
+++ b/src/frontends/basic/LoweringPipeline.cpp
@@ -231,9 +231,7 @@ void ProgramLowering::run(const Program &prog, il::core::Module &module)
     lowerer.procSignatures.clear();
     lowerer.boundsCheckId = 0;
 
-    lowerer.runtimeFeatures.reset();
-    lowerer.runtimeOrder.clear();
-    lowerer.runtimeSet.clear();
+    lowerer.runtimeTracker.reset();
 
     lowerer.scanProgram(prog);
     lowerer.declareRequiredRuntime(builder);


### PR DESCRIPTION
## Summary
- introduce a RuntimeHelperTracker that encapsulates runtime helper bookkeeping for BASIC lowering
- adapt Lowerer to forward runtime helper requests to the tracker and reset it through the lowering pipeline
- update runtime declaration logic to use the tracker while preserving ordered helper emission

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d2cd60d02c8324a2eca9eab992e994