### PR TITLE
Fix const folding trap behavior and add rounding coverage

### DIFF
--- a/tests/golden/CMakeLists.txt
+++ b/tests/golden/CMakeLists.txt
@@ -194,6 +194,33 @@ function(viper_add_golden_suite_tests)
     -DPASSES=constfold
     -P ${_VIPER_GOLDEN_DIR}/il_opt/check_opt.cmake)
 
+  viper_add_ctest(constfold_add_overflow
+    ${CMAKE_COMMAND}
+    -DILC=${BASIC_ILC}
+    -DIL_FILE=${_VIPER_GOLDEN_DIR}/constfold/constfold_add_overflow.il
+    -DGOLDEN=${_VIPER_GOLDEN_DIR}/constfold/constfold_add_overflow.opt.il
+    -DEXPECT_NONZERO=1
+    -DEXPECT_REGEX=Overflow
+    -P ${_VIPER_GOLDEN_DIR}/constfold/check_constfold.cmake)
+
+  viper_add_ctest(constfold_div_by_zero
+    ${CMAKE_COMMAND}
+    -DILC=${BASIC_ILC}
+    -DIL_FILE=${_VIPER_GOLDEN_DIR}/constfold/constfold_div_by_zero.il
+    -DGOLDEN=${_VIPER_GOLDEN_DIR}/constfold/constfold_div_by_zero.opt.il
+    -DEXPECT_NONZERO=1
+    -DEXPECT_REGEX=DivideByZero
+    -P ${_VIPER_GOLDEN_DIR}/constfold/check_constfold.cmake)
+
+  viper_add_ctest(constfold_rounding
+    ${CMAKE_COMMAND}
+    -DILC=${BASIC_ILC}
+    -DIL_FILE=${_VIPER_GOLDEN_DIR}/constfold/constfold_rounding.il
+    -DGOLDEN=${_VIPER_GOLDEN_DIR}/constfold/constfold_rounding.opt.il
+    -DEXPECT_RESULT=0
+    -DSKIP_RUNTIME=1
+    -P ${_VIPER_GOLDEN_DIR}/constfold/check_constfold.cmake)
+
   viper_add_ctest(il_opt_cbr_same_target
     ${CMAKE_COMMAND}
     -DILC=${BASIC_ILC}

--- a/tests/golden/constfold/check_constfold.cmake
+++ b/tests/golden/constfold/check_constfold.cmake
@@ -1,0 +1,66 @@
+if(NOT DEFINED ILC)
+  message(FATAL_ERROR "ILC not set")
+endif()
+if(NOT DEFINED IL_FILE)
+  message(FATAL_ERROR "IL_FILE not set")
+endif()
+if(NOT DEFINED GOLDEN)
+  message(FATAL_ERROR "GOLDEN not set")
+endif()
+get_filename_component(test_name ${IL_FILE} NAME_WE)
+set(OUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/${test_name}.constfold.il")
+execute_process(
+  COMMAND ${ILC} il-opt ${IL_FILE} -o ${OUT_FILE} --passes constfold
+  RESULT_VARIABLE opt_res
+  OUTPUT_VARIABLE opt_out
+  ERROR_VARIABLE opt_err)
+if(NOT opt_res EQUAL 0)
+  message(FATAL_ERROR "il-opt failed: ${opt_res}\n${opt_out}\n${opt_err}")
+endif()
+execute_process(
+  COMMAND diff -u ${GOLDEN} ${OUT_FILE}
+  RESULT_VARIABLE diff_res
+  OUTPUT_VARIABLE diff_out)
+if(NOT diff_res EQUAL 0)
+  set(art_dir "${CMAKE_CURRENT_BINARY_DIR}/_artifacts/constfold_${test_name}")
+  file(MAKE_DIRECTORY ${art_dir})
+  configure_file(${GOLDEN} ${art_dir}/golden.il COPYONLY)
+  configure_file(${OUT_FILE} ${art_dir}/out.il COPYONLY)
+  file(WRITE ${art_dir}/diff.txt "${diff_out}")
+  message(FATAL_ERROR "IL mismatch for constfold_${test_name}:\n${diff_out}")
+endif()
+if(NOT DEFINED SKIP_RUNTIME)
+  execute_process(
+    COMMAND ${ILC} -run ${IL_FILE}
+    RESULT_VARIABLE base_res
+    OUTPUT_VARIABLE base_out
+    ERROR_VARIABLE base_err)
+  execute_process(
+    COMMAND ${ILC} -run ${OUT_FILE}
+    RESULT_VARIABLE folded_res
+    OUTPUT_VARIABLE folded_out
+    ERROR_VARIABLE folded_err)
+  if(NOT base_res EQUAL folded_res)
+    message(FATAL_ERROR "exit status mismatch: ${base_res} vs ${folded_res}")
+  endif()
+  if(NOT base_out STREQUAL folded_out)
+    message(FATAL_ERROR "stdout mismatch\n--- base ---\n${base_out}\n--- folded ---\n${folded_out}")
+  endif()
+  if(NOT base_err STREQUAL folded_err)
+    message(FATAL_ERROR "stderr mismatch\n--- base ---\n${base_err}\n--- folded ---\n${folded_err}")
+  endif()
+  if(DEFINED EXPECT_RESULT)
+    if(NOT base_res EQUAL EXPECT_RESULT)
+      message(FATAL_ERROR "expected exit ${EXPECT_RESULT} but got ${base_res}")
+    endif()
+  elseif(DEFINED EXPECT_NONZERO)
+    if(base_res EQUAL 0)
+      message(FATAL_ERROR "expected non-zero exit")
+    endif()
+  endif()
+  if(DEFINED EXPECT_REGEX)
+    if(NOT base_out MATCHES "${EXPECT_REGEX}" AND NOT base_err MATCHES "${EXPECT_REGEX}")
+      message(FATAL_ERROR "expected regex '${EXPECT_REGEX}' not found in output")
+    endif()
+  endif()
+endif()

--- a/tests/golden/constfold/constfold_add_overflow.il
+++ b/tests/golden/constfold/constfold_add_overflow.il
@@ -1,0 +1,6 @@
+il 0.1.2
+func @main() -> i64 {
+entry:
+  %t0 = iadd.ovf 9223372036854775807, 1
+  ret %t0
+}

--- a/tests/golden/constfold/constfold_add_overflow.opt.il
+++ b/tests/golden/constfold/constfold_add_overflow.opt.il
@@ -1,0 +1,6 @@
+il 0.1.2
+func @main() -> i64 {
+entry:
+  %t0 = iadd.ovf 9223372036854775807, 1
+  ret %t0
+}

--- a/tests/golden/constfold/constfold_div_by_zero.il
+++ b/tests/golden/constfold/constfold_div_by_zero.il
@@ -1,0 +1,6 @@
+il 0.1.2
+func @main() -> i64 {
+entry:
+  %t0 = sdiv.chk0 1, 0
+  ret %t0
+}

--- a/tests/golden/constfold/constfold_div_by_zero.opt.il
+++ b/tests/golden/constfold/constfold_div_by_zero.opt.il
@@ -1,0 +1,6 @@
+il 0.1.2
+func @main() -> i64 {
+entry:
+  %t0 = sdiv.chk0 1, 0
+  ret %t0
+}

--- a/tests/golden/constfold/constfold_rounding.il
+++ b/tests/golden/constfold/constfold_rounding.il
@@ -1,0 +1,29 @@
+il 0.1.2
+extern @rt_fix_trunc(f64) -> f64
+extern @rt_int_floor(f64) -> f64
+extern @rt_print_f64(f64) -> void
+extern @rt_round_even(f64, i32) -> f64
+func @main() -> i64 {
+entry:
+  %t0 = call @rt_int_floor(1.9)
+  %t1 = call @rt_int_floor(-1.1)
+  %t2 = call @rt_fix_trunc(1.9)
+  %t3 = call @rt_fix_trunc(-1.9)
+  %t4 = call @rt_round_even(2.5, 0)
+  %t5 = call @rt_round_even(3.5, 0)
+  %t6 = call @rt_round_even(-2.5, 0)
+  %t7 = call @rt_round_even(-3.5, 0)
+  %t8 = call @rt_round_even(2.25, 1)
+  %t9 = call @rt_round_even(2.35, 1)
+  call @rt_print_f64(%t0)
+  call @rt_print_f64(%t1)
+  call @rt_print_f64(%t2)
+  call @rt_print_f64(%t3)
+  call @rt_print_f64(%t4)
+  call @rt_print_f64(%t5)
+  call @rt_print_f64(%t6)
+  call @rt_print_f64(%t7)
+  call @rt_print_f64(%t8)
+  call @rt_print_f64(%t9)
+  ret 0
+}

--- a/tests/golden/constfold/constfold_rounding.opt.il
+++ b/tests/golden/constfold/constfold_rounding.opt.il
@@ -1,0 +1,19 @@
+il 0.1.2
+extern @rt_fix_trunc(f64) -> f64
+extern @rt_int_floor(f64) -> f64
+extern @rt_print_f64(f64) -> void
+extern @rt_round_even(f64, i32) -> f64
+func @main() -> i64 {
+entry:
+  call @rt_print_f64(1)
+  call @rt_print_f64(-2)
+  call @rt_print_f64(1)
+  call @rt_print_f64(-1)
+  call @rt_print_f64(2)
+  call @rt_print_f64(4)
+  call @rt_print_f64(-2)
+  call @rt_print_f64(-4)
+  call @rt_print_f64(2.2)
+  call @rt_print_f64(2.4)
+  ret 0
+}


### PR DESCRIPTION
## Summary
- ensure const folding skips checked integer ops that would trap, including overflow and divide-by-zero cases
- fold INT/FIX/ROUND runtime helpers with banker’s rounding semantics and document the equivalence requirement
- add constfold regression tests and harness to check il-opt output and runtime behavior

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d77f10365083249f71a020f9a359e4