### PR TITLE
refactor: centralize BASIC procedure parameter registration

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -357,6 +357,9 @@ class SemanticAnalyzer
     template <typename Proc, typename BodyCallback>
     void analyzeProcedureCommon(const Proc &proc, BodyCallback &&bodyCheck);
 
+    /// @brief Register parameter @p param in the current procedure scope.
+    void registerProcedureParam(const Param &param);
+
     /// @brief Analyze body of FUNCTION @p f.
     void analyzeProc(const FunctionDecl &f);
     /// @brief Analyze body of SUB @p s.


### PR DESCRIPTION
## Summary
- extract procedure parameter registration into a dedicated helper
- reuse existing symbol/type tracking when wiring parameters into scopes

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dcbb08f5d483249a0d2b5ba6716a22