### PR TITLE
basic/lex: add DO/LOOP/UNTIL/EXIT tokens & keyword lookup

### DIFF
--- a/src/frontends/basic/Lexer.cpp
+++ b/src/frontends/basic/Lexer.cpp
@@ -25,7 +25,7 @@ struct KeywordEntry
     TokenKind kind;
 };
 
-constexpr std::array<KeywordEntry, 41> kKeywordTable{{
+constexpr std::array<KeywordEntry, 45> kKeywordTable{{
     {"ABS", TokenKind::KeywordAbs},
     {"AND", TokenKind::KeywordAnd},
     {"ANDALSO", TokenKind::KeywordAndAlso},
@@ -34,9 +34,11 @@ constexpr std::array<KeywordEntry, 41> kKeywordTable{{
     {"CEIL", TokenKind::KeywordCeil},
     {"COS", TokenKind::KeywordCos},
     {"DIM", TokenKind::KeywordDim},
+    {"DO", TokenKind::KeywordDo},
     {"ELSE", TokenKind::KeywordElse},
     {"ELSEIF", TokenKind::KeywordElseIf},
     {"END", TokenKind::KeywordEnd},
+    {"EXIT", TokenKind::KeywordExit},
     {"FALSE", TokenKind::KeywordFalse},
     {"FLOOR", TokenKind::KeywordFloor},
     {"FOR", TokenKind::KeywordFor},
@@ -46,6 +48,7 @@ constexpr std::array<KeywordEntry, 41> kKeywordTable{{
     {"INPUT", TokenKind::KeywordInput},
     {"LBOUND", TokenKind::KeywordLbound},
     {"LET", TokenKind::KeywordLet},
+    {"LOOP", TokenKind::KeywordLoop},
     {"MOD", TokenKind::KeywordMod},
     {"NEXT", TokenKind::KeywordNext},
     {"NOT", TokenKind::KeywordNot},
@@ -65,6 +68,7 @@ constexpr std::array<KeywordEntry, 41> kKeywordTable{{
     {"TO", TokenKind::KeywordTo},
     {"TRUE", TokenKind::KeywordTrue},
     {"UBOUND", TokenKind::KeywordUbound},
+    {"UNTIL", TokenKind::KeywordUntil},
     {"WEND", TokenKind::KeywordWend},
     {"WHILE", TokenKind::KeywordWhile},
 }};

--- a/src/frontends/basic/Token.cpp
+++ b/src/frontends/basic/Token.cpp
@@ -52,6 +52,8 @@ const char *tokenKindToString(TokenKind k)
             return "WHILE";
         case TokenKind::KeywordWend:
             return "WEND";
+        case TokenKind::KeywordLoop:
+            return "LOOP";
         case TokenKind::KeywordFor:
             return "FOR";
         case TokenKind::KeywordTo:
@@ -64,10 +66,14 @@ const char *tokenKindToString(TokenKind k)
             return "GOTO";
         case TokenKind::KeywordEnd:
             return "END";
+        case TokenKind::KeywordExit:
+            return "EXIT";
         case TokenKind::KeywordInput:
             return "INPUT";
         case TokenKind::KeywordDim:
             return "DIM";
+        case TokenKind::KeywordDo:
+            return "DO";
         case TokenKind::KeywordRedim:
             return "REDIM";
         case TokenKind::KeywordAs:
@@ -108,6 +114,8 @@ const char *tokenKindToString(TokenKind k)
             return "LBOUND";
         case TokenKind::KeywordUbound:
             return "UBOUND";
+        case TokenKind::KeywordUntil:
+            return "UNTIL";
         case TokenKind::KeywordBoolean:
             return "BOOLEAN";
         case TokenKind::KeywordTrue:

--- a/src/frontends/basic/Token.hpp
+++ b/src/frontends/basic/Token.hpp
@@ -36,14 +36,17 @@ enum class TokenKind
     KeywordElseIf,
     KeywordWhile,
     KeywordWend,
+    KeywordLoop,
     KeywordFor,
     KeywordTo,
     KeywordStep,
     KeywordNext,
     KeywordGoto,
     KeywordEnd,
+    KeywordExit,
     KeywordInput,
     KeywordDim,
+    KeywordDo,
     KeywordRedim,
     KeywordAs,
     KeywordRandomize,
@@ -64,6 +67,7 @@ enum class TokenKind
     KeywordReturn,
     KeywordLbound,
     KeywordUbound,
+    KeywordUntil,
 
     // Operators -------------------------------------------------------------
     Plus,         ///< '+'.


### PR DESCRIPTION
## Summary
- add DO/LOOP/UNTIL/EXIT keyword token kinds for the BASIC frontend
- teach tokenKindToString about the new keywords
- update the lexer keyword table to recognize the new keywords

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d3fdc93eb8832491c0ad206a0f2463