### PR TITLE
docs: rewrite stale doc links to consolidated locations

### DIFF
--- a/docs/il-guide.md
+++ b/docs/il-guide.md
@@ -1420,7 +1420,7 @@ done:
 Sources:
 - docs/il-guide.md#quickstart
 - docs/il-guide.md#reference
-- archive/docs/references/il.md
+- docs/il-guide.md#reference
 - docs/il-guide.md#lowering
 - docs/il-guide.md#constfold
 - docs/il-guide.md#mem2reg

--- a/runtime/rt_math.c
+++ b/runtime/rt_math.c
@@ -2,7 +2,7 @@
 // Purpose: Implements portable math helpers for the runtime.
 // Key invariants: Follows IEEE semantics; no traps on domain errors.
 // Ownership/Lifetime: None.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 
 #include "rt_math.h"
 #include "rt.hpp"

--- a/runtime/rt_math.h
+++ b/runtime/rt_math.h
@@ -2,7 +2,7 @@
 // Purpose: Declares portable math helpers for the runtime.
 // Key invariants: Functions mirror C math library semantics.
 // Ownership/Lifetime: None.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 #pragma once
 
 #include <stdint.h>

--- a/runtime/rt_random.c
+++ b/runtime/rt_random.c
@@ -2,7 +2,7 @@
 // Purpose: Implements deterministic random number generator.
 // Key invariants: Uses 64-bit LCG with fixed multiplier and increment; sequence is reproducible for
 // given seed. Ownership/Lifetime: Maintains a single internal state value; not thread-safe. Links:
-// docs/runtime-abi.md
+// docs/runtime-vm.md#runtime-abi
 
 #include "rt_random.h"
 

--- a/runtime/rt_random.h
+++ b/runtime/rt_random.h
@@ -2,7 +2,7 @@
 // Purpose: Declares deterministic random number helpers.
 // Key invariants: 64-bit linear congruential generator; reproducible across platforms.
 // Ownership/Lifetime: Uses internal global state; single-threaded.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 #pragma once
 
 #include <stdint.h>

--- a/tests/runtime/RTAbsI64OverflowTests.cpp
+++ b/tests/runtime/RTAbsI64OverflowTests.cpp
@@ -2,7 +2,7 @@
 // Purpose: Verify rt_abs_i64 traps on overflow input.
 // Key invariants: Overflowing inputs trigger runtime trap.
 // Ownership: Uses runtime library; stubs vm_trap to capture message.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 #include "rt_math.h"
 #include <cassert>
 #include <climits>

--- a/tests/runtime/RTAllocTests.cpp
+++ b/tests/runtime/RTAllocTests.cpp
@@ -2,7 +2,7 @@
 // Purpose: Verify rt_alloc traps on negative allocation sizes.
 // Key invariants: rt_alloc reports "negative allocation" when bytes < 0.
 // Ownership: Uses runtime library.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 #include "rt.hpp"
 #include <cassert>
 #include <string>

--- a/tests/runtime/RTAllocTooLargeTests.cpp
+++ b/tests/runtime/RTAllocTooLargeTests.cpp
@@ -2,7 +2,7 @@
 // Purpose: Verify rt_alloc traps when allocation exceeds size_t range.
 // Key invariants: rt_alloc reports "allocation too large" when bytes > SIZE_MAX.
 // Ownership: Uses runtime library.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 #include "rt.hpp"
 #include <cassert>
 #include <stdint.h>

--- a/tests/runtime/RTAllocZeroFillTests.cpp
+++ b/tests/runtime/RTAllocZeroFillTests.cpp
@@ -2,7 +2,7 @@
 // Purpose: Verify rt_alloc returns zero-initialized memory.
 // Key invariants: Memory returned from rt_alloc must contain only zero bytes.
 // Ownership: Uses runtime library and frees allocated memory.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 #include "rt.hpp"
 #include <assert.h>
 #include <stddef.h>

--- a/tests/runtime/RTAllocZeroTests.cpp
+++ b/tests/runtime/RTAllocZeroTests.cpp
@@ -4,7 +4,7 @@
 //                 behavior would trap. The test asserts the new logic treats
 //                 zero as a valid allocation size.
 // Ownership: Uses runtime library.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 #include "rt.hpp"
 #include <assert.h>
 #include <stddef.h>

