### PR TITLE
feat(basic): retain/release array handles

### DIFF
--- a/src/frontends/basic/LowerRuntime.cpp
+++ b/src/frontends/basic/LowerRuntime.cpp
@@ -124,6 +124,16 @@ void Lowerer::requireArrayI32Set()
     needsArrI32Set = true;
 }
 
+void Lowerer::requireArrayI32Retain()
+{
+    needsArrI32Retain = true;
+}
+
+void Lowerer::requireArrayI32Release()
+{
+    needsArrI32Release = true;
+}
+
 void Lowerer::requireArrayOobPanic()
 {
     needsArrOobPanic = true;
@@ -163,6 +173,10 @@ void Lowerer::declareRequiredRuntime(build::IRBuilder &b)
         declareManual("rt_arr_i32_get");
     if (needsArrI32Set)
         declareManual("rt_arr_i32_set");
+    if (needsArrI32Retain)
+        declareManual("rt_arr_i32_retain");
+    if (needsArrI32Release)
+        declareManual("rt_arr_i32_release");
     if (needsArrOobPanic)
         declareManual("rt_arr_oob_panic");
 }

--- a/src/frontends/basic/LowerScan.cpp
+++ b/src/frontends/basic/LowerScan.cpp
@@ -119,6 +119,11 @@ class ScanStmtVisitor final : public StmtVisitor
                 const auto *info = lowerer_.findSymbol(var->name);
                 if (!info || !info->hasType)
                     lowerer_.setSymbolType(var->name, inferAstTypeFromName(var->name));
+                if (const auto *arrayInfo = lowerer_.findSymbol(var->name); arrayInfo && arrayInfo->isArray)
+                {
+                    lowerer_.requireArrayI32Retain();
+                    lowerer_.requireArrayI32Release();
+                }
             }
         }
         else if (auto *arr = dynamic_cast<const ArrayExpr *>(stmt.target.get()))
@@ -147,6 +152,8 @@ class ScanStmtVisitor final : public StmtVisitor
         {
             lowerer_.requireArrayI32New();
             lowerer_.markArray(stmt.name);
+            lowerer_.requireArrayI32Retain();
+            lowerer_.requireArrayI32Release();
         }
         if (stmt.size)
             lowerer_.scanExpr(*stmt.size);
@@ -158,6 +165,8 @@ class ScanStmtVisitor final : public StmtVisitor
             lowerer_.markSymbolReferenced(stmt.name);
         lowerer_.markArray(stmt.name);
         lowerer_.requireArrayI32Resize();
+        lowerer_.requireArrayI32Retain();
+        lowerer_.requireArrayI32Release();
         if (stmt.size)
             lowerer_.scanExpr(*stmt.size);
     }

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -567,6 +567,9 @@ class Lowerer
     void emitCall(const std::string &callee, const std::vector<Value> &args);
 
     Value emitConstStr(const std::string &globalName);
+    void storeArray(Value slot, Value value);
+    void releaseArrayLocals(const std::unordered_set<std::string> &paramNames);
+    void releaseArrayParams(const std::unordered_set<std::string> &paramNames);
 
     void emitTrap();
 
@@ -609,6 +612,8 @@ class Lowerer
     bool needsArrI32Len{false};
     bool needsArrI32Get{false};
     bool needsArrI32Set{false};
+    bool needsArrI32Retain{false};
+    bool needsArrI32Release{false};
     bool needsArrOobPanic{false};
 
     void requireArrayI32New();
@@ -616,6 +621,8 @@ class Lowerer
     void requireArrayI32Len();
     void requireArrayI32Get();
     void requireArrayI32Set();
+    void requireArrayI32Retain();
+    void requireArrayI32Release();
     void requireArrayOobPanic();
     void requestHelper(RuntimeFeature feature);
 

--- a/src/frontends/basic/LoweringPipeline.cpp
+++ b/src/frontends/basic/LoweringPipeline.cpp
@@ -269,6 +269,8 @@ void ProgramLowering::run(const Program &prog, il::core::Module &module)
     lowerer.needsArrI32Len = false;
     lowerer.needsArrI32Get = false;
     lowerer.needsArrI32Set = false;
