### PR TITLE
Move runtime/ under src/ and update build + includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ add_link_options(${IL_LINK_FLAGS})
 
 file(GLOB_RECURSE ALL_CXX_SOURCE_FILES
      src/*.cpp src/*.hpp
-     runtime/*.cpp runtime/*.hpp)
+     src/runtime/*.cpp src/runtime/*.hpp)
 
 add_custom_target(format
   COMMAND clang-format -i ${ALL_CXX_SOURCE_FILES}
@@ -110,7 +110,7 @@ if(VIPER_BUILD_TESTING)
   enable_testing()
 endif()
 
-add_subdirectory(runtime)
+add_subdirectory(${CMAKE_SOURCE_DIR}/src/runtime)
 add_subdirectory(src)
 
 # ---- ViperTUI subproject ----

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,7 +79,7 @@ When the native backend is enabled, the same IL feeds the code generator instead
 - **Front end:** `src/frontends/basic/`.
 - **IL core:** `src/il/core/`, `src/il/io/`, `src/il/build/`, `src/il/verify/`.
 - **Passes:** `src/il/transform/`.
-- **VM:** `src/vm/`, `runtime/`.
+- **VM:** `src/vm/`, `src/runtime/`.
 - **Code generation:** `src/codegen/`.
 - **Support utilities:** `src/support/`.
 - **Tools:** `src/tools/ilc/` (driver and subcommands), `src/tools/`.
@@ -149,7 +149,7 @@ The verifier runs after passes to enforce correctness before execution or code g
 
 ### Runtime & ABI (externs)
 
-Extern symbols in IL map to C functions declared in `runtime/rt.hpp`. Strings use reference-counted heap objects; numeric values are 64-bit.
+Extern symbols in IL map to C functions declared in `src/runtime/rt.hpp`. Strings use reference-counted heap objects; numeric values are 64-bit.
 
 Initial runtime surface (all prefixed `rt_`):
 
@@ -276,7 +276,7 @@ Modules declare an IL version (`il 0.1.2`) at the top. The runtime ABI aims to r
 /CMakeLists.txt
 /cmake/              # compiler flags, toolchain helpers
 /docs/               # IL spec, developer docs, ADRs
-/runtime/            # C runtime (librt.a): rt_*.c, rt.hpp
+/src/runtime/        # C runtime (librt.a): rt_*.c, rt.hpp
 /src/
   support/           # shared utilities
   il/                # core types, IR, builder, verifier, I/O

--- a/docs/il-guide.md
+++ b/docs/il-guide.md
@@ -563,7 +563,7 @@ The IL runtime provides helper functions used by front ends and tests:
 | `@rt_alloc` | `i64 -> ptr` | allocate bytes; negative size traps |
 | `@rt_free` | `ptr -> void` | deallocate buffer (optional in v0.1.2) |
 
-Strings are reference-counted by the runtime implementation.  See [runtime/](runtime/) for additional details.
+Strings are reference-counted by the runtime implementation.  See [src/runtime/](../src/runtime/) for additional details.
 
 #### Memory Model
 IL v0.1.2 is single-threaded.  Pointers are plain addresses with no aliasing rules beyond the type requirements of `load` and `store`.  Memory obtained through `alloca` or the runtime follows the alignment rules above, and invalid accesses (null or misaligned) trap deterministically.

--- a/scripts/comment_check_excludes.txt
+++ b/scripts/comment_check_excludes.txt
@@ -26,7 +26,7 @@ src/tools/il-verify/il-verify.cpp
 src/tools/ilc/main.cpp
 src/vm/RuntimeBridge.cpp
 src/vm/VM.cpp
-runtime/rt.c
+src/runtime/rt.c
 tests/unit/test_basic_lexer.cpp
 tests/unit/test_il_roundtrip.cpp
 tests/unit/test_il_serialize.cpp

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -8,9 +8,10 @@ set(RT_SOURCES
 )
 
 add_library(rt STATIC ${RT_SOURCES})
-target_include_directories(rt PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
+target_include_directories(rt
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/runtime>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
 )
 
 if(NOT WIN32)

--- a/src/runtime/rt.hpp
+++ b/src/runtime/rt.hpp
@@ -1,4 +1,4 @@
-// File: runtime/rt.hpp
+// File: src/runtime/rt.hpp
 // Purpose: Declares C runtime utilities for memory, strings, and I/O.
 // Key invariants: Reference counts remain non-negative.
 // Ownership/Lifetime: Caller manages returned strings.

--- a/src/runtime/rt_array.c
+++ b/src/runtime/rt_array.c
@@ -1,4 +1,4 @@
-// File: runtime/rt_array.c
+// File: src/runtime/rt_array.c
 // Purpose: Implements dynamic int32 array helpers for the BASIC runtime.
 // Key invariants: Array length never exceeds capacity; allocations are zeroed on growth.
 // Ownership/Lifetime: Caller manages array handles and releases them via free().

--- a/src/runtime/rt_array.h
+++ b/src/runtime/rt_array.h
@@ -1,4 +1,4 @@
-// File: runtime/rt_array.h
+// File: src/runtime/rt_array.h
 // Purpose: Declares dynamic int32 array helpers for the BASIC runtime.
 // Key invariants: Array length never exceeds capacity; storage is contiguous.
 // Ownership/Lifetime: Caller owns array handles and must free them with free().

--- a/src/runtime/rt_internal.h
+++ b/src/runtime/rt_internal.h
@@ -1,4 +1,4 @@
-// File: runtime/rt_internal.h
+// File: src/runtime/rt_internal.h
 // Purpose: Defines internal runtime structures shared across implementation files.
 // Key invariants: Strings use reference counts; structure layout is stable.
 // Ownership/Lifetime: Caller manages lifetime of rt_string instances.

--- a/src/runtime/rt_io.c
+++ b/src/runtime/rt_io.c
@@ -1,4 +1,4 @@
-// File: runtime/rt_io.c
+// File: src/runtime/rt_io.c
 // Purpose: Implements I/O utilities and trap handling for the BASIC runtime.
 // Key invariants: Output routines do not append newlines unless specified.
 // Ownership/Lifetime: Caller manages strings passed to printing routines.

--- a/src/runtime/rt_math.c
+++ b/src/runtime/rt_math.c
@@ -1,4 +1,4 @@
-// File: runtime/rt_math.c
+// File: src/runtime/rt_math.c
 // Purpose: Implements portable math helpers for the runtime.
 // Key invariants: Follows IEEE semantics; no traps on domain errors.
 // Ownership/Lifetime: None.

--- a/src/runtime/rt_math.h
+++ b/src/runtime/rt_math.h
@@ -1,4 +1,4 @@
-// File: runtime/rt_math.h
+// File: src/runtime/rt_math.h
 // Purpose: Declares portable math helpers for the runtime.
 // Key invariants: Functions mirror C math library semantics.
 // Ownership/Lifetime: None.

--- a/src/runtime/rt_memory.c
+++ b/src/runtime/rt_memory.c
@@ -1,4 +1,4 @@
-// File: runtime/rt_memory.c
+// File: src/runtime/rt_memory.c
 // Purpose: Implements memory allocation helpers for the BASIC runtime.
 // Key invariants: Allocation sizes must be non-negative and fit in size_t.
 // Ownership/Lifetime: Caller owns and must free returned memory blocks.

--- a/src/runtime/rt_random.c
+++ b/src/runtime/rt_random.c
@@ -1,4 +1,4 @@
-// File: runtime/rt_random.c
+// File: src/runtime/rt_random.c
 // Purpose: Implements deterministic random number generator.
 // Key invariants: Uses 64-bit LCG with fixed multiplier and increment; sequence is reproducible for
 // given seed. Ownership/Lifetime: Maintains a single internal state value; not thread-safe. Links:

--- a/src/runtime/rt_random.h
+++ b/src/runtime/rt_random.h
@@ -1,4 +1,4 @@
-// File: runtime/rt_random.h
+// File: src/runtime/rt_random.h
 // Purpose: Declares deterministic random number helpers.
 // Key invariants: 64-bit linear congruential generator; reproducible across platforms.
 // Ownership/Lifetime: Uses internal global state; single-threaded.

--- a/src/runtime/rt_string.c
+++ b/src/runtime/rt_string.c
@@ -1,4 +1,4 @@
-// File: runtime/rt_string.c
+// File: src/runtime/rt_string.c
 // Purpose: Implements string manipulation utilities for the BASIC runtime.
 // Key invariants: Strings use reference counts; operations trap on invalid inputs.
 // Ownership/Lifetime: Caller manages returned strings and reference counts.


### PR DESCRIPTION
## Summary
- relocate the C runtime into `src/runtime` and update the build graph to include the new location
- expose the runtime headers via the `rt` target and refresh documentation and scripts referencing the old path

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d44f2deaf883249c6d0e8831e34309