### PR TITLE
Refactor runtime int32 arrays to use heap handles

### DIFF
--- a/src/il/runtime/RuntimeSignatures.cpp
+++ b/src/il/runtime/RuntimeSignatures.cpp
@@ -11,6 +11,7 @@
 #include "rt_internal.h"
 #include "rt_math.h"
 #include "rt_random.h"
+#include <cstdint>
 #include <initializer_list>
 #include <type_traits>
 #include <unordered_map>
@@ -82,7 +83,7 @@ void invokeRtArrI32New(void **args, void *result)
 {
     const auto lenPtr = args ? reinterpret_cast<const int64_t *>(args[0]) : nullptr;
     const size_t len = lenPtr ? static_cast<size_t>(*lenPtr) : 0;
-    void *arr = rt_arr_i32_new(len);
+    int32_t *arr = rt_arr_i32_new(len);
     if (result)
         *reinterpret_cast<void **>(result) = arr;
 }
@@ -91,7 +92,7 @@ void invokeRtArrI32New(void **args, void *result)
 void invokeRtArrI32Len(void **args, void *result)
 {
     const auto arrPtr = args ? reinterpret_cast<void *const *>(args[0]) : nullptr;
-    const void *arr = arrPtr ? *arrPtr : nullptr;
+    int32_t *arr = arrPtr ? *reinterpret_cast<int32_t *const *>(arrPtr) : nullptr;
     const size_t len = rt_arr_i32_len(arr);
     if (result)
         *reinterpret_cast<int64_t *>(result) = static_cast<int64_t>(len);
@@ -102,7 +103,7 @@ void invokeRtArrI32Get(void **args, void *result)
 {
     const auto arrPtr = args ? reinterpret_cast<void *const *>(args[0]) : nullptr;
     const auto idxPtr = args ? reinterpret_cast<const int64_t *>(args[1]) : nullptr;
-    const void *arr = arrPtr ? *arrPtr : nullptr;
+    int32_t *arr = arrPtr ? *reinterpret_cast<int32_t *const *>(arrPtr) : nullptr;
     const size_t idx = idxPtr ? static_cast<size_t>(*idxPtr) : 0;
     const int32_t value = rt_arr_i32_get(arr, idx);
     if (result)
@@ -115,7 +116,7 @@ void invokeRtArrI32Set(void **args, void * /*result*/)
     const auto arrPtr = args ? reinterpret_cast<void **>(args[0]) : nullptr;
     const auto idxPtr = args ? reinterpret_cast<const int64_t *>(args[1]) : nullptr;
     const auto valPtr = args ? reinterpret_cast<const int64_t *>(args[2]) : nullptr;
-    void *arr = arrPtr ? *arrPtr : nullptr;
+    int32_t *arr = arrPtr ? *reinterpret_cast<int32_t **>(arrPtr) : nullptr;
     const size_t idx = idxPtr ? static_cast<size_t>(*idxPtr) : 0;
     const int32_t value = valPtr ? static_cast<int32_t>(*valPtr) : 0;
     rt_arr_i32_set(arr, idx, value);
@@ -126,9 +127,14 @@ void invokeRtArrI32Resize(void **args, void *result)
 {
     const auto arrPtr = args ? reinterpret_cast<void **>(args[0]) : nullptr;
     const auto newLenPtr = args ? reinterpret_cast<const int64_t *>(args[1]) : nullptr;
-    void *arr = arrPtr ? *arrPtr : nullptr;
+    int32_t *arr = arrPtr ? *reinterpret_cast<int32_t **>(arrPtr) : nullptr;
     const size_t newLen = newLenPtr ? static_cast<size_t>(*newLenPtr) : 0;
-    void *resized = rt_arr_i32_resize(arr, newLen);
+    int32_t *local = arr;
+    int32_t **handle = arrPtr ? reinterpret_cast<int32_t **>(arrPtr) : &local;
+    int rc = rt_arr_i32_resize(handle, newLen);
+    int32_t *resized = (rc == 0) ? *handle : nullptr;
+    if (arrPtr && rc == 0)
+        *reinterpret_cast<int32_t **>(arrPtr) = resized;
     if (result)
         *reinterpret_cast<void **>(result) = resized;
 }

--- a/src/runtime/rt_array.c
+++ b/src/runtime/rt_array.c
@@ -1,112 +1,178 @@
 // File: src/runtime/rt_array.c
 // Purpose: Implements dynamic int32 array helpers for the BASIC runtime.
 // Key invariants: Array length never exceeds capacity; allocations are zeroed on growth.
-// Ownership/Lifetime: Caller manages array handles and releases them via free().
+// Ownership/Lifetime: Arrays participate in shared reference-counted heap management.
 // Links: docs/codemap.md
 
 #include "rt_array.h"
 
+#include <assert.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-struct rt_arr_i32_impl
-{
-    size_t len;
-    size_t cap;
-    int32_t data[];
-};
-
-typedef struct rt_arr_i32_impl rt_arr_i32_impl;
-
-static int compute_allocation_bytes(size_t cap, size_t *total_bytes)
-{
-    if (!total_bytes)
-        return 0;
-    if (cap == 0)
-    {
-        *total_bytes = sizeof(rt_arr_i32_impl);
-        return 1;
-    }
-    if (cap > (SIZE_MAX - sizeof(rt_arr_i32_impl)) / sizeof(int32_t))
-        return 0;
-    size_t data_bytes = cap * sizeof(int32_t);
-    *total_bytes = sizeof(rt_arr_i32_impl) + data_bytes;
-    return 1;
-}
-
-void *rt_arr_i32_new(size_t len)
-{
-    size_t total_bytes = 0;
-    if (!compute_allocation_bytes(len, &total_bytes))
-        return NULL;
-    rt_arr_i32_impl *arr = (rt_arr_i32_impl *)calloc(1, total_bytes);
-    if (!arr)
-        return NULL;
-    arr->len = len;
-    arr->cap = len;
-    return arr;
-}
-
-size_t rt_arr_i32_len(const void *arr)
-{
-    const rt_arr_i32_impl *impl = (const rt_arr_i32_impl *)arr;
-    return impl ? impl->len : 0;
-}
-
-int32_t rt_arr_i32_get(const void *arr, size_t idx)
-{
-    const rt_arr_i32_impl *impl = (const rt_arr_i32_impl *)arr;
-    return impl->data[idx];
-}
-
-void rt_arr_i32_set(void *arr, size_t idx, int32_t value)
-{
-    rt_arr_i32_impl *impl = (rt_arr_i32_impl *)arr;
-    impl->data[idx] = value;
-}
-
-void *rt_arr_i32_resize(void *arr, size_t new_len)
-{
-    rt_arr_i32_impl *impl = (rt_arr_i32_impl *)arr;
-    if (!impl)
-        return rt_arr_i32_new(new_len);
-
-    size_t old_len = impl->len;
-    if (new_len <= impl->cap)
-    {
-        if (new_len > old_len)
-        {
-            size_t grow = new_len - old_len;
-            memset(impl->data + old_len, 0, grow * sizeof(int32_t));
-        }
-        impl->len = new_len;
-        return impl;
-    }
-
-    size_t total_bytes = 0;
-    if (!compute_allocation_bytes(new_len, &total_bytes))
-        return NULL;
-
-    rt_arr_i32_impl *resized = (rt_arr_i32_impl *)realloc(impl, total_bytes);
-    if (!resized)
-        return NULL;
-
-    if (new_len > old_len)
-    {
-        size_t grow = new_len - old_len;
-        memset(resized->data + old_len, 0, grow * sizeof(int32_t));
-    }
-
-    resized->len = new_len;
-    resized->cap = new_len;
-    return resized;
-}
-
 void rt_arr_oob_panic(size_t idx, size_t len)
 {
     fprintf(stderr, "rt_arr_i32: index %zu out of bounds (len=%zu)\n", idx, len);
     abort();
+}
+
+static void rt_arr_i32_assert_header(rt_heap_hdr_t *hdr)
+{
+    assert(hdr);
+    assert(hdr->kind == RT_HEAP_ARRAY);
+    assert(hdr->elem_kind == RT_ELEM_I32);
+}
+
+static size_t rt_arr_i32_payload_bytes(size_t cap)
+{
+    if (cap == 0)
+        return 0;
+    if (cap > (SIZE_MAX - sizeof(rt_heap_hdr_t)) / sizeof(int32_t))
+        return 0;
+    return cap * sizeof(int32_t);
+}
+
+int32_t *rt_arr_i32_new(size_t len)
+{
+    return (int32_t *)rt_heap_alloc(RT_HEAP_ARRAY, RT_ELEM_I32, sizeof(int32_t), len, len);
+}
+
+void rt_arr_i32_retain(int32_t *arr)
+{
+    if (!arr)
+        return;
+    rt_heap_hdr_t *hdr = rt_arr_i32_hdr(arr);
+    rt_arr_i32_assert_header(hdr);
+    rt_heap_retain(arr);
+}
+
+void rt_arr_i32_release(int32_t *arr)
+{
+    if (!arr)
+        return;
+    rt_heap_hdr_t *hdr = rt_arr_i32_hdr(arr);
+    rt_arr_i32_assert_header(hdr);
+    rt_heap_release(arr);
+}
+
+size_t rt_arr_i32_len(int32_t *arr)
+{
+    if (!arr)
+        return 0;
+    rt_heap_hdr_t *hdr = rt_arr_i32_hdr(arr);
+    rt_arr_i32_assert_header(hdr);
+    return hdr->len;
+}
+
+size_t rt_arr_i32_cap(int32_t *arr)
+{
+    if (!arr)
+        return 0;
+    rt_heap_hdr_t *hdr = rt_arr_i32_hdr(arr);
+    rt_arr_i32_assert_header(hdr);
+    return hdr->cap;
+}
+
+int32_t rt_arr_i32_get(int32_t *arr, size_t idx)
+{
+    rt_heap_hdr_t *hdr = rt_arr_i32_hdr(arr);
+    rt_arr_i32_assert_header(hdr);
+    assert(idx < hdr->len);
+    return arr[idx];
+}
+
+void rt_arr_i32_set(int32_t *arr, size_t idx, int32_t value)
+{
+    rt_heap_hdr_t *hdr = rt_arr_i32_hdr(arr);
+    rt_arr_i32_assert_header(hdr);
+    assert(idx < hdr->len);
+    arr[idx] = value;
+}
+
+static void rt_arr_i32_copy_payload(int32_t *dst, const int32_t *src, size_t count)
+{
+    if (!dst || !src || count == 0)
+        return;
+    memcpy(dst, src, count * sizeof(int32_t));
+}
+
+static int rt_arr_i32_grow_in_place(rt_heap_hdr_t **hdr_inout,
+                                     int32_t **payload_inout,
+                                     size_t new_len)
+{
+    rt_heap_hdr_t *hdr = *hdr_inout;
+    size_t new_cap = new_len;
+    size_t payload_bytes = rt_arr_i32_payload_bytes(new_cap);
+    if (new_cap > 0 && payload_bytes == 0)
+        return -1;
+
+    size_t total_bytes = sizeof(rt_heap_hdr_t) + payload_bytes;
+    rt_heap_hdr_t *resized = (rt_heap_hdr_t *)realloc(hdr, total_bytes);
+    if (!resized)
+        return -1;
+
+    int32_t *payload = (int32_t *)rt_heap_data(resized);
+    size_t old_len = resized->len;
+    if (new_len > old_len)
+    {
+        size_t grow = new_len - old_len;
+        memset(payload + old_len, 0, grow * sizeof(int32_t));
+    }
+    resized->cap = new_cap;
+    resized->len = new_len;
+
+    *hdr_inout = resized;
+    *payload_inout = payload;
+    return 0;
+}
+
+int rt_arr_i32_resize(int32_t **a_inout, size_t new_len)
+{
+    if (!a_inout)
+        return -1;
+
+    int32_t *arr = *a_inout;
+    if (!arr)
+    {
+        int32_t *fresh = rt_arr_i32_new(new_len);
+        if (!fresh)
+            return -1;
+        *a_inout = fresh;
+        return 0;
+    }
+
+    rt_heap_hdr_t *hdr = rt_arr_i32_hdr(arr);
+    rt_arr_i32_assert_header(hdr);
+
+    size_t old_len = hdr->len;
+    size_t cap = hdr->cap;
+    if (new_len <= cap)
+    {
+        if (new_len > old_len)
+            memset(arr + old_len, 0, (new_len - old_len) * sizeof(int32_t));
+        rt_heap_set_len(arr, new_len);
+        return 0;
+    }
+
+    if (hdr->refcnt > 1)
+    {
+        int32_t *fresh = rt_arr_i32_new(new_len);
+        if (!fresh)
+            return -1;
+        size_t copy_len = old_len < new_len ? old_len : new_len;
+        rt_arr_i32_copy_payload(fresh, arr, copy_len);
+        rt_arr_i32_release(arr);
+        *a_inout = fresh;
+        return 0;
+    }
+
+    rt_heap_hdr_t *hdr_mut = hdr;
+    int32_t *payload = arr;
+    if (rt_arr_i32_grow_in_place(&hdr_mut, &payload, new_len) != 0)
+        return -1;
+    *a_inout = payload;
+    return 0;
 }
 

--- a/src/runtime/rt_array.h
+++ b/src/runtime/rt_array.h
@@ -1,9 +1,11 @@
 // File: src/runtime/rt_array.h
 // Purpose: Declares dynamic int32 array helpers for the BASIC runtime.
 // Key invariants: Array length never exceeds capacity; storage is contiguous.
-// Ownership/Lifetime: Caller owns array handles and must free them with free().
+// Ownership/Lifetime: Arrays are reference-counted; retain/release manage shared ownership.
 // Links: docs/codemap.md
 #pragma once
+
+#include "rt_heap.h"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -11,6 +13,14 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+    /// @brief Helper returning the heap header associated with @p payload.
+    /// @param payload Array payload pointer (may be NULL).
+    /// @return Heap header describing the allocation, or NULL for NULL payloads.
+    static inline rt_heap_hdr_t *rt_arr_i32_hdr(const int32_t *payload)
+    {
+        return payload ? rt_heap_hdr((void *)payload) : NULL;
+    }
 
 #if defined(__cplusplus)
 #    define RT_ARR_NORETURN [[noreturn]]
@@ -22,31 +32,44 @@ extern "C" {
 
     /// @brief Allocate a new dynamic array of 32-bit integers.
     /// @param len Number of elements to allocate.
-    /// @return Opaque array handle or NULL on allocation failure.
-    void *rt_arr_i32_new(size_t len);
+    /// @return Array payload pointer or NULL on allocation failure.
+    int32_t *rt_arr_i32_new(size_t len);
+
+    /// @brief Increment the reference count for @p arr.
+    /// @param arr Array payload pointer (may be NULL).
+    void rt_arr_i32_retain(int32_t *arr);
+
+    /// @brief Decrement the reference count for @p arr and free on zero.
+    /// @param arr Array payload pointer (may be NULL).
+    void rt_arr_i32_release(int32_t *arr);
 
     /// @brief Query the current logical length of an array.
-    /// @param arr Array handle returned by rt_arr_i32_new/rt_arr_i32_resize.
+    /// @param arr Array payload pointer returned by rt_arr_i32_new.
     /// @return Number of accessible elements; 0 when @p arr is NULL.
-    size_t rt_arr_i32_len(const void *arr);
+    size_t rt_arr_i32_len(int32_t *arr);
+
+    /// @brief Query the current capacity in elements.
+    /// @param arr Array payload pointer returned by rt_arr_i32_new.
+    /// @return Capacity in elements; 0 when @p arr is NULL.
+    size_t rt_arr_i32_cap(int32_t *arr);
 
     /// @brief Read element at index @p idx without bounds checks.
-    /// @param arr Array handle; must be non-null and in range.
+    /// @param arr Array payload pointer; must be non-null and in range.
     /// @param idx Zero-based index within the array length.
     /// @return Stored value at @p idx.
-    int32_t rt_arr_i32_get(const void *arr, size_t idx);
+    int32_t rt_arr_i32_get(int32_t *arr, size_t idx);
 
     /// @brief Write @p value to index @p idx without bounds checks.
-    /// @param arr Array handle; must be non-null and in range.
+    /// @param arr Array payload pointer; must be non-null and in range.
     /// @param idx Zero-based index within the array length.
     /// @param value Value to store.
-    void rt_arr_i32_set(void *arr, size_t idx, int32_t value);
+    void rt_arr_i32_set(int32_t *arr, size_t idx, int32_t value);
 
-    /// @brief Resize an array to @p new_len elements.
-    /// @param arr Existing array handle or NULL to allocate.
+    /// @brief Resize an array to @p new_len elements with copy-on-resize semantics.
+    /// @param a_inout Address of the array payload pointer (may point to NULL).
     /// @param new_len Requested logical length.
-    /// @return Updated array handle with zero-initialized new slots or NULL on failure.
-    void *rt_arr_i32_resize(void *arr, size_t new_len);
+    /// @return 0 on success, -1 on allocation failure; pointer may be rebound on success.
+    int rt_arr_i32_resize(int32_t **a_inout, size_t new_len);
 
     /// @brief Abort execution due to an out-of-bounds access.
     /// @param idx Failing index.

--- a/tests/runtime/RTArrayI32Tests.cpp
+++ b/tests/runtime/RTArrayI32Tests.cpp
@@ -1,7 +1,7 @@
 // File: tests/runtime/RTArrayI32Tests.cpp
 // Purpose: Verify basic behavior of the int32 runtime array helpers.
 // Key invariants: Resizing zero-initializes new slots and preserves prior values.
-// Ownership: Tests own allocated arrays and release them via free().
+// Ownership: Tests own allocated arrays and release them via rt_arr_i32_release().
 // Links: docs/runtime-vm.md#runtime-abi
 
 #include "rt_array.h"
@@ -10,7 +10,7 @@
 #include <cstddef>
 #include <cstdlib>
 
-static void expect_zero_range(void *arr, size_t start, size_t end)
+static void expect_zero_range(int32_t *arr, size_t start, size_t end)
 {
     for (size_t i = start; i < end; ++i)
         assert(rt_arr_i32_get(arr, i) == 0);
@@ -18,11 +18,11 @@ static void expect_zero_range(void *arr, size_t start, size_t end)
 
 int main()
 {
-    void *arr = rt_arr_i32_new(0);
+    int32_t *arr = rt_arr_i32_new(0);
     assert(arr != nullptr);
     assert(rt_arr_i32_len(arr) == 0);
 
-    arr = rt_arr_i32_resize(arr, 3);
+    assert(rt_arr_i32_resize(&arr, 3) == 0);
     assert(arr != nullptr);
     assert(rt_arr_i32_len(arr) == 3);
     expect_zero_range(arr, 0, 3);
@@ -34,7 +34,7 @@ int main()
     assert(rt_arr_i32_get(arr, 1) == -2);
     assert(rt_arr_i32_get(arr, 2) == 99);
 
-    arr = rt_arr_i32_resize(arr, 6);
+    assert(rt_arr_i32_resize(&arr, 6) == 0);
     assert(arr != nullptr);
     assert(rt_arr_i32_len(arr) == 6);
     assert(rt_arr_i32_get(arr, 0) == 7);
@@ -42,26 +42,27 @@ int main()
     assert(rt_arr_i32_get(arr, 2) == 99);
     expect_zero_range(arr, 3, 6);
 
-    arr = rt_arr_i32_resize(arr, 2);
+    assert(rt_arr_i32_resize(&arr, 2) == 0);
     assert(arr != nullptr);
     assert(rt_arr_i32_len(arr) == 2);
     assert(rt_arr_i32_get(arr, 0) == 7);
     assert(rt_arr_i32_get(arr, 1) == -2);
 
-    arr = rt_arr_i32_resize(arr, 5);
+    assert(rt_arr_i32_resize(&arr, 5) == 0);
     assert(arr != nullptr);
     assert(rt_arr_i32_len(arr) == 5);
     assert(rt_arr_i32_get(arr, 0) == 7);
     assert(rt_arr_i32_get(arr, 1) == -2);
     expect_zero_range(arr, 2, 5);
 
-    void *fresh = rt_arr_i32_resize(nullptr, 4);
+    int32_t *fresh = nullptr;
+    assert(rt_arr_i32_resize(&fresh, 4) == 0);
     assert(fresh != nullptr);
     assert(rt_arr_i32_len(fresh) == 4);
     expect_zero_range(fresh, 0, 4);
 
-    free(arr);
-    free(fresh);
+    rt_arr_i32_release(arr);
+    rt_arr_i32_release(fresh);
     return 0;
 }
 

--- a/tests/unit/test_vm_runtime_bridge_marshalling.cpp
+++ b/tests/unit/test_vm_runtime_bridge_marshalling.cpp
@@ -7,6 +7,7 @@
 #include "vm/RuntimeBridge.hpp"
 #include "vm/VM.hpp"
 #include "il/core/Type.hpp"
+#include "rt_array.h"
 #include "rt_internal.h"
 #include <array>
 #include <initializer_list>
@@ -149,7 +150,7 @@ int main()
                                  {Type::Kind::Ptr, Type::Kind::I64});
     assert(zeroResult.i64 == 0);
 
-    free(arrSlot.ptr);
+    rt_arr_i32_release(static_cast<int32_t *>(arrSlot.ptr));
 
     for (bool covered : coveredKinds)
         assert(covered);


### PR DESCRIPTION
## Summary
- wrap the runtime int32 array API around `rt_heap` with retain/release helpers, capacity accessors, and copy-on-resize semantics
- update runtime bridge adapters to work with the new `int32_t*` handles and resize return codes
- refresh the runtime array tests to adopt the new pointer API and release arrays via the heap

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d4bed747fc8324b5cfe6c7229a56eb