### PR TITLE
feat(frontends/basic): validate file I/O semantics

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.Procs.cpp
+++ b/src/frontends/basic/SemanticAnalyzer.Procs.cpp
@@ -59,6 +59,13 @@ SemanticAnalyzer::ProcedureScope::~ProcedureScope() noexcept
         else
             analyzer_.arrays_.erase(delta.name);
     }
+    for (const auto &delta : channelDeltas_)
+    {
+        if (delta.previouslyOpen)
+            analyzer_.openChannels_.insert(delta.channel);
+        else
+            analyzer_.openChannels_.erase(delta.channel);
+    }
     if (analyzer_.forStack_.size() > forStackDepth_)
         analyzer_.forStack_.resize(forStackDepth_);
     if (analyzer_.loopStack_.size() > loopStackDepth_)
@@ -85,6 +92,13 @@ void SemanticAnalyzer::ProcedureScope::noteArrayMutation(const std::string &name
     if (!trackedArrays_.insert(name).second)
         return;
     arrayDeltas_.push_back({name, previous});
+}
+
+void SemanticAnalyzer::ProcedureScope::noteChannelMutation(long long channel, bool previouslyOpen)
+{
+    if (!trackedChannels_.insert(channel).second)
+        return;
+    channelDeltas_.push_back({channel, previouslyOpen});
 }
 
 void SemanticAnalyzer::ProcedureScope::noteLabelInserted(int label)
@@ -204,6 +218,7 @@ void SemanticAnalyzer::analyze(const Program &prog)
     loopStack_.clear();
     varTypes_.clear();
     arrays_.clear();
+    openChannels_.clear();
     errorHandlerActive_ = false;
     errorHandlerTarget_.reset();
     procReg_.clear();

--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -84,6 +84,10 @@ class SemanticAnalyzer
     void analyzePrint(const PrintStmt &s);
     /// @brief Analyze LET statement @p s.
     void analyzeLet(LetStmt &s);
+    /// @brief Analyze OPEN statement @p s.
+    void analyzeOpen(OpenStmt &s);
+    /// @brief Analyze CLOSE statement @p s.
+    void analyzeClose(CloseStmt &s);
     /// @brief Analyze IF statement @p s.
     void analyzeIf(const IfStmt &s);
     /// @brief Analyze WHILE statement @p s.
@@ -153,6 +157,7 @@ class SemanticAnalyzer
         void noteSymbolInserted(const std::string &name);
         void noteVarTypeMutation(const std::string &name, std::optional<Type> previous);
         void noteArrayMutation(const std::string &name, std::optional<long long> previous);
+        void noteChannelMutation(long long channel, bool previouslyOpen);
         void noteLabelInserted(int label);
         void noteLabelRefInserted(int label);
 
@@ -169,6 +174,12 @@ class SemanticAnalyzer
             std::optional<long long> previous;
         };
 
+        struct ChannelDelta
+        {
+            long long channel;
+            bool previouslyOpen;
+        };
+
         SemanticAnalyzer &analyzer_;
         ProcedureScope *previous_{nullptr};
         size_t forStackDepth_{0};
@@ -178,8 +189,10 @@ class SemanticAnalyzer
         std::vector<int> newLabelRefs_;
         std::vector<VarTypeDelta> varTypeDeltas_;
         std::vector<ArrayDelta> arrayDeltas_;
+        std::vector<ChannelDelta> channelDeltas_;
         std::unordered_set<std::string> trackedVarTypes_;
         std::unordered_set<std::string> trackedArrays_;
+        std::unordered_set<long long> trackedChannels_;
         bool previousHandlerActive_{false};
         std::optional<int> previousHandlerTarget_;
     };
@@ -365,6 +378,7 @@ class SemanticAnalyzer
     std::unordered_set<std::string> symbols_;
     std::unordered_map<std::string, Type> varTypes_;
     std::unordered_map<std::string, long long> arrays_; ///< array sizes if known (-1 if dynamic)
