### PR TITLE
refactor(frontends/basic): move last separator accessor

### DIFF
--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -114,6 +114,11 @@ void Parser::StatementContext::stashPendingLine(int line)
     pendingLine_ = line;
 }
 
+Parser::StatementContext::SeparatorKind Parser::StatementContext::lastSeparator() const
+{
+    return lastSeparator_;
+}
+
 Parser::StatementContext::TerminatorInfo Parser::StatementContext::consumeStatementBody(
     const TerminatorPredicate &isTerminator,
     const TerminatorConsumer &onTerminator,

--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -84,10 +84,7 @@ class Parser
 
         /// @brief Report which separator most recently separated statements.
         /// @return Classification of the most recent separator.
-        SeparatorKind lastSeparator() const
-        {
-            return lastSeparator_;
-        }
+        SeparatorKind lastSeparator() const;
 
         /// @brief Parse statements until @p isTerminator matches and populate @p dst.
         /// @param isTerminator Predicate determining when the body ends.


### PR DESCRIPTION
## Summary
- declare `Parser::StatementContext::lastSeparator` in Parser.hpp while keeping its documentation comment
- define `Parser::StatementContext::lastSeparator` out-of-line in Parser.cpp to return `lastSeparator_`

## Testing
- cmake -S . -B build
- cmake --build build --target fe_basic
- ctest --test-dir build --output-on-failure -R fe_basic

------
https://chatgpt.com/codex/tasks/task_e_68d5a2148b348324806c1cb98a5b9bf7