### PR TITLE
Add runtime array call signature checks to IL verifier

### DIFF
--- a/tests/unit/test_il_instruction_checker.cpp
+++ b/tests/unit/test_il_instruction_checker.cpp
@@ -5,11 +5,13 @@
 // Links: docs/il-guide.md#reference
 
 #include "il/core/BasicBlock.hpp"
+#include "il/core/Extern.hpp"
 #include "il/core/Function.hpp"
 #include "il/core/Instr.hpp"
 #include "il/core/Opcode.hpp"
 #include "il/verify/InstructionChecker.hpp"
 #include <cassert>
+#include <string>
 #include <sstream>
 
 int main()
@@ -70,6 +72,51 @@ int main()
     ok = verifyInstruction(fn, bb, fadd, externs, funcs, typesBad, errBad);
     assert(!ok);
     assert(!errBad.str().empty());
+
+    Extern arrGet;
+    arrGet.name = "rt_arr_i32_get";
+    arrGet.retType = Type(Type::Kind::I64);
+    arrGet.params = {Type(Type::Kind::Ptr), Type(Type::Kind::I64)};
+    externs[arrGet.name] = &arrGet;
+
+    std::unordered_map<unsigned, Type> arrTemps;
+    arrTemps[10] = Type(Type::Kind::Ptr);
+    arrTemps[11] = Type(Type::Kind::I64);
+    std::unordered_set<unsigned> arrDefined = {10, 11};
+    TypeInference arrTypes(arrTemps, arrDefined);
+
+    Instr arrCall;
+    arrCall.result = 12u;
+    arrCall.op = Opcode::Call;
+    arrCall.type = Type(Type::Kind::I64);
+    arrCall.callee = arrGet.name;
+    arrCall.operands.push_back(Value::temp(10));
+    arrCall.operands.push_back(Value::temp(11));
+
+    std::ostringstream arrErr;
+    ok = verifyInstruction(fn, bb, arrCall, externs, funcs, arrTypes, arrErr);
+    assert(ok);
+    assert(arrErr.str().empty());
+    assert(arrTemps.at(12).kind == Type::Kind::I64);
+
+    std::unordered_map<unsigned, Type> arrTempsBad;
+    arrTempsBad[10] = Type(Type::Kind::Ptr);
+    std::unordered_set<unsigned> arrDefinedBad = {10};
+    TypeInference arrTypesBad(arrTempsBad, arrDefinedBad);
+
+    Instr arrCallBad;
+    arrCallBad.result = 20u;
+    arrCallBad.op = Opcode::Call;
+    arrCallBad.type = Type(Type::Kind::I64);
+    arrCallBad.callee = arrGet.name;
+    arrCallBad.operands.push_back(Value::temp(10));
+    arrCallBad.operands.push_back(Value::constFloat(1.0));
+
+    std::ostringstream arrErrBad;
+    ok = verifyInstruction(fn, bb, arrCallBad, externs, funcs, arrTypesBad, arrErrBad);
+    assert(!ok);
+    const std::string arrDiag = arrErrBad.str();
+    assert(arrDiag.find("@rt_arr_i32_get index operand must be i64") != std::string::npos);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a runtime array call classifier to il::verify::InstructionChecker and enforce argument/result types for rt_arr_i32_* callees
- extend the instruction checker unit test with valid and invalid rt_arr_i32_get scenarios to cover the new diagnostics

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d38bd897b883249deb370fb17bb69b