### PR TITLE
lower(basic): DIM/REDIM lower to rt_arr_i32_new/resize

### DIFF
--- a/src/frontends/basic/AST.cpp
+++ b/src/frontends/basic/AST.cpp
@@ -82,6 +82,18 @@ void ArrayExpr::accept(MutExprVisitor &visitor)
     visitor.visit(*this);
 }
 
+/// @brief Forwards this LBOUND query node to the visitor for double dispatch.
+/// @param visitor Receives the node; ownership remains with the AST.
+void LBoundExpr::accept(ExprVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void LBoundExpr::accept(MutExprVisitor &visitor)
+{
+    visitor.visit(*this);
+}
+
 /// @brief Forwards this unary operation node to the visitor for double dispatch.
 /// @param visitor Receives the node; ownership remains with the AST.
 void UnaryExpr::accept(ExprVisitor &visitor) const

--- a/src/frontends/basic/AST.hpp
+++ b/src/frontends/basic/AST.hpp
@@ -23,6 +23,7 @@ struct ArrayExpr;
 struct UnaryExpr;
 struct BinaryExpr;
 struct BuiltinCallExpr;
+struct LBoundExpr;
 struct CallExpr;
 
 struct PrintStmt;
@@ -55,6 +56,7 @@ struct ExprVisitor
     virtual void visit(const UnaryExpr &) = 0;
     virtual void visit(const BinaryExpr &) = 0;
     virtual void visit(const BuiltinCallExpr &) = 0;
+    virtual void visit(const LBoundExpr &) = 0;
     virtual void visit(const CallExpr &) = 0;
 };
 
@@ -71,6 +73,7 @@ struct MutExprVisitor
     virtual void visit(UnaryExpr &) = 0;
     virtual void visit(BinaryExpr &) = 0;
     virtual void visit(BuiltinCallExpr &) = 0;
+    virtual void visit(LBoundExpr &) = 0;
     virtual void visit(CallExpr &) = 0;
 };
 
@@ -195,6 +198,15 @@ struct ArrayExpr : Expr
     std::string name;
     /// Zero-based index expression; owned and non-null.
     ExprPtr index;
+    void accept(ExprVisitor &visitor) const override;
+    void accept(MutExprVisitor &visitor) override;
+};
+
+/// @brief Query the logical lower bound of an array.
+struct LBoundExpr : Expr
+{
+    /// Name of the array operand queried for its lower bound.
+    std::string name;
     void accept(ExprVisitor &visitor) const override;
     void accept(MutExprVisitor &visitor) override;
 };

--- a/src/frontends/basic/AstPrinter.cpp
+++ b/src/frontends/basic/AstPrinter.cpp
@@ -125,6 +125,11 @@ struct AstPrinter::ExprPrinter final : ExprVisitor
         printer.os << ')';
     }
 
+    void visit(const LBoundExpr &expr) override
+    {
+        printer.os << "(LBOUND " << expr.name << ')';
+    }
+
     void visit(const CallExpr &expr) override
     {
         printer.os << '(' << expr.callee;

--- a/src/frontends/basic/ConstFolder.cpp
+++ b/src/frontends/basic/ConstFolder.cpp
@@ -283,6 +283,8 @@ private:
         foldExpr(expr.index);
     }
 
+    void visit(LBoundExpr &) override {}
+
     void visit(UnaryExpr &expr) override
     {
         foldExpr(expr.expr);

--- a/src/frontends/basic/LowerExpr.cpp
+++ b/src/frontends/basic/LowerExpr.cpp
@@ -77,6 +77,12 @@ class LowererExprVisitor final : public ExprVisitor
         result_ = lowerer_.lowerBuiltinCall(expr);
     }
 
+    void visit(const LBoundExpr &expr) override
+    {
+        lowerer_.curLoc = expr.loc;
+        result_ = Lowerer::RVal{Value::constInt(0), il::core::Type(il::core::Type::Kind::I64)};
+    }
+
     void visit(const CallExpr &expr) override
     {
         const auto *signature = lowerer_.findProcSignature(expr.callee);

--- a/src/frontends/basic/LowerRuntime.cpp
+++ b/src/frontends/basic/LowerRuntime.cpp
@@ -99,6 +99,16 @@ void RuntimeHelperTracker::declareRequiredRuntime(build::IRBuilder &b, bool boun
     }
 }
 
