### PR TITLE
Add PRINT#/LINE INPUT# parsing support to BASIC front end

### DIFF
--- a/src/frontends/basic/AST.cpp
+++ b/src/frontends/basic/AST.cpp
@@ -166,6 +166,18 @@ void PrintStmt::accept(MutStmtVisitor &visitor)
     visitor.visit(*this);
 }
 
+/// @brief Forwards this PRINT # statement node to the visitor for double dispatch.
+/// @param visitor Receives the node; ownership remains with the AST.
+void PrintChStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void PrintChStmt::accept(MutStmtVisitor &visitor)
+{
+    visitor.visit(*this);
+}
+
 /// @brief Forwards this let statement node to the visitor for double dispatch.
 /// @param visitor Receives the node; ownership remains with the AST.
 void LetStmt::accept(StmtVisitor &visitor) const
@@ -366,6 +378,18 @@ void InputStmt::accept(StmtVisitor &visitor) const
 }
 
 void InputStmt::accept(MutStmtVisitor &visitor)
+{
+    visitor.visit(*this);
+}
+
+/// @brief Forwards this LINE INPUT # statement node to the visitor for double dispatch.
+/// @param visitor Receives the node; ownership remains with the AST.
+void LineInputChStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visit(*this);
+}
+
+void LineInputChStmt::accept(MutStmtVisitor &visitor)
 {
     visitor.visit(*this);
 }

--- a/src/frontends/basic/AstPrinter.cpp
+++ b/src/frontends/basic/AstPrinter.cpp
@@ -205,6 +205,39 @@ struct AstPrinter::StmtPrinter final : StmtVisitor
         printer.os << ')';
     }
 
+    void visit(const PrintChStmt &stmt) override
+    {
+        printer.os << "(PRINT# channel=#";
+        if (stmt.channelExpr)
+        {
+            stmt.channelExpr->accept(exprPrinter);
+        }
+        else
+        {
+            printer.os << "<null>";
+        }
+        printer.os << " args=[";
+        bool first = true;
+        for (const auto &arg : stmt.args)
+        {
+            if (!first)
+                printer.os << ' ';
+            if (arg)
+            {
+                arg->accept(exprPrinter);
+            }
+            else
+            {
+                printer.os << "<null>";
+            }
+            first = false;
+        }
+        printer.os << ']';
+        if (!stmt.trailingNewline)
+            printer.os << " no-newline";
+        printer.os << ')';
+    }
+
     void visit(const LetStmt &stmt) override
     {
         printer.os << "(LET ";
@@ -460,6 +493,29 @@ struct AstPrinter::StmtPrinter final : StmtVisitor
             printer.os << ',';
         }
         printer.os << ' ' << stmt.var << ')';
+    }
+
+    void visit(const LineInputChStmt &stmt) override
+    {
+        printer.os << "(LINE-INPUT# channel=#";
+        if (stmt.channelExpr)
+        {
+            stmt.channelExpr->accept(exprPrinter);
+        }
+        else
+        {
+            printer.os << "<null>";
+        }
+        printer.os << " target=";
+        if (stmt.targetVar)
+        {
+            stmt.targetVar->accept(exprPrinter);
+        }
+        else
+        {
+            printer.os << "<null>";
+        }
+        printer.os << ')';
     }
 
     void visit(const ReturnStmt &stmt) override

--- a/src/frontends/basic/ConstFolder.cpp
+++ b/src/frontends/basic/ConstFolder.cpp
@@ -654,6 +654,13 @@ private:
         }
     }
 
+    void visit(PrintChStmt &stmt) override
+    {
+        foldExpr(stmt.channelExpr);
+        for (auto &arg : stmt.args)
+            foldExpr(arg);
+    }
+
     void visit(LetStmt &stmt) override
     {
         foldExpr(stmt.target);
@@ -729,7 +736,17 @@ private:
     void visit(OnErrorGoto &) override {}
     void visit(Resume &) override {}
     void visit(EndStmt &) override {}
-    void visit(InputStmt &) override {}
+    void visit(InputStmt &stmt) override
+    {
+        if (stmt.prompt)
+            foldExpr(stmt.prompt);
+    }
+
+    void visit(LineInputChStmt &stmt) override
+    {
+        foldExpr(stmt.channelExpr);
+        foldExpr(stmt.targetVar);
+    }
     void visit(ReturnStmt &) override {}
 
     void visit(FunctionDecl &) override {}

--- a/src/frontends/basic/LowerScan.cpp
+++ b/src/frontends/basic/LowerScan.cpp
@@ -108,6 +108,15 @@ class ScanStmtVisitor final : public StmtVisitor
         }
     }
 