+    lowerer.needsArrI32Retain = false;
+    lowerer.needsArrI32Release = false;
     lowerer.needsArrOobPanic = false;
 
     lowerer.scanProgram(prog);
@@ -374,6 +376,9 @@ void ProcedureLowering::emit(const std::string &name,
     lowerer.lowerStatementSequence(metadata.bodyStmts, /*stopOnTerminated=*/true);
 
     ctx.setCurrent(&f.blocks[ctx.exitIndex()]);
+    lowerer.curLoc = {};
+    lowerer.releaseArrayLocals(metadata.paramNames);
+    lowerer.releaseArrayParams(metadata.paramNames);
     lowerer.curLoc = {};
     config.emitFinalReturn();
 

--- a/tests/basic/goldens/SuffixFreeVars.il
+++ b/tests/basic/goldens/SuffixFreeVars.il
@@ -8,6 +8,8 @@ extern @rt_arr_i32_new(i64) -> ptr
 extern @rt_arr_i32_len(ptr) -> i64
 extern @rt_arr_i32_get(ptr, i64) -> i64
 extern @rt_arr_i32_set(ptr, i64, i64) -> void
+extern @rt_arr_i32_retain(ptr) -> void
+extern @rt_arr_i32_release(ptr) -> void
 extern @rt_arr_oob_panic(i64, i64) -> void
 global const str @.L0 = "ok"
 global const str @.L1 = "
@@ -15,6 +17,7 @@ global const str @.L1 = "
 func @main() -> i64 {
 entry:
   %t0 = alloca 8
+  store ptr, %t0, null
   %t1 = alloca 8
   %t2 = alloca 8
   br L08
@@ -32,93 +35,102 @@ L08:
   .loc 1 3 1
   %t3 = call @rt_arr_i32_new(2)
   .loc 1 3 1
+  call @rt_arr_i32_retain(%t3)
+  .loc 1 3 1
+  %t4 = load ptr, %t0
+  .loc 1 3 1
+  call @rt_arr_i32_release(%t4)
+  .loc 1 3 1
   store ptr, %t0, %t3
   .loc 1 4 15
-  %t4 = const_str @.L0
+  %t5 = const_str @.L0
   .loc 1 4 1
-  store str, %t2, %t4
+  store str, %t2, %t5
   .loc 1 5 1
   store i64, %t1, 5
   .loc 1 6 17
-  %t5 = load i64, %t1
+  %t6 = load i64, %t1
   .loc 1 6 17
-  %t6 = load ptr, %t0
+  %t7 = load ptr, %t0
   .loc 1 6 5
-  %t7 = call @rt_arr_i32_len(%t6)
+  %t8 = call @rt_arr_i32_len(%t7)
   .loc 1 6 5
-  %t8 = scmp_lt 0, 0
+  %t9 = scmp_lt 0, 0
   .loc 1 6 5
-  %t9 = scmp_ge 0, %t7
-  .loc 1 6 5
-  %t10 = zext1 %t8
+  %t10 = scmp_ge 0, %t8
   .loc 1 6 5
   %t11 = zext1 %t9
   .loc 1 6 5
-  %t12 = add %t10, %t11
+  %t12 = zext1 %t10
   .loc 1 6 5
-  %t13 = scmp_gt %t12, 0
+  %t13 = add %t11, %t12
   .loc 1 6 5
-  cbr %t13, bc_oob0, bc_ok0
+  %t14 = scmp_gt %t13, 0
+  .loc 1 6 5
+  cbr %t14, bc_oob0, bc_ok0
   .loc 1 7 7
-  %t14 = load str, %t2
-  .loc 1 7 1
-  call @rt_print_str(%t14)
-  .loc 1 7 1
-  %t15 = const_str @.L1
+  %t15 = load str, %t2
   .loc 1 7 1
   call @rt_print_str(%t15)
+  .loc 1 7 1
+  %t16 = const_str @.L1
+  .loc 1 7 1
+  call @rt_print_str(%t16)
   .loc 1 8 7
-  %t16 = load i64, %t1
+  %t17 = load i64, %t1
   .loc 1 8 1
-  call @rt_print_i64(%t16)
+  call @rt_print_i64(%t17)
   .loc 1 8 1
-  %t17 = const_str @.L1
+  %t18 = const_str @.L1
   .loc 1 8 1
-  call @rt_print_str(%t17)
+  call @rt_print_str(%t18)
   .loc 1 9 7
-  %t18 = load ptr, %t0
+  %t19 = load ptr, %t0
   .loc 1 9 7
-  %t19 = call @rt_arr_i32_len(%t18)
+  %t20 = call @rt_arr_i32_len(%t19)
   .loc 1 9 7
-  %t20 = scmp_lt 0, 0
+  %t21 = scmp_lt 0, 0
   .loc 1 9 7
-  %t21 = scmp_ge 0, %t19
-  .loc 1 9 7
-  %t22 = zext1 %t20
+  %t22 = scmp_ge 0, %t20
   .loc 1 9 7
   %t23 = zext1 %t21
   .loc 1 9 7
-  %t24 = add %t22, %t23
+  %t24 = zext1 %t22
   .loc 1 9 7
-  %t25 = scmp_gt %t24, 0
+  %t25 = add %t23, %t24
   .loc 1 9 7
-  cbr %t25, bc_oob1, bc_ok1
+  %t26 = scmp_gt %t25, 0
+  .loc 1 9 7
+  cbr %t26, bc_oob1, bc_ok1
 exit:
+  %t29 = load ptr, %t0
+  call @rt_arr_i32_release(%t29)
+  store ptr, %t0, null
   ret 0
 bc_ok0:
   .loc 1 6 1
-  call @rt_arr_i32_set(%t6, 0, %t5)
+  call @rt_arr_i32_set(%t7, 0, %t6)
   .loc 1 6 1
   br L08
 bc_oob0:
   .loc 1 6 5
-  call @rt_arr_oob_panic(0, %t7)
+  call @rt_arr_oob_panic(0, %t8)
   .loc 1 6 5
   trap
 bc_ok1:
   .loc 1 9 7
-  %t26 = call @rt_arr_i32_get(%t18, 0)
+  %t27 = call @rt_arr_i32_get(%t19, 0)
   .loc 1 9 1
-  call @rt_print_i64(%t26)
+  call @rt_print_i64(%t27)
   .loc 1 9 1
-  %t27 = const_str @.L1
+  %t28 = const_str @.L1
   .loc 1 9 1
-  call @rt_print_str(%t27)
+  call @rt_print_str(%t28)
   .loc 1 9 1
   br exit
 bc_oob1:
   .loc 1 9 7
-  call @rt_arr_oob_panic(0, %t19)
+  call @rt_arr_oob_panic(0, %t20)
   .loc 1 9 7
   trap
 }

--- a/tests/golden/basic_to_il/array_dim_redim.il
+++ b/tests/golden/basic_to_il/array_dim_redim.il
@@ -6,29 +6,47 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_arr_i32_new(i64) -> ptr
 extern @rt_arr_i32_resize(ptr, i64) -> ptr
+extern @rt_arr_i32_retain(ptr) -> void
+extern @rt_arr_i32_release(ptr) -> void
 func @main() -> i64 {
 entry:
   %t0 = alloca 8
+  store ptr, %t0, null
   br L10
 L10:
   .loc 1 1 4
   %t1 = call @rt_arr_i32_new(3)
+  .loc 1 1 4
+  call @rt_arr_i32_retain(%t1)
+  .loc 1 1 4
+  %t2 = load ptr, %t0
+  .loc 1 1 4
+  call @rt_arr_i32_release(%t2)
   .loc 1 1 4
   store ptr, %t0, %t1
   .loc 1 1 4
   br L20
 L20:
   .loc 1 2 4
-  %t2 = load ptr, %t0
+  %t3 = load ptr, %t0
   .loc 1 2 4
-  %t3 = call @rt_arr_i32_resize(%t2, 5)
+  %t4 = call @rt_arr_i32_resize(%t3, 5)
   .loc 1 2 4
-  store ptr, %t0, %t3
+  call @rt_arr_i32_retain(%t4)
+  .loc 1 2 4
+  %t5 = load ptr, %t0
+  .loc 1 2 4
+  call @rt_arr_i32_release(%t5)
+  .loc 1 2 4
+  store ptr, %t0, %t4
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 4
   br exit
 exit:
+  %t6 = load ptr, %t0
+  call @rt_arr_i32_release(%t6)
+  store ptr, %t0, null
   ret 0
 }

--- a/tests/golden/basic_to_il/array_dim_runtime.il
+++ b/tests/golden/basic_to_il/array_dim_runtime.il
@@ -9,6 +9,8 @@ extern @rt_arr_i32_resize(ptr, i64) -> ptr
 extern @rt_arr_i32_len(ptr) -> i64
 extern @rt_arr_i32_get(ptr, i64) -> i64
 extern @rt_arr_i32_set(ptr, i64, i64) -> void
+extern @rt_arr_i32_retain(ptr) -> void
+extern @rt_arr_i32_release(ptr) -> void
 extern @rt_arr_oob_panic(i64, i64) -> void
 global const str @.L0 = "
 "
@@ -17,127 +19,143 @@ entry:
   %t0 = alloca 8
   %t1 = alloca 8
   %t2 = alloca 8
+  store ptr, %t2, null
   br L10
 L10:
   .loc 1 1 4
   %t3 = call @rt_arr_i32_new(1)
+  .loc 1 1 4
+  call @rt_arr_i32_retain(%t3)
+  .loc 1 1 4
+  %t4 = load ptr, %t2
+  .loc 1 1 4
+  call @rt_arr_i32_release(%t4)
   .loc 1 1 4
   store ptr, %t2, %t3
   .loc 1 1 4
   br L20
 L20:
   .loc 1 2 13
-  %t4 = load ptr, %t2
+  %t5 = load ptr, %t2
   .loc 1 2 13
-  %t5 = call @rt_arr_i32_len(%t4)
+  %t6 = call @rt_arr_i32_len(%t5)
   .loc 1 2 13
-  %t6 = sub %t5, 1
+  %t7 = sub %t6, 1
   .loc 1 2 4
-  store i64, %t1, %t6
+  store i64, %t1, %t7
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 12
-  %t7 = load i64, %t1
+  %t8 = load i64, %t1
   .loc 1 3 15
-  %t8 = add %t7, 2
+  %t9 = add %t8, 2
   .loc 1 3 4
-  %t9 = load ptr, %t2
+  %t10 = load ptr, %t2
   .loc 1 3 4
-  %t10 = call @rt_arr_i32_resize(%t9, %t8)
+  %t11 = call @rt_arr_i32_resize(%t10, %t9)
   .loc 1 3 4
-  store ptr, %t2, %t10
+  call @rt_arr_i32_retain(%t11)
+  .loc 1 3 4
+  %t12 = load ptr, %t2
+  .loc 1 3 4
+  call @rt_arr_i32_release(%t12)
+  .loc 1 3 4
+  store ptr, %t2, %t11
   .loc 1 3 4
   br L40
 L40:
   .loc 1 4 16
-  %t11 = load ptr, %t2
+  %t13 = load ptr, %t2
   .loc 1 4 10
-  %t12 = load i64, %t1
+  %t14 = load i64, %t1
   .loc 1 4 8
-  %t13 = call @rt_arr_i32_len(%t11)
+  %t15 = call @rt_arr_i32_len(%t13)
   .loc 1 4 8
-  %t14 = scmp_lt %t12, 0
+  %t16 = scmp_lt %t14, 0
   .loc 1 4 8
-  %t15 = scmp_ge %t12, %t13
+  %t17 = scmp_ge %t14, %t15
   .loc 1 4 8
-  %t16 = zext1 %t14
+  %t18 = zext1 %t16
   .loc 1 4 8
-  %t17 = zext1 %t15
+  %t19 = zext1 %t17
   .loc 1 4 8
-  %t18 = add %t16, %t17
+  %t20 = add %t18, %t19
   .loc 1 4 8
-  %t19 = scmp_gt %t18, 0
+  %t21 = scmp_gt %t20, 0
   .loc 1 4 8
-  cbr %t19, bc_oob0, bc_ok0
+  cbr %t21, bc_oob0, bc_ok0
 L50:
   .loc 1 5 12
-  %t20 = load ptr, %t2
+  %t22 = load ptr, %t2
   .loc 1 5 14
-  %t21 = load i64, %t1
+  %t23 = load i64, %t1
   .loc 1 5 12
-  %t22 = call @rt_arr_i32_len(%t20)
+  %t24 = call @rt_arr_i32_len(%t22)
   .loc 1 5 12
-  %t23 = scmp_lt %t21, 0
+  %t25 = scmp_lt %t23, 0
   .loc 1 5 12
-  %t24 = scmp_ge %t21, %t22
+  %t26 = scmp_ge %t23, %t24
   .loc 1 5 12
-  %t25 = zext1 %t23
+  %t27 = zext1 %t25
   .loc 1 5 12
-  %t26 = zext1 %t24
+  %t28 = zext1 %t26
   .loc 1 5 12
-  %t27 = add %t25, %t26
+  %t29 = add %t27, %t28
   .loc 1 5 12
-  %t28 = scmp_gt %t27, 0
+  %t30 = scmp_gt %t29, 0
   .loc 1 5 12
-  cbr %t28, bc_oob1, bc_ok1
+  cbr %t30, bc_oob1, bc_ok1
 L60:
   .loc 1 6 10
-  %t30 = load i64, %t1
+  %t32 = load i64, %t1
   .loc 1 6 4
-  call @rt_print_i64(%t30)
+  call @rt_print_i64(%t32)
   .loc 1 6 4
-  %t31 = const_str @.L0
+  %t33 = const_str @.L0
   .loc 1 6 4
-  call @rt_print_str(%t31)
+  call @rt_print_str(%t33)
   .loc 1 6 4
   br L70
 L70:
   .loc 1 7 10
-  %t32 = load i64, %t0
+  %t34 = load i64, %t0
   .loc 1 7 4
-  call @rt_print_i64(%t32)
+  call @rt_print_i64(%t34)
   .loc 1 7 4
-  %t33 = const_str @.L0
+  %t35 = const_str @.L0
   .loc 1 7 4
-  call @rt_print_str(%t33)
+  call @rt_print_str(%t35)
   .loc 1 7 4
   br L80
 L80:
   .loc 1 8 4
   br exit
 exit:
+  %t36 = load ptr, %t2
+  call @rt_arr_i32_release(%t36)
+  store ptr, %t2, null
   ret 0
 bc_ok0:
   .loc 1 4 4
-  call @rt_arr_i32_set(%t11, %t12, 7)
+  call @rt_arr_i32_set(%t13, %t14, 7)
   .loc 1 4 4
   br L50
 bc_oob0:
   .loc 1 4 8
-  call @rt_arr_oob_panic(%t12, %t13)
+  call @rt_arr_oob_panic(%t14, %t15)
   .loc 1 4 8
   trap
 bc_ok1:
   .loc 1 5 12
-  %t29 = call @rt_arr_i32_get(%t20, %t21)
+  %t31 = call @rt_arr_i32_get(%t22, %t23)
   .loc 1 5 4
-  store i64, %t0, %t29
+  store i64, %t0, %t31
   .loc 1 5 4
   br L60
 bc_oob1:
   .loc 1 5 12
-  call @rt_arr_oob_panic(%t21, %t22)
+  call @rt_arr_oob_panic(%t23, %t24)
   .loc 1 5 12
   trap
 }

