### PR TITLE
docs: add consolidated doc skeletons + index outline

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,11 @@
+---
+status: active
+audience: public
+last-verified: 2025-09-23
+---
+
+## Overview
+
+## TUI architecture
+
+## C++ project overview

--- a/docs/basic-language.md
+++ b/docs/basic-language.md
@@ -1,0 +1,9 @@
+---
+status: active
+audience: public
+last-verified: 2025-09-23
+---
+
+## Reference
+
+## Examples

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -1,0 +1,17 @@
+---
+status: active
+audience: public
+last-verified: 2025-09-23
+---
+
+## Contributing
+
+## Style
+
+## Testing
+
+## Frontend Internals
+
+## Debugging
+
+## Migrations

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,11 @@
+---
+status: active
+audience: public
+last-verified: 2025-09-23
+---
+
+## Build
+
+## Run
+
+## First Programs

--- a/docs/il-guide.md
+++ b/docs/il-guide.md
@@ -1,0 +1,15 @@
+---
+status: active
+audience: public
+last-verified: 2025-09-23
+---
+
+## Quickstart
+
+## Reference
+
+## Lowering rules
+
+## Passes
+
+## Examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+---
+status: active
+audience: public
+last-verified: 2025-09-23
+---
+
+## Document Index
+
+- [Architecture](architecture.md)
+- [Getting Started](getting-started.md)
+- [Basic Language](basic-language.md)
+- [IL Guide](il-guide.md)
+- [Runtime and VM](runtime-vm.md)
+- [Tools](tools.md)
+- [Tutorials and Examples](tutorials-examples.md)
+- [Contributor Guide](contributor-guide.md)
+- [Code Map](codemap.md)

--- a/docs/runtime-vm.md
+++ b/docs/runtime-vm.md
@@ -1,0 +1,11 @@
+---
+status: active
+audience: public
+last-verified: 2025-09-23
+---
+
+## Runtime ABI
+
+## VM Internals
+
+## VM Externs

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,9 @@
+---
+status: active
+audience: public
+last-verified: 2025-09-23
+---
+
+## ilc CLI
+
+## Tool notes

--- a/docs/tutorials-examples.md
+++ b/docs/tutorials-examples.md
@@ -1,0 +1,11 @@
+---
+status: active
+audience: public
+last-verified: 2025-09-23
+---
+
+## BASIC tutorial
+
+## IL tutorial
+
+## Examples index


### PR DESCRIPTION
## Summary
- add YAML-fronted skeletons for the consolidated documentation set
- add an index page linking to the new skeletons and the existing codemap overview

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d2ea98eab4832494dc4c7980d606cb