### PR TITLE
feat: expose precise numerics in ilc version output

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,11 @@
+---
+status: active
+audience: public
+last-verified: 2025-09-24
+---
+
+# Documentation Changelog
+
+## 2025-09-24 — Precise numerics update
+- Documented the addition of checked IL arithmetic opcodes (`*.ovf`, `*.chk0`) and checked cast instructions (`cast.*.chk`) introduced with the precise numerics work.
+- Recorded that BASIC lowering now emits those checked operations to preserve the new overflow and divide-by-zero traps.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,6 +37,15 @@ After the build finishes, confirm the primary tools respond to `--help`:
 
 Explore the [tutorials-examples.md#examples](tutorials-examples.md#examples) section to run a sample end-to-end once the binaries are in place.
 
+## Precise Numerics
+
+Viper's execution model ships with deterministic numeric semantics ([specs/numerics.md](specs/numerics.md)) so IL and BASIC behave identically across interpreters and builds:
+
+- Integer arithmetic traps on overflow instead of wrapping, keeping logic predictable.
+- `/` always performs floating-point division while `\` truncates toward zero; `MOD` keeps the dividend's sign.
+- All rounding follows banker's rounding (ties-to-even) and casts use checked variants that raise when a value is out of range.
+- `VAL` and `STR$` guarantee consistent parse/print round-trips without locale surprises.
+
 ## What to read next
 
 - Architecture → [architecture.md](architecture.md)

--- a/src/tools/ilc/main.cpp
+++ b/src/tools/ilc/main.cpp
@@ -7,8 +7,25 @@
 
 #include "cli.hpp"
 #include "frontends/basic/Intrinsics.hpp"
+#include "il/core/Module.hpp"
 #include <iostream>
 #include <string>
+#include <string_view>
+
+namespace
+{
+
+constexpr std::string_view kIlcVersion = "0.1.0";
+
+void printVersion()
+{
+    std::cout << "ilc v" << kIlcVersion << "\n";
+    const il::core::Module module;
+    std::cout << "IL version: " << module.version << "\n";
+    std::cout << "Precise Numerics: enabled\n";
+}
+
+} // namespace
 
 /// @brief Print synopsis and option hints for the `ilc` CLI.
 /// @details Lists supported subcommands (`-run`, `front basic`, and `il-opt`)
@@ -22,7 +39,7 @@
 void usage()
 {
     std::cerr
-        << "ilc v0.1.0\n"
+        << "ilc v" << kIlcVersion << "\n"
         << "Usage: ilc -run <file.il> [--trace=il|src] [--stdin-from <file>] [--max-steps N]"
            " [--break label|file:line]* [--break-src file:line]* [--watch name]* [--bounds-checks] "
            "[--count] [--time]\n"
@@ -61,6 +78,11 @@ int main(int argc, char **argv)
         return 1;
     }
     std::string cmd = argv[1];
+    if (cmd == "--version")
+    {
+        printVersion();
+        return 0;
+    }
     if (cmd == "-run")
     {
         return cmdRunIL(argc - 2, argv + 2);


### PR DESCRIPTION
## Summary
- add a dedicated `--version` handler to `ilc` that prints the tool banner, IL version, and precise numerics status
- reuse the shared banner in the usage help text to avoid version drift
- document the precise numerics guarantees in the getting-started guide and changelog

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure
- ./build/src/tools/ilc/ilc --version

------
https://chatgpt.com/codex/tasks/task_e_68da9134d44883249e015f55d4ac66dd