### PR TITLE
refactor(il/transform): centralize liveness view definitions

### DIFF
--- a/src/il/transform/PassManager.cpp
+++ b/src/il/transform/PassManager.cpp
@@ -37,21 +37,15 @@ namespace il::transform
 /// @return True when the identifier is within range and flagged live.
 bool LivenessInfo::SetView::contains(unsigned valueId) const
 {
-    return bits_ && valueId < bits_->size() && (*bits_)[valueId];
+    return bits_ != nullptr && valueId < bits_->size() && (*bits_)[valueId];
 }
 
 /// @brief Check whether the set contains any live values.
 /// @return True when no value bits are set.
 bool LivenessInfo::SetView::empty() const
 {
-    if (!bits_)
-        return true;
-    for (bool bit : *bits_)
-    {
-        if (bit)
-            return false;
-    }
-    return true;
+    return bits_ == nullptr ||
+           std::none_of(bits_->begin(), bits_->end(), [](bool bit) { return bit; });
 }
 
 /// @brief Access the underlying bitset for integration tests or debugging.


### PR DESCRIPTION
## Summary
- ensure `LivenessInfo::SetView` helpers are defined out-of-line in `PassManager.cpp`
- tighten null checks and use `std::none_of` when determining whether a liveness set is empty

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d5a4d3ca54832491277ba8b2527b70