### PR TITLE
feat: parse BASIC OPEN/CLOSE statements

### DIFF
--- a/src/frontends/basic/AST.cpp
+++ b/src/frontends/basic/AST.cpp
@@ -298,6 +298,30 @@ void GotoStmt::accept(MutStmtVisitor &visitor)
     visitor.visit(*this);
 }
 
+/// @brief Forwards this OPEN statement node to the visitor for double dispatch.
+/// @param visitor Receives the node; ownership remains with the AST.
+void OpenStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void OpenStmt::accept(MutStmtVisitor &visitor)
+{
+    visitor.visit(*this);
+}
+
+/// @brief Forwards this CLOSE statement node to the visitor for double dispatch.
+/// @param visitor Receives the node; ownership remains with the AST.
+void CloseStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void CloseStmt::accept(MutStmtVisitor &visitor)
+{
+    visitor.visit(*this);
+}
+
 /// @brief Forward this ON ERROR GOTO statement node to the visitor.
 /// @param visitor Receives the node; ownership remains with the AST.
 void OnErrorGoto::accept(StmtVisitor &visitor) const

--- a/src/frontends/basic/AST.hpp
+++ b/src/frontends/basic/AST.hpp
@@ -40,6 +40,8 @@ struct NextStmt;
 struct ExitStmt;
 struct GotoStmt;
 struct EndStmt;
+struct OpenStmt;
+struct CloseStmt;
 struct InputStmt;
 struct ReturnStmt;
 struct OnErrorGoto;
@@ -100,6 +102,8 @@ struct StmtVisitor
     virtual void visit(const NextStmt &) = 0;
     virtual void visit(const ExitStmt &) = 0;
     virtual void visit(const GotoStmt &) = 0;
+    virtual void visit(const OpenStmt &) = 0;
+    virtual void visit(const CloseStmt &) = 0;
     virtual void visit(const OnErrorGoto &) = 0;
     virtual void visit(const Resume &) = 0;
     virtual void visit(const EndStmt &) = 0;
@@ -126,6 +130,8 @@ struct MutStmtVisitor
     virtual void visit(NextStmt &) = 0;
     virtual void visit(ExitStmt &) = 0;
     virtual void visit(GotoStmt &) = 0;
+    virtual void visit(OpenStmt &) = 0;
+    virtual void visit(CloseStmt &) = 0;
     virtual void visit(OnErrorGoto &) = 0;
     virtual void visit(Resume &) = 0;
     virtual void visit(EndStmt &) = 0;
@@ -557,6 +563,39 @@ struct GotoStmt : Stmt
 {
     /// Target line number to jump to.
     int target;
+    void accept(StmtVisitor &visitor) const override;
+    void accept(MutStmtVisitor &visitor) override;
+};
+
+/// @brief OPEN statement configuring a file channel.
+struct OpenStmt : Stmt
+{
+    /// File path expression.
+    ExprPtr pathExpr;
+
+    /// Access mode requested for the channel.
+    enum class Mode
+    {
+        Input = 0,  ///< OPEN ... FOR INPUT
+        Output = 1, ///< OPEN ... FOR OUTPUT
+        Append = 2, ///< OPEN ... FOR APPEND
+        Binary = 3, ///< OPEN ... FOR BINARY
+        Random = 4, ///< OPEN ... FOR RANDOM
+    } mode{Mode::Input};
+
+    /// Channel number expression that follows the '#'.
+    ExprPtr channelExpr;
+
+    void accept(StmtVisitor &visitor) const override;
+    void accept(MutStmtVisitor &visitor) override;
+};
+
+/// @brief CLOSE statement releasing a file channel.
+struct CloseStmt : Stmt
+{
+    /// Channel number expression that follows the '#'.
+    ExprPtr channelExpr;
+
     void accept(StmtVisitor &visitor) const override;
     void accept(MutStmtVisitor &visitor) override;
 };

--- a/src/frontends/basic/AstPrinter.cpp
+++ b/src/frontends/basic/AstPrinter.cpp
@@ -32,6 +32,24 @@ const char *typeToString(Type ty)
     return "I64";
 }
 
+const char *openModeToString(OpenStmt::Mode mode)
+{
+    switch (mode)
+    {
+        case OpenStmt::Mode::Input:
+            return "INPUT";
+        case OpenStmt::Mode::Output:
+            return "OUTPUT";
+        case OpenStmt::Mode::Append:
+            return "APPEND";
+        case OpenStmt::Mode::Binary:
+            return "BINARY";
+        case OpenStmt::Mode::Random:
+            return "RANDOM";
+    }
+    return "INPUT";
+}
+
 } // namespace
 
 struct AstPrinter::ExprPrinter final : ExprVisitor