+void Lowerer::requireArrayI32New()
+{
+    needsArrI32New = true;
+}
+
+void Lowerer::requireArrayI32Resize()
+{
+    needsArrI32Resize = true;
+}
+
 void Lowerer::requestHelper(RuntimeFeature feature)
 {
     runtimeTracker.requestHelper(feature);
@@ -117,6 +127,16 @@ void Lowerer::trackRuntime(RuntimeFeature feature)
 void Lowerer::declareRequiredRuntime(build::IRBuilder &b)
 {
     runtimeTracker.declareRequiredRuntime(b, boundsChecks);
+
+    auto declareManual = [&](std::string_view name) {
+        if (const auto *desc = il::runtime::findRuntimeDescriptor(name))
+            b.addExtern(std::string(desc->name), desc->signature.retType, desc->signature.paramTypes);
+    };
+
+    if (needsArrI32New)
+        declareManual("rt_arr_i32_new");
+    if (needsArrI32Resize)
+        declareManual("rt_arr_i32_resize");
 }
 
 } // namespace il::frontends::basic

--- a/src/frontends/basic/LowerScan.hpp
+++ b/src/frontends/basic/LowerScan.hpp
@@ -19,6 +19,7 @@ ExprType scanExpr(const Expr &e);
 ExprType scanUnaryExpr(const UnaryExpr &u);
 ExprType scanBinaryExpr(const BinaryExpr &b);
 ExprType scanArrayExpr(const ArrayExpr &arr);
+ExprType scanLBoundExpr(const LBoundExpr &expr);
 
 public:
 ExprType scanBuiltinCallExpr(const BuiltinCallExpr &c);

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -516,7 +516,11 @@ class Lowerer
     using RuntimeFeature = il::runtime::RuntimeFeature;
 
     RuntimeHelperTracker runtimeTracker;
+    bool needsArrI32New{false};
+    bool needsArrI32Resize{false};
 
+    void requireArrayI32New();
+    void requireArrayI32Resize();
     void requestHelper(RuntimeFeature feature);
 
     bool isHelperNeeded(RuntimeFeature feature) const;

--- a/src/frontends/basic/LoweringPipeline.cpp
+++ b/src/frontends/basic/LoweringPipeline.cpp
@@ -48,6 +48,12 @@ class VarCollectExprVisitor final : public ExprVisitor
             expr.index->accept(*this);
     }
 
+    void visit(const LBoundExpr &expr) override
+    {
+        lowerer_.markSymbolReferenced(expr.name);
+        lowerer_.markArray(expr.name);
+    }
+
     void visit(const UnaryExpr &expr) override
     {
         if (expr.expr)
@@ -241,6 +247,8 @@ void ProgramLowering::run(const Program &prog, il::core::Module &module)
     lowerer.procSignatures.clear();
 
     lowerer.runtimeTracker.reset();
+    lowerer.needsArrI32New = false;
+    lowerer.needsArrI32Resize = false;
 
     lowerer.scanProgram(prog);
     lowerer.declareRequiredRuntime(builder);

--- a/src/frontends/basic/Parser_Expr.cpp
+++ b/src/frontends/basic/Parser_Expr.cpp
@@ -364,6 +364,21 @@ ExprPtr Parser::parsePrimary()
         consume();
         return b;
     }
+    if (at(TokenKind::KeywordLbound))
+    {
+        auto loc = peek().loc;
+        consume();
+        expect(TokenKind::LParen);
+        std::string name;
+        Token ident = expect(TokenKind::Identifier);
+        if (ident.kind == TokenKind::Identifier)
+            name = ident.lexeme;
+        expect(TokenKind::RParen);
+        auto l = std::make_unique<LBoundExpr>();
+        l->loc = loc;
+        l->name = std::move(name);
+        return l;
+    }
     if (!at(TokenKind::Identifier))
     {
         if (auto b = lookupBuiltin(peek().lexeme))

--- a/src/frontends/basic/SemanticAnalyzer.Exprs.cpp
+++ b/src/frontends/basic/SemanticAnalyzer.Exprs.cpp
@@ -184,6 +184,8 @@ class SemanticAnalyzerExprVisitor final : public MutExprVisitor
 
     void visit(BuiltinCallExpr &expr) override { result_ = analyzer_.analyzeBuiltinCall(expr); }
 
+    void visit(LBoundExpr &expr) override { result_ = analyzer_.analyzeLBound(expr); }
+
     void visit(CallExpr &expr) override { result_ = analyzer_.analyzeCall(expr); }
 
     [[nodiscard]] SemanticAnalyzer::Type result() const noexcept { return result_; }
@@ -410,6 +412,33 @@ SemanticAnalyzer::Type SemanticAnalyzer::analyzeArray(ArrayExpr &a)
                 de.emit(il::support::Severity::Warning, "B3001", a.loc, 1, std::move(msg));
             }
         }
