### PR TITLE
docs: document DO/LOOP, EXIT *, and FOR loop-var immutability

### DIFF
--- a/docs/basic-language.md
+++ b/docs/basic-language.md
@@ -1,7 +1,7 @@
 ---
 status: active
 audience: public
-last-verified: 2025-09-23
+last-verified: 2025-09-24
 ---
 
 <a id="basic-reference"></a>
@@ -123,6 +123,38 @@ Conditional blocks evaluate boolean expressions. Each branch ends with `END IF`.
 40 WEND
 ```
 
+#### DO / LOOP
+`DO` / `LOOP` supports both pre-test and post-test forms. `WHILE` repeats while
+the condition is true; `UNTIL` repeats until the condition becomes true.
+
+```basic
+10 DO WHILE I < 3
+20   PRINT I
+30   LET I = I + 1
+40 LOOP
+
+50 DO UNTIL READY
+60   INPUT READY
+70 LOOP
+
+80 DO
+90   PRINT "tick"
+100  LET I = I + 1
+110 LOOP WHILE I < 5
+
+120 DO
+130   PRINT "polling"
+140 LOOP UNTIL DONE()
+
+150 DO
+160   PRINT "infinite"
+170   EXIT DO        ' exit manually when ready
+180 LOOP
+```
+
+The final form above runs indefinitely unless an `EXIT DO` transfers control to
+the loop's `LOOP` terminator.
+
 #### FOR / NEXT
 `FOR` loops iterate over an inclusive range.
 
@@ -131,6 +163,14 @@ Conditional blocks evaluate boolean expressions. Each branch ends with `END IF`.
 20   PRINT I
 30 NEXT I
 ```
+
+The loop variable is immutable inside the body. Attempting to reassign it (for
+example, `I = I + 1`) is rejected during semantic analysis with an error such as
+`error: FOR loop variable 'I' cannot be reassigned inside the loop`.
+
+#### EXIT statements
+`EXIT FOR`, `EXIT WHILE`, and `EXIT DO` terminate the innermost loop of the
+matching kind and continue execution after that loop.
 
 #### Multi-statement lines
 Separate statements on the same line with `:`.

--- a/docs/il-guide.md
+++ b/docs/il-guide.md
@@ -744,7 +744,10 @@ stay stable. Within a procedure `proc`, block names follow these patterns:
 * `entry_proc` and `ret_proc` for the entry and synthetic return blocks.
 * `if_then_k_proc`, `if_else_k_proc`, `if_end_k_proc` for `IF` constructs.
 * `while_head_k_proc`, `while_body_k_proc`, `while_end_k_proc` for `WHILE`.
+* `do_head_k_proc`, `do_body_k_proc`, `do_end_k_proc` for `DO` / `LOOP`.
 * `for_head_k_proc`, `for_body_k_proc`, `for_inc_k_proc`, `for_end_k_proc` for `FOR`.
+* `exit_end_k_proc` is not used; `EXIT` statements branch directly to the
+  surrounding loop's `*_end_k_proc` block.
 * `call_cont_k_proc` for call continuations.
 
 The counter `k` is monotonic **per procedure**; labels never depend on container


### PR DESCRIPTION
## Summary
- document DO/LOOP variants, EXIT statements, and FOR loop variable immutability in the BASIC reference and refresh the verification date
- note the block naming convention for DO/EXIT in the IL guide

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d43d97ca708324ab6e5e01c6d8cab7