@@ -356,6 +374,44 @@ struct AstPrinter::StmtPrinter final : StmtVisitor
     void visit(const GotoStmt &stmt) override
     {
         printer.os << "(GOTO " << stmt.target << ')';
+    }
+
+    void visit(const OpenStmt &stmt) override
+    {
+        printer.os << "(OPEN mode=" << openModeToString(stmt.mode) << '('
+                    << static_cast<int>(stmt.mode) << ") path=";
+        if (stmt.pathExpr)
+        {
+            stmt.pathExpr->accept(exprPrinter);
+        }
+        else
+        {
+            printer.os << "<null>";
+        }
+        printer.os << " channel=#";
+        if (stmt.channelExpr)
+        {
+            stmt.channelExpr->accept(exprPrinter);
+        }
+        else
+        {
+            printer.os << "<null>";
+        }
+        printer.os << ')';
+    }
+
+    void visit(const CloseStmt &stmt) override
+    {
+        printer.os << "(CLOSE channel=#";
+        if (stmt.channelExpr)
+        {
+            stmt.channelExpr->accept(exprPrinter);
+        }
+        else
+        {
+            printer.os << "<null>";
+        }
+        printer.os << ')';
     }
 
     void visit(const OnErrorGoto &stmt) override

--- a/src/frontends/basic/ConstFolder.cpp
+++ b/src/frontends/basic/ConstFolder.cpp
@@ -714,6 +714,18 @@ private:
     void visit(NextStmt &) override {}
     void visit(ExitStmt &) override {}
     void visit(GotoStmt &) override {}
+    void visit(OpenStmt &stmt) override
+    {
+        if (stmt.pathExpr)
+            foldExpr(stmt.pathExpr);
+        if (stmt.channelExpr)
+            foldExpr(stmt.channelExpr);
+    }
+    void visit(CloseStmt &stmt) override
+    {
+        if (stmt.channelExpr)
+            foldExpr(stmt.channelExpr);
+    }
     void visit(OnErrorGoto &) override {}
     void visit(Resume &) override {}
     void visit(EndStmt &) override {}

--- a/src/frontends/basic/LowerScan.cpp
+++ b/src/frontends/basic/LowerScan.cpp
@@ -240,6 +240,20 @@ class ScanStmtVisitor final : public StmtVisitor
 
     void visit(const GotoStmt &) override {}
 
+    void visit(const OpenStmt &stmt) override
+    {
+        if (stmt.pathExpr)
+            lowerer_.scanExpr(*stmt.pathExpr);
+        if (stmt.channelExpr)
+            lowerer_.scanExpr(*stmt.channelExpr);
+    }
+
+    void visit(const CloseStmt &stmt) override
+    {
+        if (stmt.channelExpr)
+            lowerer_.scanExpr(*stmt.channelExpr);
+    }
+
     void visit(const OnErrorGoto &) override {}
 
     void visit(const Resume &) override {}

--- a/src/frontends/basic/LowerStmt.cpp
+++ b/src/frontends/basic/LowerStmt.cpp
@@ -54,6 +54,10 @@ class LowererStmtVisitor final : public StmtVisitor
 
     void visit(const GotoStmt &stmt) override { lowerer_.lowerGoto(stmt); }
 
+    void visit(const OpenStmt &) override {}
+
+    void visit(const CloseStmt &) override {}
+
     void visit(const OnErrorGoto &stmt) override { lowerer_.lowerOnErrorGoto(stmt); }
 
     void visit(const Resume &stmt) override { lowerer_.lowerResume(stmt); }

--- a/src/frontends/basic/LoweringPipeline.cpp
+++ b/src/frontends/basic/LoweringPipeline.cpp
@@ -224,6 +224,20 @@ class VarCollectStmtVisitor final : public StmtVisitor
 
     void visit(const GotoStmt &) override {}
 
+    void visit(const OpenStmt &stmt) override
+    {
+        if (stmt.pathExpr)
+            stmt.pathExpr->accept(exprVisitor_);
+        if (stmt.channelExpr)
+            stmt.channelExpr->accept(exprVisitor_);
+    }
+
+    void visit(const CloseStmt &stmt) override
+    {
+        if (stmt.channelExpr)
+            stmt.channelExpr->accept(exprVisitor_);
+    }
+
     void visit(const OnErrorGoto &) override {}
 
     void visit(const Resume &) override {}