--- a/tests/golden/basic_to_il/bounds_check.il
+++ b/tests/golden/basic_to_il/bounds_check.il
@@ -8,17 +8,26 @@ extern @rt_trap(str) -> void
 extern @rt_arr_i32_new(i64) -> ptr
 extern @rt_arr_i32_len(ptr) -> i64
 extern @rt_arr_i32_get(ptr, i64) -> i64
+extern @rt_arr_i32_retain(ptr) -> void
+extern @rt_arr_i32_release(ptr) -> void
 extern @rt_arr_oob_panic(i64, i64) -> void
 global const str @.L0 = "
 "
 func @main() -> i64 {
 entry:
   %t0 = alloca 8
+  store ptr, %t0, null
   %t1 = alloca 8
   br L10
 L10:
   .loc 1 1 4
   %t2 = call @rt_arr_i32_new(2)
+  .loc 1 1 4
+  call @rt_arr_i32_retain(%t2)
+  .loc 1 1 4
+  %t3 = load ptr, %t0
+  .loc 1 1 4
+  call @rt_arr_i32_release(%t3)
   .loc 1 1 4
   store ptr, %t0, %t2
   .loc 1 1 4
@@ -27,39 +36,42 @@ L10:
   br L20
 L20:
   .loc 1 2 10
-  %t3 = load ptr, %t0
+  %t4 = load ptr, %t0
   .loc 1 2 10
-  %t4 = call @rt_arr_i32_len(%t3)
+  %t5 = call @rt_arr_i32_len(%t4)
   .loc 1 2 10
-  %t5 = scmp_lt 1, 0
+  %t6 = scmp_lt 1, 0
   .loc 1 2 10
-  %t6 = scmp_ge 1, %t4
-  .loc 1 2 10
-  %t7 = zext1 %t5
+  %t7 = scmp_ge 1, %t5
   .loc 1 2 10
   %t8 = zext1 %t6
   .loc 1 2 10
-  %t9 = add %t7, %t8
+  %t9 = zext1 %t7
   .loc 1 2 10
-  %t10 = scmp_gt %t9, 0
+  %t10 = add %t8, %t9
   .loc 1 2 10
-  cbr %t10, bc_oob0, bc_ok0
+  %t11 = scmp_gt %t10, 0
+  .loc 1 2 10
+  cbr %t11, bc_oob0, bc_ok0
 exit:
+  %t14 = load ptr, %t0
+  call @rt_arr_i32_release(%t14)
+  store ptr, %t0, null
   ret 0
 bc_ok0:
   .loc 1 2 10
-  %t11 = call @rt_arr_i32_get(%t3, 1)
+  %t12 = call @rt_arr_i32_get(%t4, 1)
   .loc 1 2 4
-  call @rt_print_i64(%t11)
+  call @rt_print_i64(%t12)
   .loc 1 2 4
-  %t12 = const_str @.L0
+  %t13 = const_str @.L0
   .loc 1 2 4
-  call @rt_print_str(%t12)
+  call @rt_print_str(%t13)
   .loc 1 2 4
   br exit
 bc_oob0:
   .loc 1 2 10
-  call @rt_arr_oob_panic(1, %t4)
+  call @rt_arr_oob_panic(1, %t5)
   .loc 1 2 10
   trap
 }

