### PR TITLE
basic/parse: implement DO {WHILE|UNTIL} … LOOP [WHILE|UNTIL]

### DIFF
--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -42,8 +42,9 @@ class Parser
         /// @brief Aggregated information about a terminating keyword.
         struct TerminatorInfo
         {
-            int line = 0;                            ///< Optional line number that preceded the terminator.
-            il::support::SourceLoc loc{};            ///< Source location where the terminator keyword appeared.
+            int line = 0; ///< Optional line number that preceded the terminator.
+            il::support::SourceLoc
+                loc{}; ///< Source location where the terminator keyword appeared.
         };
 
         /// @brief Classification of the last separator consumed by the context.
@@ -54,8 +55,10 @@ class Parser
             LineBreak, ///< A line break separated the previous and next statements.
         };
 
-        using TerminatorPredicate = std::function<bool(int)>;                     ///< Predicate identifying terminator tokens.
-        using TerminatorConsumer = std::function<void(int, TerminatorInfo &)>;     ///< Callback consuming the terminator tokens.
+        using TerminatorPredicate =
+            std::function<bool(int)>; ///< Predicate identifying terminator tokens.
+        using TerminatorConsumer = std::function<void(
+            int, TerminatorInfo &)>; ///< Callback consuming the terminator tokens.
 
         /// @brief Construct a context bound to @p parser.
         /// @param parser Owning parser providing token accessors.
@@ -81,7 +84,10 @@ class Parser
 
         /// @brief Report which separator most recently separated statements.
         /// @return Classification of the most recent separator.
-        SeparatorKind lastSeparator() const { return lastSeparator_; }
+        SeparatorKind lastSeparator() const
+        {
+            return lastSeparator_;
+        }
 
         /// @brief Parse statements until @p isTerminator matches and populate @p dst.
         /// @param isTerminator Predicate determining when the body ends.
@@ -89,8 +95,8 @@ class Parser
         /// @param dst Destination vector receiving parsed statements.
         /// @return Line/location metadata of the terminating keyword.
         TerminatorInfo consumeStatementBody(const TerminatorPredicate &isTerminator,
-                                           const TerminatorConsumer &onTerminator,
-                                           std::vector<StmtPtr> &dst);
+                                            const TerminatorConsumer &onTerminator,
+                                            std::vector<StmtPtr> &dst);
 
         /// @brief Parse statements until @p terminator is encountered.
         /// @param terminator Token that terminates the body.
@@ -99,9 +105,10 @@ class Parser
         TerminatorInfo consumeStatementBody(TokenKind terminator, std::vector<StmtPtr> &dst);
 
       private:
-        Parser &parser_; ///< Parent parser that owns the token stream.
+        Parser &parser_;       ///< Parent parser that owns the token stream.
         int pendingLine_ = -1; ///< Deferred line label for the next statement.
-        SeparatorKind lastSeparator_ = SeparatorKind::LineBreak; ///< Classification of the last separator consumed.
+        SeparatorKind lastSeparator_ =
+            SeparatorKind::LineBreak; ///< Classification of the last separator consumed.
     };
 
     /// @brief Create a statement context bound to this parser instance.
@@ -138,7 +145,8 @@ class Parser
         StmtPtr (Parser::*with_line)(int) = nullptr; ///< Handler requiring line number.
     };
 
-    std::array<StmtHandler, static_cast<std::size_t>(TokenKind::Count)> stmtHandlers_{}; ///< Token to parser mapping.
+    std::array<StmtHandler, static_cast<std::size_t>(TokenKind::Count)>
+        stmtHandlers_{}; ///< Token to parser mapping.
 
 #include "frontends/basic/Parser_Token.hpp"
 
@@ -168,6 +176,10 @@ class Parser
     /// @brief Parse a WHILE loop.
     /// @return WHILE statement node.
     StmtPtr parseWhile();
+
+    /// @brief Parse a DO ... LOOP statement.
+    /// @return DO statement node with optional tests.
+    StmtPtr parseDo();
 
     /// @brief Parse a FOR loop.
     /// @return FOR statement node.