--- a/tests/runtime/RTChrAscTests.cpp
+++ b/tests/runtime/RTChrAscTests.cpp
@@ -2,7 +2,7 @@
 // Purpose: Validate CHR$ and ASC runtime helpers.
 // Key invariants: CHR$ validates 0-255 range; ASC returns 0 for empty string.
 // Ownership: Uses runtime library.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 #include "rt.hpp"
 #include <cassert>
 

--- a/tests/runtime/RTChrInvalidTests.cpp
+++ b/tests/runtime/RTChrInvalidTests.cpp
@@ -2,7 +2,7 @@
 // Purpose: Ensure rt_chr traps on out-of-range input.
 // Key invariants: Codes outside 0-255 trigger runtime trap.
 // Ownership: Uses runtime library.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 #include "rt.hpp"
 #include <cassert>
 #include <string>

--- a/tests/runtime/RTInputLineFailTests.cpp
+++ b/tests/runtime/RTInputLineFailTests.cpp
@@ -2,7 +2,7 @@
 // Purpose: Verify rt_input_line returns NULL when buffer expansion fails.
 // Key invariants: Function aborts reading on realloc failure and reports trap.
 // Ownership: Uses runtime library; stubs realloc and trap for simulation.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 #include "rt.hpp"
 #include <cassert>
 #include <cstring>

--- a/tests/runtime/RTInputLineTests.cpp
+++ b/tests/runtime/RTInputLineTests.cpp
@@ -1,7 +1,7 @@
 // File: tests/runtime/RTInputLineTests.cpp
 // Purpose: Ensure rt_input_line handles lines longer than the initial buffer and EOF-terminated
 // lines. Key invariants: rt_input_line returns full line content for >1023 chars, with or without
-// trailing newline. Ownership: Uses runtime library. Links: docs/runtime-abi.md
+// trailing newline. Ownership: Uses runtime library. Links: docs/runtime-vm.md#runtime-abi
 #include "rt_internal.h"
 #include <cassert>
 #include <cstring>

--- a/tests/runtime/RTInstrTests.cpp
+++ b/tests/runtime/RTInstrTests.cpp
@@ -3,7 +3,7 @@
 // Key invariants: 1-based indexing semantics; empty needle returns clamped
 // start; extreme start values clamp to 1.
 // Ownership: Uses runtime library.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 #include "rt.hpp"
 #include <cassert>
 #include <limits.h>

--- a/tests/runtime/RTMathCoreTests.cpp
+++ b/tests/runtime/RTMathCoreTests.cpp
@@ -2,7 +2,7 @@
 // Purpose: Validate basic math runtime wrappers.
 // Key invariants: Results match libm within tolerance.
 // Ownership: Uses runtime library.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 #include "rt_math.h"
 #include <cassert>
 #include <cmath>

--- a/tests/runtime/RTRandomTests.cpp
+++ b/tests/runtime/RTRandomTests.cpp
@@ -2,7 +2,7 @@
 // Purpose: Validate deterministic LCG random generator.
 // Key invariants: Sequence reproducible for given seed; outputs in [0,1).
 // Ownership: Uses runtime library.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 #include "rt_random.h"
 #include <cassert>
 

--- a/tests/runtime/RTStringRangeTests.cpp
+++ b/tests/runtime/RTStringRangeTests.cpp
@@ -2,7 +2,7 @@
 // Purpose: Verify runtime string helpers report negative start/length diagnostics.
 // Key invariants: LEFT$ and MID$ trap with specific messages on invalid ranges.
 // Ownership: Uses runtime library.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 #include "rt.hpp"
 #include <cassert>
 #include <string>

--- a/tests/runtime/RTTrimCaseTests.cpp
+++ b/tests/runtime/RTTrimCaseTests.cpp
@@ -2,7 +2,7 @@
 // Purpose: Validate string trimming and case mapping runtime helpers.
 // Key invariants: Whitespace includes only space and tab; case maps affect ASCII letters only.
 // Ownership: Uses runtime library.
-// Links: docs/runtime-abi.md
+// Links: docs/runtime-vm.md#runtime-abi
 #include "rt.hpp"
 #include <cassert>
 


### PR DESCRIPTION
## Summary
- update runtime source and test comments to point from `docs/runtime-abi.md` to `docs/runtime-vm.md#runtime-abi`
- retarget the IL guide reference from `archive/docs/references/il.md` to `docs/il-guide.md#reference`

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build -N

------
https://chatgpt.com/codex/tasks/task_e_68d3414c5d68832489be02f80b8b4421