### PR TITLE
feat: register array retain/release externs

### DIFF
--- a/src/il/runtime/RuntimeSignatures.cpp
+++ b/src/il/runtime/RuntimeSignatures.cpp
@@ -153,7 +153,7 @@ void invokeRtArrOobPanic(void **args, void * /*result*/)
 std::vector<RuntimeDescriptor> buildRegistry()
 {
     std::vector<RuntimeDescriptor> entries;
-    entries.reserve(48);
+    entries.reserve(50);
     auto add = [&](std::string_view name,
                    Kind ret,
                    std::initializer_list<Kind> params,
@@ -243,6 +243,16 @@ std::vector<RuntimeDescriptor> buildRegistry()
         Kind::Ptr,
         {Kind::I64},
         &invokeRtArrI32New,
+        manual());
+    add("rt_arr_i32_retain",
+        Kind::Void,
+        {Kind::Ptr},
+        &DirectHandler<&rt_arr_i32_retain, void, int32_t *>::invoke,
+        manual());
+    add("rt_arr_i32_release",
+        Kind::Void,
+        {Kind::Ptr},
+        &DirectHandler<&rt_arr_i32_release, void, int32_t *>::invoke,
         manual());
     add("rt_arr_i32_len",
         Kind::I64,


### PR DESCRIPTION
## Summary
- register the rt_arr_i32_retain and rt_arr_i32_release helpers in the runtime descriptor registry with manual lowering metadata
- update the registry reservation to cover the expanded array helper set

## Testing
- cmake -S . -B build
- cmake --build build -j4
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d4c7677dfc83249a0484972bdb4492