### PR TITLE
feat(vm): add structured trap diagnostics and tests

### DIFF
--- a/src/vm/RuntimeBridge.hpp
+++ b/src/vm/RuntimeBridge.hpp
@@ -7,6 +7,7 @@
 
 #include "rt.hpp"
 #include "support/source_location.hpp"
+#include "vm/Trap.hpp"
 #include <string>
 #include <vector>
 
@@ -43,7 +44,8 @@ class RuntimeBridge
 
     /// @brief Report a trap with source location @p loc within function @p fn and
     /// block @p block.
-    static void trap(const std::string &msg,
+    static void trap(TrapKind kind,
+                     const std::string &msg,
                      const il::support::SourceLoc &loc,
                      const std::string &fn,
                      const std::string &block);

--- a/src/vm/Trap.hpp
+++ b/src/vm/Trap.hpp
@@ -1,0 +1,41 @@
+// File: src/vm/Trap.hpp
+// Purpose: Defines trap classification for VM diagnostics.
+// Key invariants: Enum values map directly to trap categories used in diagnostics.
+// Ownership/Lifetime: Not applicable.
+// Links: docs/il-guide.md#reference
+#pragma once
+
+#include <string_view>
+
+namespace il::vm
+{
+
+/// @brief Categorises runtime traps for diagnostic reporting.
+enum class TrapKind
+{
+    DivideByZero, ///< Integer division or remainder by zero.
+    Overflow,     ///< Arithmetic or conversion overflow.
+    InvalidCast,  ///< Invalid cast or conversion semantics.
+    DomainError,  ///< Semantic domain violation or user trap.
+};
+
+/// @brief Convert trap kind to canonical diagnostic string.
+/// @param kind Enumerated trap kind.
+/// @return Stable string view naming the trap category.
+constexpr std::string_view toString(TrapKind kind)
+{
+    switch (kind)
+    {
+        case TrapKind::DivideByZero:
+            return "DivideByZero";
+        case TrapKind::Overflow:
+            return "Overflow";
+        case TrapKind::InvalidCast:
+            return "InvalidCast";
+        case TrapKind::DomainError:
+            return "DomainError";
+    }
+    return "DomainError";
+}
+
+} // namespace il::vm

--- a/src/vm/control_flow.cpp
+++ b/src/vm/control_flow.cpp
@@ -194,7 +194,7 @@ VM::ExecResult OpHandlers::handleTrap(VM &vm,
     (void)vm;
     (void)blocks;
     (void)ip;
-    RuntimeBridge::trap("trap", in.loc, fr.func->name, bb->label);
+    RuntimeBridge::trap(TrapKind::DomainError, "trap", in.loc, fr.func->name, bb->label);
     VM::ExecResult result{};
     result.returned = true;
     return result;

--- a/src/vm/fp_ops.cpp
+++ b/src/vm/fp_ops.cpp
@@ -279,14 +279,20 @@ VM::ExecResult OpHandlers::handleCastFpToSiRteChk(VM &vm,
     const double operand = value.f64;
     if (!std::isfinite(operand))
     {
-        RuntimeBridge::trap("invalid fp operand in cast.fp_to_si.rte.chk", in.loc, fr.func->name,
+        RuntimeBridge::trap(TrapKind::InvalidCast,
+                            "invalid fp operand in cast.fp_to_si.rte.chk",
+                            in.loc,
+                            fr.func->name,
                             bb ? bb->label : "");
     }
 
     const double rounded = std::nearbyint(operand);
     if (!std::isfinite(rounded))
     {
-        RuntimeBridge::trap("fp overflow in cast.fp_to_si.rte.chk", in.loc, fr.func->name,
+        RuntimeBridge::trap(TrapKind::Overflow,
+                            "fp overflow in cast.fp_to_si.rte.chk",
+                            in.loc,
+                            fr.func->name,
                             bb ? bb->label : "");
     }
 
@@ -294,7 +300,10 @@ VM::ExecResult OpHandlers::handleCastFpToSiRteChk(VM &vm,
     constexpr double kMax = static_cast<double>(std::numeric_limits<int64_t>::max());
     if (rounded < kMin || rounded > kMax)
     {
-        RuntimeBridge::trap("fp overflow in cast.fp_to_si.rte.chk", in.loc, fr.func->name,
+        RuntimeBridge::trap(TrapKind::Overflow,
+                            "fp overflow in cast.fp_to_si.rte.chk",
+                            in.loc,
+                            fr.func->name,
                             bb ? bb->label : "");
     }
 

--- a/src/vm/int_ops.cpp
+++ b/src/vm/int_ops.cpp
@@ -109,7 +109,10 @@ VM::ExecResult OpHandlers::handleIAddOvf(VM &vm,
                                 if (__builtin_add_overflow(lhsVal.i64, rhsVal.i64, &result))
                                 {
                                     RuntimeBridge::trap(
-                                        "integer overflow in iadd.ovf", in.loc, fr.func->name,
+                                        TrapKind::Overflow,
+                                        "integer overflow in iadd.ovf",
+                                        in.loc,
+                                        fr.func->name,
                                         bb ? bb->label : "");
                                 }
                                 out.i64 = result;
@@ -135,7 +138,10 @@ VM::ExecResult OpHandlers::handleISubOvf(VM &vm,
                                 if (__builtin_sub_overflow(lhsVal.i64, rhsVal.i64, &result))
                                 {
                                     RuntimeBridge::trap(
-                                        "integer overflow in isub.ovf", in.loc, fr.func->name,
+                                        TrapKind::Overflow,
+                                        "integer overflow in isub.ovf",
+                                        in.loc,
+                                        fr.func->name,
                                         bb ? bb->label : "");
                                 }
                                 out.i64 = result;
@@ -161,7 +167,10 @@ VM::ExecResult OpHandlers::handleIMulOvf(VM &vm,
                                 if (__builtin_mul_overflow(lhsVal.i64, rhsVal.i64, &result))
                                 {
                                     RuntimeBridge::trap(
-                                        "integer overflow in imul.ovf", in.loc, fr.func->name,
+                                        TrapKind::Overflow,
+                                        "integer overflow in imul.ovf",
+                                        in.loc,
+                                        fr.func->name,
                                         bb ? bb->label : "");
                                 }
                                 out.i64 = result;
@@ -187,14 +196,20 @@ VM::ExecResult OpHandlers::handleSDivChk0(VM &vm,
                                 if (divisor == 0)
                                 {
                                     RuntimeBridge::trap(
-                                        "divide by zero in sdiv.chk0", in.loc, fr.func->name,
+                                        TrapKind::DivideByZero,
+                                        "divide by zero in sdiv.chk0",
+                                        in.loc,
+                                        fr.func->name,
                                         bb ? bb->label : "");
                                 }
                                 const auto dividend = lhsVal.i64;
                                 if (dividend == std::numeric_limits<int64_t>::min() && divisor == -1)
                                 {
                                     RuntimeBridge::trap(
-                                        "integer overflow in sdiv.chk0", in.loc, fr.func->name,
+                                        TrapKind::Overflow,
+                                        "integer overflow in sdiv.chk0",
+                                        in.loc,
+                                        fr.func->name,
                                         bb ? bb->label : "");
                                 }
                                 out.i64 = dividend / divisor;
@@ -220,7 +235,10 @@ VM::ExecResult OpHandlers::handleUDivChk0(VM &vm,
                                 if (divisor == 0)
                                 {
                                     RuntimeBridge::trap(
-                                        "divide by zero in udiv.chk0", in.loc, fr.func->name,
+                                        TrapKind::DivideByZero,
+                                        "divide by zero in udiv.chk0",
+                                        in.loc,
+                                        fr.func->name,
                                         bb ? bb->label : "");
                                 }
                                 const auto dividend = static_cast<uint64_t>(lhsVal.i64);
@@ -247,14 +265,20 @@ VM::ExecResult OpHandlers::handleSRemChk0(VM &vm,
                                 if (divisor == 0)
                                 {
                                     RuntimeBridge::trap(
-                                        "divide by zero in srem.chk0", in.loc, fr.func->name,
+                                        TrapKind::DivideByZero,
+                                        "divide by zero in srem.chk0",
+                                        in.loc,
+                                        fr.func->name,
                                         bb ? bb->label : "");
                                 }
                                 const auto dividend = lhsVal.i64;
                                 if (dividend == std::numeric_limits<int64_t>::min() && divisor == -1)
                                 {
                                     RuntimeBridge::trap(
-                                        "integer overflow in srem.chk0", in.loc, fr.func->name,
+                                        TrapKind::Overflow,
+                                        "integer overflow in srem.chk0",
+                                        in.loc,
+                                        fr.func->name,
                                         bb ? bb->label : "");
                                 }
                                 out.i64 = dividend % divisor;
@@ -280,7 +304,10 @@ VM::ExecResult OpHandlers::handleURemChk0(VM &vm,
                                 if (divisor == 0)
                                 {
                                     RuntimeBridge::trap(
-                                        "divide by zero in urem.chk0", in.loc, fr.func->name,
+                                        TrapKind::DivideByZero,
+                                        "divide by zero in urem.chk0",
+                                        in.loc,
+                                        fr.func->name,
                                         bb ? bb->label : "");
                                 }
                                 const auto dividend = static_cast<uint64_t>(lhsVal.i64);

--- a/src/vm/mem_ops.cpp
+++ b/src/vm/mem_ops.cpp
@@ -47,7 +47,7 @@ VM::ExecResult OpHandlers::handleAlloca(VM &vm,
     (void)ip;
     if (in.operands.empty())
     {
-        RuntimeBridge::trap("missing allocation size", in.loc, fr.func->name, "");
+        RuntimeBridge::trap(TrapKind::DomainError, "missing allocation size", in.loc, fr.func->name, "");
         VM::ExecResult result{};
         result.returned = true;
         return result;
@@ -56,7 +56,7 @@ VM::ExecResult OpHandlers::handleAlloca(VM &vm,
     int64_t bytes = vm.eval(fr, in.operands[0]).i64;
     if (bytes < 0)
     {
-        RuntimeBridge::trap("negative allocation", in.loc, fr.func->name, "");
+        RuntimeBridge::trap(TrapKind::DomainError, "negative allocation", in.loc, fr.func->name, "");
         VM::ExecResult result{};
         result.returned = true;
         return result;
@@ -67,7 +67,7 @@ VM::ExecResult OpHandlers::handleAlloca(VM &vm,
     const size_t stackSize = fr.stack.size();
 
     auto trapOverflow = [&]() -> VM::ExecResult {
-        RuntimeBridge::trap("stack overflow in alloca", in.loc, fr.func->name, "");
+        RuntimeBridge::trap(TrapKind::Overflow, "stack overflow in alloca", in.loc, fr.func->name, "");
         VM::ExecResult result{};
         result.returned = true;
         return result;

--- a/tests/unit/test_vm_rt_trap_loc.cpp
+++ b/tests/unit/test_vm_rt_trap_loc.cpp
@@ -47,7 +47,7 @@ int main()
     int status = 0;
     waitpid(pid, &status, 0);
     std::string out(buf);
-    bool ok = out.find("main: entry (1:1:1)") != std::string::npos;
+    bool ok = out.find("runtime trap: DomainError @ main: entry[#1] (1:1:1): rt_to_int: invalid") != std::string::npos;
     assert(ok);
     return 0;
 }

--- a/tests/unit/test_vm_rt_unknown_helper.cpp
+++ b/tests/unit/test_vm_rt_unknown_helper.cpp
@@ -50,11 +50,8 @@ int main()
     assert(WIFEXITED(status) && WEXITSTATUS(status) == 1);
     std::string out(buf);
     bool messageOk =
-        out.find("runtime trap: attempted to call unknown runtime helper 'rt_missing'") != std::string::npos;
-    bool functionOk = out.find("main: entry") != std::string::npos;
-    bool locationOk = out.find("(1:1:1)") != std::string::npos;
+        out.find("runtime trap: DomainError @ main: entry[#0] (1:1:1): attempted to call unknown runtime helper 'rt_missing'") !=
+        std::string::npos;
     assert(messageOk && "expected runtime trap diagnostic for unknown runtime helper");
-    assert(functionOk && "expected function and block context in runtime diagnostic");
-    assert(locationOk && "expected source location in runtime diagnostic");
     return 0;
 }

--- a/tests/unit/test_vm_trap_loc.cpp
+++ b/tests/unit/test_vm_trap_loc.cpp
@@ -45,7 +45,7 @@ int main()
     int status = 0;
     waitpid(pid, &status, 0);
     std::string out(buf);
-    bool ok = out.find("main: entry (1:1:1)") != std::string::npos;
+    bool ok = out.find("runtime trap: DomainError @ main: entry[#0] (1:1:1): trap") != std::string::npos;
     assert(ok);
     return 0;
 }

--- a/tests/vm/CMakeLists.txt
+++ b/tests/vm/CMakeLists.txt
@@ -59,6 +59,24 @@ function(viper_add_vm_unit_tests)
     return()
   endif()
 
+  set(_VIPER_VM_DIR ${CMAKE_CURRENT_FUNCTION_LIST_DIR})
+
+  viper_add_test_exe(test_vm_trap_domain_error ${_VIPER_VM_DIR}/TrapDomainErrorTests.cpp)
+  target_link_libraries(test_vm_trap_domain_error PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
+  viper_add_ctest(test_vm_trap_domain_error test_vm_trap_domain_error)
+
+  viper_add_test_exe(test_vm_trap_divide_by_zero ${_VIPER_VM_DIR}/TrapDivideByZeroTests.cpp)
+  target_link_libraries(test_vm_trap_divide_by_zero PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
+  viper_add_ctest(test_vm_trap_divide_by_zero test_vm_trap_divide_by_zero)
+
+  viper_add_test_exe(test_vm_trap_overflow ${_VIPER_VM_DIR}/TrapOverflowTests.cpp)
+  target_link_libraries(test_vm_trap_overflow PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
+  viper_add_ctest(test_vm_trap_overflow test_vm_trap_overflow)
+
+  viper_add_test_exe(test_vm_trap_invalid_cast ${_VIPER_VM_DIR}/TrapInvalidCastTests.cpp)
+  target_link_libraries(test_vm_trap_invalid_cast PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
+  viper_add_ctest(test_vm_trap_invalid_cast test_vm_trap_invalid_cast)
+
   viper_add_test_exe(test_vm_trap_loc ${VIPER_TESTS_DIR}/unit/test_vm_trap_loc.cpp)
   target_link_libraries(test_vm_trap_loc PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   viper_add_ctest(test_vm_trap_loc test_vm_trap_loc)

--- a/tests/vm/TrapDivideByZeroTests.cpp
+++ b/tests/vm/TrapDivideByZeroTests.cpp
@@ -1,0 +1,75 @@
+// File: tests/vm/TrapDivideByZeroTests.cpp
+// Purpose: Ensure DivideByZero traps report kind and instruction index.
+// Key invariants: Diagnostic mentions DivideByZero and instruction #0 for the failing op.
+// Ownership/Lifetime: Forks child VM process to capture trap output.
+// Links: docs/codemap.md
+
+#include "il/build/IRBuilder.hpp"
+#include "vm/VM.hpp"
+
+#include <cassert>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+using namespace il::core;
+
+namespace
+{
+std::string captureTrap(Module &module)
+{
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        il::vm::VM vm(module);
+        vm.run();
+        _exit(0);
+    }
+    close(fds[1]);
+    char buffer[512];
+    ssize_t n = read(fds[0], buffer, sizeof(buffer) - 1);
+    if (n < 0)
+        n = 0;
+    buffer[n] = '\0';
+    close(fds[0]);
+    int status = 0;
+    waitpid(pid, &status, 0);
+    assert(WIFEXITED(status) && WEXITSTATUS(status) == 1);
+    return std::string(buffer);
+}
+} // namespace
+
+int main()
+{
+    Module module;
+    il::build::IRBuilder builder(module);
+    auto &fn = builder.startFunction("main", Type(Type::Kind::I64), {});
+    auto &bb = builder.addBlock(fn, "entry");
+    builder.setInsertPoint(bb);
+
+    Instr div;
+    div.result = builder.reserveTempId();
+    div.op = Opcode::SDivChk0;
+    div.type = Type(Type::Kind::I64);
+    div.operands.push_back(Value::constInt(1));
+    div.operands.push_back(Value::constInt(0));
+    div.loc = {1, 1, 1};
+    bb.instructions.push_back(div);
+
+    Instr ret;
+    ret.op = Opcode::Ret;
+    ret.type = Type(Type::Kind::Void);
+    ret.loc = {1, 1, 1};
+    bb.instructions.push_back(ret);
+
+    const std::string out = captureTrap(module);
+    const bool ok =
+        out.find("runtime trap: DivideByZero @ main: entry[#0] (1:1:1): divide by zero in sdiv.chk0") != std::string::npos;
+    assert(ok && "expected DivideByZero trap diagnostic with instruction index");
+    return 0;
+}

--- a/tests/vm/TrapDomainErrorTests.cpp
+++ b/tests/vm/TrapDomainErrorTests.cpp
@@ -1,0 +1,71 @@
+// File: tests/vm/TrapDomainErrorTests.cpp
+// Purpose: Verify DomainError trap diagnostics include kind and instruction index.
+// Key invariants: Trap output must mention DomainError and #0 for the trap terminator.
+// Ownership/Lifetime: Spawns child process to capture VM stderr.
+// Links: docs/codemap.md
+
+#include "il/build/IRBuilder.hpp"
+#include "vm/VM.hpp"
+
+#include <cassert>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+using namespace il::core;
+
+namespace
+{
+std::string captureTrap(Module &module)
+{
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        il::vm::VM vm(module);
+        vm.run();
+        _exit(0);
+    }
+    close(fds[1]);
+    char buffer[512];
+    ssize_t n = read(fds[0], buffer, sizeof(buffer) - 1);
+    if (n < 0)
+        n = 0;
+    buffer[n] = '\0';
+    close(fds[0]);
+    int status = 0;
+    waitpid(pid, &status, 0);
+    assert(WIFEXITED(status) && WEXITSTATUS(status) == 1);
+    return std::string(buffer);
+}
+} // namespace
+
+int main()
+{
+    Module module;
+    il::build::IRBuilder builder(module);
+    auto &fn = builder.startFunction("main", Type(Type::Kind::I64), {});
+    auto &bb = builder.addBlock(fn, "entry");
+    builder.setInsertPoint(bb);
+
+    Instr trap;
+    trap.op = Opcode::Trap;
+    trap.type = Type(Type::Kind::Void);
+    trap.loc = {1, 1, 1};
+    bb.instructions.push_back(trap);
+
+    Instr ret;
+    ret.op = Opcode::Ret;
+    ret.type = Type(Type::Kind::Void);
+    ret.loc = {1, 1, 1};
+    bb.instructions.push_back(ret);
+
+    const std::string out = captureTrap(module);
+    const bool ok = out.find("runtime trap: DomainError @ main: entry[#0] (1:1:1): trap") != std::string::npos;
+    assert(ok && "expected DomainError trap diagnostic with instruction index");
+    return 0;
+}

--- a/tests/vm/TrapInvalidCastTests.cpp
+++ b/tests/vm/TrapInvalidCastTests.cpp
@@ -1,0 +1,77 @@
+// File: tests/vm/TrapInvalidCastTests.cpp
+// Purpose: Ensure InvalidCast traps report kind and instruction index.
+// Key invariants: Diagnostic mentions InvalidCast and instruction #0 for cast op.
+// Ownership/Lifetime: Uses forked VM process to capture stderr.
+// Links: docs/codemap.md
+
+#include "il/build/IRBuilder.hpp"
+#include "vm/VM.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+using namespace il::core;
+
+namespace
+{
+std::string captureTrap(Module &module)
+{
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        il::vm::VM vm(module);
+        vm.run();
+        _exit(0);
+    }
+    close(fds[1]);
+    char buffer[512];
+    ssize_t n = read(fds[0], buffer, sizeof(buffer) - 1);
+    if (n < 0)
+        n = 0;
+    buffer[n] = '\0';
+    close(fds[0]);
+    int status = 0;
+    waitpid(pid, &status, 0);
+    assert(WIFEXITED(status) && WEXITSTATUS(status) == 1);
+    return std::string(buffer);
+}
+} // namespace
+
+int main()
+{
+    Module module;
+    il::build::IRBuilder builder(module);
+    auto &fn = builder.startFunction("main", Type(Type::Kind::I64), {});
+    auto &bb = builder.addBlock(fn, "entry");
+    builder.setInsertPoint(bb);
+
+    Instr cast;
+    cast.result = builder.reserveTempId();
+    cast.op = Opcode::CastFpToSiRteChk;
+    cast.type = Type(Type::Kind::I64);
+    cast.operands.push_back(Value::constFloat(std::numeric_limits<double>::quiet_NaN()));
+    cast.loc = {1, 1, 1};
+    bb.instructions.push_back(cast);
+
+    Instr ret;
+    ret.op = Opcode::Ret;
+    ret.type = Type(Type::Kind::Void);
+    ret.loc = {1, 1, 1};
+    bb.instructions.push_back(ret);
+
+    const std::string out = captureTrap(module);
+    const bool ok = out.find(
+                       "runtime trap: InvalidCast @ main: entry[#0] (1:1:1): invalid fp operand in cast.fp_to_si.rte.chk") !=
+                   std::string::npos;
+    assert(ok && "expected InvalidCast trap diagnostic with instruction index");
+    return 0;
+}

--- a/tests/vm/TrapOverflowTests.cpp
+++ b/tests/vm/TrapOverflowTests.cpp
@@ -1,0 +1,76 @@
+// File: tests/vm/TrapOverflowTests.cpp
+// Purpose: Ensure Overflow traps report kind and instruction index.
+// Key invariants: Diagnostic must mention Overflow and instruction #0.
+// Ownership/Lifetime: Forks child VM process to capture trap diagnostics.
+// Links: docs/codemap.md
+
+#include "il/build/IRBuilder.hpp"
+#include "vm/VM.hpp"
+
+#include <cassert>
+#include <limits>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+using namespace il::core;
+
+namespace
+{
+std::string captureTrap(Module &module)
+{
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        il::vm::VM vm(module);
+        vm.run();
+        _exit(0);
+    }
+    close(fds[1]);
+    char buffer[512];
+    ssize_t n = read(fds[0], buffer, sizeof(buffer) - 1);
+    if (n < 0)
+        n = 0;
+    buffer[n] = '\0';
+    close(fds[0]);
+    int status = 0;
+    waitpid(pid, &status, 0);
+    assert(WIFEXITED(status) && WEXITSTATUS(status) == 1);
+    return std::string(buffer);
+}
+} // namespace
+
+int main()
+{
+    Module module;
+    il::build::IRBuilder builder(module);
+    auto &fn = builder.startFunction("main", Type(Type::Kind::I64), {});
+    auto &bb = builder.addBlock(fn, "entry");
+    builder.setInsertPoint(bb);
+
+    Instr add;
+    add.result = builder.reserveTempId();
+    add.op = Opcode::IAddOvf;
+    add.type = Type(Type::Kind::I64);
+    add.operands.push_back(Value::constInt(std::numeric_limits<long long>::max()));
+    add.operands.push_back(Value::constInt(1));
+    add.loc = {1, 1, 1};
+    bb.instructions.push_back(add);
+
+    Instr ret;
+    ret.op = Opcode::Ret;
+    ret.type = Type(Type::Kind::Void);
+    ret.loc = {1, 1, 1};
+    bb.instructions.push_back(ret);
+
+    const std::string out = captureTrap(module);
+    const bool ok =
+        out.find("runtime trap: Overflow @ main: entry[#0] (1:1:1): integer overflow in iadd.ovf") != std::string::npos;
+    assert(ok && "expected Overflow trap diagnostic with instruction index");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a TrapKind enum and capture trap metadata in the VM so diagnostics include function, block, instruction index, and source location
- update the runtime bridge and opcode handlers to raise typed traps and emit consistent messages
- add deterministic tests that cover DomainError, DivideByZero, Overflow, and InvalidCast traps

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d6aa5a952c8324ad1a6e4a326649b3