+    std::unordered_set<long long> openChannels_; ///< Channels opened by literal handles.
     std::unordered_set<int> labels_;
     std::unordered_set<int> labelRefs_;
     std::vector<std::string> forStack_; ///< Active FOR loop variables.

--- a/tests/basic/CMakeLists.txt
+++ b/tests/basic/CMakeLists.txt
@@ -110,6 +110,10 @@ function(viper_add_basic_main_tests)
   target_link_libraries(test_frontends_basic_semantic_on_error PRIVATE ${VIPER_BASIC_LIBS})
   viper_add_ctest(test_frontends_basic_semantic_on_error test_frontends_basic_semantic_on_error)
 
+  viper_add_test_exe(test_frontends_basic_semantic_file_io ${VIPER_TESTS_DIR}/frontends/basic/SemanticsFileIoTests.cpp)
+  target_link_libraries(test_frontends_basic_semantic_file_io PRIVATE ${VIPER_BASIC_LIBS})
+  viper_add_ctest(test_frontends_basic_semantic_file_io test_frontends_basic_semantic_file_io)
+
   viper_add_test_exe(test_frontends_basic_type_rules ${VIPER_TESTS_DIR}/frontends/basic/TypeRulesTests.cpp)
   target_link_libraries(test_frontends_basic_type_rules PRIVATE ${VIPER_BASIC_LIBS})
   viper_add_ctest(test_frontends_basic_type_rules test_frontends_basic_type_rules)

--- a/tests/frontends/basic/SemanticsFileIoTests.cpp
+++ b/tests/frontends/basic/SemanticsFileIoTests.cpp
@@ -1,0 +1,71 @@
+// File: tests/frontends/basic/SemanticsFileIoTests.cpp
+// Purpose: Validate BASIC semantic analyzer file I/O statement checking.
+// Key invariants: OPEN requires string paths and integer channels; CLOSE requires integer channels.
+// Ownership/Lifetime: Tests allocate analyzer resources per snippet.
+// Links: docs/codemap.md
+
+#include "frontends/basic/DiagnosticEmitter.hpp"
+#include "frontends/basic/Parser.hpp"
+#include "frontends/basic/SemanticAnalyzer.hpp"
+#include "support/source_manager.hpp"
+
+#include <cassert>
+#include <sstream>
+#include <string>
+
+using namespace il::frontends::basic;
+using namespace il::support;
+
+namespace
+{
+
+struct AnalysisResult
+{
+    size_t errors;
+    size_t warnings;
+    std::string output;
+};
+
+AnalysisResult analyzeSnippet(const std::string &src)
+{
+    SourceManager sm;
+    uint32_t fid = sm.addFile("snippet.bas");
+    Parser parser(src, fid);
+    auto program = parser.parseProgram();
+    assert(program);
+
+    DiagnosticEngine de;
+    DiagnosticEmitter emitter(de, sm);
+    emitter.addSource(fid, src);
+
+    SemanticAnalyzer analyzer(emitter);
+    analyzer.analyze(*program);
+
+    std::ostringstream oss;
+    emitter.printAll(oss);
+    return {emitter.errorCount(), emitter.warningCount(), oss.str()};
+}
+
+} // namespace
+
+int main()
+{
+    {
+        auto result = analyzeSnippet("10 OPEN \"x\" FOR INPUT AS #1\n20 END\n");
+        assert(result.errors == 0);
+    }
+
+    {
+        auto result = analyzeSnippet("10 OPEN 5 FOR INPUT AS #1\n20 END\n");
+        assert(result.errors == 1);
+        assert(result.output.find("error[B2001]") != std::string::npos);
+    }
+
+    {
+        auto result = analyzeSnippet("10 CLOSE #\"1\"\n20 END\n");
+        assert(result.errors == 1);
+        assert(result.output.find("error[B2001]") != std::string::npos);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement semantic checks for BASIC OPEN/CLOSE statements, including mode validation and literal channel tracking
- preserve literal channel open state across procedure scopes for warnings on re-open
- add semantic analyzer file I/O tests and register them in the BASIC test suite

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dc7080e884832489c79de63ae79b18