### PR TITLE
feat(frontends/basic): add numeric type rules

### DIFF
--- a/src/frontends/basic/CMakeLists.txt
+++ b/src/frontends/basic/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(fe_basic STATIC
   Parser_Token.cpp
   NameMangler.cpp
   TypeSuffix.cpp
+  TypeRules.cpp
   LoweringContext.cpp
   LoweringPipeline.cpp
   BuiltinRegistry.cpp

--- a/src/frontends/basic/TypeRules.cpp
+++ b/src/frontends/basic/TypeRules.cpp
@@ -1,0 +1,140 @@
+// File: src/frontends/basic/TypeRules.cpp
+// License: MIT License. See LICENSE in the project root for full license
+//          information.
+// Purpose: Implements BASIC numeric type promotion and operator result rules.
+// Key invariants: Operator lookup table reflects INTEGER/LONG/SINGLE/DOUBLE semantics.
+// Ownership/Lifetime: Stateless helpers.
+// Links: docs/codemap.md
+
+#include "frontends/basic/TypeRules.hpp"
+
+#include <array>
+#include <cassert>
+
+namespace il::frontends::basic
+{
+namespace
+{
+using NumericType = TypeRules::NumericType;
+using BinaryFn = NumericType (*)(NumericType, NumericType) noexcept;
+
+constexpr bool isInteger(NumericType type) noexcept
+{
+    return type == NumericType::Integer || type == NumericType::Long;
+}
+
+constexpr bool isFloat(NumericType type) noexcept
+{
+    return type == NumericType::Single || type == NumericType::Double;
+}
+
+constexpr NumericType promoteInteger(NumericType lhs, NumericType rhs) noexcept
+{
+    return (lhs == NumericType::Long || rhs == NumericType::Long) ? NumericType::Long
+                                                                  : NumericType::Integer;
+}
+
+constexpr NumericType promoteFloat(NumericType lhs, NumericType rhs) noexcept
+{
+    return (lhs == NumericType::Double || rhs == NumericType::Double) ? NumericType::Double
+                                                                      : NumericType::Single;
+}
+
+constexpr NumericType arithmeticResult(NumericType lhs, NumericType rhs) noexcept
+{
+    if (isInteger(lhs) && isInteger(rhs))
+        return promoteInteger(lhs, rhs);
+    return promoteFloat(lhs, rhs);
+}
+
+constexpr NumericType divisionResult(NumericType lhs, NumericType rhs) noexcept
+{
+    if (lhs == NumericType::Double || rhs == NumericType::Double)
+        return NumericType::Double;
+    if (lhs == NumericType::Single || rhs == NumericType::Single)
+        return NumericType::Single;
+    return NumericType::Double;
+}
+
+constexpr NumericType integerResult(NumericType lhs, NumericType rhs) noexcept
+{
+    return promoteInteger(lhs, rhs);
+}
+
+constexpr NumericType powerResult(NumericType, NumericType) noexcept
+{
+    return NumericType::Double;
+}
+
+struct BinaryRule
+{
+    std::string_view op;
+    BinaryFn fn;
+};
+
+constexpr std::array<BinaryRule, 7> Rules = {{{"+", &arithmeticResult},
+                                              {"-", &arithmeticResult},
+                                              {"*", &arithmeticResult},
+                                              {"/", &divisionResult},
+                                              {"\\", &integerResult},
+                                              {"MOD", &integerResult},
+                                              {"^", &powerResult}}};
+
+constexpr char upperChar(char c) noexcept
+{
+    return (c >= 'a' && c <= 'z') ? static_cast<char>(c - 'a' + 'A') : c;
+}
+
+constexpr bool equalsIgnoreCase(std::string_view lhs, std::string_view rhs) noexcept
+{
+    if (lhs.size() != rhs.size())
+        return false;
+    for (std::size_t i = 0; i < lhs.size(); ++i)
+    {
+        if (upperChar(lhs[i]) != upperChar(rhs[i]))
+            return false;
+    }
+    return true;
+}
+
+} // namespace
+
+TypeRules::NumericType TypeRules::resultType(std::string_view op,
+                                             NumericType lhs,
+                                             NumericType rhs) noexcept
+{
+    if (op.size() == 1)
+        return resultType(op.front(), lhs, rhs);
+
+    for (const auto &rule : Rules)
+    {
+        if (equalsIgnoreCase(rule.op, op))
+            return rule.fn(lhs, rhs);
+    }
+    assert(false && "Unsupported operator");
+    return lhs;
+}
+
+TypeRules::NumericType TypeRules::resultType(char op,
+                                             NumericType lhs,
+                                             NumericType rhs) noexcept
+{
+    for (const auto &rule : Rules)
+    {
+        if (rule.op.size() == 1 && rule.op.front() == op)
+            return rule.fn(lhs, rhs);
+    }
+    assert(false && "Unsupported operator");
+    return lhs;
+}
+
+TypeRules::NumericType TypeRules::unaryResultType(char op, NumericType operand) noexcept
+{
+    assert(op == '-' && "Only unary minus supported");
+    if (isFloat(operand) || isInteger(operand))
+        return operand;
+    assert(false && "Unsupported operand type for unary minus");
+    return operand;
+}
+
+} // namespace il::frontends::basic

--- a/src/frontends/basic/TypeRules.hpp
+++ b/src/frontends/basic/TypeRules.hpp
@@ -1,0 +1,43 @@
+// File: src/frontends/basic/TypeRules.hpp
+// Purpose: Declares BASIC numeric type promotion and operator result rules.
+// Key invariants: Operator tables implement the INTEGER/LONG/SINGLE/DOUBLE lattice.
+// Ownership/Lifetime: Pure stateless utility; no retained resources.
+// Links: docs/codemap.md
+#pragma once
+
+#include <string_view>
+
+namespace il::frontends::basic
+{
+
+/// @brief Numeric BASIC scalar types.
+/// @details INTEGER and LONG are integral; SINGLE and DOUBLE are floating-point.
+class TypeRules
+{
+  public:
+    /// @brief Available numeric types ordered by promotion lattice.
+    enum class NumericType
+    {
+        Integer, ///< 16-bit signed integer.
+        Long,    ///< 32-bit signed integer.
+        Single,  ///< 32-bit IEEE-754 floating-point.
+        Double,  ///< 64-bit IEEE-754 floating-point.
+    };
+
+    /// @brief Determine the binary operator result type.
+    /// @param op Operator token ("+", "-", "*", "/", "\\", "MOD", "^").
+    /// @param lhs Left operand numeric type.
+    /// @param rhs Right operand numeric type.
+    /// @return Resulting numeric type according to BASIC promotion rules.
+    static NumericType resultType(std::string_view op, NumericType lhs, NumericType rhs) noexcept;
+
+    /// @brief Determine binary operator result type for single-character operators.
+    static NumericType resultType(char op, NumericType lhs, NumericType rhs) noexcept;
+
+    /// @brief Determine the unary operator result type.
+    /// @param op Unary operator (currently only '-').
+    /// @param operand Operand numeric type.
+    static NumericType unaryResultType(char op, NumericType operand) noexcept;
+};
+
+} // namespace il::frontends::basic

--- a/tests/basic/CMakeLists.txt
+++ b/tests/basic/CMakeLists.txt
@@ -94,6 +94,10 @@ function(viper_add_basic_main_tests)
   target_link_libraries(test_frontends_basic_semantic_exprs PRIVATE ${VIPER_BASIC_LIBS})
   viper_add_ctest(test_frontends_basic_semantic_exprs test_frontends_basic_semantic_exprs)
 
+  viper_add_test_exe(test_frontends_basic_type_rules ${VIPER_TESTS_DIR}/frontends/basic/TypeRulesTests.cpp)
+  target_link_libraries(test_frontends_basic_type_rules PRIVATE ${VIPER_BASIC_LIBS})
+  viper_add_ctest(test_frontends_basic_type_rules test_frontends_basic_type_rules)
+
   viper_add_test_exe(test_basic_intrinsics ${_VIPER_BASIC_UNIT_DIR}/test_basic_intrinsics.cpp)
   target_link_libraries(test_basic_intrinsics PRIVATE ${VIPER_BASIC_LIBS})
   viper_add_ctest(test_basic_intrinsics test_basic_intrinsics)

--- a/tests/frontends/basic/TypeRulesTests.cpp
+++ b/tests/frontends/basic/TypeRulesTests.cpp
@@ -1,0 +1,29 @@
+// File: tests/frontends/basic/TypeRulesTests.cpp
+// Purpose: Validate BASIC numeric type promotion and operator result helpers.
+// Key invariants: TypeRules provides deterministic lattice-based results.
+// Ownership/Lifetime: Standalone executable using simple assertions.
+// Links: docs/codemap.md
+
+#include "frontends/basic/TypeRules.hpp"
+
+#include <cassert>
+
+using il::frontends::basic::TypeRules;
+
+int main()
+{
+    using NumericType = TypeRules::NumericType;
+
+    assert(TypeRules::resultType('/', NumericType::Integer, NumericType::Integer) ==
+           NumericType::Double);
+    assert(TypeRules::resultType('/', NumericType::Single, NumericType::Integer) ==
+           NumericType::Single);
+    assert(TypeRules::resultType('\\', NumericType::Integer, NumericType::Long) ==
+           NumericType::Long);
+    assert(TypeRules::resultType("MOD", NumericType::Long, NumericType::Integer) ==
+           NumericType::Long);
+    assert(TypeRules::resultType('^', NumericType::Single, NumericType::Single) ==
+           NumericType::Double);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a TypeRules helper that defines promotion and operator result semantics for BASIC numeric types
- wire the new helper into the BASIC front-end build and add unit coverage for key operator combinations

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d6f9ce220483249189700ce2cd9f65