--- a/tests/golden/basic_to_il/ex6_array_sum.il
+++ b/tests/golden/basic_to_il/ex6_array_sum.il
@@ -10,6 +10,8 @@ extern @rt_arr_i32_new(i64) -> ptr
 extern @rt_arr_i32_len(ptr) -> i64
 extern @rt_arr_i32_get(ptr, i64) -> i64
 extern @rt_arr_i32_set(ptr, i64, i64) -> void
+extern @rt_arr_i32_retain(ptr) -> void
+extern @rt_arr_i32_release(ptr) -> void
 extern @rt_arr_oob_panic(i64, i64) -> void
 global const str @.L0 = "
 "
@@ -18,6 +20,7 @@ entry:
   %t0 = alloca 8
   %t1 = alloca 8
   %t2 = alloca 8
+  store ptr, %t2, null
   %t3 = alloca 8
   br L10
 L10:
@@ -34,6 +37,12 @@ L20:
   %t6 = load i64, %t3
   .loc 1 2 4
   %t7 = call @rt_arr_i32_new(%t6)
+  .loc 1 2 4
+  call @rt_arr_i32_retain(%t7)
+  .loc 1 2 4
+  %t8 = load ptr, %t2
+  .loc 1 2 4
+  call @rt_arr_i32_release(%t8)
   .loc 1 2 4
   store ptr, %t2, %t7
   .loc 1 2 4