+    }
+    return Type::Int;
+}
+
+SemanticAnalyzer::Type SemanticAnalyzer::analyzeLBound(LBoundExpr &expr)
+{
+    resolveAndTrackSymbol(expr.name, SymbolKind::Reference);
+    if (!arrays_.count(expr.name))
+    {
+        std::string msg = "unknown array '" + expr.name + "'";
+        de.emit(il::support::Severity::Error,
+                "B1001",
+                expr.loc,
+                static_cast<uint32_t>(expr.name.size()),
+                std::move(msg));
+        return Type::Unknown;
+    }
+    if (auto itType = varTypes_.find(expr.name);
+        itType != varTypes_.end() && itType->second != Type::ArrayInt)
+    {
+        std::string msg = "variable '" + expr.name + "' is not an array";
+        de.emit(il::support::Severity::Error,
+                "B2001",
+                expr.loc,
+                static_cast<uint32_t>(expr.name.size()),
+                std::move(msg));
+        return Type::Unknown;
     }
     return Type::Int;
 }

--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -199,6 +199,8 @@ class SemanticAnalyzer
     Type analyzeUnary(const UnaryExpr &u);
     /// @brief Analyze binary expression.
     Type analyzeBinary(const BinaryExpr &b);
+    /// @brief Analyze LBOUND expression.
+    Type analyzeLBound(LBoundExpr &expr);
     /// @brief Emit operand type mismatch diagnostic for binary expressions.
     void emitOperandTypeMismatch(const BinaryExpr &expr, std::string_view diagId);
     /// @brief Emit divide-by-zero diagnostic when appropriate.

--- a/tests/basic/CMakeLists.txt
+++ b/tests/basic/CMakeLists.txt
@@ -254,6 +254,13 @@ function(viper_add_basic_to_il_golden_tests)
     -DGOLDEN=${_VIPER_BASIC_TO_IL_DIR}/ex6_array_sum.il
     -P ${_VIPER_BASIC_TO_IL_CHECK})
 
+  viper_add_ctest(basic_to_il_array_dim_redim
+    ${CMAKE_COMMAND}
+    -DILC=${_VIPER_BASIC_ILC}
+    -DBAS_FILE=${_VIPER_BASIC_TO_IL_DIR}/array_dim_redim.bas
+    -DGOLDEN=${_VIPER_BASIC_TO_IL_DIR}/array_dim_redim.il
+    -P ${_VIPER_BASIC_TO_IL_CHECK})
+
   viper_add_ctest(basic_to_il_not
     ${CMAKE_COMMAND}
     -DILC=${_VIPER_BASIC_ILC}

--- a/tests/basic/goldens/SuffixFreeVars.il
+++ b/tests/basic/goldens/SuffixFreeVars.il
@@ -4,7 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
-extern @rt_alloc(i64) -> ptr
+extern @rt_arr_i32_new(i64) -> ptr
 global const str @.L0 = "ok"
 global const str @.L1 = "
 "
@@ -26,57 +26,55 @@ L08:
   .loc 1 1 1
   br L08
   .loc 1 3 1
-  %t3 = mul 2, 8
+  %t3 = call @rt_arr_i32_new(2)
   .loc 1 3 1
-  %t4 = call @rt_alloc(%t3)
-  .loc 1 3 1
-  store ptr, %t0, %t4
+  store ptr, %t0, %t3
   .loc 1 4 15
-  %t5 = const_str @.L0
+  %t4 = const_str @.L0
   .loc 1 4 1
-  store str, %t2, %t5
+  store str, %t2, %t4
   .loc 1 5 1
   store i64, %t1, 5
   .loc 1 6 17
-  %t6 = load i64, %t1
+  %t5 = load i64, %t1
   .loc 1 6 17
-  %t7 = load ptr, %t0
+  %t6 = load ptr, %t0
   .loc 1 6 5
-  %t8 = shl 0, 3
+  %t7 = shl 0, 3
   .loc 1 6 5
-  %t9 = gep %t7, %t8
+  %t8 = gep %t6, %t7
   .loc 1 6 1
-  store i64, %t9, %t6
+  store i64, %t8, %t5
   .loc 1 7 7
-  %t10 = load str, %t2
+  %t9 = load str, %t2
+  .loc 1 7 1
+  call @rt_print_str(%t9)
+  .loc 1 7 1
+  %t10 = const_str @.L1
   .loc 1 7 1
   call @rt_print_str(%t10)
-  .loc 1 7 1
-  %t11 = const_str @.L1
-  .loc 1 7 1
-  call @rt_print_str(%t11)
   .loc 1 8 7
-  %t12 = load i64, %t1
+  %t11 = load i64, %t1
   .loc 1 8 1
-  call @rt_print_i64(%t12)
+  call @rt_print_i64(%t11)
   .loc 1 8 1
-  %t13 = const_str @.L1
+  %t12 = const_str @.L1
   .loc 1 8 1
-  call @rt_print_str(%t13)
+  call @rt_print_str(%t12)
   .loc 1 9 7
-  %t14 = load ptr, %t0
+  %t13 = load ptr, %t0
   .loc 1 9 7
-  %t15 = shl 0, 3
+  %t14 = shl 0, 3
   .loc 1 9 7
-  %t16 = gep %t14, %t15
+  %t15 = gep %t13, %t14
   .loc 1 9 7
-  %t17 = load i64, %t16
+  %t16 = load i64, %t15
   .loc 1 9 1
-  call @rt_print_i64(%t17)
+  call @rt_print_i64(%t16)
   .loc 1 9 1
-  %t18 = const_str @.L1
+  %t17 = const_str @.L1
   .loc 1 9 1
-  call @rt_print_str(%t18)
+  call @rt_print_str(%t17)
 exit:
   ret 0
 }

