### PR TITLE
refactor(runtime): use shared heap for strings

### DIFF
--- a/src/runtime/rt_heap.h
+++ b/src/runtime/rt_heap.h
@@ -30,6 +30,11 @@ typedef struct rt_heap_hdr
 
 #define RT_MAGIC 0x52504956u /* 'VIPR' little-endian */
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 void *rt_heap_alloc(rt_heap_kind_t kind,
                     rt_elem_kind_t elem_kind,
                     size_t elem_size,
@@ -42,3 +47,7 @@ void *rt_heap_data(rt_heap_hdr_t *h);
 size_t rt_heap_len(void *payload);
 size_t rt_heap_cap(void *payload);
 void rt_heap_set_len(void *payload, size_t new_len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/runtime/rt_internal.h
+++ b/src/runtime/rt_internal.h
@@ -7,11 +7,12 @@
 #pragma once
 
 #include "rt.hpp"
+#include "rt_heap.h"
 
 struct rt_string_impl
 {
-    int64_t refcnt;
-    int64_t size;
-    int64_t capacity;
-    const char *data;
+    char *data;
+    rt_heap_hdr_t *heap;
+    size_t literal_len;
+    size_t literal_refs;
 };

--- a/tests/runtime/RTInputLineTests.cpp
+++ b/tests/runtime/RTInputLineTests.cpp
@@ -27,7 +27,7 @@ static void feed_and_check(size_t len, bool with_newline)
     close(fds[0]);
     rt_string s = rt_input_line();
     assert(s);
-    assert(s->size == (int64_t)input.size());
+    assert(rt_len(s) == (int64_t)input.size());
     assert(std::memcmp(s->data, input.data(), input.size()) == 0);
 }
 

--- a/tests/runtime/RTValStrTests.cpp
+++ b/tests/runtime/RTValStrTests.cpp
@@ -17,9 +17,9 @@ int main()
     assert(rt_val(rt_const_cstr("")) == 0.0);
 
     rt_string s42 = rt_str(42.0);
-    assert(std::string(s42->data, (size_t)s42->size) == "42");
+    assert(std::string(s42->data, rt_heap_len(s42->data)) == "42");
     rt_string sn = rt_str(-3.5);
-    assert(std::string(sn->data, (size_t)sn->size) == "-3.5");
+    assert(std::string(sn->data, rt_heap_len(sn->data)) == "-3.5");
 
     double vals[] = {0.0, 1.25, -2.5, 123.456};
     for (double v : vals)
@@ -34,6 +34,6 @@ int main()
     char tmp[64];
     int len = std::snprintf(tmp, sizeof(tmp), "%g", static_cast<double>(big));
     rt_string sbig = rt_str(static_cast<double>(big));
-    assert(std::string(sbig->data, (size_t)sbig->size) == std::string(tmp, (size_t)len));
+    assert(std::string(sbig->data, rt_heap_len(sbig->data)) == std::string(tmp, (size_t)len));
     return 0;
 }

--- a/tests/unit/test_rt_conv.cpp
+++ b/tests/unit/test_rt_conv.cpp
@@ -10,9 +10,9 @@
 int main()
 {
     rt_string si = rt_int_to_str(-42);
-    assert(si && std::string(si->data, (size_t)si->size) == "-42");
+    assert(si && std::string(si->data, rt_heap_len(si->data)) == "-42");
     rt_string sf = rt_f64_to_str(3.5);
-    std::string s(sf->data, (size_t)sf->size);
+    std::string s(sf->data, rt_heap_len(sf->data));
     assert(s.find("3.5") != std::string::npos);
     return 0;
 }

--- a/tests/unit/test_rt_int_to_str_big.cpp
+++ b/tests/unit/test_rt_int_to_str_big.cpp
@@ -64,6 +64,6 @@ int main()
     rt_string s = rt_int_to_str(1234567890LL);
     std::string expected(40, '0');
     expected.replace(expected.size() - 10, 10, "1234567890");
-    assert(s && std::string(s->data, (size_t)s->size) == expected);
+    assert(s && std::string(s->data, rt_heap_len(s->data)) == expected);
     return 0;
 }

--- a/tests/unit/test_rt_string.cpp
+++ b/tests/unit/test_rt_string.cpp
@@ -82,8 +82,10 @@ int main()
         rt_string joined = rt_concat(left_ref, right_ref);
         auto *left_impl = (rt_string_impl *)left_owned;
         auto *right_impl = (rt_string_impl *)right_owned;
-        assert(left_impl->refcnt == 1);
-        assert(right_impl->refcnt == 1);
+        assert(left_impl->heap == nullptr);
+        assert(right_impl->heap == nullptr);
+        assert(left_impl->literal_refs == 1);
+        assert(right_impl->literal_refs == 1);
         rt_string_unref(joined);
         rt_string_unref(left_owned);
         rt_string_unref(right_owned);
@@ -95,7 +97,8 @@ int main()
         rt_string second = rt_string_ref(base);
         rt_string doubled = rt_concat(first, second);
         auto *base_impl = (rt_string_impl *)base;
-        assert(base_impl->refcnt == 1);
+        assert(base_impl->heap == nullptr);
+        assert(base_impl->literal_refs == 1);
         rt_string_unref(doubled);
         rt_string_unref(base);
     }

--- a/tests/unit/test_vm_runtime_bridge_marshalling.cpp
+++ b/tests/unit/test_vm_runtime_bridge_marshalling.cpp
@@ -70,7 +70,7 @@ int main()
     Slot strNumberResult = callBridge("rt_int_to_str", {numberArg}, Type::Kind::Str, {Type::Kind::I64});
     assert(strNumberResult.str != nullptr);
     rt_string numberStr = strNumberResult.str;
-    std::string numberText(numberStr->data, static_cast<size_t>(numberStr->size));
+    std::string numberText(numberStr->data, rt_heap_len(numberStr->data));
     assert(numberText == "12345");
     rt_string_unref(numberStr);
 


### PR DESCRIPTION
## Summary
- replace the bespoke runtime string bookkeeping with shared heap metadata, including storing heap headers on each string
- keep rt_const_cstr wrapping literal data while routing new allocations through rt_heap_alloc and managing manual refcounts for non-heap strings
- update runtime helpers and tests to consume the new string representation via rt_heap_len/rt_heap_retain and maintain literal pointer expectations

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d489fd871083249835952e5b2deb85