### PR TITLE
Refactor BASIC tools to share source loading helper

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,12 +129,18 @@ target_link_libraries(il-dis PRIVATE support il_core il_build il_io)
 
 add_subdirectory(frontends/basic)
 
-add_executable(basic-ast-dump tools/basic-ast-dump/main.cpp)
+add_executable(basic-ast-dump
+  tools/basic-ast-dump/main.cpp
+  tools/basic/common.cpp)
 set_target_properties(basic-ast-dump PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/basic-ast-dump)
 target_link_libraries(basic-ast-dump PRIVATE fe_basic support)
-add_executable(basic-lex-dump tools/basic-lex-dump/main.cpp)
+target_compile_definitions(basic-ast-dump PRIVATE VIPER_BASIC_TOOL_USAGE="Usage: basic-ast-dump <file.bas>\\n")
+add_executable(basic-lex-dump
+  tools/basic-lex-dump/main.cpp
+  tools/basic/common.cpp)
 set_target_properties(basic-lex-dump PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/basic-lex-dump)
 target_link_libraries(basic-lex-dump PRIVATE fe_basic support)
+target_compile_definitions(basic-lex-dump PRIVATE VIPER_BASIC_TOOL_USAGE="Usage: basic-lex-dump <file.bas>\\n")
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/support/
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/viper/support

--- a/src/tools/basic-ast-dump/main.cpp
+++ b/src/tools/basic-ast-dump/main.cpp
@@ -8,12 +8,15 @@
 #include "frontends/basic/AstPrinter.hpp"
 #include "frontends/basic/Parser.hpp"
 #include "support/source_manager.hpp"
-#include <fstream>
+#include "tools/basic/common.hpp"
+
 #include <iostream>
-#include <sstream>
+#include <optional>
+#include <string>
 
 using namespace il::frontends::basic;
 using namespace il::support;
