### PR TITLE
feat(frontends-basic): add lexer tokens for file IO

### DIFF
--- a/src/frontends/basic/Lexer.cpp
+++ b/src/frontends/basic/Lexer.cpp
@@ -25,19 +25,23 @@ struct KeywordEntry
     TokenKind kind;
 };
 
-constexpr std::array<KeywordEntry, 48> kKeywordTable{{
+constexpr std::array<KeywordEntry, 56> kKeywordTable{{
     {"ABS", TokenKind::KeywordAbs},
     {"AND", TokenKind::KeywordAnd},
     {"ANDALSO", TokenKind::KeywordAndAlso},
+    {"APPEND", TokenKind::KeywordAppend},
     {"AS", TokenKind::KeywordAs},
+    {"BINARY", TokenKind::KeywordBinary},
     {"BOOLEAN", TokenKind::KeywordBoolean},
     {"CEIL", TokenKind::KeywordCeil},
+    {"CLOSE", TokenKind::KeywordClose},
     {"COS", TokenKind::KeywordCos},
     {"DIM", TokenKind::KeywordDim},
     {"DO", TokenKind::KeywordDo},
     {"ELSE", TokenKind::KeywordElse},
     {"ELSEIF", TokenKind::KeywordElseIf},
     {"END", TokenKind::KeywordEnd},
+    {"EOF", TokenKind::KeywordEof},
     {"ERROR", TokenKind::KeywordError},
     {"EXIT", TokenKind::KeywordExit},
     {"FALSE", TokenKind::KeywordFalse},
@@ -49,15 +53,19 @@ constexpr std::array<KeywordEntry, 48> kKeywordTable{{
     {"INPUT", TokenKind::KeywordInput},
     {"LBOUND", TokenKind::KeywordLbound},
     {"LET", TokenKind::KeywordLet},
+    {"LINE", TokenKind::KeywordLine},
     {"LOOP", TokenKind::KeywordLoop},
     {"MOD", TokenKind::KeywordMod},
     {"NEXT", TokenKind::KeywordNext},
     {"NOT", TokenKind::KeywordNot},
     {"ON", TokenKind::KeywordOn},
+    {"OPEN", TokenKind::KeywordOpen},
     {"OR", TokenKind::KeywordOr},
     {"ORELSE", TokenKind::KeywordOrElse},
+    {"OUTPUT", TokenKind::KeywordOutput},
     {"POW", TokenKind::KeywordPow},
     {"PRINT", TokenKind::KeywordPrint},
+    {"RANDOM", TokenKind::KeywordRandom},
     {"RANDOMIZE", TokenKind::KeywordRandomize},
     {"REDIM", TokenKind::KeywordRedim},
     {"RESUME", TokenKind::KeywordResume},
@@ -376,6 +384,8 @@ Token Lexer::next()
             return {TokenKind::Semicolon, ";", loc};
         case ':':
             return {TokenKind::Colon, ":", loc};
+        case '#':
+            return {TokenKind::Hash, "#", loc};
     }
     return {TokenKind::Unknown, std::string(1, c), loc};
 }

--- a/src/frontends/basic/Token.cpp
+++ b/src/frontends/basic/Token.cpp
@@ -132,6 +132,22 @@ const char *tokenKindToString(TokenKind k)
             return "ANDALSO";
         case TokenKind::KeywordOrElse:
             return "ORELSE";
+        case TokenKind::KeywordOpen:
+            return "OPEN";
+        case TokenKind::KeywordClose:
+            return "CLOSE";
+        case TokenKind::KeywordOutput:
+            return "OUTPUT";
+        case TokenKind::KeywordAppend:
+            return "APPEND";
+        case TokenKind::KeywordBinary:
+            return "BINARY";
+        case TokenKind::KeywordRandom:
+            return "RANDOM";
+        case TokenKind::KeywordLine:
+            return "LINE";
+        case TokenKind::KeywordEof:
+            return "EOF";
         case TokenKind::Plus:
             return "+";
         case TokenKind::Minus:
@@ -166,6 +182,8 @@ const char *tokenKindToString(TokenKind k)
             return ";";
         case TokenKind::Colon:
             return ":";
+        case TokenKind::Hash:
+            return "#";
         case TokenKind::Count:
             break;
     }

--- a/src/frontends/basic/Token.hpp
+++ b/src/frontends/basic/Token.hpp
@@ -92,6 +92,7 @@ enum class TokenKind
     Comma,     ///< ','.
     Semicolon, ///< ';'.
     Colon,     ///< ':'.
+    Hash,      ///< '#'.
 
     // Additional keywords and literals (appended to preserve existing values).
     KeywordBoolean, ///< 'BOOLEAN'.
@@ -99,6 +100,14 @@ enum class TokenKind
     KeywordFalse,   ///< 'FALSE'.
     KeywordAndAlso, ///< 'ANDALSO'.
     KeywordOrElse,  ///< 'ORELSE'.
+    KeywordOpen,    ///< 'OPEN'.
+    KeywordClose,   ///< 'CLOSE'.
+    KeywordOutput,  ///< 'OUTPUT'.
+    KeywordAppend,  ///< 'APPEND'.
+    KeywordBinary,  ///< 'BINARY'.
+    KeywordRandom,  ///< 'RANDOM'.
+    KeywordLine,    ///< 'LINE'.
+    KeywordEof,     ///< 'EOF'.
 
     Count, ///< Total number of token kinds (sentinel, not a real token).
 };

--- a/tests/basic/CMakeLists.txt
+++ b/tests/basic/CMakeLists.txt
@@ -94,6 +94,10 @@ function(viper_add_basic_main_tests)
   target_link_libraries(test_frontends_basic_parse_on_error PRIVATE ${VIPER_BASIC_LIBS})
   viper_add_ctest(test_frontends_basic_parse_on_error test_frontends_basic_parse_on_error)
 
+  viper_add_test_exe(test_frontends_basic_lexer_file_io ${VIPER_TESTS_DIR}/frontends/basic/LexerFileIoTests.cpp)
+  target_link_libraries(test_frontends_basic_lexer_file_io PRIVATE ${VIPER_BASIC_LIBS})
+  viper_add_ctest(test_frontends_basic_lexer_file_io test_frontends_basic_lexer_file_io)
+
   viper_add_test_exe(test_frontends_basic_semantic_exprs ${VIPER_TESTS_DIR}/frontends/basic/SemanticAnalyzerBinaryExprTests.cpp)
   target_link_libraries(test_frontends_basic_semantic_exprs PRIVATE ${VIPER_BASIC_LIBS})
   viper_add_ctest(test_frontends_basic_semantic_exprs test_frontends_basic_semantic_exprs)

--- a/tests/frontends/basic/LexerFileIoTests.cpp
+++ b/tests/frontends/basic/LexerFileIoTests.cpp
@@ -1,0 +1,98 @@
+// File: tests/frontends/basic/LexerFileIoTests.cpp
+// Purpose: Ensure BASIC lexer recognizes file I/O related keywords and '#'.
+// Key invariants: Lexer should classify new keywords distinctly.
+// Ownership/Lifetime: Test owns source buffers used for lexing.
+// Links: docs/codemap.md
+
+#include "frontends/basic/Lexer.hpp"
+#include "support/source_manager.hpp"
+
+#include <cassert>
+#include <string>
+#include <string_view>
+
+using namespace il::frontends::basic;
+using namespace il::support;
+
+namespace
+{
+Token nextToken(std::string_view text)
+{
+    SourceManager sm;
+    uint32_t fid = sm.addFile("lexer_file_io.bas");
+    Lexer lexer(text, fid);
+    return lexer.next();
+}
+} // namespace
+
+int main()
+{
+    {
+        Token tok = nextToken("OPEN");
+        assert(tok.kind == TokenKind::KeywordOpen);
+    }
+
+    {
+        Token tok = nextToken("FOR");
+        assert(tok.kind == TokenKind::KeywordFor);
+    }
+
+    {
+        Token tok = nextToken("AS");
+        assert(tok.kind == TokenKind::KeywordAs);
+    }
+
+    {
+        Token tok = nextToken("CLOSE");
+        assert(tok.kind == TokenKind::KeywordClose);
+    }
+
+    {
+        Token tok = nextToken("OUTPUT");
+        assert(tok.kind == TokenKind::KeywordOutput);
+    }
+
+    {
+        Token tok = nextToken("APPEND");
+        assert(tok.kind == TokenKind::KeywordAppend);
+    }
+
+    {
+        Token tok = nextToken("BINARY");
+        assert(tok.kind == TokenKind::KeywordBinary);
+    }
+
+    {
+        Token tok = nextToken("RANDOM");
+        assert(tok.kind == TokenKind::KeywordRandom);
+    }
+
+    {
+        SourceManager sm;
+        uint32_t fid = sm.addFile("hash_literal.bas");
+        Lexer lexer("#1", fid);
+        Token tok = lexer.next();
+        assert(tok.kind == TokenKind::Hash);
+        assert(tok.lexeme == "#");
+        tok = lexer.next();
+        assert(tok.kind == TokenKind::Number);
+        assert(tok.lexeme == "1");
+    }
+
+    {
+        Token tok = nextToken("LINE");
+        assert(tok.kind == TokenKind::KeywordLine);
+    }
+
+    {
+        Token tok = nextToken("INPUT");
+        assert(tok.kind == TokenKind::KeywordInput);
+    }
+
+    {
+        Token tok = nextToken("EOF");
+        assert(tok.kind == TokenKind::KeywordEof);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extend the BASIC keyword table with file I/O verbs and expose a hash punctuation token
- update token string mappings so the new keywords render with diagnostic-friendly names
- add LexerFileIoTests to exercise the new tokens and register the test in the BASIC suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dc2df2832483248fa882df50d883e0