### PR TITLE
Refactor BASIC channel normalization helper

### DIFF
--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -446,6 +446,8 @@ class Lowerer
 
     RVal ensureF64(RVal v, il::support::SourceLoc loc);
 
+    RVal normalizeChannelToI32(RVal channel, il::support::SourceLoc loc);
+
     void lowerLet(const LetStmt &stmt);
 
     void lowerPrint(const PrintStmt &stmt);


### PR DESCRIPTION
## Summary
- add a Lowerer::normalizeChannelToI32 helper to share the existing ensure-and-narrow logic
- reuse the helper across OPEN, CLOSE, PRINT #, and LINE INPUT # lowering sites

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dcb5b8f35483249be228f385b91e75