--- a/tests/golden/basic_to_il/array_dim_redim.bas
+++ b/tests/golden/basic_to_il/array_dim_redim.bas
@@ -1,0 +1,3 @@
+10 DIM A(3)
+20 REDIM A(5)
+30 END

--- a/tests/golden/basic_to_il/array_dim_redim.il
+++ b/tests/golden/basic_to_il/array_dim_redim.il
@@ -1,0 +1,34 @@
+il 0.1.2
+extern @rt_print_str(str) -> void
+extern @rt_print_i64(i64) -> void
+extern @rt_print_f64(f64) -> void
+extern @rt_len(str) -> i64
+extern @rt_substr(str, i64, i64) -> str
+extern @rt_arr_i32_new(i64) -> ptr
+extern @rt_arr_i32_resize(ptr, i64) -> ptr
+func @main() -> i64 {
+entry:
+  %t0 = alloca 8
+  br L10
+L10:
+  .loc 1 1 4
+  %t1 = call @rt_arr_i32_new(3)
+  .loc 1 1 4
+  store ptr, %t0, %t1
+  .loc 1 1 4
+  br L20
+L20:
+  .loc 1 2 4
+  %t2 = load ptr, %t0
+  .loc 1 2 4
+  %t3 = call @rt_arr_i32_resize(%t2, 5)
+  .loc 1 2 4
+  store ptr, %t0, %t3
+  .loc 1 2 4
+  br L30
+L30:
+  .loc 1 3 4
+  br exit
+exit:
+  ret 0
+}

--- a/tests/golden/basic_to_il/bounds_check.il
+++ b/tests/golden/basic_to_il/bounds_check.il
@@ -5,7 +5,7 @@ extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_trap(str) -> void
-extern @rt_alloc(i64) -> ptr
+extern @rt_arr_i32_new(i64) -> ptr
 global const str @.L0 = "bounds check failed: A[i]"
 global const str @.L1 = "
 "
@@ -16,56 +16,54 @@ entry:
   br L10
 L10:
   .loc 1 1 4
-  %t2 = mul 2, 8
+  %t2 = call @rt_arr_i32_new(2)
   .loc 1 1 4
-  %t3 = call @rt_alloc(%t2)
-  .loc 1 1 4
-  store ptr, %t0, %t3
+  store ptr, %t0, %t2
   .loc 1 1 4
   store i64, %t1, 2
   .loc 1 1 4
   br L20
 L20:
   .loc 1 2 10
-  %t4 = load ptr, %t0
+  %t3 = load ptr, %t0
   .loc 1 2 10
-  %t5 = load i64, %t1
+  %t4 = load i64, %t1
   .loc 1 2 10
-  %t6 = scmp_lt 1, 0
+  %t5 = scmp_lt 1, 0
   .loc 1 2 10
