### PR TITLE
fix(il/verify): out-of-line CollectingDiagSink methods

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ target_include_directories(il_build PUBLIC
 add_subdirectory(il/io)
 
 add_library(il_verify STATIC
+  il/verify/DiagSink.cpp
   il/verify/Verifier.cpp
   il/verify/ExternVerifier.cpp
   il/verify/GlobalVerifier.cpp

--- a/src/il/verify/DiagSink.cpp
+++ b/src/il/verify/DiagSink.cpp
@@ -1,0 +1,32 @@
+// File: src/il/verify/DiagSink.cpp
+// Purpose: Implements diagnostic sink utilities used by verifier components.
+// Key invariants: CollectingDiagSink appends diagnostics in the order received.
+// Ownership/Lifetime: CollectingDiagSink stores diagnostics until cleared.
+// Links: docs/il-guide.md#reference
+
+#include "il/verify/DiagSink.hpp"
+
+#include <utility>
+
+namespace il::verify
+{
+
+void CollectingDiagSink::report(il::support::Diag diag)
+{
+    // Store diagnostics in arrival order for later inspection.
+    diags_.push_back(std::move(diag));
+}
+
+const std::vector<il::support::Diag> &CollectingDiagSink::diagnostics() const
+{
+    // Expose immutable access to the stored diagnostics without copying.
+    return diags_;
+}
+
+void CollectingDiagSink::clear()
+{
+    // Remove all stored diagnostics to reset the sink state.
+    diags_.clear();
+}
+
+} // namespace il::verify

--- a/src/il/verify/DiagSink.hpp
+++ b/src/il/verify/DiagSink.hpp
@@ -7,7 +7,6 @@
 
 #include "support/diag_expected.hpp"
 
-#include <utility>
 #include <vector>
 
 namespace il::verify
@@ -30,23 +29,14 @@ class CollectingDiagSink : public DiagSink
   public:
     /// @brief Append @p diag to the collection.
     /// @param diag Diagnostic to store.
-    void report(il::support::Diag diag) override
-    {
-        diags_.push_back(std::move(diag));
-    }
+    void report(il::support::Diag diag) override;
 
     /// @brief Access the accumulated diagnostics.
     /// @return Immutable view of the recorded diagnostics.
-    [[nodiscard]] const std::vector<il::support::Diag> &diagnostics() const
-    {
-        return diags_;
-    }
+    [[nodiscard]] const std::vector<il::support::Diag> &diagnostics() const;
 
     /// @brief Remove all stored diagnostics.
-    void clear()
-    {
-        diags_.clear();
-    }
+    void clear();
 
   private:
     std::vector<il::support::Diag> diags_;


### PR DESCRIPTION
## Summary
- move CollectingDiagSink member definitions from the header into a new implementation file
- hook the new translation unit into the il_verify static library build

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d5a22c1c248324af43d8646db561be