### PR TITLE
refactor(il/verify): out-of-line global map accessor

### DIFF
--- a/src/il/verify/GlobalVerifier.cpp
+++ b/src/il/verify/GlobalVerifier.cpp
@@ -19,6 +19,11 @@ using il::support::Expected;
 using il::support::makeError;
 }
 
+[[nodiscard]] const GlobalVerifier::GlobalMap &GlobalVerifier::globals() const
+{
+    return globals_;
+}
+
 Expected<void> GlobalVerifier::run(const Module &module, DiagSink &)
 {
     globals_.clear();

--- a/src/il/verify/GlobalVerifier.hpp
+++ b/src/il/verify/GlobalVerifier.hpp
@@ -28,10 +28,7 @@ class GlobalVerifier
     using GlobalMap = std::unordered_map<std::string, const il::core::Global *>;
 
     /// @brief Access the verified global lookup table.
-    [[nodiscard]] const GlobalMap &globals() const
-    {
-        return globals_;
-    }
+    [[nodiscard]] const GlobalMap &globals() const;
 
     /// @brief Verify globals in @p module and populate the lookup table.
     /// @param module Module to inspect.


### PR DESCRIPTION
## Summary
- declare GlobalVerifier::globals in the header and provide an out-of-line definition
- preserve the [[nodiscard]] qualifier while returning the cached globals map

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d5a23502348324b8c9dd2b0170476c