-  %t7 = scmp_ge 1, %t5
+  %t6 = scmp_ge 1, %t4
+  .loc 1 2 10
+  %t7 = zext1 %t5
   .loc 1 2 10
   %t8 = zext1 %t6
   .loc 1 2 10
-  %t9 = zext1 %t7
+  %t9 = or %t7, %t8
   .loc 1 2 10
-  %t10 = or %t8, %t9
+  %t10 = trunc1 %t9
   .loc 1 2 10
-  %t11 = trunc1 %t10
-  .loc 1 2 10
-  cbr %t11, bc_fail0, bc_ok0
+  cbr %t10, bc_fail0, bc_ok0
 exit:
   ret 0
 bc_ok0:
   .loc 1 2 10
-  %t13 = shl 1, 3
+  %t12 = shl 1, 3
   .loc 1 2 10
-  %t14 = gep %t4, %t13
+  %t13 = gep %t3, %t12
   .loc 1 2 10
-  %t15 = load i64, %t14
+  %t14 = load i64, %t13
   .loc 1 2 4
-  call @rt_print_i64(%t15)
+  call @rt_print_i64(%t14)
   .loc 1 2 4
-  %t16 = const_str @.L1
+  %t15 = const_str @.L1
   .loc 1 2 4
-  call @rt_print_str(%t16)
+  call @rt_print_str(%t15)
   .loc 1 2 4
   br exit
 bc_fail0:
   .loc 1 2 10
-  %t12 = const_str @.L0
+  %t11 = const_str @.L0
   .loc 1 2 10
-  call @rt_trap(%t12)
+  call @rt_trap(%t11)
   .loc 1 2 10
   trap
 }

--- a/tests/golden/basic_to_il/ex6_array_sum.il
+++ b/tests/golden/basic_to_il/ex6_array_sum.il
@@ -6,7 +6,7 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_input_line() -> str
 extern @rt_to_int(str) -> i64
