### PR TITLE
Add rt_arr_i32 refcount regression tests

### DIFF
--- a/tests/runtime/RTArrayI32RefcountTests.cpp
+++ b/tests/runtime/RTArrayI32RefcountTests.cpp
@@ -1,0 +1,108 @@
+// File: tests/runtime/RTArrayI32RefcountTests.cpp
+// Purpose: Validate rt_arr_i32 reference-counting and copy-on-resize semantics.
+// Key invariants: Shared handles must observe consistent refcounts and aliasing guarantees.
+// Ownership: Tests manage retains/releases explicitly and ensure all arrays are freed.
+// Links: docs/runtime-vm.md#runtime-abi
+
+#include "rt_array.h"
+#include "rt_heap.h"
+
+#include <cassert>
+#include <cstddef>
+
+static size_t refcount(int32_t *arr)
+{
+    rt_heap_hdr_t *hdr = rt_arr_i32_hdr(arr);
+    assert(hdr != nullptr);
+    return hdr->refcnt;
+}
+
+static void test_refcount_lifecycle()
+{
+    int32_t *arr = rt_arr_i32_new(3);
+    assert(arr != nullptr);
+    assert(refcount(arr) == 1);
+
+    rt_arr_i32_retain(arr);
+    assert(refcount(arr) == 2);
+
+    rt_arr_i32_release(arr);
+    assert(refcount(arr) == 1);
+
+    size_t remaining = rt_heap_release(arr);
+    assert(remaining == 0);
+}
+
+static void test_aliasing_visibility()
+{
+    int32_t *a = rt_arr_i32_new(2);
+    assert(a != nullptr);
+    rt_arr_i32_set(a, 0, 11);
+
+    int32_t *b = a;
+    rt_arr_i32_retain(b);
+    assert(refcount(a) == 2);
+
+    rt_arr_i32_set(a, 1, -7);
+    assert(rt_arr_i32_get(b, 0) == 11);
+    assert(rt_arr_i32_get(b, 1) == -7);
+
+    rt_arr_i32_release(b);
+    assert(refcount(a) == 1);
+    rt_arr_i32_release(a);
+}
+
+static void test_copy_on_resize()
+{
+    int32_t *a = rt_arr_i32_new(2);
+    assert(a != nullptr);
+    rt_arr_i32_set(a, 0, 5);
+    rt_arr_i32_set(a, 1, 8);
+
+    int32_t *b = a;
+    rt_arr_i32_retain(b);
+    assert(refcount(a) == 2);
+
+    int32_t *original = a;
+    assert(rt_arr_i32_resize(&a, 4) == 0);
+    assert(a != nullptr);
+    assert(rt_arr_i32_len(a) == 4);
+    assert(rt_arr_i32_get(a, 0) == 5);
+    assert(rt_arr_i32_get(a, 1) == 8);
+    assert(rt_arr_i32_get(a, 2) == 0);
+    assert(rt_arr_i32_get(a, 3) == 0);
+
+    assert(a != b);
+    assert(original == b);
+
+    assert(refcount(a) == 1);
+    assert(refcount(b) == 1);
+    assert(rt_arr_i32_len(b) == 2);
+    assert(rt_arr_i32_get(b, 0) == 5);
+    assert(rt_arr_i32_get(b, 1) == 8);
+
+    rt_arr_i32_release(b);
+    rt_arr_i32_release(a);
+}
+
+static void test_self_assignment_no_refcount_change()
+{
+    int32_t *arr = rt_arr_i32_new(1);
+    assert(arr != nullptr);
+    assert(refcount(arr) == 1);
+
+    int32_t *alias = arr; // self-assignment/aliasing without retain should not change refcount.
+    (void)alias;
+    assert(refcount(arr) == 1);
+
+    rt_arr_i32_release(arr);
+}
+
+int main()
+{
+    test_refcount_lifecycle();
+    test_aliasing_visibility();
+    test_copy_on_resize();
+    test_self_assignment_no_refcount_change();
+    return 0;
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -91,6 +91,10 @@ function(viper_add_runtime_tests)
   target_link_libraries(test_rt_array_i32 PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_array_i32 test_rt_array_i32)
 
+  viper_add_test_exe(test_rt_array_i32_refcount ${VIPER_TESTS_DIR}/runtime/RTArrayI32RefcountTests.cpp)
+  target_link_libraries(test_rt_array_i32_refcount PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
+  viper_add_ctest(test_rt_array_i32_refcount test_rt_array_i32_refcount)
+
   viper_add_test_exe(test_rt_input_line ${VIPER_TESTS_DIR}/runtime/RTInputLineTests.cpp)
   target_link_libraries(test_rt_input_line PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_input_line test_rt_input_line)


### PR DESCRIPTION
## Summary
- add runtime coverage for rt_arr_i32 reference-counting, aliasing, and copy-on-resize behavior
- register the new runtime test executable with the unit test suite

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d54a437ad88324a928d7794e7d4735