### PR TITLE
feat(runtime): implement file io error handling

### DIFF
--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -4,6 +4,7 @@ set(RT_SOURCES
   rt_memory.c
   rt_string.c
   rt_io.c
+  rt_file.c
   rt_math.c
   rt_random.c
   rt_array.c
@@ -23,6 +24,7 @@ set(RT_PUBLIC_HEADERS
   ${CMAKE_CURRENT_SOURCE_DIR}/rt_array.h
   ${CMAKE_CURRENT_SOURCE_DIR}/rt_heap.h
   ${CMAKE_CURRENT_SOURCE_DIR}/rt_debug.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/rt_file.h
 )
 
 add_library(viper_runtime STATIC ${RT_SOURCES})

--- a/src/runtime/rt.hpp
+++ b/src/runtime/rt.hpp
@@ -10,6 +10,7 @@
 #include "rt_array.h"
 #include "rt_debug.h"
 #include "rt_error.h"
+#include "rt_file.h"
 #include "rt_string.h"
 
 #ifdef __cplusplus

--- a/src/runtime/rt_file.c
+++ b/src/runtime/rt_file.c
@@ -1,0 +1,358 @@
+// File: src/runtime/rt_file.c
+// Purpose: Implement BASIC runtime file helpers using POSIX descriptors.
+// Key invariants: Negative descriptor marks closed handles; helpers never abort on I/O failures.
+// Ownership/Lifetime: Callers manage RtFile lifetime and must close open descriptors.
+// Links: docs/specs/errors.md
+
+#include "rt_file.h"
+
+#include "rt_internal.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0
+#endif
+
+static int32_t rt_file_clamp_errno(int err)
+{
+    if (err > INT32_MAX)
+        return INT32_MAX;
+    if (err < INT32_MIN)
+        return INT32_MIN;
+    return (int32_t)err;
+}
+
+static void rt_file_set_error(RtError *out_err, enum Err kind, int err)
+{
+    if (!out_err)
+        return;
+    out_err->kind = kind;
+    out_err->code = rt_file_clamp_errno(err);
+}
+
+static void rt_file_set_ok(RtError *out_err)
+{
+    if (out_err)
+        *out_err = RT_ERROR_NONE;
+}
+
+static bool rt_file_parse_mode(const char *mode, int *flags_out)
+{
+    if (!mode || !mode[0])
+        return false;
+    int flags = 0;
+    switch (mode[0])
+    {
+    case 'r':
+        flags = O_RDONLY;
+        break;
+    case 'w':
+        flags = O_WRONLY | O_CREAT | O_TRUNC;
+        break;
+    case 'a':
+        flags = O_WRONLY | O_CREAT | O_APPEND;
+        break;
+    default:
+        return false;
+    }
+
+    bool plus = false;
+    for (const char *p = mode + 1; *p; ++p)
+    {
+        if (*p == '+')
+            plus = true;
+        else if (*p == 'b' || *p == 't')
+            continue;
+        else
+            return false;
+    }
+    if (plus)
+    {
+        flags &= ~(O_RDONLY | O_WRONLY);
+        flags |= O_RDWR;
+    }
+    flags |= O_CLOEXEC;
+    *flags_out = flags;
+    return true;
+}
+
+void rt_file_init(RtFile *file)
+{
+    if (!file)
+        return;
+    file->fd = -1;
+}
+
+bool rt_file_open(RtFile *file, const char *path, const char *mode, RtError *out_err)
+{
+    if (!file || !path || !mode)
+    {
+        rt_file_set_error(out_err, Err_InvalidOperation, 0);
+        return false;
+    }
+    int flags = 0;
+    if (!rt_file_parse_mode(mode, &flags))
+    {
+        rt_file_set_error(out_err, Err_InvalidOperation, 0);
+        file->fd = -1;
+        return false;
+    }
+
+    mode_t perms = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
+    errno = 0;
+    int fd = (flags & O_CREAT) ? open(path, flags, perms) : open(path, flags);
+    if (fd < 0)
+    {
+        int err = errno;
+        if (err == ENOENT)
+            rt_file_set_error(out_err, Err_FileNotFound, err);
+        else
+            rt_file_set_error(out_err, Err_IOError, err ? err : EIO);
+        file->fd = -1;
+        return false;
+    }
+
+    file->fd = fd;
+    rt_file_set_ok(out_err);
+    return true;
+}
+
+bool rt_file_close(RtFile *file, RtError *out_err)
+{
+    if (!file)
+    {
+        rt_file_set_error(out_err, Err_InvalidOperation, 0);
+        return false;
+    }
+    if (file->fd < 0)
+    {
+        rt_file_set_ok(out_err);
+        return true;
+    }
+    errno = 0;
+    int rc = close(file->fd);
+    if (rc < 0)
+    {
+        rt_file_set_error(out_err, Err_IOError, errno ? errno : EIO);
+        return false;
+    }
+    file->fd = -1;
+    rt_file_set_ok(out_err);
+    return true;
+}
+
+static bool rt_file_check_fd(const RtFile *file, RtError *out_err)
+{
+    if (!file)
+    {
+        rt_file_set_error(out_err, Err_InvalidOperation, 0);
+        return false;
+    }
+    if (file->fd < 0)
+    {
+        rt_file_set_error(out_err, Err_IOError, EBADF);
+        return false;
+    }
+    return true;
+}
+
+bool rt_file_read_byte(RtFile *file, uint8_t *out_byte, RtError *out_err)
+{
+    if (!out_byte)
+    {
+        rt_file_set_error(out_err, Err_InvalidOperation, 0);
+        return false;
+    }
+    if (!rt_file_check_fd(file, out_err))
+        return false;
+
+    for (;;)
+    {
+        uint8_t byte = 0;
+        errno = 0;
+        ssize_t n = read(file->fd, &byte, 1);
+        if (n == 1)
+        {
+            *out_byte = byte;
+            rt_file_set_ok(out_err);
+            return true;
+        }
+        if (n == 0)
+        {
+            rt_file_set_error(out_err, Err_EOF, 0);
+            return false;
+        }
+        if (n < 0 && errno == EINTR)
+            continue;
+        rt_file_set_error(out_err, Err_IOError, errno ? errno : EIO);
+        return false;
+    }
+}
+
+bool rt_file_read_line(RtFile *file, rt_string *out_line, RtError *out_err)
+{
+    if (out_line)
+        *out_line = NULL;
+    if (!out_line)
+    {
+        rt_file_set_error(out_err, Err_InvalidOperation, 0);
+        return false;
+    }
+    if (!rt_file_check_fd(file, out_err))
+        return false;
+
+    size_t cap = 128;
+    size_t len = 0;
+    char *buffer = (char *)malloc(cap);
+    if (!buffer)
+    {
+        rt_file_set_error(out_err, Err_RuntimeError, ENOMEM);
+        return false;
+    }
+
+    for (;;)
+    {
+        char ch = 0;
+        errno = 0;
+        ssize_t n = read(file->fd, &ch, 1);
+        if (n == 1)
+        {
+            if (ch == '\n')
+                break;
+            if (len + 1 >= cap)
+            {
+                size_t new_cap = cap * 2;
+                char *nbuf = (char *)realloc(buffer, new_cap);
+                if (!nbuf)
+                {
+                    free(buffer);
+                    rt_file_set_error(out_err, Err_RuntimeError, ENOMEM);
+                    return false;
+                }
+                buffer = nbuf;
+                cap = new_cap;
+            }
+            buffer[len++] = ch;
+            continue;
+        }
+        if (n == 0)
+        {
+            if (len == 0)
+            {
+                free(buffer);
+                rt_file_set_error(out_err, Err_EOF, 0);
+                return false;
+            }
+            break;
+        }
+        if (n < 0 && errno == EINTR)
+            continue;
+        free(buffer);
+        rt_file_set_error(out_err, Err_IOError, errno ? errno : EIO);
+        return false;
+    }
+
+    if (len + 1 > cap)
+    {
+        char *nbuf = (char *)realloc(buffer, len + 1);
+        if (!nbuf)
+        {
+            free(buffer);
+            rt_file_set_error(out_err, Err_RuntimeError, ENOMEM);
+            return false;
+        }
+        buffer = nbuf;
+    }
+    buffer[len] = '\0';
+
+    rt_string s = (rt_string)calloc(1, sizeof(*s));
+    if (!s)
+    {
+        free(buffer);
+        rt_file_set_error(out_err, Err_RuntimeError, ENOMEM);
+        return false;
+    }
+    char *payload = (char *)rt_heap_alloc(RT_HEAP_STRING, RT_ELEM_NONE, 1, len, len + 1);
+    if (!payload)
+    {
+        free(buffer);
+        free(s);
+        rt_file_set_error(out_err, Err_RuntimeError, ENOMEM);
+        return false;
+    }
+    memcpy(payload, buffer, len + 1);
+    free(buffer);
+
+    s->data = payload;
+    s->heap = rt_heap_hdr(payload);
+    s->literal_len = 0;
+    s->literal_refs = 0;
+
+    *out_line = s;
+    rt_file_set_ok(out_err);
+    return true;
+}
+
+bool rt_file_seek(RtFile *file, int64_t offset, int origin, RtError *out_err)
+{
+    if (!rt_file_check_fd(file, out_err))
+        return false;
+
+    errno = 0;
+    off_t target = (off_t)offset;
+    off_t pos = lseek(file->fd, target, origin);
+    if (pos == (off_t)-1)
+    {
+        rt_file_set_error(out_err, Err_IOError, errno ? errno : EIO);
+        return false;
+    }
+    rt_file_set_ok(out_err);
+    return true;
+}
+
+bool rt_file_write(RtFile *file, const uint8_t *data, size_t len, RtError *out_err)
+{
+    if (len == 0)
+    {
+        rt_file_set_ok(out_err);
+        return true;
+    }
+    if (!data)
+    {
+        rt_file_set_error(out_err, Err_InvalidOperation, 0);
+        return false;
+    }
+    if (!rt_file_check_fd(file, out_err))
+        return false;
+
+    size_t written = 0;
+    while (written < len)
+    {
+        errno = 0;
+        ssize_t n = write(file->fd, data + written, len - written);
+        if (n < 0)
+        {
+            if (errno == EINTR)
+                continue;
+            rt_file_set_error(out_err, Err_IOError, errno ? errno : EIO);
+            return false;
+        }
+        if (n == 0)
+        {
+            rt_file_set_error(out_err, Err_IOError, EIO);
+            return false;
+        }
+        written += (size_t)n;
+    }
+    rt_file_set_ok(out_err);
+    return true;
+}
+

--- a/src/runtime/rt_file.h
+++ b/src/runtime/rt_file.h
@@ -1,0 +1,76 @@
+// File: src/runtime/rt_file.h
+// Purpose: Declare BASIC runtime file I/O helpers using the shared error model.
+// Key invariants: File handles encapsulate POSIX descriptors; negative fd marks closed state.
+// Ownership/Lifetime: Callers initialize RtFile and close via rt_file_close when finished.
+// Links: docs/specs/errors.md
+#pragma once
+
+#include "rt_error.h"
+#include "rt_string.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    /// @brief Lightweight handle representing an open runtime file.
+    typedef struct RtFile
+    {
+        int fd; ///< Underlying POSIX file descriptor or -1 when closed.
+    } RtFile;
+
+    /// @brief Initialize @p file to a closed handle state.
+    /// @param file Handle to initialize; ignored when NULL.
+    void rt_file_init(RtFile *file);
+
+    /// @brief Open @p path with the specified @p mode string.
+    /// @param file Output handle populated on success.
+    /// @param path Null-terminated filesystem path.
+    /// @param mode fopen-style mode string (e.g., "r", "w", "a", variants with '+').
+    /// @param out_err Optional error record receiving failure details.
+    /// @return True on success; false when an error is reported via @p out_err.
+    bool rt_file_open(RtFile *file, const char *path, const char *mode, RtError *out_err);
+
+    /// @brief Close @p file when open.
+    /// @param file Handle to close; remains valid for reuse after success.
+    /// @param out_err Optional error record receiving failure details.
+    /// @return True on success; false when closing fails.
+    bool rt_file_close(RtFile *file, RtError *out_err);
+
+    /// @brief Read a single byte from @p file.
+    /// @param file Handle to read.
+    /// @param out_byte Output byte when successful.
+    /// @param out_err Optional error record receiving failure details.
+    /// @return True when a byte is read; false on EOF or error.
+    bool rt_file_read_byte(RtFile *file, uint8_t *out_byte, RtError *out_err);
+
+    /// @brief Read a single line terminated by '\n' (newline excluded) from @p file.
+    /// @param file Handle to read.
+    /// @param out_line Receives newly allocated runtime string; NULL on failure.
+    /// @param out_err Optional error record receiving failure details.
+    /// @return True when a line is produced; false on EOF or error.
+    bool rt_file_read_line(RtFile *file, rt_string *out_line, RtError *out_err);
+
+    /// @brief Seek to @p offset relative to @p origin within @p file.
+    /// @param file Handle to reposition.
+    /// @param offset Byte offset to apply.
+    /// @param origin One of SEEK_SET, SEEK_CUR, or SEEK_END.
+    /// @param out_err Optional error record receiving failure details.
+    /// @return True on success; false on error.
+    bool rt_file_seek(RtFile *file, int64_t offset, int origin, RtError *out_err);
+
+    /// @brief Write @p len bytes from @p data to @p file.
+    /// @param file Handle to write.
+    /// @param data Buffer containing bytes to write.
+    /// @param len Number of bytes to write.
+    /// @param out_err Optional error record receiving failure details.
+    /// @return True when the entire buffer is written; false otherwise.
+    bool rt_file_write(RtFile *file, const uint8_t *data, size_t len, RtError *out_err);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/tests/runtime/ErrorsIoTests.c
+++ b/tests/runtime/ErrorsIoTests.c
@@ -1,0 +1,114 @@
+// File: tests/runtime/ErrorsIoTests.c
+// Purpose: Validate runtime file helpers return structured errors on failure paths.
+// Key invariants: Missing files map to Err_FileNotFound, EOF detection yields Err_EOF, and OS failures surface Err_IOError.
+// Ownership: Exercises the C runtime API directly without higher-level wrappers.
+// Links: docs/specs/errors.md
+
+#define _XOPEN_SOURCE 700
+
+#include "rt_error.h"
+#include "rt_file.h"
+#include "rt_string.h"
+
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+static void ensure_missing_open_sets_file_not_found(void)
+{
+    char path[] = "/tmp/viper_io_missingXXXXXX";
+    int fd = mkstemp(path);
+    if (fd >= 0)
+    {
+        close(fd);
+        unlink(path);
+    }
+
+    RtFile file;
+    rt_file_init(&file);
+    RtError err = { Err_None, 0 };
+    bool ok = rt_file_open(&file, path, "r", &err);
+    assert(!ok);
+    assert(err.kind == Err_FileNotFound);
+    assert(err.code != 0);
+}
+
+static void ensure_read_byte_reports_eof(void)
+{
+    char path[] = "/tmp/viper_io_emptyXXXXXX";
+    int fd = mkstemp(path);
+    assert(fd >= 0);
+    close(fd);
+
+    RtFile file;
+    rt_file_init(&file);
+    RtError err = { Err_None, 0 };
+    bool ok = rt_file_open(&file, path, "r", &err);
+    assert(ok);
+
+    uint8_t value = 0xFF;
+    err.kind = Err_RuntimeError;
+    err.code = -1;
+    ok = rt_file_read_byte(&file, &value, &err);
+    assert(!ok);
+    assert(err.kind == Err_EOF);
+    assert(err.code == 0);
+
+    ok = rt_file_close(&file, &err);
+    assert(ok);
+    unlink(path);
+}
+
+static void ensure_read_line_reports_eof(void)
+{
+    char path[] = "/tmp/viper_io_lineXXXXXX";
+    int fd = mkstemp(path);
+    assert(fd >= 0);
+    close(fd);
+
+    RtFile file;
+    rt_file_init(&file);
+    RtError err = { Err_None, 0 };
+    bool ok = rt_file_open(&file, path, "r", &err);
+    assert(ok);
+
+    rt_string line = NULL;
+    err.kind = Err_RuntimeError;
+    err.code = -1;
+    ok = rt_file_read_line(&file, &line, &err);
+    assert(!ok);
+    assert(err.kind == Err_EOF);
+    assert(err.code == 0);
+    assert(line == NULL);
+
+    ok = rt_file_close(&file, &err);
+    assert(ok);
+    unlink(path);
+}
+
+static void ensure_invalid_handle_surfaces_ioerror(void)
+{
+    RtFile file;
+    rt_file_init(&file);
+    file.fd = -1;
+
+    RtError err = { Err_None, 0 };
+    bool ok = rt_file_seek(&file, 0, SEEK_SET, &err);
+    assert(!ok);
+    assert(err.kind == Err_IOError);
+    assert(err.code != 0);
+}
+
+int main(void)
+{
+    ensure_missing_open_sets_file_not_found();
+    ensure_read_byte_reports_eof();
+    ensure_read_line_reports_eof();
+    ensure_invalid_handle_surfaces_ioerror();
+    return 0;
+}
+

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -55,6 +55,10 @@ function(viper_add_runtime_tests)
   target_link_libraries(test_rt_error_plumbing PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_error_plumbing test_rt_error_plumbing)
 
+  viper_add_test_exe(test_rt_errors_io ${VIPER_TESTS_DIR}/runtime/ErrorsIoTests.c)
+  target_link_libraries(test_rt_errors_io PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
+  viper_add_ctest(test_rt_errors_io test_rt_errors_io)
+
   viper_add_test_exe(test_rt_abs_i64_overflow ${VIPER_TESTS_DIR}/runtime/RTAbsI64OverflowTests.cpp)
   target_link_libraries(test_rt_abs_i64_overflow PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_abs_i64_overflow test_rt_abs_i64_overflow)


### PR DESCRIPTION
## Summary
- add a runtime file I/O module that maps OS failures to structured `RtError` codes for open/read/seek/write helpers
- expose the new helpers through the runtime headers and extend the unit suite with targeted error-behaviour coverage

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68dbeb81b2b08324a9cce3be9c578a64