### PR TITLE
refactor: centralize integer cast range checks

### DIFF
--- a/src/runtime/rt_numeric.c
+++ b/src/runtime/rt_numeric.c
@@ -26,52 +26,51 @@ extern "C" {
         return nearbyint(x);
     }
 
-    static int16_t rt_cast_i16(double value, bool *ok)
+    static inline double rt_cast_integer_checked(
+        double value,
+        bool *ok,
+        double min_value,
+        double max_value,
+        const char *null_ok_trap)
     {
         if (!ok)
         {
-            rt_trap("rt_cast_i16: null ok");
-            return 0;
+            rt_trap(null_ok_trap);
+            return 0.0;
         }
 
         if (!isfinite(value))
         {
             *ok = false;
-            return 0;
+            return 0.0;
         }
 
-        if (value < (double)INT16_MIN || value > (double)INT16_MAX)
+        if (value < min_value || value > max_value)
         {
             *ok = false;
-            return 0;
+            return 0.0;
         }
 
         *ok = true;
-        return (int16_t)value;
+        return value;
+    }
+
+#define RT_CAST_INTEGER(value, ok, type, min_value, max_value, null_ok_trap) \
+    ((type)rt_cast_integer_checked(                                             \
+        (value),                                                                \
+        (ok),                                                                   \
+        (double)(min_value),                                                    \
+        (double)(max_value),                                                    \
+        (null_ok_trap)))
+
+    static int16_t rt_cast_i16(double value, bool *ok)
+    {
+        return RT_CAST_INTEGER(value, ok, int16_t, INT16_MIN, INT16_MAX, "rt_cast_i16: null ok");
     }
 
     static int32_t rt_cast_i32(double value, bool *ok)
     {
-        if (!ok)
-        {
-            rt_trap("rt_cast_i32: null ok");
-            return 0;
-        }
-
-        if (!isfinite(value))
-        {
-            *ok = false;
-            return 0;
-        }
-
-        if (value < (double)INT32_MIN || value > (double)INT32_MAX)
-        {
-            *ok = false;
-            return 0;
-        }
-
-        *ok = true;
-        return (int32_t)value;
+        return RT_CAST_INTEGER(value, ok, int32_t, INT32_MIN, INT32_MAX, "rt_cast_i32: null ok");
     }
 
     int16_t rt_cint_from_double(double x, bool *ok)


### PR DESCRIPTION
## Summary
- add a reusable helper in the runtime to share the finite-range checking logic for integer casts
- update `rt_cast_i16` and `rt_cast_i32` to call the helper while preserving their trap messages

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dcbfaad8d083248804cb1cf3b198da