### PR TITLE
Add EXIT loop kind parsing to BASIC frontend

### DIFF
--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -30,6 +30,7 @@ Parser::Parser(std::string_view src, uint32_t file_id, DiagnosticEmitter *emitte
     setHandler(TokenKind::KeywordDo, {&Parser::parseDo, nullptr});
     setHandler(TokenKind::KeywordFor, {&Parser::parseFor, nullptr});
     setHandler(TokenKind::KeywordNext, {&Parser::parseNext, nullptr});
+    setHandler(TokenKind::KeywordExit, {&Parser::parseExit, nullptr});
     setHandler(TokenKind::KeywordGoto, {&Parser::parseGoto, nullptr});
     setHandler(TokenKind::KeywordEnd, {&Parser::parseEnd, nullptr});
     setHandler(TokenKind::KeywordInput, {&Parser::parseInput, nullptr});

--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -189,6 +189,10 @@ class Parser
     /// @return NEXT statement node.
     StmtPtr parseNext();
 
+    /// @brief Parse an EXIT statement identifying the loop kind.
+    /// @return EXIT statement node.
+    StmtPtr parseExit();
+
     /// @brief Parse a GOTO statement.
     /// @return GOTO statement node.
     StmtPtr parseGoto();

--- a/tests/unit/test_basic_parse_loops.cpp
+++ b/tests/unit/test_basic_parse_loops.cpp
@@ -50,5 +50,26 @@ int main()
         assert(endStmt);
     }
 
+    {
+        std::string src = "10 EXIT FOR\n20 EXIT WHILE\n30 EXIT DO\n40 END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("loops.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        assert(prog);
+        assert(prog->main.size() == 4);
+        auto *exitFor = dynamic_cast<ExitStmt *>(prog->main[0].get());
+        assert(exitFor);
+        assert(exitFor->kind == ExitStmt::LoopKind::For);
+        auto *exitWhile = dynamic_cast<ExitStmt *>(prog->main[1].get());
+        assert(exitWhile);
+        assert(exitWhile->kind == ExitStmt::LoopKind::While);
+        auto *exitDo = dynamic_cast<ExitStmt *>(prog->main[2].get());
+        assert(exitDo);
+        assert(exitDo->kind == ExitStmt::LoopKind::Do);
+        auto *endStmt = dynamic_cast<EndStmt *>(prog->main[3].get());
+        assert(endStmt);
+    }
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- register the EXIT statement parser and add parseExit() to build ExitStmt nodes with loop kinds
- diagnose missing loop-kind keywords after EXIT and return an error sentinel
- cover EXIT FOR/WHILE/DO parsing with a unit test case

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d40cc81f4c8324a97cacb2ea910d00