@@ -53,107 +62,110 @@ L50:
   br loop_head
 L100:
   .loc 1 10 11
-  %t37 = load i64, %t0
+  %t38 = load i64, %t0
   .loc 1 10 5
-  call @rt_print_i64(%t37)
+  call @rt_print_i64(%t38)
   .loc 1 10 5
-  %t38 = const_str @.L0
+  %t39 = const_str @.L0
   .loc 1 10 5
-  call @rt_print_str(%t38)
+  call @rt_print_str(%t39)
   .loc 1 10 5
   br L110
 L110:
   .loc 1 11 5
   br exit
 exit:
+  %t40 = load ptr, %t2
+  call @rt_arr_i32_release(%t40)
+  store ptr, %t2, null
   ret 0
 loop_head:
   .loc 1 5 10
-  %t8 = load i64, %t1
+  %t9 = load i64, %t1
   .loc 1 5 14
-  %t9 = load i64, %t3
+  %t10 = load i64, %t3
   .loc 1 5 12
-  %t10 = scmp_lt %t8, %t9
+  %t11 = scmp_lt %t9, %t10
   .loc 1 5 4
-  cbr %t10, loop_body, done
+  cbr %t11, loop_body, done
 loop_body:
   .loc 1 6 17
-  %t11 = load i64, %t1
-  .loc 1 6 21
   %t12 = load i64, %t1