+using il::tools::basic::loadBasicSource;
 
 /**
  * @brief Entry point for the BASIC AST dump tool.
@@ -30,23 +33,15 @@ using namespace il::support;
  */
 int main(int argc, char **argv)
 {
-    if (argc != 2)
-    {
-        std::cerr << "Usage: basic-ast-dump <file.bas>\n";
-        return 1;
-    }
-    std::ifstream in(argv[1]);
-    if (!in)
-    {
-        std::cerr << "cannot open " << argv[1] << "\n";
-        return 1;
-    }
-    std::ostringstream ss;
-    ss << in.rdbuf();
-    std::string src = ss.str();
+    std::string src;
     SourceManager sm;
-    uint32_t fid = sm.addFile(argv[1]);
-    Parser p(src, fid);
+    std::optional<std::uint32_t> fileId = loadBasicSource(argc == 2 ? argv[1] : nullptr, src, sm);
+    if (!fileId)
+    {
+        return 1;
+    }
+
+    Parser p(src, *fileId);
     auto prog = p.parseProgram();
     AstPrinter printer;
     std::cout << printer.dump(*prog);

--- a/src/tools/basic-lex-dump/main.cpp
+++ b/src/tools/basic-lex-dump/main.cpp
@@ -8,12 +8,15 @@
 #include "frontends/basic/Lexer.hpp"
 #include "frontends/basic/Token.hpp"
 #include "support/source_manager.hpp"
-#include <fstream>
+#include "tools/basic/common.hpp"
+
 #include <iostream>
-#include <sstream>
+#include <optional>
+#include <string>
 
 using namespace il::frontends::basic;
 using namespace il::support;
+using il::tools::basic::loadBasicSource;
 
 /// @brief Tool entry point that dumps BASIC source tokens for golden tests.
 ///
@@ -26,23 +29,15 @@ using namespace il::support;
 /// a non-zero status.
 int main(int argc, char **argv)
 {
-    if (argc != 2)
-    {
-        std::cerr << "Usage: basic-lex-dump <file.bas>\n";
-        return 1;
-    }
-    std::ifstream in(argv[1]);
-    if (!in)
-    {
-        std::cerr << "cannot open " << argv[1] << "\n";
-        return 1;
-    }
-    std::ostringstream ss;
-    ss << in.rdbuf();
-    std::string src = ss.str();
+    std::string src;
     SourceManager sm;
-    uint32_t fid = sm.addFile(argv[1]);
-    Lexer lex(src, fid);
+    std::optional<std::uint32_t> fileId = loadBasicSource(argc == 2 ? argv[1] : nullptr, src, sm);
+    if (!fileId)
+    {
+        return 1;
+    }
+
+    Lexer lex(src, *fileId);
     for (Token t = lex.next();; t = lex.next())
     {
         std::cout << t.loc.line << ":" << t.loc.column << " " << tokenKindToString(t.kind);

--- a/src/tools/basic/common.cpp
+++ b/src/tools/basic/common.cpp
@@ -1,0 +1,54 @@
+// File: src/tools/basic/common.cpp
+// Purpose: Implement shared helpers for BASIC command-line tools.
+// Key invariants: Diagnostics must match legacy tool output exactly.
+// Ownership/Lifetime: Functions operate on caller-provided buffers and managers.
+// License: MIT License. See LICENSE in the project root for full license information.
+// Links: docs/codemap.md
+
+#include "tools/basic/common.hpp"
+
+#include "support/source_manager.hpp"
+
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <sstream>
+
+namespace il::tools::basic
+{
+
+namespace
+{
+#ifdef VIPER_BASIC_TOOL_USAGE
+constexpr const char *kUsageMessage = VIPER_BASIC_TOOL_USAGE;
+#else
+#error "VIPER_BASIC_TOOL_USAGE must be defined for BASIC tool builds"
+#endif
+} // namespace
+
+std::optional<std::uint32_t> loadBasicSource(const char *path,
+                                             std::string &buffer,
+                                             il::support::SourceManager &sm)
+{
+    if (path == nullptr)
+    {
+        std::cerr << kUsageMessage;
+        return std::nullopt;
+    }
+
+    std::ifstream in(path);
+    if (!in)
+    {
+        std::cerr << "cannot open " << path << "\n";
+        return std::nullopt;
+    }
+
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    buffer = ss.str();
+
+    std::uint32_t fileId = sm.addFile(path);
+    return fileId;
+}
+
+} // namespace il::tools::basic

--- a/src/tools/basic/common.hpp
+++ b/src/tools/basic/common.hpp
@@ -1,0 +1,36 @@
+// File: src/tools/basic/common.hpp
+// Purpose: Shared utilities for BASIC command-line tools.
+// Key invariants: Helpers must preserve existing CLI diagnostics.
+// Ownership/Lifetime: Callers retain ownership of buffers and SourceManager instances.
+// License: MIT License. See LICENSE in the project root for full license information.
+// Links: docs/codemap.md
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace il::support
+{
+class SourceManager;
+}
+
+namespace il::tools::basic
+{
+
+/// @brief Load BASIC source into a buffer and register it with the SourceManager.
+///
+/// @param path Path to the BASIC source file. If null, a usage message is printed and
+/// the load fails.
+/// @param buffer Destination for the loaded source contents. On success it is populated
+/// with the file contents; on failure it is left unchanged.
+/// @param sm Source manager responsible for tracking file identifiers.
+///
+/// @return The assigned file identifier on success; std::nullopt if the usage check or
+/// file loading fails.
+std::optional<std::uint32_t> loadBasicSource(const char *path,
+                                             std::string &buffer,
+                                             il::support::SourceManager &sm);
+
+} // namespace il::tools::basic


### PR DESCRIPTION
## Summary
- add a shared loadBasicSource helper for BASIC tools with consistent diagnostics
- update basic-ast-dump and basic-lex-dump to reuse the helper
- build both tools with per-target usage messages

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68dcb03a416083249a63952870eb42fe