### PR TITLE
feat: introduce runtime error plumbing scaffolding

### DIFF
--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(RT_SOURCES
+  rt_error.c
   rt_fp.c
   rt_memory.c
   rt_string.c
@@ -12,6 +13,7 @@ set(RT_SOURCES
 )
 
 set(RT_PUBLIC_HEADERS
+  ${CMAKE_CURRENT_SOURCE_DIR}/rt_error.h
   ${CMAKE_CURRENT_SOURCE_DIR}/rt.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/rt_fp.h
   ${CMAKE_CURRENT_SOURCE_DIR}/rt_math.h

--- a/src/runtime/rt.hpp
+++ b/src/runtime/rt.hpp
@@ -9,6 +9,7 @@
 
 #include "rt_array.h"
 #include "rt_debug.h"
+#include "rt_error.h"
 #include "rt_string.h"
 
 #ifdef __cplusplus

--- a/src/runtime/rt_error.c
+++ b/src/runtime/rt_error.c
@@ -1,0 +1,19 @@
+// File: src/runtime/rt_error.c
+// Purpose: Provides shared constants for the runtime error model.
+// Key invariants: Exposes RT_ERROR_NONE as canonical success value.
+// Ownership/Lifetime: None; values are static storage duration.
+// Links: docs/codemap.md
+
+#include "rt_error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    /// @brief Canonical success error record.
+    const RtError RT_ERROR_NONE = { Err_None, 0 };
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/src/runtime/rt_error.h
+++ b/src/runtime/rt_error.h
@@ -1,0 +1,50 @@
+// File: src/runtime/rt_error.h
+// Purpose: Defines runtime error codes shared across runtime helpers.
+// Key invariants: Err_None represents success; other kinds encode failure classes.
+// Ownership/Lifetime: Plain value type with no dynamic resources.
+// Links: docs/codemap.md
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    /// @brief Canonical runtime error codes surfaced by runtime helpers.
+    enum Err
+    {
+        Err_None = 0,            ///< Success.
+        Err_FileNotFound = 1,    ///< File could not be located.
+        Err_EOF = 2,             ///< Reached end of input.
+        Err_IOError = 3,         ///< Generic input/output failure.
+        Err_Overflow = 4,        ///< Numeric overflow or underflow occurred.
+        Err_InvalidCast = 5,     ///< Requested cast is invalid.
+        Err_DomainError = 6,     ///< Input outside valid domain.
+        Err_Bounds = 7,          ///< Bounds check failed.
+        Err_InvalidOperation = 8,///< Operation unsupported in current state.
+        Err_RuntimeError = 9     ///< Unclassified runtime error.
+    };
+
+    /// @brief Structured runtime error record propagated via out-parameters.
+    typedef struct RtError
+    {
+        enum Err kind; ///< High-level error category.
+        int32_t code;  ///< Implementation-specific detail code.
+    } RtError;
+
+    /// @brief Helper returning whether @p error encodes success.
+    /// @param error Error record to inspect.
+    /// @return True when the error represents success.
+    static inline bool rt_ok(RtError error)
+    {
+        return error.kind == Err_None;
+    }
+
+    /// @brief Constant representing a successful runtime operation.
+    extern const RtError RT_ERROR_NONE;
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/runtime/rt_numeric.c
+++ b/src/runtime/rt_numeric.c
@@ -246,24 +246,32 @@ extern "C" {
             rt_trap("rt_format: truncated");
     }
 
-    void rt_str_from_double(double x, char *out, size_t cap)
+    void rt_str_from_double(double x, char *out, size_t cap, RtError *out_err)
     {
         rt_format(out, cap, "%.17g", x);
+        if (out_err)
+            *out_err = RT_ERROR_NONE;
     }
 
-    void rt_str_from_float(float x, char *out, size_t cap)
+    void rt_str_from_float(float x, char *out, size_t cap, RtError *out_err)
     {
         rt_format(out, cap, "%.9g", (double)x);
+        if (out_err)
+            *out_err = RT_ERROR_NONE;
     }
 
-    void rt_str_from_i32(int32_t x, char *out, size_t cap)
+    void rt_str_from_i32(int32_t x, char *out, size_t cap, RtError *out_err)
     {
         rt_format(out, cap, "%" PRId32, x);
+        if (out_err)
+            *out_err = RT_ERROR_NONE;
     }
 
-    void rt_str_from_i16(int16_t x, char *out, size_t cap)
+    void rt_str_from_i16(int16_t x, char *out, size_t cap, RtError *out_err)
     {
         rt_format(out, cap, "%" PRId16, x);
+        if (out_err)
+            *out_err = RT_ERROR_NONE;
     }
 
 #ifdef __cplusplus

--- a/src/runtime/rt_numeric.h
+++ b/src/runtime/rt_numeric.h
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include "rt_error.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -62,25 +64,29 @@ extern "C" {
     /// @param x Value to format.
     /// @param out Destination buffer; must not be NULL.
     /// @param cap Capacity of @p out in bytes; must be non-zero.
-    void rt_str_from_double(double x, char *out, size_t cap);
+    /// @param out_err Optional error record receiving Err_None on success.
+    void rt_str_from_double(double x, char *out, size_t cap, RtError *out_err);
 
     /// @brief Format SINGLE @p x into @p out using round-trip precision.
     /// @param x Value to format.
     /// @param out Destination buffer; must not be NULL.
     /// @param cap Capacity of @p out in bytes; must be non-zero.
-    void rt_str_from_float(float x, char *out, size_t cap);
+    /// @param out_err Optional error record receiving Err_None on success.
+    void rt_str_from_float(float x, char *out, size_t cap, RtError *out_err);
 
     /// @brief Format LONG @p x into @p out as minimal decimal digits.
     /// @param x Value to format.
     /// @param out Destination buffer; must not be NULL.
     /// @param cap Capacity of @p out in bytes; must be non-zero.
-    void rt_str_from_i32(int32_t x, char *out, size_t cap);
+    /// @param out_err Optional error record receiving Err_None on success.
+    void rt_str_from_i32(int32_t x, char *out, size_t cap, RtError *out_err);
 
     /// @brief Format INTEGER @p x into @p out as minimal decimal digits.
     /// @param x Value to format.
     /// @param out Destination buffer; must not be NULL.
     /// @param cap Capacity of @p out in bytes; must be non-zero.
-    void rt_str_from_i16(int16_t x, char *out, size_t cap);
+    /// @param out_err Optional error record receiving Err_None on success.
+    void rt_str_from_i16(int16_t x, char *out, size_t cap, RtError *out_err);
 
 #ifdef __cplusplus
 }

--- a/src/runtime/rt_string.c
+++ b/src/runtime/rt_string.c
@@ -748,7 +748,7 @@ rt_string rt_int_to_str(int64_t v)
 rt_string rt_f64_to_str(double v)
 {
     char buf[64];
-    rt_str_from_double(v, buf, sizeof(buf));
+    rt_str_from_double(v, buf, sizeof(buf), NULL);
     return rt_string_from_bytes(buf, strlen(buf));
 }
 
@@ -765,7 +765,7 @@ rt_string rt_f64_to_str(double v)
 rt_string rt_str_d_alloc(double v)
 {
     char buf[64];
-    rt_str_from_double(v, buf, sizeof(buf));
+    rt_str_from_double(v, buf, sizeof(buf), NULL);
     return rt_string_from_bytes(buf, strlen(buf));
 }
 
@@ -782,7 +782,7 @@ rt_string rt_str_d_alloc(double v)
 rt_string rt_str_f_alloc(float v)
 {
     char buf[32];
-    rt_str_from_float(v, buf, sizeof(buf));
+    rt_str_from_float(v, buf, sizeof(buf), NULL);
     return rt_string_from_bytes(buf, strlen(buf));
 }
 
@@ -799,7 +799,7 @@ rt_string rt_str_f_alloc(float v)
 rt_string rt_str_i32_alloc(int32_t v)
 {
     char buf[32];
-    rt_str_from_i32(v, buf, sizeof(buf));
+    rt_str_from_i32(v, buf, sizeof(buf), NULL);
     return rt_string_from_bytes(buf, strlen(buf));
 }
 
@@ -816,7 +816,7 @@ rt_string rt_str_i32_alloc(int32_t v)
 rt_string rt_str_i16_alloc(int16_t v)
 {
     char buf[16];
-    rt_str_from_i16(v, buf, sizeof(buf));
+    rt_str_from_i16(v, buf, sizeof(buf), NULL);
     return rt_string_from_bytes(buf, strlen(buf));
 }
 

--- a/tests/runtime/RtErrorPlumbingTests.cpp
+++ b/tests/runtime/RtErrorPlumbingTests.cpp
@@ -1,0 +1,28 @@
+// File: tests/runtime/RtErrorPlumbingTests.cpp
+// Purpose: Exercise the runtime error plumbing for numeric formatting helpers.
+// Key invariants: Formatting helpers populate Err_None on success.
+// Ownership: Links against the C runtime library.
+// Links: docs/specs/numerics.md
+
+#include "rt_error.h"
+#include "rt_numeric.h"
+
+#include <cassert>
+#include <cstring>
+
+int main()
+{
+    char buffer[32];
+    RtError err = { Err_RuntimeError, -1 };
+    rt_str_from_double(42.0, buffer, sizeof(buffer), &err);
+    assert(rt_ok(err));
+    assert(std::strcmp(buffer, "42") == 0);
+
+    err.kind = Err_RuntimeError;
+    err.code = -1;
+    rt_str_from_i32(1234, buffer, sizeof(buffer), &err);
+    assert(err.kind == Err_None);
+    assert(err.code == 0);
+
+    return 0;
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -51,6 +51,10 @@ function(viper_add_runtime_tests)
   target_link_libraries(test_rt_numeric PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_numeric test_rt_numeric)
 
+  viper_add_test_exe(test_rt_error_plumbing ${VIPER_TESTS_DIR}/runtime/RtErrorPlumbingTests.cpp)
+  target_link_libraries(test_rt_error_plumbing PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
+  viper_add_ctest(test_rt_error_plumbing test_rt_error_plumbing)
+
   viper_add_test_exe(test_rt_abs_i64_overflow ${VIPER_TESTS_DIR}/runtime/RTAbsI64OverflowTests.cpp)
   target_link_libraries(test_rt_abs_i64_overflow PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_abs_i64_overflow test_rt_abs_i64_overflow)


### PR DESCRIPTION
## Summary
- add a shared runtime error definition with helper utilities
- update numeric formatting helpers to accept RtError out-parameters and propagate success codes
- register a runtime unit test covering the new error plumbing

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dbe66d34a88324adaf5b76fa5d5989