### PR TITLE
refactor(frontends/basic): move core type helper to cpp

### DIFF
--- a/src/frontends/basic/LoweringPipeline.cpp
+++ b/src/frontends/basic/LoweringPipeline.cpp
@@ -16,6 +16,26 @@
 namespace il::frontends::basic
 {
 
+namespace pipeline_detail
+{
+il::core::Type coreTypeForAstType(::il::frontends::basic::Type ty)
+{
+    using il::core::Type;
+    switch (ty)
+    {
+        case ::il::frontends::basic::Type::I64:
+            return Type(Type::Kind::I64);
+        case ::il::frontends::basic::Type::F64:
+            return Type(Type::Kind::F64);
+        case ::il::frontends::basic::Type::Str:
+            return Type(Type::Kind::Str);
+        case ::il::frontends::basic::Type::Bool:
+            return Type(Type::Kind::I1);
+    }
+    return Type(Type::Kind::I64);
+}
+} // namespace pipeline_detail
+
 using pipeline_detail::coreTypeForAstType;
 
 namespace

--- a/src/frontends/basic/LoweringPipeline.hpp
+++ b/src/frontends/basic/LoweringPipeline.hpp
@@ -22,22 +22,7 @@ namespace pipeline_detail
 /// @brief Translate a BASIC AST scalar type into the IL core representation.
 /// @param ty BASIC semantic type sourced from the front-end AST.
 /// @return Corresponding IL type used for stack slots and temporaries.
-inline il::core::Type coreTypeForAstType(::il::frontends::basic::Type ty)
-{
-    using il::core::Type;
-    switch (ty)
-    {
-        case ::il::frontends::basic::Type::I64:
-            return Type(Type::Kind::I64);
-        case ::il::frontends::basic::Type::F64:
-            return Type(Type::Kind::F64);
-        case ::il::frontends::basic::Type::Str:
-            return Type(Type::Kind::Str);
-        case ::il::frontends::basic::Type::Bool:
-            return Type(Type::Kind::I1);
-    }
-    return Type(Type::Kind::I64);
-}
+il::core::Type coreTypeForAstType(::il::frontends::basic::Type ty);
 
 } // namespace pipeline_detail
 


### PR DESCRIPTION
## Summary
- declare the BASIC-to-IL type helper in the lowering pipeline header
- provide the helper definition in the cpp within the pipeline_detail namespace

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d59d5e000c83249772865d15cda718