+  .loc 1 6 21
+  %t13 = load i64, %t1
   .loc 1 6 19
-  %t13 = mul %t11, %t12
+  %t14 = mul %t12, %t13
   .loc 1 6 19
-  %t14 = load ptr, %t2
+  %t15 = load ptr, %t2
   .loc 1 6 12
-  %t15 = load i64, %t1
+  %t16 = load i64, %t1
   .loc 1 6 10
-  %t16 = call @rt_arr_i32_len(%t14)
+  %t17 = call @rt_arr_i32_len(%t15)
   .loc 1 6 10
-  %t17 = scmp_lt %t15, 0
+  %t18 = scmp_lt %t16, 0
   .loc 1 6 10
-  %t18 = scmp_ge %t15, %t16
-  .loc 1 6 10
-  %t19 = zext1 %t17
+  %t19 = scmp_ge %t16, %t17
   .loc 1 6 10
   %t20 = zext1 %t18
   .loc 1 6 10
-  %t21 = add %t19, %t20
+  %t21 = zext1 %t19
   .loc 1 6 10
-  %t22 = scmp_gt %t21, 0
+  %t22 = add %t20, %t21
   .loc 1 6 10
-  cbr %t22, bc_oob0, bc_ok0
+  %t23 = scmp_gt %t22, 0
+  .loc 1 6 10
+  cbr %t23, bc_oob0, bc_ok0
 done:
   .loc 1 5 4
   br L100
 bc_ok0:
   .loc 1 6 6