--- a/tests/frontends/basic/ParserStatementContextTests.cpp
+++ b/tests/frontends/basic/ParserStatementContextTests.cpp
@@ -30,13 +30,12 @@ int main()
     }
 
     {
-        std::string src =
-            "10 WHILE FLAG\n"
-            "20 FOR I = 1 TO 3\n"
-            "30 PRINT I: IF I = 2 THEN PRINT 99\n"
-            "40 NEXT I\n"
-            "50 WEND\n"
-            "60 END\n";
+        std::string src = "10 WHILE FLAG\n"
+                          "20 FOR I = 1 TO 3\n"
+                          "30 PRINT I: IF I = 2 THEN PRINT 99\n"
+                          "40 NEXT I\n"
+                          "50 WEND\n"
+                          "60 END\n";
         SourceManager sm;
         uint32_t fid = sm.addFile("nested.bas");
         Parser p(src, fid);
@@ -57,12 +56,11 @@ int main()
     }
 
     {
-        std::string src =
-            "10 IF FLAG THEN\n"
-            "20 PRINT 1\n"
-            "30 ELSE\n"
-            "40 PRINT 2\n"
-            "50 END\n";
+        std::string src = "10 IF FLAG THEN\n"
+                          "20 PRINT 1\n"
+                          "30 ELSE\n"
+                          "40 PRINT 2\n"
+                          "50 END\n";
         SourceManager sm;
         uint32_t fid = sm.addFile("ifnewlines.bas");
         Parser p(src, fid);
@@ -78,14 +76,13 @@ int main()
     }
 
     {
-        std::string src =
-            "10 IF FLAG THEN\n"
-            "20 PRINT 1\n"
-            "30 ELSEIF OTHER THEN\n"
-            "40 PRINT 2\n"
-            "50 ELSE\n"
-            "60 PRINT 3\n"
-            "70 END\n";
+        std::string src = "10 IF FLAG THEN\n"
+                          "20 PRINT 1\n"
+                          "30 ELSEIF OTHER THEN\n"
+                          "40 PRINT 2\n"
+                          "50 ELSE\n"
+                          "60 PRINT 3\n"
+                          "70 END\n";
         SourceManager sm;
         uint32_t fid = sm.addFile("ifelseif.bas");
         Parser p(src, fid);
@@ -107,9 +104,8 @@ int main()
     }
 
     {
-        std::string src =
-            "10 IF FLAG THEN PRINT 1 ELSEIF OTHER THEN PRINT 2 ELSE PRINT 3\n"
-            "20 END\n";
+        std::string src = "10 IF FLAG THEN PRINT 1 ELSEIF OTHER THEN PRINT 2 ELSE PRINT 3\n"
+                          "20 END\n";
         SourceManager sm;
         uint32_t fid = sm.addFile("ifinline.bas");
         Parser p(src, fid);
@@ -127,9 +123,8 @@ int main()
     }
 
     {
-        std::string src =
-            "10 IF FLAG THEN PRINT 1: PRINT 2\n"
-            "20 END\n";
+        std::string src = "10 IF FLAG THEN PRINT 1: PRINT 2\n"
+                          "20 END\n";
         SourceManager sm;
         uint32_t fid = sm.addFile("ifcolon.bas");
         Parser p(src, fid);
@@ -142,6 +137,68 @@ int main()
         auto *ifStmt = dynamic_cast<IfStmt *>(list->stmts[0].get());
         assert(ifStmt);
         assert(dynamic_cast<PrintStmt *>(list->stmts[1].get()));
+    }
+
+    {
+        std::string src = "10 DO WHILE FLAG\n"
+                          "20 PRINT 1\n"
+                          "30 LOOP\n"
+                          "40 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("dowhile.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        assert(prog);
+        assert(prog->main.size() == 2);
+        auto *doStmt = dynamic_cast<DoStmt *>(prog->main[0].get());
+        assert(doStmt);
+        assert(doStmt->condKind == DoStmt::CondKind::While);
+        assert(doStmt->testPos == DoStmt::TestPos::Pre);
+        assert(doStmt->cond);
+        auto *var = dynamic_cast<VarExpr *>(doStmt->cond.get());
+        assert(var);
+        assert(var->name == "FLAG");
+        assert(doStmt->body.size() == 1);
+        assert(dynamic_cast<PrintStmt *>(doStmt->body[0].get()));
+    }
+
+    {
+        std::string src = "10 DO\n"
+                          "20 PRINT 1\n"
+                          "30 LOOP UNTIL DONE\n"
+                          "40 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("dountil.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        assert(prog);
+        assert(prog->main.size() == 2);
+        auto *doStmt = dynamic_cast<DoStmt *>(prog->main[0].get());
+        assert(doStmt);
+        assert(doStmt->condKind == DoStmt::CondKind::Until);
+        assert(doStmt->testPos == DoStmt::TestPos::Post);
+        assert(doStmt->cond);
+        auto *var = dynamic_cast<VarExpr *>(doStmt->cond.get());
+        assert(var);
+        assert(var->name == "DONE");
+        assert(doStmt->body.size() == 1);
+        assert(dynamic_cast<PrintStmt *>(doStmt->body[0].get()));
+    }
+
+    {
+        std::string src = "10 DO: LOOP\n"
+                          "20 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("doloop.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        assert(prog);
+        assert(prog->main.size() == 2);
+        auto *doStmt = dynamic_cast<DoStmt *>(prog->main[0].get());
+        assert(doStmt);
+        assert(doStmt->condKind == DoStmt::CondKind::None);
+        assert(!doStmt->cond);
+        assert(doStmt->body.empty());
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- register a DO statement handler and declaration in the BASIC parser
- implement DO … LOOP parsing with optional pre- and post-conditions plus diagnostics
- extend parser statement context tests to cover DO loop forms

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d405b4ebe0832489c0080773ac6731