### PR TITLE
docs: document 1-D int32 arrays in BASIC + IL lowering notes

### DIFF
--- a/docs/basic-language.md
+++ b/docs/basic-language.md
@@ -46,6 +46,25 @@ Programs can include top-level statements and user-defined procedures. Procedure
 50 LET A(1) = I
 ```
 
+### Arrays (1-D)
+Arrays use zero-based indexing. `DIM` allocates a fixed-length array and `REDIM`
+changes its length in place. `LBOUND(arrayVar)` always returns `0`, and
+`UBOUND(arrayVar)` evaluates to `len - 1`. Elements are currently stored as
+`Int32`; additional element types are planned.
+
+```basic
+10 DIM A(3)
+20 LET A(0) = 10
+30 PRINT LBOUND(A), UBOUND(A)
+40 PRINT A(0), A(2)
+50 PRINT A(3)  ' runtime error: index 3 is out of bounds (array length is 3)
+60 REDIM A(5)
+70 PRINT UBOUND(A)
+```
+
+Out-of-bounds accesses trigger a runtime bounds check that terminates the
+program with an error message.
+
 ### Variables and assignment
 Variables are created with `LET`. Scalars are named without suffix (int), with `#` (float), or `$` (string).
 

--- a/docs/il-guide.md
+++ b/docs/il-guide.md
@@ -666,6 +666,11 @@ Modules must begin with `il 0.1.2`.  A conforming implementation accepts this gr
 
 Integer arguments to `SQR`, `FLOOR`, and `CEIL` are first widened to `f64`.
 
+> **Arrays today.** BASIC array declarations and accesses lower to runtime
+> helpers such as `@rt_arr_i32_new`, `@rt_arr_i32_len`, `@rt_arr_i32_get`, and
+> `@rt_arr_i32_set`. The front end emits bounds checks in IL; failing a check
+> calls `@rt_arr_oob_panic` before touching the array storage.
+
 ### Procedure calls
 
 User-defined `FUNCTION` and `SUB` calls lower to direct `call` instructions.


### PR DESCRIPTION
## Summary
- add a BASIC language reference section covering 1-D array indexing, sizing, and bounds checks
- note in the IL guide that array operations currently use rt_arr_i32_* runtime helpers with IL-level bounds checks

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d3a02eadb48324877f107edbe691e3