### PR TITLE
tests: diagnostics for FOR immutability (B1010) and EXIT misuse (B1011)

### DIFF
--- a/tests/basic/semantics/test_exit_misplaced.bas
+++ b/tests/basic/semantics/test_exit_misplaced.bas
@@ -1,0 +1,4 @@
+10 EXIT DO      ' error: no active DO
+20 WHILE 0
+30   EXIT FOR   ' error: innermost is WHILE
+40 WEND

--- a/tests/basic/semantics/test_exit_misplaced.diag
+++ b/tests/basic/semantics/test_exit_misplaced.diag
@@ -1,0 +1,6 @@
+tests/basic/semantics/test_exit_misplaced.bas:1:4: error[B1011]: EXIT DO used outside of any loop
+10 EXIT DO      ' error: no active DO
+   ^^^^
+tests/basic/semantics/test_exit_misplaced.bas:3:6: error[B1011]: EXIT FOR does not match innermost loop (WHILE)
+30   EXIT FOR   ' error: innermost is WHILE
+     ^^^^

--- a/tests/basic/semantics/test_for_loopvar_immutable.bas
+++ b/tests/basic/semantics/test_for_loopvar_immutable.bas
@@ -1,0 +1,3 @@
+10 FOR I = 1 TO 3
+20 LET I = 5   ' error
+30 NEXT I

--- a/tests/basic/semantics/test_for_loopvar_immutable.diag
+++ b/tests/basic/semantics/test_for_loopvar_immutable.diag
@@ -1,0 +1,3 @@
+tests/basic/semantics/test_for_loopvar_immutable.bas:2:4: error[B1010]: cannot assign to loop variable 'I' inside FOR
+20 LET I = 5   ' error
+   ^


### PR DESCRIPTION
## Summary
- add a BASIC semantics diagnostic test that confirms loop variables cannot be reassigned inside FOR blocks
- add a BASIC semantics diagnostic test that catches EXIT statements outside or mismatching active loops

## Testing
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d4478e36908324b68a9f89457e6aa5