### PR TITLE
Add CMake install rules and package config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.16)
-project(ilc LANGUAGES C CXX VERSION 0.1.0)
+project(Viper LANGUAGES C CXX VERSION 0.1.0)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+option(VIPER_INSTALL_TUI "Install TUI apps/libraries" OFF)
+option(VIPER_BUILD_TESTING "Enable CTest-based tests" ON)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -99,22 +105,93 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   message(STATUS "Stdlib (Clang): libc++=${IL_USE_LIBCXX}")
 endif()
 
-enable_testing()
+if(VIPER_BUILD_TESTING)
+  enable_testing()
+endif()
 
 add_subdirectory(runtime)
 add_subdirectory(src)
 
 # ---- ViperTUI subproject ----
 option(BUILD_TUI "Build ViperTUI subproject" ON)
+if(VIPER_INSTALL_TUI AND NOT BUILD_TUI)
+  message(WARNING "VIPER_INSTALL_TUI is ON but BUILD_TUI is OFF; no TUI targets will be installed.")
+endif()
 if(BUILD_TUI)
   add_subdirectory(tui)
 endif()
-add_subdirectory(tests)
+
+if(VIPER_BUILD_TESTING)
+  add_subdirectory(tests)
+endif()
 
 add_custom_target(distclean
   COMMAND "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/cmake/DistClean.cmake"
   COMMENT "Scrub CMake-generated files in this build tree"
 )
+
+set(VIPER_PUBLIC_LIB_TARGETS
+  support
+  rt
+  il_core
+  il_runtime
+  il_build
+  il_io
+  il_verify
+  il_analysis
+  il_transform
+  il_utils
+  il_vm
+  fe_basic
+  il_api
+)
+
+install(TARGETS ${VIPER_PUBLIC_LIB_TARGETS}
+  EXPORT ViperTargets
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper
+)
+
+set(VIPER_CLI_TARGETS ilc il-verify il-dis)
+install(TARGETS ${VIPER_CLI_TARGETS}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+export(EXPORT ViperTargets
+  NAMESPACE viper::
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/ViperTargets.cmake"
+)
+
+install(EXPORT ViperTargets
+  NAMESPACE viper::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Viper
+)
+
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/ViperConfigVersion.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file(
+  "${CMAKE_CURRENT_LIST_DIR}/cmake/ViperConfig.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/ViperConfig.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Viper
+)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/ViperConfig.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/ViperConfigVersion.cmake"
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Viper
+)
+
+set(CPACK_PACKAGE_NAME "Viper")
+set(CPACK_PACKAGE_VENDOR "Viper Project")
+set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
+set(CPACK_GENERATOR "TGZ;ZIP")
+include(CPack)
 
 # Silence benign duplicate-library warnings on macOS
 option(VIPER_SUPPRESS_DUPLIB_WARN "Suppress ld64 duplicate library warnings" ON)

--- a/cmake/ViperConfig.cmake.in
+++ b/cmake/ViperConfig.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+include("${CMAKE_CURRENT_LIST_DIR}/ViperTargets.cmake")
+
+check_required_components(Viper)