-extern @rt_alloc(i64) -> ptr
+extern @rt_arr_i32_new(i64) -> ptr
 global const str @.L0 = "
 "
 func @main() -> i64 {
@@ -29,11 +29,9 @@ L20:
   .loc 1 2 10
   %t6 = load i64, %t3
   .loc 1 2 4
-  %t7 = mul %t6, 8
+  %t7 = call @rt_arr_i32_new(%t6)
   .loc 1 2 4
-  %t8 = call @rt_alloc(%t7)
-  .loc 1 2 4
-  store ptr, %t2, %t8
+  store ptr, %t2, %t7
   .loc 1 2 4
   br L30
 L30:
@@ -51,13 +49,13 @@ L50:
   br loop_head
 L100:
   .loc 1 10 11
-  %t28 = load i64, %t0
+  %t27 = load i64, %t0
   .loc 1 10 5
-  call @rt_print_i64(%t28)
+  call @rt_print_i64(%t27)
   .loc 1 10 5
-  %t29 = const_str @.L0
+  %t28 = const_str @.L0
   .loc 1 10 5
-  call @rt_print_str(%t29)
+  call @rt_print_str(%t28)
   .loc 1 10 5
   br L110
 L110:
@@ -67,52 +65,52 @@ exit:
   ret 0
 loop_head:
   .loc 1 5 10
-  %t9 = load i64, %t1
+  %t8 = load i64, %t1
   .loc 1 5 14
-  %t10 = load i64, %t3
+  %t9 = load i64, %t3
   .loc 1 5 12
-  %t11 = scmp_lt %t9, %t10
+  %t10 = scmp_lt %t8, %t9
   .loc 1 5 4
-  cbr %t11, loop_body, done
+  cbr %t10, loop_body, done
 loop_body:
   .loc 1 6 17
-  %t12 = load i64, %t1
+  %t11 = load i64, %t1
   .loc 1 6 21
-  %t13 = load i64, %t1
+  %t12 = load i64, %t1
   .loc 1 6 19
-  %t14 = mul %t12, %t13
+  %t13 = mul %t11, %t12
   .loc 1 6 19
-  %t15 = load ptr, %t2
+  %t14 = load ptr, %t2
   .loc 1 6 12
-  %t16 = load i64, %t1
+  %t15 = load i64, %t1
   .loc 1 6 10
-  %t17 = shl %t16, 3
+  %t16 = shl %t15, 3
   .loc 1 6 10
-  %t18 = gep %t15, %t17
+  %t17 = gep %t14, %t16
   .loc 1 6 6
-  store i64, %t18, %t14
+  store i64, %t17, %t13
   .loc 1 7 14
-  %t19 = load i64, %t0
+  %t18 = load i64, %t0
   .loc 1 7 18
-  %t20 = load ptr, %t2
+  %t19 = load ptr, %t2
   .loc 1 7 20
-  %t21 = load i64, %t1
+  %t20 = load i64, %t1
   .loc 1 7 18
-  %t22 = shl %t21, 3
+  %t21 = shl %t20, 3
   .loc 1 7 18
-  %t23 = gep %t20, %t22
+  %t22 = gep %t19, %t21
   .loc 1 7 18
-  %t24 = load i64, %t23
+  %t23 = load i64, %t22
   .loc 1 7 16
-  %t25 = add %t19, %t24
+  %t24 = add %t18, %t23
   .loc 1 7 6
-  store i64, %t0, %t25
+  store i64, %t0, %t24
   .loc 1 8 14
-  %t26 = load i64, %t1
+  %t25 = load i64, %t1
   .loc 1 8 16
-  %t27 = add %t26, 1
+  %t26 = add %t25, 1
   .loc 1 8 6
-  store i64, %t1, %t27
+  store i64, %t1, %t26
   .loc 1 5 4
   br loop_head
 done:

--- a/tests/golden/basic_to_il/not.il
+++ b/tests/golden/basic_to_il/not.il
@@ -4,7 +4,6 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
-extern @rt_alloc(i64) -> ptr
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/il/boolean_and.il
+++ b/tests/golden/il/boolean_and.il
@@ -6,7 +6,6 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_input_line() -> str
 extern @rt_to_int(str) -> i64
-extern @rt_alloc(i64) -> ptr
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/il/boolean_andalso.il
+++ b/tests/golden/il/boolean_andalso.il
@@ -6,7 +6,6 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_input_line() -> str
 extern @rt_to_int(str) -> i64
-extern @rt_alloc(i64) -> ptr
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/il/boolean_branch_join_skeleton.il
+++ b/tests/golden/il/boolean_branch_join_skeleton.il
@@ -4,7 +4,6 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
-extern @rt_alloc(i64) -> ptr
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/il/boolean_dim_and_assign.il
+++ b/tests/golden/il/boolean_dim_and_assign.il
@@ -4,7 +4,6 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
-extern @rt_alloc(i64) -> ptr
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/il/boolean_literals.il
+++ b/tests/golden/il/boolean_literals.il
@@ -6,7 +6,6 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_input_line() -> str
 extern @rt_to_int(str) -> i64
-extern @rt_alloc(i64) -> ptr
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/il/boolean_not.il
+++ b/tests/golden/il/boolean_not.il
@@ -4,7 +4,6 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
-extern @rt_alloc(i64) -> ptr
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/il/boolean_or.il
+++ b/tests/golden/il/boolean_or.il
@@ -6,7 +6,6 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_input_line() -> str
 extern @rt_to_int(str) -> i64
-extern @rt_alloc(i64) -> ptr
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/il/boolean_orelse.il
+++ b/tests/golden/il/boolean_orelse.il
@@ -6,7 +6,6 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_input_line() -> str
 extern @rt_to_int(str) -> i64
-extern @rt_alloc(i64) -> ptr
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/unit/test_basic_parse_array_var.cpp
+++ b/tests/unit/test_basic_parse_array_var.cpp
@@ -40,6 +40,18 @@ int main()
         assert(idx && idx->value == 1);
     }
 
+    // LBOUND expression
+    {
+        std::string src = "10 DIM A(2)\n20 LET X = LBOUND(A)\n30 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("test.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        auto *let = dynamic_cast<LetStmt *>(prog->main[1].get());
+        auto *lb = dynamic_cast<LBoundExpr *>(let->expr.get());
+        assert(lb && lb->name == "A");
+    }
+
     // REDIM statement
     {
         std::string src = "10 DIM A(2)\n20 REDIM A(4)\n30 END\n";


### PR DESCRIPTION
## Summary
- lower BASIC DIM/REDIM statements to allocate and resize via rt_arr_i32_new/rt_arr_i32_resize while tracking manual runtime externs
- add an LBOUND expression node with parser, semantic, and lowering support returning a zero constant
- refresh BASIC IL golden outputs for array and boolean cases and add a new DIM/REDIM sample

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d366adfd188324adec149646f51c1d