### PR TITLE
build: align CMake configuration with C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 3.16)
-project(Viper LANGUAGES C CXX VERSION 0.1.0)
+cmake_minimum_required(VERSION 3.20)
+project(Viper LANGUAGES CXX VERSION 0.1.0)
+enable_language(C)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
@@ -10,7 +11,7 @@ option(VIPER_BUILD_TESTING "Enable CTest-based tests" ON)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 


### PR DESCRIPTION
## Summary
- raise the top-level cmake minimum version to 3.20, scope the project to C++ and re-enable the C runtime language
- enforce C++20 as the global standard via the root configuration

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure -N

------
https://chatgpt.com/codex/tasks/task_e_68d2da469a78832486ba840f968cad11