--- a/docs/tools/ilc.md
+++ b/docs/tools/ilc.md
@@ -164,6 +164,15 @@ Without `--passes`, the default pipeline is `mem2reg,constfold,peephole,dce`.
 ilc il-opt foo.il -o foo.opt.il --mem2reg-stats
 ```
 
+## CMake integration
+
+Projects embedding Viper tooling can consume the exported CMake package:
+
+```cmake
+find_package(Viper CONFIG REQUIRED)
+target_link_libraries(mytool PRIVATE viper::il_core viper::il_io viper::il_vm)
+```
+
 ## Exit codes
 
 | Code | Meaning |

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,3 +1,16 @@
 add_library(rt STATIC rt_memory.c rt_string.c rt_io.c rt_math.c rt_random.c)
-target_include_directories(rt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(rt PUBLIC m)
+target_include_directories(rt PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
+)
+
+if(NOT WIN32)
+  target_link_libraries(rt PUBLIC m)
+endif()
+
+install(FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/rt.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/rt_math.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/rt_random.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,15 +11,24 @@ add_library(il_core STATIC
   il/core/Extern.cpp
   il/core/Module.cpp
 )
-target_include_directories(il_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(il_core PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
+)
 
 add_library(il_runtime STATIC il/runtime/RuntimeSignatures.cpp)
 target_link_libraries(il_runtime PUBLIC il_core rt)
-target_include_directories(il_runtime PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(il_runtime PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
+)
 
 add_library(il_build STATIC il/build/IRBuilder.cpp)
 target_link_libraries(il_build PUBLIC il_core support)
-target_include_directories(il_build PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(il_build PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
+)
 
 add_subdirectory(il/io)
 
@@ -32,18 +41,27 @@ add_library(il_verify STATIC
   il/verify/ControlFlowChecker.cpp
   il/verify/TypeInference.cpp)
 target_link_libraries(il_verify PUBLIC il_core il_runtime)
-target_include_directories(il_verify PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(il_verify PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
+)
 
 add_library(il_api STATIC il/api/expected_api.cpp)
 target_link_libraries(il_api
   PUBLIC support il_io il_verify)
-target_include_directories(il_api PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(il_api PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
+)
 
 add_library(il_analysis STATIC
   il/analysis/CFG.cpp
   il/analysis/Dominators.cpp)
 target_link_libraries(il_analysis PUBLIC il_core)
-target_include_directories(il_analysis PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(il_analysis PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
+)
 
 add_library(il_transform STATIC
   il/transform/PassManager.cpp
@@ -52,11 +70,17 @@ add_library(il_transform STATIC
   il/transform/DCE.cpp
   il/transform/Mem2Reg.cpp)
 target_link_libraries(il_transform PUBLIC il_core il_verify il_analysis)
-target_include_directories(il_transform PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(il_transform PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
+)
 
 add_library(il_utils STATIC il/utils/Utils.cpp)
 target_link_libraries(il_utils PUBLIC il_core)
-target_include_directories(il_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(il_utils PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
+)
 
 add_library(il_vm STATIC
   vm/VM.cpp
@@ -72,7 +96,10 @@ add_library(il_vm STATIC
   vm/int_ops.cpp
   vm/fp_ops.cpp
   vm/control_flow.cpp)
-target_include_directories(il_vm PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(il_vm PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
+)
 target_link_libraries(il_vm PUBLIC il_core il_runtime rt support)
 
 add_library(il_codegen_x86_64 STATIC codegen/x86_64/placeholder.cpp)
@@ -104,3 +131,63 @@ target_link_libraries(basic-ast-dump PRIVATE fe_basic support)
 add_executable(basic-lex-dump tools/basic-lex-dump/main.cpp)
 set_target_properties(basic-lex-dump PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/basic-lex-dump)
 target_link_libraries(basic-lex-dump PRIVATE fe_basic support)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/support/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper/support
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/il/core/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper/il/core
+  FILES_MATCHING PATTERN "*.hpp" PATTERN "*.def"
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/il/build/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper/il/build
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/il/io/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper/il/io
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/il/verify/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper/il/verify
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/il/analysis/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper/il/analysis
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/il/transform/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper/il/transform
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/il/runtime/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper/il/runtime
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/il/api/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper/il/api
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/il/utils/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper/il/utils
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/vm/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper/vm
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/frontends/basic/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper/frontends/basic
+  FILES_MATCHING PATTERN "*.hpp"
+)

--- a/src/frontends/basic/CMakeLists.txt
+++ b/src/frontends/basic/CMakeLists.txt
@@ -32,4 +32,7 @@ add_library(fe_basic STATIC
 )
 
 target_link_libraries(fe_basic PUBLIC support il_build il_core il_runtime)
-target_include_directories(fe_basic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+target_include_directories(fe_basic PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
+)

--- a/src/il/io/CMakeLists.txt
+++ b/src/il/io/CMakeLists.txt
@@ -11,4 +11,7 @@ add_library(il_io STATIC
 
 target_link_libraries(il_io PUBLIC il_core)
 
-target_include_directories(il_io PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+target_include_directories(il_io PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
+)

--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -9,4 +9,7 @@ add_library(support STATIC
   diag_capture.cpp
 )
 
-target_include_directories(support PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_include_directories(support PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
+)

--- a/tui/CMakeLists.txt
+++ b/tui/CMakeLists.txt
@@ -42,9 +42,29 @@ add_library(tui STATIC
   src/config/config.cpp
 )
 
-target_include_directories(tui PUBLIC include)
+target_include_directories(tui PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
+)
+
+if(VIPER_INSTALL_TUI)
+  install(TARGETS tui
+    EXPORT ViperTargets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper
+  )
+
+  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/tui/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper/tui
+    FILES_MATCHING PATTERN "*.hpp"
+  )
+endif()
 
 add_subdirectory(apps)
 
-enable_testing()
-add_subdirectory(tests)
+if(VIPER_BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/tui/apps/CMakeLists.txt
+++ b/tui/apps/CMakeLists.txt
@@ -1,3 +1,9 @@
 add_executable(tui_demo tui_demo.cpp)
 
 target_link_libraries(tui_demo PRIVATE tui)
+
+if(VIPER_INSTALL_TUI)
+  install(TARGETS tui_demo
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  )
+endif()


### PR DESCRIPTION
## Summary
- add GNUInstallDirs, install/export configuration, and CPack setup to the top-level build
- install public headers and targets across runtime, IL, frontend, and optional TUI components and generate ViperConfig/ViperTargets exports
- guard the runtime libm dependency on non-Windows platforms and document find_package usage for downstream consumers

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d2d290855c8324ae161cc520dbc6fc