### PR TITLE
basic/ast: add DoStmt and ExitStmt; extend visitors and printer

### DIFF
--- a/src/frontends/basic/AST.cpp
+++ b/src/frontends/basic/AST.cpp
@@ -238,6 +238,18 @@ void WhileStmt::accept(MutStmtVisitor &visitor)
     visitor.visit(*this);
 }
 
+/// @brief Forwards this DO loop node to the visitor for double dispatch.
+/// @param visitor Receives the node; ownership remains with the AST.
+void DoStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void DoStmt::accept(MutStmtVisitor &visitor)
+{
+    visitor.visit(*this);
+}
+
 /// @brief Forwards this for loop node to the visitor for double dispatch.
 /// @param visitor Receives the node; ownership remains with the AST.
 void ForStmt::accept(StmtVisitor &visitor) const
@@ -258,6 +270,18 @@ void NextStmt::accept(StmtVisitor &visitor) const
 }
 
 void NextStmt::accept(MutStmtVisitor &visitor)
+{
+    visitor.visit(*this);
+}
+
+/// @brief Forwards this EXIT statement node to the visitor for double dispatch.
+/// @param visitor Receives the node; ownership remains with the AST.
+void ExitStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void ExitStmt::accept(MutStmtVisitor &visitor)
 {
     visitor.visit(*this);
 }

--- a/src/frontends/basic/ConstFolder.cpp
+++ b/src/frontends/basic/ConstFolder.cpp
@@ -545,6 +545,14 @@ private:
             foldStmt(bodyStmt);
     }
 
+    void visit(DoStmt &stmt) override
+    {
+        if (stmt.cond)
+            foldExpr(stmt.cond);
+        for (auto &bodyStmt : stmt.body)
+            foldStmt(bodyStmt);
+    }
+
     void visit(ForStmt &stmt) override
     {
         foldExpr(stmt.start);
@@ -556,6 +564,7 @@ private:
     }
 
     void visit(NextStmt &) override {}
+    void visit(ExitStmt &) override {}
     void visit(GotoStmt &) override {}
     void visit(EndStmt &) override {}
     void visit(InputStmt &) override {}

--- a/src/frontends/basic/LowerEmit.hpp
+++ b/src/frontends/basic/LowerEmit.hpp
@@ -117,6 +117,7 @@ bool lowerIfBranch(const Stmt *stmt,
                    il::support::SourceLoc loc);
 void lowerIf(const IfStmt &stmt);
 void lowerWhile(const WhileStmt &stmt);
+void lowerDo(const DoStmt &stmt);
 void lowerLoopBody(const std::vector<StmtPtr> &body);
 void lowerFor(const ForStmt &stmt);
 void lowerForConstStep(const ForStmt &stmt, Value slot, RVal end, RVal step, int64_t stepConst);
@@ -124,6 +125,7 @@ void lowerForVarStep(const ForStmt &stmt, Value slot, RVal end, RVal step);
 ForBlocks setupForBlocks(bool varStep);
 void emitForStep(Value slot, Value step);
 void lowerNext(const NextStmt &stmt);
+void lowerExit(const ExitStmt &stmt);
 void lowerGoto(const GotoStmt &stmt);
 void lowerEnd(const EndStmt &stmt);
 void lowerInput(const InputStmt &stmt);

--- a/src/frontends/basic/LowerScan.cpp
+++ b/src/frontends/basic/LowerScan.cpp
@@ -196,6 +196,17 @@ class ScanStmtVisitor final : public StmtVisitor
         }
     }
 
+    void visit(const DoStmt &stmt) override
+    {
+        if (stmt.cond)
+            lowerer_.scanExpr(*stmt.cond);
+        for (const auto &child : stmt.body)
+        {
+            if (child)
+                lowerer_.scanStmt(*child);
+        }
+    }
+
     void visit(const ForStmt &stmt) override
     {
         if (!stmt.var.empty())
@@ -216,6 +227,7 @@ class ScanStmtVisitor final : public StmtVisitor
     }
 
     void visit(const NextStmt &) override {}
+    void visit(const ExitStmt &) override {}
 
     void visit(const GotoStmt &) override {}
 

