### PR TITLE
Refactor IL verifier diagnostics to use shared formatter

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ target_include_directories(il_build PUBLIC
 add_subdirectory(il/io)
 
 add_library(il_verify STATIC
+  il/verify/DiagFormat.cpp
   il/verify/DiagSink.cpp
   il/verify/Verifier.cpp
   il/verify/ExternVerifier.cpp

--- a/src/il/verify/ControlFlowChecker.cpp
+++ b/src/il/verify/ControlFlowChecker.cpp
@@ -11,6 +11,7 @@
 #include "il/core/Function.hpp"
 #include "il/core/Instr.hpp"
 #include "il/core/Param.hpp"
+#include "il/verify/DiagFormat.hpp"
 #include "il/verify/DiagSink.hpp"
 #include "support/diag_expected.hpp"
 
@@ -40,28 +41,6 @@ using VerifyInstrFnExpected = std::function<Expected<void>(const Function &fn,
 
 namespace
 {
-std::string formatBlockDiag(const Function &fn,
-                            const BasicBlock &bb,
-                            std::string_view message)
-{
-    std::ostringstream oss;
-    oss << fn.name << ":" << bb.label;
-    if (!message.empty())
-        oss << ": " << message;
-    return oss.str();
-}
-
-std::string formatInstrDiag(const Function &fn,
-                            const BasicBlock &bb,
-                            const Instr &instr,
-                            std::string_view message)
-{
-    std::ostringstream oss;
-    oss << fn.name << ":" << bb.label << ": " << makeSnippet(instr);
-    if (!message.empty())
-        oss << ": " << message;
-    return oss.str();
-}
 
 /// @brief Validates block parameter declarations against IL structural rules.
 /// @param fn Function owning @p bb; used for diagnostics.

--- a/src/il/verify/DiagFormat.cpp
+++ b/src/il/verify/DiagFormat.cpp
@@ -1,0 +1,43 @@
+// File: src/il/verify/DiagFormat.cpp
+// Purpose: Define shared helpers for formatting IL verifier diagnostics.
+// Key invariants: Functions are pure and rely solely on immutable IL inputs.
+// Ownership/Lifetime: Callers retain ownership of IL structures; helpers copy strings.
+// Links: docs/il-guide.md#reference
+
+#include "il/verify/DiagFormat.hpp"
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/verify/TypeInference.hpp"
+
+#include <sstream>
+
+namespace il::verify
+{
+
+std::string formatBlockDiag(const core::Function &fn,
+                            const core::BasicBlock &bb,
+                            std::string_view message)
+{
+    std::ostringstream oss;
+    oss << fn.name << ":" << bb.label;
+    if (!message.empty())
+        oss << ": " << message;
+    return oss.str();
+}
+
+std::string formatInstrDiag(const core::Function &fn,
+                            const core::BasicBlock &bb,
+                            const core::Instr &instr,
+                            std::string_view message)
+{
+    std::ostringstream oss;
+    oss << fn.name << ":" << bb.label << ": " << makeSnippet(instr);
+    if (!message.empty())
+        oss << ": " << message;
+    return oss.str();
+}
+
+} // namespace il::verify
+

--- a/src/il/verify/DiagFormat.hpp
+++ b/src/il/verify/DiagFormat.hpp
@@ -1,0 +1,37 @@
+// File: src/il/verify/DiagFormat.hpp
+// Purpose: Declare shared helpers for formatting IL verifier diagnostics.
+// Key invariants: Formatting helpers only inspect immutable IL structures.
+// Ownership/Lifetime: Non-owning references to IL structures provided by callers.
+// Links: docs/il-guide.md#reference
+#pragma once
+
+#include "il/core/fwd.hpp"
+
+#include <string>
+#include <string_view>
+
+namespace il::verify
+{
+
+/// @brief Format a diagnostic string describing a basic block.
+/// @param fn Function owning the block used to provide context.
+/// @param bb Basic block referenced by the diagnostic.
+/// @param message Optional trailing text appended to the diagnostic.
+/// @return Single-line diagnostic including the function and block label.
+std::string formatBlockDiag(const il::core::Function &fn,
+                            const il::core::BasicBlock &bb,
+                            std::string_view message = {});
+
+/// @brief Format a diagnostic string describing an instruction.
+/// @param fn Function owning the instruction.
+/// @param bb Basic block containing the instruction.
+/// @param instr Instruction rendered via makeSnippet for context.
+/// @param message Optional trailing text appended to the diagnostic.
+/// @return Single-line diagnostic with function, block, instruction snippet and message.
+std::string formatInstrDiag(const il::core::Function &fn,
+                            const il::core::BasicBlock &bb,
+                            const il::core::Instr &instr,
+                            std::string_view message = {});
+
+} // namespace il::verify
+

--- a/src/il/verify/FunctionVerifier.cpp
+++ b/src/il/verify/FunctionVerifier.cpp
@@ -13,6 +13,7 @@
 #include "il/core/Module.hpp"
 #include "il/core/Type.hpp"
 #include "il/verify/ControlFlowChecker.hpp"
+#include "il/verify/DiagFormat.hpp"
 #include "il/verify/InstructionChecker.hpp"
 #include "il/verify/TypeInference.hpp"
 
@@ -37,29 +38,6 @@ namespace
 {
 
 using HandlerInfo = std::pair<unsigned, unsigned>;
-
-std::string formatInstrDiag(const Function &fn,
-                            const BasicBlock &bb,
-                            const Instr &instr,
-                            std::string_view message)
-{
-    std::ostringstream oss;
-    oss << fn.name << ":" << bb.label << ": " << makeSnippet(instr);
-    if (!message.empty())
-        oss << ": " << message;
-    return oss.str();
-}
-
-std::string formatBlockDiag(const Function &fn,
-                            const BasicBlock &bb,
-                            std::string_view message)
-{
-    std::ostringstream oss;
-    oss << fn.name << ":" << bb.label;
-    if (!message.empty())
-        oss << ": " << message;
-    return oss.str();
-}
 
 bool isResumeOpcode(Opcode op)
 {

--- a/src/il/verify/InstructionChecker.cpp
+++ b/src/il/verify/InstructionChecker.cpp
@@ -12,6 +12,7 @@
 #include "il/core/Instr.hpp"
 #include "il/core/Opcode.hpp"
 #include "il/core/OpcodeInfo.hpp"
+#include "il/verify/DiagFormat.hpp"
 #include "il/verify/DiagSink.hpp"
 #include "il/verify/TypeInference.hpp"
 #include "support/diag_expected.hpp"
@@ -33,11 +34,6 @@ using il::support::Diag;
 using il::support::Expected;
 using il::support::Severity;
 using il::support::makeError;
-
-std::string formatInstrDiag(const Function &fn,
-                            const BasicBlock &bb,
-                            const Instr &instr,
-                            std::string_view message);
 
 enum class RuntimeArrayCallee
 {
@@ -216,24 +212,6 @@ Expected<void> checkRuntimeArrayCall(const Function &fn,
     }
 
     return {};
-}
-
-/// @brief Format a canonical diagnostic string for an instruction.
-/// @param fn Function that owns the instruction.
-/// @param bb Basic block containing the instruction.
-/// @param instr Instruction that triggered the diagnostic.
-/// @param message Additional detail appended to the diagnostic message.
-/// @return Fully formatted verifier diagnostic payload.
-std::string formatInstrDiag(const Function &fn,
-                            const BasicBlock &bb,
-                            const Instr &instr,
-                            std::string_view message)
-{
-    std::ostringstream oss;
-    oss << fn.name << ":" << bb.label << ": " << makeSnippet(instr);
-    if (!message.empty())
-        oss << ": " << message;
-    return oss.str();
 }
 
 /// @brief Append a warning diagnostic associated with @p instr.

--- a/src/il/verify/TypeInference.cpp
+++ b/src/il/verify/TypeInference.cpp
@@ -6,6 +6,7 @@
 // Links: docs/il-guide.md#reference
 
 #include "il/verify/TypeInference.hpp"
+#include "il/verify/DiagFormat.hpp"
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Function.hpp"
 #include "il/core/Instr.hpp"
@@ -31,18 +32,6 @@ std::string formatOperands(const Instr &instr)
     for (size_t i = 0; i < instr.labels.size(); ++i)
         os << " label " << instr.labels[i];
     return os.str();
-}
-
-std::string formatInstrDiag(const Function &fn,
-                            const BasicBlock &bb,
-                            const Instr &instr,
-                            std::string_view message)
-{
-    std::ostringstream oss;
-    oss << fn.name << ":" << bb.label << ": " << makeSnippet(instr);
-    if (!message.empty())
-        oss << ": " << message;
-    return oss.str();
 }
 
 } // namespace


### PR DESCRIPTION
## Summary
- add a shared il/verify diagnostic formatting helper and wire it into the build
- update verifier components to include the new helper instead of local formatters
- make the verifier type inference utility reuse the shared instruction formatter

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure -R "test_il_(instruction_checker|control_flow_checker|verify_forward_call|verify_release_lifetime|verify_trap|type_inference)"


------
https://chatgpt.com/codex/tasks/task_e_68dc837f80fc83248d262e6cd5cf64c4