--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -32,6 +32,8 @@ Parser::Parser(std::string_view src, uint32_t file_id, DiagnosticEmitter *emitte
     setHandler(TokenKind::KeywordNext, {&Parser::parseNext, nullptr});
     setHandler(TokenKind::KeywordExit, {&Parser::parseExit, nullptr});
     setHandler(TokenKind::KeywordGoto, {&Parser::parseGoto, nullptr});
+    setHandler(TokenKind::KeywordOpen, {&Parser::parseOpen, nullptr});
+    setHandler(TokenKind::KeywordClose, {&Parser::parseClose, nullptr});
     setHandler(TokenKind::KeywordOn, {&Parser::parseOnErrorGoto, nullptr});
     setHandler(TokenKind::KeywordResume, {&Parser::parseResume, nullptr});
     setHandler(TokenKind::KeywordEnd, {&Parser::parseEnd, nullptr});

--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -194,6 +194,14 @@ class Parser
     /// @return GOTO statement node.
     StmtPtr parseGoto();
 
+    /// @brief Parse an OPEN statement configuring file I/O.
+    /// @return OPEN statement node.
+    StmtPtr parseOpen();
+
+    /// @brief Parse a CLOSE statement releasing a channel.
+    /// @return CLOSE statement node.
+    StmtPtr parseClose();
+
     /// @brief Parse an ON ERROR GOTO statement.
     /// @return ON ERROR statement node.
     StmtPtr parseOnErrorGoto();

--- a/src/frontends/basic/SemanticAnalyzer.Stmts.cpp
+++ b/src/frontends/basic/SemanticAnalyzer.Stmts.cpp
@@ -39,6 +39,8 @@ class SemanticAnalyzerStmtVisitor final : public MutStmtVisitor
     void visit(NextStmt &stmt) override { analyzer_.analyzeNext(stmt); }
     void visit(ExitStmt &stmt) override { analyzer_.analyzeExit(stmt); }
     void visit(GotoStmt &stmt) override { analyzer_.analyzeGoto(stmt); }
+    void visit(OpenStmt &) override {}
+    void visit(CloseStmt &) override {}
     void visit(OnErrorGoto &stmt) override { analyzer_.analyzeOnErrorGoto(stmt); }
     void visit(EndStmt &stmt) override { analyzer_.analyzeEnd(stmt); }
     void visit(InputStmt &stmt) override { analyzer_.analyzeInput(stmt); }

--- a/tests/basic/CMakeLists.txt
+++ b/tests/basic/CMakeLists.txt
@@ -94,6 +94,10 @@ function(viper_add_basic_main_tests)
   target_link_libraries(test_frontends_basic_parse_on_error PRIVATE ${VIPER_BASIC_LIBS})
   viper_add_ctest(test_frontends_basic_parse_on_error test_frontends_basic_parse_on_error)
 
+  viper_add_test_exe(test_frontends_basic_parse_file_io ${VIPER_TESTS_DIR}/frontends/basic/ParseFileIoTests.cpp)
+  target_link_libraries(test_frontends_basic_parse_file_io PRIVATE ${VIPER_BASIC_LIBS})
+  viper_add_ctest(test_frontends_basic_parse_file_io test_frontends_basic_parse_file_io)
+
   viper_add_test_exe(test_frontends_basic_lexer_file_io ${VIPER_TESTS_DIR}/frontends/basic/LexerFileIoTests.cpp)
   target_link_libraries(test_frontends_basic_lexer_file_io PRIVATE ${VIPER_BASIC_LIBS})
   viper_add_ctest(test_frontends_basic_lexer_file_io test_frontends_basic_lexer_file_io)

--- a/tests/frontends/basic/ParseFileIoTests.cpp
+++ b/tests/frontends/basic/ParseFileIoTests.cpp
@@ -1,0 +1,43 @@
+// File: tests/frontends/basic/ParseFileIoTests.cpp
+// Purpose: Validate parsing of BASIC OPEN/CLOSE statements for file I/O.
+// Key invariants: AST printer reflects mode enum numeric values and fields.
+// Ownership/Lifetime: Test owns parser and AST instances.
+// Links: docs/codemap.md
+
+#include "frontends/basic/AstPrinter.hpp"
+#include "frontends/basic/Parser.hpp"
+#include "support/source_manager.hpp"
+#include <cassert>
+#include <string>
+
+using namespace il::frontends::basic;
+using namespace il::support;
+
+namespace
+{
+std::string dumpProgram(const std::string &src)
+{
+    SourceManager sm;
+    uint32_t fid = sm.addFile("fileio.bas");
+    Parser parser(src, fid);
+    auto prog = parser.parseProgram();
+    assert(prog);
+    AstPrinter printer;
+    return printer.dump(*prog);
+}
+} // namespace
+
+int main()
+{
+    {
+        std::string dump =
+            dumpProgram("10 OPEN \"foo.txt\" FOR INPUT AS #1\n20 END\n");
+        assert(dump ==
+               "10: (OPEN mode=INPUT(0) path=\"foo.txt\" channel=#1)\n20: (END)\n");
+    }
+
+    {
+        std::string dump = dumpProgram("10 CLOSE #1\n20 END\n");
+        assert(dump == "10: (CLOSE channel=#1)\n20: (END)\n");
+    }
+}


### PR DESCRIPTION
## Summary
- add AST nodes and visitor plumbing for BASIC OPEN/CLOSE statements
- extend the parser and AST printer to handle file-channel syntax
- add parser regression coverage for OPEN/CLOSE including CMake wiring

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dc3557846c8324aaae08ef29754ba7