--- a/src/frontends/basic/LowerStmt.cpp
+++ b/src/frontends/basic/LowerStmt.cpp
@@ -44,9 +44,13 @@ class LowererStmtVisitor final : public StmtVisitor
 
     void visit(const WhileStmt &stmt) override { lowerer_.lowerWhile(stmt); }
 
+    void visit(const DoStmt &stmt) override { lowerer_.lowerDo(stmt); }
+
     void visit(const ForStmt &stmt) override { lowerer_.lowerFor(stmt); }
 
     void visit(const NextStmt &stmt) override { lowerer_.lowerNext(stmt); }
+
+    void visit(const ExitStmt &stmt) override { lowerer_.lowerExit(stmt); }
 
     void visit(const GotoStmt &stmt) override { lowerer_.lowerGoto(stmt); }
 
@@ -437,6 +441,12 @@ void Lowerer::lowerWhile(const WhileStmt &stmt)
     done->terminated = term;
 }
 
+void Lowerer::lowerDo(const DoStmt &stmt)
+{
+    (void)stmt;
+    // TODO: Implement DO ... LOOP lowering.
+}
+
 /// @brief Create the block layout shared by FOR loops.
 /// @param varStep Whether the loop has a variable (runtime) step expression.
 /// @return Descriptor pointing to the inserted head/body/inc/done blocks.
@@ -625,6 +635,12 @@ void Lowerer::lowerFor(const ForStmt &stmt)
 void Lowerer::lowerNext(const NextStmt &next)
 {
     (void)next;
+}
+
+void Lowerer::lowerExit(const ExitStmt &stmt)
+{
+    (void)stmt;
+    // TODO: Implement EXIT lowering.
 }
 
 /// @brief Lower a GOTO jump.

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -437,6 +437,8 @@ class Lowerer
 
     void lowerWhile(const WhileStmt &stmt);
 
+    void lowerDo(const DoStmt &stmt);
+
     void lowerLoopBody(const std::vector<StmtPtr> &body);
 
     void lowerFor(const ForStmt &stmt);
@@ -450,6 +452,8 @@ class Lowerer
     void emitForStep(Value slot, Value step);
 
     void lowerNext(const NextStmt &stmt);
+
+    void lowerExit(const ExitStmt &stmt);
 
     void lowerGoto(const GotoStmt &stmt);
 

--- a/src/frontends/basic/LoweringPipeline.cpp
+++ b/src/frontends/basic/LoweringPipeline.cpp
@@ -170,6 +170,15 @@ class VarCollectStmtVisitor final : public StmtVisitor
                 sub->accept(*this);
     }
 
+    void visit(const DoStmt &stmt) override
+    {
+        if (stmt.cond)
+            stmt.cond->accept(exprVisitor_);
+        for (const auto &sub : stmt.body)
+            if (sub)
+                sub->accept(*this);
+    }
+
     void visit(const ForStmt &stmt) override
     {
         if (!stmt.var.empty())
@@ -190,6 +199,8 @@ class VarCollectStmtVisitor final : public StmtVisitor
         if (!stmt.var.empty())
             lowerer_.markSymbolReferenced(stmt.var);
     }
+
+    void visit(const ExitStmt &) override {}
 
     void visit(const GotoStmt &) override {}
 

--- a/src/frontends/basic/SemanticAnalyzer.Stmts.cpp
+++ b/src/frontends/basic/SemanticAnalyzer.Stmts.cpp
@@ -34,8 +34,10 @@ class SemanticAnalyzerStmtVisitor final : public MutStmtVisitor
     void visit(RandomizeStmt &stmt) override { analyzer_.analyzeRandomize(stmt); }
     void visit(IfStmt &stmt) override { analyzer_.analyzeIf(stmt); }
     void visit(WhileStmt &stmt) override { analyzer_.analyzeWhile(stmt); }
+    void visit(DoStmt &stmt) override { analyzer_.analyzeDo(stmt); }
     void visit(ForStmt &stmt) override { analyzer_.analyzeFor(stmt); }
     void visit(NextStmt &stmt) override { analyzer_.analyzeNext(stmt); }
+    void visit(ExitStmt &stmt) override { analyzer_.analyzeExit(stmt); }
     void visit(GotoStmt &stmt) override { analyzer_.analyzeGoto(stmt); }
     void visit(EndStmt &stmt) override { analyzer_.analyzeEnd(stmt); }
     void visit(InputStmt &stmt) override { analyzer_.analyzeInput(stmt); }
