### PR TITLE
Add minimal runtime int32 array support

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(rt STATIC rt_memory.c rt_string.c rt_io.c rt_math.c rt_random.c)
+add_library(rt STATIC rt_memory.c rt_string.c rt_io.c rt_math.c rt_random.c rt_array.c)
 target_include_directories(rt PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
@@ -12,5 +12,6 @@ install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/rt.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/rt_math.h
   ${CMAKE_CURRENT_SOURCE_DIR}/rt_random.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/rt_array.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper
 )

--- a/runtime/rt_array.c
+++ b/runtime/rt_array.c
@@ -1,0 +1,112 @@
+// File: runtime/rt_array.c
+// Purpose: Implements dynamic int32 array helpers for the BASIC runtime.
+// Key invariants: Array length never exceeds capacity; allocations are zeroed on growth.
+// Ownership/Lifetime: Caller manages array handles and releases them via free().
+// Links: docs/codemap.md
+
+#include "rt_array.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct rt_arr_i32_impl
+{
+    size_t len;
+    size_t cap;
+    int32_t data[];
+};
+
+typedef struct rt_arr_i32_impl rt_arr_i32_impl;
+
+static int compute_allocation_bytes(size_t cap, size_t *total_bytes)
+{
+    if (!total_bytes)
+        return 0;
+    if (cap == 0)
+    {
+        *total_bytes = sizeof(rt_arr_i32_impl);
+        return 1;
+    }
+    if (cap > (SIZE_MAX - sizeof(rt_arr_i32_impl)) / sizeof(int32_t))
+        return 0;
+    size_t data_bytes = cap * sizeof(int32_t);
+    *total_bytes = sizeof(rt_arr_i32_impl) + data_bytes;
+    return 1;
+}
+
+void *rt_arr_i32_new(size_t len)
+{
+    size_t total_bytes = 0;
+    if (!compute_allocation_bytes(len, &total_bytes))
+        return NULL;
+    rt_arr_i32_impl *arr = (rt_arr_i32_impl *)calloc(1, total_bytes);
+    if (!arr)
+        return NULL;
+    arr->len = len;
+    arr->cap = len;
+    return arr;
+}
+
+size_t rt_arr_i32_len(const void *arr)
+{
+    const rt_arr_i32_impl *impl = (const rt_arr_i32_impl *)arr;
+    return impl ? impl->len : 0;
+}
+
+int32_t rt_arr_i32_get(const void *arr, size_t idx)
+{
+    const rt_arr_i32_impl *impl = (const rt_arr_i32_impl *)arr;
+    return impl->data[idx];
+}
+
+void rt_arr_i32_set(void *arr, size_t idx, int32_t value)
+{
+    rt_arr_i32_impl *impl = (rt_arr_i32_impl *)arr;
+    impl->data[idx] = value;
+}
+
+void *rt_arr_i32_resize(void *arr, size_t new_len)
+{
+    rt_arr_i32_impl *impl = (rt_arr_i32_impl *)arr;
+    if (!impl)
+        return rt_arr_i32_new(new_len);
+
+    size_t old_len = impl->len;
+    if (new_len <= impl->cap)
+    {
+        if (new_len > old_len)
+        {
+            size_t grow = new_len - old_len;
+            memset(impl->data + old_len, 0, grow * sizeof(int32_t));
+        }
+        impl->len = new_len;
+        return impl;
+    }
+
+    size_t total_bytes = 0;
+    if (!compute_allocation_bytes(new_len, &total_bytes))
+        return NULL;
+
+    rt_arr_i32_impl *resized = (rt_arr_i32_impl *)realloc(impl, total_bytes);
+    if (!resized)
+        return NULL;
+
+    if (new_len > old_len)
+    {
+        size_t grow = new_len - old_len;
+        memset(resized->data + old_len, 0, grow * sizeof(int32_t));
+    }
+
+    resized->len = new_len;
+    resized->cap = new_len;
+    return resized;
+}
+
+void rt_arr_oob_panic(size_t idx, size_t len)
+{
+    fprintf(stderr, "rt_arr_i32: index %zu out of bounds (len=%zu)\n", idx, len);
+    abort();
+}
+