-  call @rt_arr_i32_set(%t14, %t15, %t13)
+  call @rt_arr_i32_set(%t15, %t16, %t14)
   .loc 1 7 14
-  %t23 = load i64, %t0
+  %t24 = load i64, %t0
   .loc 1 7 18
-  %t24 = load ptr, %t2
+  %t25 = load ptr, %t2
   .loc 1 7 20
-  %t25 = load i64, %t1
+  %t26 = load i64, %t1
   .loc 1 7 18
-  %t26 = call @rt_arr_i32_len(%t24)
+  %t27 = call @rt_arr_i32_len(%t25)
   .loc 1 7 18
-  %t27 = scmp_lt %t25, 0
+  %t28 = scmp_lt %t26, 0
   .loc 1 7 18
-  %t28 = scmp_ge %t25, %t26
-  .loc 1 7 18
-  %t29 = zext1 %t27
+  %t29 = scmp_ge %t26, %t27
   .loc 1 7 18
   %t30 = zext1 %t28
   .loc 1 7 18
-  %t31 = add %t29, %t30
+  %t31 = zext1 %t29
   .loc 1 7 18
-  %t32 = scmp_gt %t31, 0
+  %t32 = add %t30, %t31
   .loc 1 7 18
-  cbr %t32, bc_oob1, bc_ok1
+  %t33 = scmp_gt %t32, 0
+  .loc 1 7 18
+  cbr %t33, bc_oob1, bc_ok1
 bc_oob0:
   .loc 1 6 10
