### PR TITLE
refactor(il/verify): define extern map accessor out of line

### DIFF
--- a/src/il/verify/ExternVerifier.cpp
+++ b/src/il/verify/ExternVerifier.cpp
@@ -43,6 +43,11 @@ bool signaturesMatch(const Extern &decl, const il::runtime::RuntimeSignature &ru
 
 } // namespace
 
+[[nodiscard]] const ExternVerifier::ExternMap &ExternVerifier::externs() const
+{
+    return externs_;
+}
+
 Expected<void> ExternVerifier::run(const Module &module, DiagSink &)
 {
     externs_.clear();

--- a/src/il/verify/ExternVerifier.hpp
+++ b/src/il/verify/ExternVerifier.hpp
@@ -28,10 +28,7 @@ class ExternVerifier
     using ExternMap = std::unordered_map<std::string, const il::core::Extern *>;
 
     /// @brief Access verified extern descriptors keyed by symbol name.
-    [[nodiscard]] const ExternMap &externs() const
-    {
-        return externs_;
-    }
+    [[nodiscard]] const ExternMap &externs() const;
 
     /// @brief Verify extern declarations in @p module and populate the lookup map.
     /// @param module Module whose extern table should be validated.


### PR DESCRIPTION
## Summary
- declare `ExternVerifier::externs` in the header and define it out of line in the implementation file
- return the cached extern map from the new definition while keeping the accessor `[[nodiscard]]`

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d5a473bd508324ac282f0af0061ed9