### PR TITLE
basic/semantics: enforce FOR loop variable immutability (B1010)

### DIFF
--- a/tests/golden/CMakeLists.txt
+++ b/tests/golden/CMakeLists.txt
@@ -28,6 +28,24 @@ function(viper_add_golden_suite_tests)
     "-DEXPECT=${EXPECT_MISMATCHED_NEXT}"
     -P ${_VIPER_GOLDEN_DIR}/basic_errors/check_error.cmake)
 
+  file(READ ${_VIPER_GOLDEN_DIR}/basic_errors/loop_var_assignment.stderr EXPECT_LOOP_VAR_ASSIGNMENT)
+  string(STRIP "${EXPECT_LOOP_VAR_ASSIGNMENT}" EXPECT_LOOP_VAR_ASSIGNMENT)
+  viper_add_ctest(basic_error_loop_var_assignment
+    ${CMAKE_COMMAND}
+    -DILC=${BASIC_ILC}
+    -DBAS_FILE=${_VIPER_GOLDEN_DIR}/basic_errors/loop_var_assignment.bas
+    "-DEXPECT=${EXPECT_LOOP_VAR_ASSIGNMENT}"
+    -P ${_VIPER_GOLDEN_DIR}/basic_errors/check_error.cmake)
+
+  file(READ ${_VIPER_GOLDEN_DIR}/basic_errors/loop_var_input.stderr EXPECT_LOOP_VAR_INPUT)
+  string(STRIP "${EXPECT_LOOP_VAR_INPUT}" EXPECT_LOOP_VAR_INPUT)
+  viper_add_ctest(basic_error_loop_var_input
+    ${CMAKE_COMMAND}
+    -DILC=${BASIC_ILC}
+    -DBAS_FILE=${_VIPER_GOLDEN_DIR}/basic_errors/loop_var_input.bas
+    "-DEXPECT=${EXPECT_LOOP_VAR_INPUT}"
+    -P ${_VIPER_GOLDEN_DIR}/basic_errors/check_error.cmake)
+
   file(READ ${_VIPER_GOLDEN_DIR}/basic_errors/bad_goto.stderr EXPECT_BAD_GOTO)
   string(STRIP "${EXPECT_BAD_GOTO}" EXPECT_BAD_GOTO)
   viper_add_ctest(basic_error_bad_goto

--- a/tests/golden/basic_errors/loop_var_assignment.bas
+++ b/tests/golden/basic_errors/loop_var_assignment.bas
@@ -1,0 +1,3 @@
+10 FOR I = 1 TO 3
+20 LET I = 2
+30 NEXT I

--- a/tests/golden/basic_errors/loop_var_assignment.stderr
+++ b/tests/golden/basic_errors/loop_var_assignment.stderr
@@ -1,0 +1,1 @@
+B1010.*cannot assign to loop variable 'I' inside FOR

--- a/tests/golden/basic_errors/loop_var_input.bas
+++ b/tests/golden/basic_errors/loop_var_input.bas
@@ -1,0 +1,3 @@
+10 FOR I = 1 TO 3
+20 INPUT I
+30 NEXT I

--- a/tests/golden/basic_errors/loop_var_input.stderr
+++ b/tests/golden/basic_errors/loop_var_input.stderr
@@ -1,0 +1,1 @@
+B1010.*cannot assign to loop variable 'I' inside FOR


### PR DESCRIPTION
## Summary
- reject assignments to the active FOR loop variable inside LET and INPUT statements and surface diagnostic B1010
- add BASIC golden tests covering LET and INPUT attempts to mutate loop variables

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d4108b70008324a4381471d34cd846