-  call @rt_arr_oob_panic(%t15, %t16)
+  call @rt_arr_oob_panic(%t16, %t17)
   .loc 1 6 10
   trap
 bc_ok1:
   .loc 1 7 18
-  %t33 = call @rt_arr_i32_get(%t24, %t25)
+  %t34 = call @rt_arr_i32_get(%t25, %t26)
   .loc 1 7 16
-  %t34 = add %t23, %t33
+  %t35 = add %t24, %t34
   .loc 1 7 6
-  store i64, %t0, %t34
+  store i64, %t0, %t35
   .loc 1 8 14
-  %t35 = load i64, %t1
+  %t36 = load i64, %t1
   .loc 1 8 16
-  %t36 = add %t35, 1
+  %t37 = add %t36, 1
   .loc 1 8 6
-  store i64, %t1, %t36
+  store i64, %t1, %t37
   .loc 1 5 4
   br loop_head
 bc_oob1:
   .loc 1 7 18
-  call @rt_arr_oob_panic(%t25, %t26)
+  call @rt_arr_oob_panic(%t26, %t27)
   .loc 1 7 18
   trap
 }

--- a/tests/golden/basic_to_il/ubound.il
+++ b/tests/golden/basic_to_il/ubound.il
@@ -6,34 +6,46 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_arr_i32_new(i64) -> ptr
 extern @rt_arr_i32_len(ptr) -> i64
+extern @rt_arr_i32_retain(ptr) -> void
+extern @rt_arr_i32_release(ptr) -> void
 global const str @.L0 = "
 "
 func @main() -> i64 {
 entry:
   %t0 = alloca 8
+  store ptr, %t0, null
   br L10
 L10:
   .loc 1 1 4
   %t1 = call @rt_arr_i32_new(0)
+  .loc 1 1 4
+  call @rt_arr_i32_retain(%t1)
+  .loc 1 1 4
+  %t2 = load ptr, %t0
+  .loc 1 1 4
+  call @rt_arr_i32_release(%t2)
   .loc 1 1 4
   store ptr, %t0, %t1
   .loc 1 1 4
   br L20
 L20:
   .loc 1 2 10
-  %t2 = load ptr, %t0
+  %t3 = load ptr, %t0
   .loc 1 2 10
-  %t3 = call @rt_arr_i32_len(%t2)
+  %t4 = call @rt_arr_i32_len(%t3)
   .loc 1 2 10
-  %t4 = sub %t3, 1
+  %t5 = sub %t4, 1
   .loc 1 2 4
-  call @rt_print_i64(%t4)
+  call @rt_print_i64(%t5)
   .loc 1 2 4
-  %t5 = const_str @.L0
+  %t6 = const_str @.L0
   .loc 1 2 4
-  call @rt_print_str(%t5)
+  call @rt_print_str(%t6)
   .loc 1 2 4
   br exit
 exit:
+  %t7 = load ptr, %t0
+  call @rt_arr_i32_release(%t7)
+  store ptr, %t0, null
   ret 0
 }


### PR DESCRIPTION
## Summary
- add a `storeArray` helper so array assignments retain the incoming handle and release the previous value, covering DIM/REDIM and let statements
- retain array results from calls, release local and by-value array handles on scope exit, and request the new runtime helpers during scanning/pipeline setup
- refresh BASIC IL goldens to include the new retain/release behaviour

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d4cc4b6f688324a9f44494c21c7d40