### PR TITLE
feat(runtime): add Viper string file wrappers

### DIFF
--- a/src/il/runtime/RuntimeSignatures.cpp
+++ b/src/il/runtime/RuntimeSignatures.cpp
@@ -546,6 +546,16 @@ std::vector<RuntimeDescriptor> buildRegistry()
         {},
         &DirectHandler<&rt_rnd, double>::invoke,
         feature(RuntimeFeature::Rnd, true));
+    add("rt_open_err_vstr",
+        Kind::I32,
+        {Kind::Str, Kind::I32, Kind::I32},
+        &DirectHandler<&rt_open_err_vstr, int32_t, ViperString *, int32_t, int32_t>::invoke,
+        manual());
+    add("rt_close_err",
+        Kind::I32,
+        {Kind::I32},
+        &DirectHandler<&rt_close_err, int32_t, int32_t>::invoke,
+        manual());
     add("rt_const_cstr",
         Kind::Str,
         {Kind::Ptr},

--- a/src/runtime/rt_file.h
+++ b/src/runtime/rt_file.h
@@ -70,6 +70,28 @@ extern "C" {
     /// @return True when the entire buffer is written; false otherwise.
     bool rt_file_write(RtFile *file, const uint8_t *data, size_t len, RtError *out_err);
 
+    /// @brief Enumerates BASIC OPEN modes understood by the runtime wrapper API.
+    enum RtFileMode
+    {
+        RT_F_INPUT = 0,  ///< OPEN ... FOR INPUT
+        RT_F_OUTPUT = 1, ///< OPEN ... FOR OUTPUT
+        RT_F_APPEND = 2, ///< OPEN ... FOR APPEND
+        RT_F_BINARY = 3, ///< OPEN ... FOR BINARY
+        RT_F_RANDOM = 4, ///< OPEN ... FOR RANDOM
+    };
+
+    /// @brief Open @p path for the specified BASIC @p mode on @p channel.
+    /// @param path Runtime string describing the filesystem path.
+    /// @param mode Mode enumerator matching BASIC OPEN semantics.
+    /// @param channel Numeric channel identifier provided by the caller.
+    /// @return 0 on success; error code aligned with @ref Err otherwise.
+    int32_t rt_open_err_vstr(ViperString *path, int32_t mode, int32_t channel);
+
+    /// @brief Close the runtime file associated with @p channel when present.
+    /// @param channel Numeric channel identifier previously passed to OPEN.
+    /// @return 0 on success; error code aligned with @ref Err otherwise.
+    int32_t rt_close_err(int32_t channel);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/runtime/rt_string.h
+++ b/src/runtime/rt_string.h
@@ -12,6 +12,10 @@ extern "C" {
 #endif
 
     struct rt_string_impl;
+
+    /// @brief Exposes the runtime string object layout for host interop wrappers.
+    typedef struct rt_string_impl ViperString;
+
     typedef struct rt_string_impl *rt_string;
 
     /// @brief Increment the reference count of @p s when non-null.

--- a/tests/runtime/FileWrappersTests.c
+++ b/tests/runtime/FileWrappersTests.c
@@ -1,0 +1,20 @@
+// File: tests/runtime/FileWrappersTests.c
+// Purpose: Validate runtime file wrappers using Viper string inputs.
+// Key invariants: Missing files return Err_FileNotFound; closing unopened channel is invalid.
+// Ownership/Lifetime: Uses runtime library; relies on shared literals.
+// Links: docs/codemap.md
+#include "rt_file.h"
+#include "rt_string.h"
+
+#include <assert.h>
+
+int main(void)
+{
+    rt_string missing = rt_const_cstr("tests/runtime/does-not-exist.txt");
+    int32_t code = rt_open_err_vstr(missing, RT_F_INPUT, 7);
+    assert(code == Err_FileNotFound);
+
+    int32_t close_code = rt_close_err(7);
+    assert(close_code == Err_InvalidOperation);
+    return 0;
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -59,6 +59,10 @@ function(viper_add_runtime_tests)
   target_link_libraries(test_rt_errors_io PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_errors_io test_rt_errors_io)
 
+  viper_add_test_exe(test_rt_file_wrappers ${VIPER_TESTS_DIR}/runtime/FileWrappersTests.c)
+  target_link_libraries(test_rt_file_wrappers PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
+  viper_add_ctest(test_rt_file_wrappers test_rt_file_wrappers)
+
   viper_add_test_exe(test_rt_abs_i64_overflow ${VIPER_TESTS_DIR}/runtime/RTAbsI64OverflowTests.cpp)
   target_link_libraries(test_rt_abs_i64_overflow PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_abs_i64_overflow test_rt_abs_i64_overflow)


### PR DESCRIPTION
## Summary
- add runtime file channel wrappers that accept Viper strings and return Err codes
- register the new helpers in the runtime signature table and expose the ViperString alias
- add a runtime test for missing files and hook it into the unit test suite

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dc58a3c13483248e9d8bbf42221570