@@ -247,6 +249,16 @@ void SemanticAnalyzer::analyzeWhile(const WhileStmt &w)
             visitStmt(*bs);
 }
 
+void SemanticAnalyzer::analyzeDo(const DoStmt &d)
+{
+    if (d.cond)
+        checkConditionExpr(*d.cond);
+    ScopeTracker::ScopedScope scope(scopes_);
+    for (const auto &bs : d.body)
+        if (bs)
+            visitStmt(*bs);
+}
+
 void SemanticAnalyzer::analyzeFor(ForStmt &f)
 {
     resolveAndTrackSymbol(f.var, SymbolKind::Definition);
@@ -295,6 +307,12 @@ void SemanticAnalyzer::analyzeNext(const NextStmt &n)
     {
         forStack_.pop_back();
     }
+}
+
+void SemanticAnalyzer::analyzeExit(const ExitStmt &stmt)
+{
+    (void)stmt;
+    // TODO: Validate EXIT statements once loop tracking is implemented.
 }
 
 void SemanticAnalyzer::analyzeEnd(const EndStmt &)

--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -88,12 +88,16 @@ class SemanticAnalyzer
     void analyzeIf(const IfStmt &s);
     /// @brief Analyze WHILE statement @p s.
     void analyzeWhile(const WhileStmt &s);
+    /// @brief Analyze DO statement @p s.
+    void analyzeDo(const DoStmt &s);
     /// @brief Analyze FOR statement @p s.
     void analyzeFor(ForStmt &s);
     /// @brief Analyze GOTO statement @p s.
     void analyzeGoto(const GotoStmt &s);
     /// @brief Analyze NEXT statement @p s.
     void analyzeNext(const NextStmt &s);
+    /// @brief Analyze EXIT statement @p s.
+    void analyzeExit(const ExitStmt &s);
     /// @brief Analyze END statement @p s.
     void analyzeEnd(const EndStmt &s);
     /// @brief Analyze RANDOMIZE statement @p s.

--- a/tests/unit/test_basic_ast_printer.cpp
+++ b/tests/unit/test_basic_ast_printer.cpp
@@ -233,6 +233,24 @@ int main()
     forStmt->body.push_back(std::move(forPrint));
     prog.main.push_back(std::move(forStmt));
 
+    auto doStmt = std::make_unique<DoStmt>();
+    doStmt->line = 85;
+    doStmt->testPos = DoStmt::TestPos::Post;
+    doStmt->condKind = DoStmt::CondKind::Until;
+    doStmt->cond = makeVar("DONE");
+    auto doPrint = std::make_unique<PrintStmt>();
+    doPrint->line = 86;
+    PrintItem doItem;
+    doItem.expr = makeString("LOOP");
+    doPrint->items.push_back(std::move(doItem));
+    doStmt->body.push_back(std::move(doPrint));
+    prog.main.push_back(std::move(doStmt));
+
+    auto exitStmt = std::make_unique<ExitStmt>();
+    exitStmt->line = 87;
+    exitStmt->kind = ExitStmt::LoopKind::Do;
+    prog.main.push_back(std::move(exitStmt));
+
     auto nextStmt = std::make_unique<NextStmt>();
     nextStmt->line = 90;
     nextStmt->var = "I";
@@ -271,6 +289,8 @@ int main()
                                  "0) THEN (PRINT \"NEG\") ELSE (PRINT \"ZERO\"))\n"
                                  "70: (WHILE (NOT DONE) {71:(PRINT 1)})\n"
                                  "80: (FOR I = 1 TO 5 STEP 2 {81:(PRINT I)})\n"
+                                 "85: (DO post UNTIL DONE {86:(PRINT \"LOOP\")})\n"
+                                 "87: (EXIT DO)\n"
                                  "90: (NEXT I)\n"
                                  "100: (GOTO 200)\n"
                                  "110: (RETURN (FNRESULT B ARR(I)))\n"


### PR DESCRIPTION
## Summary
- add DoStmt and ExitStmt AST node definitions with visitor hooks
- update BASIC frontend passes and printer to visit the new statements
- extend the AST printer unit test to cover DO loops and EXIT

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d400d3d96c8324a804d457be41b303