### PR TITLE
fix(fe/basic): widen numeric conversion results

### DIFF
--- a/src/frontends/basic/LowerStmt.cpp
+++ b/src/frontends/basic/LowerStmt.cpp
@@ -193,7 +193,8 @@ void Lowerer::lowerPrint(const PrintStmt &stmt)
             case PrintItem::Kind::Expr:
             {
                 RVal v = lowerExpr(*it.expr);
-                if (v.type.kind == Type::Kind::I1)
+                if (v.type.kind == Type::Kind::I1 || v.type.kind == Type::Kind::I16 ||
+                    v.type.kind == Type::Kind::I32)
                 {
                     v = coerceToI64(std::move(v), stmt.loc);
                 }

--- a/src/il/runtime/RuntimeSignatures.cpp
+++ b/src/il/runtime/RuntimeSignatures.cpp
@@ -291,25 +291,25 @@ std::vector<RuntimeDescriptor> buildRegistry()
         &DirectHandler<&rt_f64_to_str, rt_string, double>::invoke,
         feature(RuntimeFeature::F64ToStr));
     add("rt_cint_from_double",
-        Kind::I16,
+        Kind::I64,
         {Kind::F64, Kind::Ptr},
         &invokeRtCintFromDouble,
-        manual());
+        feature(RuntimeFeature::CintFromDouble, true));
     add("rt_clng_from_double",
-        Kind::I32,
+        Kind::I64,
         {Kind::F64, Kind::Ptr},
         &invokeRtClngFromDouble,
-        manual());
+        feature(RuntimeFeature::ClngFromDouble, true));
     add("rt_csng_from_double",
         Kind::F64,
         {Kind::F64, Kind::Ptr},
         &invokeRtCsngFromDouble,
-        manual());
+        feature(RuntimeFeature::CsngFromDouble, true));
     add("rt_cdbl_from_any",
         Kind::F64,
         {Kind::F64},
         &DirectHandler<&rt_cdbl_from_any, double, double>::invoke,
-        manual());
+        feature(RuntimeFeature::CdblFromAny, true));
     add("rt_int_floor",
         Kind::F64,
         {Kind::F64},


### PR DESCRIPTION
## Summary
- update the CINT/CLNG builtin lowering to call the runtime helpers with i64 IL results and insert a cast when promoting narrow integers
- coerce 16-bit and 32-bit PRINT operands to i64 before dispatching to `rt_print_i64`
- mark the conversion runtime helpers as returning i64 in the shared signature table so the VM receives widened values

## Testing
- `cmake --build build`
- `ctest --test-dir build --output-on-failure -R basic_numerics_conversions`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68d74a966fd48324bfca859f0d27f7f5