### PR TITLE
Fix conversions golden test for typed cast

### DIFF
--- a/tests/golden/basic_to_il/conversions.il
+++ b/tests/golden/basic_to_il/conversions.il
@@ -37,7 +37,7 @@ L30:
   .loc 1 3 15
   %t5 = load i64, %t4
   .loc 1 3 15
-  %t6 = cast.si_narrow.chk %t5
+  %t6:i32 = cast.si_narrow.chk %t5
   .loc 1 3 10
   %t7 = call @rt_str_i32_alloc(%t6)
   .loc 1 3 4


### PR DESCRIPTION
## Summary
- update the BASIC conversions golden to expect the typed si_narrow result

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dad7e4ef248324bab76acec187bd04