### PR TITLE
feat: add runtime channel io helpers

### DIFF
--- a/src/il/runtime/RuntimeSignatures.cpp
+++ b/src/il/runtime/RuntimeSignatures.cpp
@@ -556,6 +556,21 @@ std::vector<RuntimeDescriptor> buildRegistry()
         {Kind::I32},
         &DirectHandler<&rt_close_err, int32_t, int32_t>::invoke,
         manual());
+    add("rt_write_ch_err",
+        Kind::I32,
+        {Kind::I32, Kind::Str},
+        &DirectHandler<&rt_write_ch_err, int32_t, int32_t, ViperString *>::invoke,
+        manual());
+    add("rt_println_ch_err",
+        Kind::I32,
+        {Kind::I32, Kind::Str},
+        &DirectHandler<&rt_println_ch_err, int32_t, int32_t, ViperString *>::invoke,
+        manual());
+    add("rt_line_input_ch_err",
+        Kind::I32,
+        {Kind::I32, Kind::Ptr},
+        &DirectHandler<&rt_line_input_ch_err, int32_t, int32_t, ViperString **>::invoke,
+        manual());
     add("rt_const_cstr",
         Kind::Str,
         {Kind::Ptr},

--- a/src/runtime/rt_file.h
+++ b/src/runtime/rt_file.h
@@ -92,6 +92,24 @@ extern "C" {
     /// @return 0 on success; error code aligned with @ref Err otherwise.
     int32_t rt_close_err(int32_t channel);
 
+    /// @brief Write @p s to the file bound to @p channel without a trailing newline.
+    /// @param channel Numeric channel identifier previously passed to OPEN.
+    /// @param s Runtime string to write; NULL strings are ignored.
+    /// @return 0 on success; error code aligned with @ref Err otherwise.
+    int32_t rt_write_ch_err(int32_t channel, ViperString *s);
+
+    /// @brief Write @p s to the file bound to @p channel followed by a newline.
+    /// @param channel Numeric channel identifier previously passed to OPEN.
+    /// @param s Runtime string to write; NULL strings are treated as empty.
+    /// @return 0 on success; error code aligned with @ref Err otherwise.
+    int32_t rt_println_ch_err(int32_t channel, ViperString *s);
+
+    /// @brief Read a line of text from @p channel into a newly allocated runtime string.
+    /// @param channel Numeric channel identifier previously passed to OPEN FOR INPUT.
+    /// @param out Receives allocated string on success; set to NULL on failure.
+    /// @return 0 on success; error code aligned with @ref Err otherwise.
+    int32_t rt_line_input_ch_err(int32_t channel, ViperString **out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/runtime/FileChannelIoTests.c
+++ b/tests/runtime/FileChannelIoTests.c
@@ -1,0 +1,61 @@
+// File: tests/runtime/FileChannelIoTests.c
+// Purpose: Exercise runtime channel I/O helpers with success paths.
+// Key invariants: Wrappers return Err_None on success and allocate readable strings.
+// Ownership/Lifetime: Runtime owns allocations; test releases acquired strings.
+// Links: docs/codemap.md
+#include "rt_file.h"
+#include "rt_string.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(void)
+{
+    char template_path[128];
+    int written = snprintf(template_path,
+                           sizeof(template_path),
+                           "tmp_channel_io_%ld.txt",
+                           (long)getpid());
+    assert(written > 0 && written < (int)sizeof(template_path));
+    remove(template_path);
+
+    ViperString *path = rt_const_cstr(template_path);
+    assert(path != NULL);
+
+    int32_t open_out = rt_open_err_vstr(path, RT_F_OUTPUT, 5);
+    assert(open_out == Err_None);
+
+    ViperString *hello = rt_const_cstr("hello ");
+    int32_t write_rc = rt_write_ch_err(5, hello);
+    assert(write_rc == Err_None);
+
+    ViperString *world = rt_const_cstr("world");
+    int32_t println_rc = rt_println_ch_err(5, world);
+    assert(println_rc == Err_None);
+
+    int32_t close_out = rt_close_err(5);
+    assert(close_out == Err_None);
+
+    int32_t open_in = rt_open_err_vstr(path, RT_F_INPUT, 5);
+    assert(open_in == Err_None);
+
+    ViperString *line = NULL;
+    int32_t input_rc = rt_line_input_ch_err(5, &line);
+    assert(input_rc == Err_None);
+    assert(line != NULL);
+    const char *line_view = rt_string_cstr(line);
+    assert(line_view != NULL);
+    assert(strcmp(line_view, "hello world") == 0);
+    rt_string_unref(line);
+
+    int32_t close_in = rt_close_err(5);
+    assert(close_in == Err_None);
+
+    remove(template_path);
+    rt_string_unref(world);
+    rt_string_unref(hello);
+    rt_string_unref(path);
+    return 0;
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -63,6 +63,10 @@ function(viper_add_runtime_tests)
   target_link_libraries(test_rt_file_wrappers PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_file_wrappers test_rt_file_wrappers)
 
+  viper_add_test_exe(test_rt_file_channel_io ${VIPER_TESTS_DIR}/runtime/FileChannelIoTests.c)
+  target_link_libraries(test_rt_file_channel_io PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
+  viper_add_ctest(test_rt_file_channel_io test_rt_file_channel_io)
+
   viper_add_test_exe(test_rt_abs_i64_overflow ${VIPER_TESTS_DIR}/runtime/RTAbsI64OverflowTests.cpp)
   target_link_libraries(test_rt_abs_i64_overflow PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_abs_i64_overflow test_rt_abs_i64_overflow)


### PR DESCRIPTION
## Summary
- add rt_write_ch_err, rt_println_ch_err, and rt_line_input_ch_err channel wrappers that return Err codes
- publish the new helpers in RuntimeSignatures so lowering can request them
- add a runtime test that writes and reads through the channel APIs and wire it into the suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68dc95aa6bf08324bfd08fc9e46aff49