### PR TITLE
build(runtime): consolidate exported runtime headers

### DIFF
--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -8,6 +8,14 @@ set(RT_SOURCES
   rt_heap.c
 )
 
+set(RT_PUBLIC_HEADERS
+  ${CMAKE_CURRENT_SOURCE_DIR}/rt.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/rt_math.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/rt_random.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/rt_array.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/rt_heap.h
+)
+
 add_library(rt STATIC ${RT_SOURCES})
 target_include_directories(rt
   PUBLIC
@@ -19,11 +27,6 @@ if(NOT WIN32)
   target_link_libraries(rt PUBLIC m)
 endif()
 
-install(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/rt.hpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/rt_math.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/rt_random.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/rt_array.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/rt_heap.h
+install(FILES ${RT_PUBLIC_HEADERS}
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper
 )


### PR DESCRIPTION
## Summary
- add an explicit `RT_PUBLIC_HEADERS` list in `src/runtime/CMakeLists.txt`
- reuse the list when installing runtime headers so `rt_heap.h` is exported with the other public headers

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d4c2b30ddc83249cdb6d3004e75813