### PR TITLE
fix: enforce IL handler verification rules

### DIFF
--- a/src/il/verify/FunctionVerifier.hpp
+++ b/src/il/verify/FunctionVerifier.hpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace il::core
@@ -79,6 +80,7 @@ class FunctionVerifier
 
     const ExternMap &externs_;
     std::unordered_map<std::string, const il::core::Function *> functionMap_;
+    std::unordered_map<std::string, std::pair<unsigned, unsigned>> handlerInfo_;
     std::vector<std::unique_ptr<InstructionStrategy>> strategies_;
 };
 

--- a/tests/il/negatives/handler_bad_signature.expected
+++ b/tests/il/negatives/handler_bad_signature.expected
@@ -1,0 +1,1 @@
+error: main:bad: handler params must be named %err and %tok

--- a/tests/il/negatives/handler_bad_signature.il
+++ b/tests/il/negatives/handler_bad_signature.il
@@ -1,0 +1,9 @@
+il 0.1.2
+func @main() -> void {
+entry:
+  eh.push ^bad
+  ret
+handler ^bad(%err:Error, %token:ResumeTok):
+  eh.entry
+  resume.next %token
+}

--- a/tests/il/negatives/resume_outside_handler.expected
+++ b/tests/il/negatives/resume_outside_handler.expected
@@ -1,0 +1,1 @@
+error: main:entry: resume.next %tok: resume.* only allowed in handler block

--- a/tests/il/negatives/resume_outside_handler.il
+++ b/tests/il/negatives/resume_outside_handler.il
@@ -1,0 +1,5 @@
+il 0.1.2
+func @main() -> void {
+entry(%tok:ResumeTok):
+  resume.next %tok
+}

--- a/tests/il/negatives/unbalanced_eh.expected
+++ b/tests/il/negatives/unbalanced_eh.expected
@@ -1,0 +1,1 @@
+error: main:entry: ret: unmatched eh.push depth 1; path: entry

--- a/tests/il/negatives/unbalanced_eh.il
+++ b/tests/il/negatives/unbalanced_eh.il
@@ -1,0 +1,9 @@
+il 0.1.2
+func @main() -> void {
+entry:
+  eh.push ^handler
+  ret
+handler ^handler(%err:Error, %tok:ResumeTok):
+  eh.entry
+  resume.next %tok
+}


### PR DESCRIPTION
## Summary
- enforce handler declaration, resume usage, and eh.push/eh.pop balance in the function verifier
- add negative IL tests for malformed handlers and resume misuse

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68daebcb035c8324bb44f98e02da9f57