+    void visit(const PrintChStmt &stmt) override
+    {
+        if (stmt.channelExpr)
+            lowerer_.scanExpr(*stmt.channelExpr);
+        for (const auto &arg : stmt.args)
+            if (arg)
+                lowerer_.scanExpr(*arg);
+    }
+
     void visit(const LetStmt &stmt) override
     {
         if (stmt.expr)
@@ -275,6 +284,14 @@ class ScanStmtVisitor final : public StmtVisitor
             if (!info || !info->hasType)
                 lowerer_.setSymbolType(stmt.var, inferAstTypeFromName(stmt.var));
         }
+    }
+
+    void visit(const LineInputChStmt &stmt) override
+    {
+        if (stmt.channelExpr)
+            lowerer_.scanExpr(*stmt.channelExpr);
+        if (stmt.targetVar)
+            lowerer_.scanExpr(*stmt.targetVar);
     }
 
     void visit(const ReturnStmt &stmt) override

--- a/src/frontends/basic/LowerStmt.cpp
+++ b/src/frontends/basic/LowerStmt.cpp
@@ -29,6 +29,12 @@ class LowererStmtVisitor final : public StmtVisitor
 
     void visit(const PrintStmt &stmt) override { lowerer_.lowerPrint(stmt); }
 
+    void visit(const PrintChStmt &stmt) override
+    {
+        (void)stmt;
+        // Channel-based PRINT lowering will be implemented in a future change.
+    }
+
     void visit(const LetStmt &stmt) override { lowerer_.lowerLet(stmt); }
 
     void visit(const DimStmt &stmt) override
@@ -66,6 +72,12 @@ class LowererStmtVisitor final : public StmtVisitor
     void visit(const EndStmt &stmt) override { lowerer_.lowerEnd(stmt); }
 
     void visit(const InputStmt &stmt) override { lowerer_.lowerInput(stmt); }
+
+    void visit(const LineInputChStmt &stmt) override
+    {
+        (void)stmt;
+        // Channel-based LINE INPUT lowering will be implemented in a future change.
+    }
 
     void visit(const ReturnStmt &stmt) override { lowerer_.lowerReturn(stmt); }
 

--- a/src/frontends/basic/LoweringPipeline.cpp
+++ b/src/frontends/basic/LoweringPipeline.cpp
@@ -128,6 +128,15 @@ class VarCollectStmtVisitor final : public StmtVisitor
                 item.expr->accept(exprVisitor_);
     }
 
+    void visit(const PrintChStmt &stmt) override
+    {
+        if (stmt.channelExpr)
+            stmt.channelExpr->accept(exprVisitor_);
+        for (const auto &arg : stmt.args)
+            if (arg)
+                arg->accept(exprVisitor_);
+    }
+
     void visit(const LetStmt &stmt) override
     {
         if (stmt.target)
@@ -250,6 +259,14 @@ class VarCollectStmtVisitor final : public StmtVisitor
             stmt.prompt->accept(exprVisitor_);
         if (!stmt.var.empty())
             lowerer_.markSymbolReferenced(stmt.var);
+    }
+
+    void visit(const LineInputChStmt &stmt) override
+    {
+        if (stmt.channelExpr)
+            stmt.channelExpr->accept(exprVisitor_);
+        if (stmt.targetVar)
+            stmt.targetVar->accept(exprVisitor_);
     }
 
     void visit(const ReturnStmt &stmt) override

--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -38,6 +38,7 @@ Parser::Parser(std::string_view src, uint32_t file_id, DiagnosticEmitter *emitte
     setHandler(TokenKind::KeywordResume, {&Parser::parseResume, nullptr});
     setHandler(TokenKind::KeywordEnd, {&Parser::parseEnd, nullptr});
     setHandler(TokenKind::KeywordInput, {&Parser::parseInput, nullptr});
+    setHandler(TokenKind::KeywordLine, {&Parser::parseLineInput, nullptr});
     setHandler(TokenKind::KeywordDim, {&Parser::parseDim, nullptr});
     setHandler(TokenKind::KeywordRedim, {&Parser::parseReDim, nullptr});
     setHandler(TokenKind::KeywordRandomize, {&Parser::parseRandomize, nullptr});

--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -214,6 +214,10 @@ class Parser
     /// @return INPUT statement node.
     StmtPtr parseInput();
 
+    /// @brief Parse a LINE INPUT # statement.
+    /// @return LINE INPUT statement node.
+    StmtPtr parseLineInput();
+
     /// @brief Parse a RESUME statement.
     /// @return RESUME statement node.
     StmtPtr parseResume();

--- a/src/frontends/basic/SemanticAnalyzer.Stmts.cpp
+++ b/src/frontends/basic/SemanticAnalyzer.Stmts.cpp
@@ -28,6 +28,7 @@ class SemanticAnalyzerStmtVisitor final : public MutStmtVisitor
     }
 
     void visit(PrintStmt &stmt) override { analyzer_.analyzePrint(stmt); }
