### PR TITLE
Add overflow trap diagnostic golden test

### DIFF
--- a/tests/golden/CMakeLists.txt
+++ b/tests/golden/CMakeLists.txt
@@ -172,6 +172,12 @@ function(viper_add_golden_suite_tests)
     "-DEXPECT=${EXPECT_VM_TRAP_LOC}"
     -P ${_VIPER_GOLDEN_DIR}/check_vm_trap_loc.cmake)
 
+  viper_add_ctest(vm_trap_overflow_message
+    ${CMAKE_COMMAND}
+    -DILC=${BASIC_ILC}
+    -DIL_FILE=${_VIPER_GOLDEN_DIR}/vm_trap_overflow.il
+    -P ${_VIPER_GOLDEN_DIR}/check_vm_trap_overflow.cmake)
+
   set(NUMERICS_IL_DIR ${_VIPER_GOLDEN_DIR}/numerics_il)
 
   viper_add_ctest(numerics_il_i16_add_overflow

--- a/tests/golden/check_vm_trap_overflow.cmake
+++ b/tests/golden/check_vm_trap_overflow.cmake
@@ -1,0 +1,33 @@
+if(NOT DEFINED ILC)
+  message(FATAL_ERROR "ILC not set")
+endif()
+if(NOT DEFINED IL_FILE)
+  message(FATAL_ERROR "IL_FILE not set")
+endif()
+
+execute_process(
+  COMMAND ${ILC} -run ${IL_FILE}
+  RESULT_VARIABLE res
+  OUTPUT_VARIABLE ignored_stdout
+  ERROR_VARIABLE stderr
+)
+
+if(res EQUAL 0)
+  message(FATAL_ERROR "expected non-zero exit")
+endif()
+
+string(STRIP "${stderr}" stderr_stripped)
+string(REGEX MATCH "^Trap @([^#]+)#([0-9]+) line (-1|[0-9]+): Overflow \\(code=0\\)$" _match "${stderr_stripped}")
+if(NOT _match)
+  message(FATAL_ERROR "unexpected trap diagnostic: ${stderr_stripped}")
+endif()
+
+if(NOT CMAKE_MATCH_1 STREQUAL "main")
+  message(FATAL_ERROR "unexpected function name: ${CMAKE_MATCH_1}")
+endif()
+if(NOT CMAKE_MATCH_2 STREQUAL "0")
+  message(FATAL_ERROR "unexpected instruction index: ${CMAKE_MATCH_2}")
+endif()
+if(NOT CMAKE_MATCH_3)
+  message(FATAL_ERROR "missing source line in diagnostic")
+endif()

--- a/tests/golden/vm_trap_overflow.il
+++ b/tests/golden/vm_trap_overflow.il
@@ -1,0 +1,7 @@
+il 0.1.2
+func @main() -> i64 {
+entry:
+  .loc 1 1 1
+  %t0:i64 = iadd.ovf 9223372036854775807, 1
+  ret %t0
+}

--- a/tests/golden/vm_trap_overflow.stderr
+++ b/tests/golden/vm_trap_overflow.stderr
@@ -1,0 +1,1 @@
+Trap @main#0 line 1: Overflow \(code=0\)


### PR DESCRIPTION
## Summary
- add an IL golden program that triggers an unhandled integer overflow
- add a dedicated CMake harness to assert the trap diagnostic includes the function name, instruction index, and line number

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dcb4140ecc8324b42b5a749ba8084c