### PR TITLE
refactor(frontends/basic): move BasicCompilerResult succeeded definition

### DIFF
--- a/src/frontends/basic/BasicCompiler.cpp
+++ b/src/frontends/basic/BasicCompiler.cpp
@@ -14,6 +14,11 @@
 namespace il::frontends::basic
 {
 
+[[nodiscard]] bool BasicCompilerResult::succeeded() const
+{
+    return emitter && emitter->errorCount() == 0;
+}
+
 BasicCompilerResult compileBasic(const BasicCompilerInput &input,
                                  const BasicCompilerOptions &options,
                                  il::support::SourceManager &sm)

--- a/src/frontends/basic/BasicCompiler.hpp
+++ b/src/frontends/basic/BasicCompiler.hpp
@@ -51,10 +51,7 @@ struct BasicCompilerResult
     il::core::Module module{};
 
     /// @brief Helper indicating whether compilation succeeded without errors.
-    [[nodiscard]] bool succeeded() const
-    {
-        return emitter && emitter->errorCount() == 0;
-    }
+    [[nodiscard]] bool succeeded() const;
 };
 
 /// @brief Compile BASIC source text into IL.


### PR DESCRIPTION
## Summary
- declare BasicCompilerResult::succeeded in the header while keeping its documentation intact
- define BasicCompilerResult::succeeded in BasicCompiler.cpp so it preserves the original return condition and qualifiers

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d5a20c76ec8324b959ee931f46a34d