--- a/runtime/rt_array.h
+++ b/runtime/rt_array.h
@@ -1,0 +1,61 @@
+// File: runtime/rt_array.h
+// Purpose: Declares dynamic int32 array helpers for the BASIC runtime.
+// Key invariants: Array length never exceeds capacity; storage is contiguous.
+// Ownership/Lifetime: Caller owns array handles and must free them with free().
+// Links: docs/codemap.md
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__cplusplus)
+#    define RT_ARR_NORETURN [[noreturn]]
+#elif defined(_MSC_VER)
+#    define RT_ARR_NORETURN __declspec(noreturn)
+#else
+#    define RT_ARR_NORETURN __attribute__((noreturn))
+#endif
+
+    /// @brief Allocate a new dynamic array of 32-bit integers.
+    /// @param len Number of elements to allocate.
+    /// @return Opaque array handle or NULL on allocation failure.
+    void *rt_arr_i32_new(size_t len);
+
+    /// @brief Query the current logical length of an array.
+    /// @param arr Array handle returned by rt_arr_i32_new/rt_arr_i32_resize.
+    /// @return Number of accessible elements; 0 when @p arr is NULL.
+    size_t rt_arr_i32_len(const void *arr);
+
+    /// @brief Read element at index @p idx without bounds checks.
+    /// @param arr Array handle; must be non-null and in range.
+    /// @param idx Zero-based index within the array length.
+    /// @return Stored value at @p idx.
+    int32_t rt_arr_i32_get(const void *arr, size_t idx);
+
+    /// @brief Write @p value to index @p idx without bounds checks.
+    /// @param arr Array handle; must be non-null and in range.
+    /// @param idx Zero-based index within the array length.
+    /// @param value Value to store.
+    void rt_arr_i32_set(void *arr, size_t idx, int32_t value);
+
+    /// @brief Resize an array to @p new_len elements.
+    /// @param arr Existing array handle or NULL to allocate.
+    /// @param new_len Requested logical length.
+    /// @return Updated array handle with zero-initialized new slots or NULL on failure.
+    void *rt_arr_i32_resize(void *arr, size_t new_len);
+
+    /// @brief Abort execution due to an out-of-bounds access.
+    /// @param idx Failing index.
+    /// @param len Array length observed by the caller.
+    RT_ARR_NORETURN void rt_arr_oob_panic(size_t idx, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#undef RT_ARR_NORETURN
+

--- a/tests/runtime/RTArrayI32Tests.cpp
+++ b/tests/runtime/RTArrayI32Tests.cpp
@@ -1,0 +1,67 @@
+// File: tests/runtime/RTArrayI32Tests.cpp
+// Purpose: Verify basic behavior of the int32 runtime array helpers.
+// Key invariants: Resizing zero-initializes new slots and preserves prior values.
+// Ownership: Tests own allocated arrays and release them via free().
+// Links: docs/runtime-vm.md#runtime-abi
+
+#include "rt_array.h"
+
+#include <cassert>
+#include <cstddef>
+#include <cstdlib>
+
+static void expect_zero_range(void *arr, size_t start, size_t end)
+{
+    for (size_t i = start; i < end; ++i)
+        assert(rt_arr_i32_get(arr, i) == 0);
+}
+
+int main()
+{
+    void *arr = rt_arr_i32_new(0);
+    assert(arr != nullptr);
+    assert(rt_arr_i32_len(arr) == 0);
+
+    arr = rt_arr_i32_resize(arr, 3);
+    assert(arr != nullptr);
+    assert(rt_arr_i32_len(arr) == 3);
+    expect_zero_range(arr, 0, 3);
+
+    rt_arr_i32_set(arr, 0, 7);
+    rt_arr_i32_set(arr, 1, -2);
+    rt_arr_i32_set(arr, 2, 99);
+    assert(rt_arr_i32_get(arr, 0) == 7);
+    assert(rt_arr_i32_get(arr, 1) == -2);
+    assert(rt_arr_i32_get(arr, 2) == 99);
+
+    arr = rt_arr_i32_resize(arr, 6);
+    assert(arr != nullptr);
+    assert(rt_arr_i32_len(arr) == 6);
+    assert(rt_arr_i32_get(arr, 0) == 7);
+    assert(rt_arr_i32_get(arr, 1) == -2);
+    assert(rt_arr_i32_get(arr, 2) == 99);
+    expect_zero_range(arr, 3, 6);
+
+    arr = rt_arr_i32_resize(arr, 2);
+    assert(arr != nullptr);
+    assert(rt_arr_i32_len(arr) == 2);
+    assert(rt_arr_i32_get(arr, 0) == 7);
+    assert(rt_arr_i32_get(arr, 1) == -2);
+
+    arr = rt_arr_i32_resize(arr, 5);
+    assert(arr != nullptr);
+    assert(rt_arr_i32_len(arr) == 5);
+    assert(rt_arr_i32_get(arr, 0) == 7);
+    assert(rt_arr_i32_get(arr, 1) == -2);
+    expect_zero_range(arr, 2, 5);
+
+    void *fresh = rt_arr_i32_resize(nullptr, 4);
+    assert(fresh != nullptr);
+    assert(rt_arr_i32_len(fresh) == 4);
+    expect_zero_range(fresh, 0, 4);
+
+    free(arr);
+    free(fresh);
+    return 0;
+}
+

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -87,6 +87,10 @@ function(viper_add_runtime_tests)
   target_link_libraries(test_rt_alloc_zero_fill PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_alloc_zero_fill test_rt_alloc_zero_fill)
 
+  viper_add_test_exe(test_rt_array_i32 ${VIPER_TESTS_DIR}/runtime/RTArrayI32Tests.cpp)
+  target_link_libraries(test_rt_array_i32 PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
+  viper_add_ctest(test_rt_array_i32 test_rt_array_i32)
+
   viper_add_test_exe(test_rt_input_line ${VIPER_TESTS_DIR}/runtime/RTInputLineTests.cpp)
   target_link_libraries(test_rt_input_line PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_input_line test_rt_input_line)


### PR DESCRIPTION
## Summary
- add a runtime rt_array module that implements dynamic int32 arrays with allocation, resize, and panic helpers
- install the new public header and compile the implementation into the rt static library
- cover array creation, resizing, and get/set behaviour with a new runtime unit test wired into the suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d3497f7bc0832483600a39c90c8bba