### PR TITLE
Refactor manual runtime helper tracking in BASIC lowerer

### DIFF
--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -13,6 +13,7 @@
 #include "il/build/IRBuilder.hpp"
 #include "il/core/Module.hpp"
 #include "il/runtime/RuntimeSignatures.hpp"
+#include <array>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -603,18 +604,37 @@ class Lowerer
     using RuntimeFeature = il::runtime::RuntimeFeature;
 
     RuntimeHelperTracker runtimeTracker;
-    bool needsArrI32New{false};
-    bool needsArrI32Resize{false};
-    bool needsArrI32Len{false};
-    bool needsArrI32Get{false};
-    bool needsArrI32Set{false};
-    bool needsArrI32Retain{false};
-    bool needsArrI32Release{false};
-    bool needsArrOobPanic{false};
-    bool needsOpenErrVstr{false};
-    bool needsCloseErr{false};
-    bool needsPrintlnChErr{false};
-    bool needsLineInputChErr{false};
+
+    enum class ManualRuntimeHelper : std::size_t
+    {
+        ArrayI32New = 0,
+        ArrayI32Resize,
+        ArrayI32Len,
+        ArrayI32Get,
+        ArrayI32Set,
+        ArrayI32Retain,
+        ArrayI32Release,
+        ArrayOobPanic,
+        OpenErrVstr,
+        CloseErr,
+        PrintlnChErr,
+        LineInputChErr,
+        Count
+    };
+
+    static constexpr std::size_t manualRuntimeHelperCount =
+        static_cast<std::size_t>(ManualRuntimeHelper::Count);
+
+    static constexpr std::size_t manualRuntimeHelperIndex(ManualRuntimeHelper helper) noexcept
+    {
+        return static_cast<std::size_t>(helper);
+    }
+
+    std::array<bool, manualRuntimeHelperCount> manualHelperRequirements_{};
+
+    void setManualHelperRequired(ManualRuntimeHelper helper);
+    [[nodiscard]] bool isManualHelperRequired(ManualRuntimeHelper helper) const;
+    void resetManualHelpers();
 
     void requireArrayI32New();
     void requireArrayI32Resize();

--- a/src/frontends/basic/LoweringPipeline.cpp
+++ b/src/frontends/basic/LoweringPipeline.cpp
@@ -319,18 +319,7 @@ void ProgramLowering::run(const Program &prog, il::core::Module &module)
     lowerer.procSignatures.clear();
 
     lowerer.runtimeTracker.reset();
-    lowerer.needsArrI32New = false;
-    lowerer.needsArrI32Resize = false;
-    lowerer.needsArrI32Len = false;
-    lowerer.needsArrI32Get = false;
-    lowerer.needsArrI32Set = false;
-    lowerer.needsArrI32Retain = false;
-    lowerer.needsArrI32Release = false;
-    lowerer.needsArrOobPanic = false;
-    lowerer.needsOpenErrVstr = false;
-    lowerer.needsCloseErr = false;
-    lowerer.needsPrintlnChErr = false;
-    lowerer.needsLineInputChErr = false;
+    lowerer.resetManualHelpers();
 
     lowerer.scanProgram(prog);
     lowerer.declareRequiredRuntime(builder);


### PR DESCRIPTION
## Summary
- replace Lowerer manual helper booleans with an enum-indexed array and dedicated setters
- emit manual runtime externs by iterating a static descriptor table to simplify additions

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dcbf68bb2483249bec380e4e64d7f3