+    void visit(PrintChStmt &stmt) override { analyzer_.analyzePrintCh(stmt); }
     void visit(LetStmt &stmt) override { analyzer_.analyzeLet(stmt); }
     void visit(DimStmt &stmt) override { analyzer_.analyzeDim(stmt); }
     void visit(ReDimStmt &stmt) override { analyzer_.analyzeReDim(stmt); }
@@ -44,6 +45,7 @@ class SemanticAnalyzerStmtVisitor final : public MutStmtVisitor
     void visit(OnErrorGoto &stmt) override { analyzer_.analyzeOnErrorGoto(stmt); }
     void visit(EndStmt &stmt) override { analyzer_.analyzeEnd(stmt); }
     void visit(InputStmt &stmt) override { analyzer_.analyzeInput(stmt); }
+    void visit(LineInputChStmt &stmt) override { analyzer_.analyzeLineInputCh(stmt); }
     void visit(Resume &stmt) override { analyzer_.analyzeResume(stmt); }
     void visit(ReturnStmt &stmt) override { analyzer_.analyzeReturn(stmt); }
     void visit(FunctionDecl &) override {}
@@ -72,6 +74,15 @@ void SemanticAnalyzer::analyzePrint(const PrintStmt &p)
     for (const auto &it : p.items)
         if (it.kind == PrintItem::Kind::Expr && it.expr)
             visitExpr(*it.expr);
+}
+
+void SemanticAnalyzer::analyzePrintCh(const PrintChStmt &p)
+{
+    if (p.channelExpr)
+        visitExpr(*p.channelExpr);
+    for (const auto &arg : p.args)
+        if (arg)
+            visitExpr(*arg);
 }
 
 void SemanticAnalyzer::analyzeVarAssignment(VarExpr &v, const LetStmt &l)
@@ -583,6 +594,14 @@ void SemanticAnalyzer::analyzeInput(InputStmt &inp)
                 static_cast<uint32_t>(inp.var.size()),
                 std::move(msg));
     }
+}
+
+void SemanticAnalyzer::analyzeLineInputCh(LineInputChStmt &inp)
+{
+    if (inp.channelExpr)
+        visitExpr(*inp.channelExpr);
+    if (inp.targetVar)
+        visitExpr(*inp.targetVar);
 }
 
 void SemanticAnalyzer::analyzeDim(DimStmt &d)

--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -82,6 +82,8 @@ class SemanticAnalyzer
     void analyzeStmtList(const StmtList &s);
     /// @brief Analyze PRINT statement @p s.
     void analyzePrint(const PrintStmt &s);
+    /// @brief Analyze PRINT # statement @p s.
+    void analyzePrintCh(const PrintChStmt &s);
     /// @brief Analyze LET statement @p s.
     void analyzeLet(LetStmt &s);
     /// @brief Analyze OPEN statement @p s.
@@ -114,6 +116,8 @@ class SemanticAnalyzer
     void analyzeRandomize(const RandomizeStmt &s);
     /// @brief Analyze INPUT statement @p s.
     void analyzeInput(InputStmt &s);
+    /// @brief Analyze LINE INPUT # statement @p s.
+    void analyzeLineInputCh(LineInputChStmt &s);
     /// @brief Analyze DIM statement @p s.
     void analyzeDim(DimStmt &s);
     /// @brief Analyze REDIM statement @p s.

--- a/tests/frontends/basic/ParseFileIoTests.cpp
+++ b/tests/frontends/basic/ParseFileIoTests.cpp
@@ -40,4 +40,14 @@ int main()
         std::string dump = dumpProgram("10 CLOSE #1\n20 END\n");
         assert(dump == "10: (CLOSE channel=#1)\n20: (END)\n");
     }
+
+    {
+        std::string dump = dumpProgram("10 PRINT #1, X, Y\n20 END\n");
+        assert(dump == "10: (PRINT# channel=#1 args=[X Y])\n20: (END)\n");
+    }
+
+    {
+        std::string dump = dumpProgram("10 LINE INPUT #1, A$\n20 END\n");
+        assert(dump == "10: (LINE-INPUT# channel=#1 target=A$)\n20: (END)\n");
+    }
 }


### PR DESCRIPTION
## Summary
- add PrintChStmt and LineInputChStmt AST nodes and hook them into the statement visitor hierarchy
- extend the BASIC parser to recognize `PRINT #` and `LINE INPUT #` and update downstream utilities such as the AST printer and analyzers
- cover the new syntax with parser regression tests for file I/O statements

## Testing
- cmake --build build --target fe_basic
- ctest --test-dir build -R test_frontends_basic_parse_file_io --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dc84068b208324b917c30c69e46024