### PR TITLE
Add BASIC e2e test covering multiple runtime errors

### DIFF
--- a/tests/e2e/basic/errors_all.bas
+++ b/tests/e2e/basic/errors_all.bas
@@ -1,0 +1,15 @@
+ON ERROR GOTO H1
+x = 1 : y = 0 : PRINT x \ y : PRINT "unreached"
+H1:
+  PRINT "dz" : RESUME NEXT
+  PRINT "cont1"
+
+ON ERROR GOTO H2
+OPEN "missing.txt" FOR INPUT AS #1
+H2:
+  PRINT "fnf" : RESUME NEXT
+
+ON ERROR GOTO H3
+DIM a(1 TO 2) : PRINT a(3)
+H3:
+  PRINT "bounds" : RESUME NEXT

--- a/tests/e2e/basic/errors_all.bas.out
+++ b/tests/e2e/basic/errors_all.bas.out
@@ -1,0 +1,4 @@
+dz
+cont1
+fnf
+bounds


### PR DESCRIPTION
## Summary
- add a consolidated BASIC e2e program to exercise divide-by-zero, file-not-found, and bounds error handling
- capture the expected output sequence that confirms each handler resumes correctly

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dcb1840bdc8324badb91e1a95f3758