### PR TITLE
Refactor verifier helpers into dedicated modules

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,9 @@ add_library(il_verify STATIC
   il/verify/GlobalVerifier.cpp
   il/verify/FunctionVerifier.cpp
   il/verify/InstructionChecker.cpp
+  il/verify/InstructionStrategies.cpp
+  il/verify/ExceptionHandlerAnalysis.cpp
+  il/verify/BranchVerifier.cpp
   il/verify/ControlFlowChecker.cpp
   il/verify/TypeInference.cpp)
 target_link_libraries(il_verify PUBLIC il_core il_runtime)

--- a/src/il/verify/BranchVerifier.cpp
+++ b/src/il/verify/BranchVerifier.cpp
@@ -1,0 +1,132 @@
+// File: src/il/verify/BranchVerifier.cpp
+// Purpose: Implement branch and return verification helpers shared by the IL verifier.
+// Key invariants: Branch instructions respect target parameter lists; returns match function
+// signatures. Ownership/Lifetime: Operates on caller-owned IL data without persisting references
+// beyond invocation. Links: docs/il-guide.md#reference
+
+#include "il/verify/BranchVerifier.hpp"
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Type.hpp"
+#include "il/verify/DiagFormat.hpp"
+#include "il/verify/TypeInference.hpp"
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+using namespace il::core;
+
+namespace il::verify
+{
+using il::support::Expected;
+using il::support::makeError;
+
+namespace
+{
+
+Expected<void> verifyBranchArgs(const Function &fn,
+                                const BasicBlock &bb,
+                                const Instr &instr,
+                                const BasicBlock &target,
+                                const std::vector<Value> *args,
+                                std::string_view label,
+                                TypeInference &types)
+{
+    size_t argCount = args ? args->size() : 0;
+    if (argCount != target.params.size())
+        return Expected<void>{makeError(
+            instr.loc,
+            formatInstrDiag(
+                fn, bb, instr, "branch arg count mismatch for label " + std::string(label)))};
+
+    for (size_t i = 0; i < argCount; ++i)
+    {
+        if (types.valueType((*args)[i]).kind != target.params[i].type.kind)
+            return Expected<void>{
+                makeError(instr.loc,
+                          formatInstrDiag(
+                              fn, bb, instr, "arg type mismatch for label " + std::string(label)))};
+    }
+    return {};
+}
+
+} // namespace
+
+Expected<void> verifyBr_E(const Function &fn,
+                          const BasicBlock &bb,
+                          const Instr &instr,
+                          const std::unordered_map<std::string, const BasicBlock *> &blockMap,
+                          TypeInference &types)
+{
+    bool argsOk = instr.operands.empty() && instr.labels.size() == 1;
+    if (!argsOk)
+        return Expected<void>{
+            makeError(instr.loc, formatInstrDiag(fn, bb, instr, "branch mismatch"))};
+
+    if (auto it = blockMap.find(instr.labels[0]); it != blockMap.end())
+    {
+        const BasicBlock &target = *it->second;
+        const std::vector<Value> *argsVec = !instr.brArgs.empty() ? &instr.brArgs[0] : nullptr;
+        if (auto result = verifyBranchArgs(fn, bb, instr, target, argsVec, instr.labels[0], types);
+            !result)
+            return result;
+    }
+
+    return {};
+}
+
+Expected<void> verifyCBr_E(const Function &fn,
+                           const BasicBlock &bb,
+                           const Instr &instr,
+                           const std::unordered_map<std::string, const BasicBlock *> &blockMap,
+                           TypeInference &types)
+{
+    bool condOk = instr.operands.size() == 1 && instr.labels.size() == 2 &&
+                  types.valueType(instr.operands[0]).kind == Type::Kind::I1;
+    if (condOk)
+    {
+        for (size_t t = 0; t < 2; ++t)
+        {
+            auto it = blockMap.find(instr.labels[t]);
+            if (it == blockMap.end())
+                continue;
+            const BasicBlock &target = *it->second;
+            const std::vector<Value> *argsVec =
+                instr.brArgs.size() > t ? &instr.brArgs[t] : nullptr;
+            if (auto result =
+                    verifyBranchArgs(fn, bb, instr, target, argsVec, instr.labels[t], types);
+                !result)
+                return result;
+        }
+        return {};
+    }
+
+    return Expected<void>{
+        makeError(instr.loc, formatInstrDiag(fn, bb, instr, "conditional branch mismatch"))};
+}
+
+Expected<void> verifyRet_E(const Function &fn,
+                           const BasicBlock &bb,
+                           const Instr &instr,
+                           TypeInference &types)
+{
+    if (fn.retType.kind == Type::Kind::Void)
+    {
+        if (!instr.operands.empty())
+            return Expected<void>{
+                makeError(instr.loc, formatInstrDiag(fn, bb, instr, "ret void with value"))};
+        return {};
+    }
+
+    if (instr.operands.size() == 1 && types.valueType(instr.operands[0]).kind == fn.retType.kind)
+        return {};
+
+    return Expected<void>{
+        makeError(instr.loc, formatInstrDiag(fn, bb, instr, "ret value type mismatch"))};
+}
+
+} // namespace il::verify

--- a/src/il/verify/BranchVerifier.hpp
+++ b/src/il/verify/BranchVerifier.hpp
@@ -1,0 +1,44 @@
+// File: src/il/verify/BranchVerifier.hpp
+// Purpose: Declare helpers that validate branch and return terminators during verification.
+// Key invariants: Branch labels/arguments and return values match their targets and function
+// signatures. Ownership/Lifetime: Stateless helpers operating on caller-provided verifier context.
+// Links: docs/il-guide.md#reference
+#pragma once
+
+#include "support/diag_expected.hpp"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace il::core
+{
+struct BasicBlock;
+struct Function;
+struct Instr;
+} // namespace il::core
+
+namespace il::verify
+{
+class TypeInference;
+
+il::support::Expected<void> verifyBr_E(
+    const il::core::Function &fn,
+    const il::core::BasicBlock &bb,
+    const il::core::Instr &instr,
+    const std::unordered_map<std::string, const il::core::BasicBlock *> &blockMap,
+    TypeInference &types);
+
+il::support::Expected<void> verifyCBr_E(
+    const il::core::Function &fn,
+    const il::core::BasicBlock &bb,
+    const il::core::Instr &instr,
+    const std::unordered_map<std::string, const il::core::BasicBlock *> &blockMap,
+    TypeInference &types);
+
+il::support::Expected<void> verifyRet_E(const il::core::Function &fn,
+                                        const il::core::BasicBlock &bb,
+                                        const il::core::Instr &instr,
+                                        TypeInference &types);
+
+} // namespace il::verify

--- a/src/il/verify/ExceptionHandlerAnalysis.cpp
+++ b/src/il/verify/ExceptionHandlerAnalysis.cpp
@@ -1,0 +1,245 @@
+// File: src/il/verify/ExceptionHandlerAnalysis.cpp
+// Purpose: Implement helpers that analyse exception-handling blocks and EH stack usage.
+// Key invariants: Handler entry must appear first with (%err:Error, %tok:ResumeTok) signature; EH
+// pushes/pops balance. Ownership/Lifetime: Operates on caller-provided IR structures without
+// retaining ownership. Links: docs/il-guide.md#reference
+
+#include "il/verify/ExceptionHandlerAnalysis.hpp"
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Type.hpp"
+#include "il/verify/DiagFormat.hpp"
+
+#include <algorithm>
+#include <deque>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+using namespace il::core;
+
+namespace il::verify
+{
+using il::support::Expected;
+using il::support::makeError;
+
+namespace
+{
+
+using HandlerInfo = std::pair<unsigned, unsigned>;
+
+bool isTerminatorForEh(Opcode op)
+{
+    switch (op)
+    {
+        case Opcode::Br:
+        case Opcode::CBr:
+        case Opcode::Ret:
+        case Opcode::Trap:
+        case Opcode::TrapKind:
+        case Opcode::TrapFromErr:
+        case Opcode::TrapErr:
+        case Opcode::ResumeSame:
+        case Opcode::ResumeNext:
+        case Opcode::ResumeLabel:
+            return true;
+        default:
+            return false;
+    }
+}
+
+struct EhState
+{
+    const BasicBlock *block = nullptr;
+    int depth = 0;
+    int parent = -1;
+};
+
+std::vector<const BasicBlock *> gatherSuccessors(
+    const Instr &terminator, const std::unordered_map<std::string, const BasicBlock *> &blockMap)
+{
+    std::vector<const BasicBlock *> successors;
+    switch (terminator.op)
+    {
+        case Opcode::Br:
+            if (!terminator.labels.empty())
+            {
+                if (auto it = blockMap.find(terminator.labels[0]); it != blockMap.end())
+                    successors.push_back(it->second);
+            }
+            break;
+        case Opcode::CBr:
+            for (size_t idx = 0; idx < terminator.labels.size(); ++idx)
+            {
+                if (auto it = blockMap.find(terminator.labels[idx]); it != blockMap.end())
+                    successors.push_back(it->second);
+            }
+            break;
+        case Opcode::ResumeLabel:
+            if (!terminator.labels.empty())
+            {
+                if (auto it = blockMap.find(terminator.labels[0]); it != blockMap.end())
+                    successors.push_back(it->second);
+            }
+            break;
+        default:
+            break;
+    }
+    return successors;
+}
+
+std::vector<const BasicBlock *> buildPath(const std::vector<EhState> &states, int index)
+{
+    std::vector<const BasicBlock *> path;
+    for (int cur = index; cur >= 0; cur = states[cur].parent)
+        path.push_back(states[cur].block);
+    std::reverse(path.begin(), path.end());
+    return path;
+}
+
+std::string formatPathString(const std::vector<const BasicBlock *> &path)
+{
+    std::ostringstream oss;
+    for (size_t i = 0; i < path.size(); ++i)
+    {
+        if (i != 0)
+            oss << " -> ";
+        oss << path[i]->label;
+    }
+    return oss.str();
+}
+
+} // namespace
+
+Expected<std::optional<HandlerSignature>> analyzeHandlerBlock(const Function &fn,
+                                                              const BasicBlock &bb)
+{
+    if (bb.instructions.empty())
+        return std::optional<HandlerSignature>{};
+
+    const Instr &first = bb.instructions.front();
+    if (first.op != Opcode::EhEntry)
+    {
+        for (size_t idx = 1; idx < bb.instructions.size(); ++idx)
+        {
+            if (bb.instructions[idx].op == Opcode::EhEntry)
+            {
+                return Expected<std::optional<HandlerSignature>>{
+                    makeError(bb.instructions[idx].loc,
+                              formatInstrDiag(
+                                  fn,
+                                  bb,
+                                  bb.instructions[idx],
+                                  "eh.entry only allowed as first instruction of handler block"))};
+            }
+        }
+        return std::optional<HandlerSignature>{};
+    }
+
+    if (bb.params.size() != 2)
+        return Expected<std::optional<HandlerSignature>>{makeError(
+            {},
+            formatBlockDiag(fn, bb, "handler blocks must declare (%err:Error, %tok:ResumeTok)"))};
+
+    if (bb.params[0].type.kind != Type::Kind::Error ||
+        bb.params[1].type.kind != Type::Kind::ResumeTok)
+        return Expected<std::optional<HandlerSignature>>{makeError(
+            {}, formatBlockDiag(fn, bb, "handler params must be (%err:Error, %tok:ResumeTok)"))};
+
+    if (bb.params[0].name != "err" || bb.params[1].name != "tok")
+        return Expected<std::optional<HandlerSignature>>{
+            makeError({}, formatBlockDiag(fn, bb, "handler params must be named %err and %tok"))};
+
+    HandlerSignature sig = {bb.params[0].id, bb.params[1].id};
+    return std::optional<HandlerSignature>{sig};
+}
+
+Expected<void> checkEhStackBalance(
+    const Function &fn, const std::unordered_map<std::string, const BasicBlock *> &blockMap)
+{
+    if (fn.blocks.empty())
+        return {};
+
+    std::deque<int> worklist;
+    std::vector<EhState> states;
+    std::unordered_map<const BasicBlock *, std::unordered_set<int>> visited;
+
+    states.push_back({&fn.blocks.front(), 0, -1});
+    worklist.push_back(0);
+    visited[&fn.blocks.front()].insert(0);
+
+    while (!worklist.empty())
+    {
+        const int stateIndex = worklist.front();
+        worklist.pop_front();
+
+        const EhState &state = states[stateIndex];
+        const BasicBlock &bb = *state.block;
+        int depth = state.depth;
+
+        const Instr *terminator = nullptr;
+        for (const auto &instr : bb.instructions)
+        {
+            if (instr.op == Opcode::EhPush)
+            {
+                ++depth;
+            }
+            else if (instr.op == Opcode::EhPop)
+            {
+                if (depth == 0)
+                {
+                    std::vector<const BasicBlock *> path = buildPath(states, stateIndex);
+                    std::string message =
+                        formatInstrDiag(fn,
+                                        bb,
+                                        instr,
+                                        std::string("eh.pop without matching eh.push; path: ") +
+                                            formatPathString(path));
+                    return Expected<void>{makeError(instr.loc, message)};
+                }
+                --depth;
+            }
+
+            if (isTerminatorForEh(instr.op))
+            {
+                terminator = &instr;
+                break;
+            }
+        }
+
+        if (!terminator)
+            continue;
+
+        if (terminator->op == Opcode::Ret && depth != 0)
+        {
+            std::vector<const BasicBlock *> path = buildPath(states, stateIndex);
+            std::string message =
+                formatInstrDiag(fn,
+                                bb,
+                                *terminator,
+                                std::string("unmatched eh.push depth ") + std::to_string(depth) +
+                                    "; path: " + formatPathString(path));
+            return Expected<void>{makeError(terminator->loc, message)};
+        }
+
+        const std::vector<const BasicBlock *> successors = gatherSuccessors(*terminator, blockMap);
+        for (const BasicBlock *succ : successors)
+        {
+            if (!visited[succ].insert(depth).second)
+                continue;
+            const int nextIndex = static_cast<int>(states.size());
+            states.push_back({succ, depth, stateIndex});
+            worklist.push_back(nextIndex);
+        }
+    }
+
+    return {};
+}
+
+} // namespace il::verify

--- a/src/il/verify/ExceptionHandlerAnalysis.hpp
+++ b/src/il/verify/ExceptionHandlerAnalysis.hpp
@@ -1,0 +1,45 @@
+// File: src/il/verify/ExceptionHandlerAnalysis.hpp
+// Purpose: Declare helpers that analyse exception-handler blocks and EH stack balance.
+// Key invariants: Handler blocks must declare (%err:Error, %tok:ResumeTok) and EH pushes/pops nest
+// properly. Ownership/Lifetime: Operates on verifier-supplied IL references without owning them.
+// Links: docs/il-guide.md#reference
+#pragma once
+
+#include "support/diag_expected.hpp"
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace il::core
+{
+struct BasicBlock;
+struct Function;
+} // namespace il::core
+
+namespace il::verify
+{
+
+/// @brief Captures the parameter IDs associated with a handler's %err and %tok values.
+struct HandlerSignature
+{
+    unsigned errorParam = 0;
+    unsigned resumeTokenParam = 0;
+};
+
+/// @brief Inspect @p bb and determine whether it is a handler block with a valid signature.
+/// @param fn Function providing diagnostic context.
+/// @param bb Basic block to analyse.
+/// @return Empty optional when @p bb is not a handler, signature when valid, diagnostic otherwise.
+il::support::Expected<std::optional<HandlerSignature>> analyzeHandlerBlock(
+    const il::core::Function &fn, const il::core::BasicBlock &bb);
+
+/// @brief Validate that EH push/pop usage across the function maintains stack balance.
+/// @param fn Function being analysed.
+/// @param blockMap Lookup table for successors by label.
+/// @return Success when balanced; diagnostic when unmatched push/pop pairs are discovered.
+il::support::Expected<void> checkEhStackBalance(
+    const il::core::Function &fn,
+    const std::unordered_map<std::string, const il::core::BasicBlock *> &blockMap);
+
+} // namespace il::verify

--- a/src/il/verify/FunctionVerifier.hpp
+++ b/src/il/verify/FunctionVerifier.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "il/verify/DiagSink.hpp"
+#include "il/verify/ExceptionHandlerAnalysis.hpp"
 
 #include "support/diag_expected.hpp"
 
@@ -80,7 +81,7 @@ class FunctionVerifier
 
     const ExternMap &externs_;
     std::unordered_map<std::string, const il::core::Function *> functionMap_;
-    std::unordered_map<std::string, std::pair<unsigned, unsigned>> handlerInfo_;
+    std::unordered_map<std::string, HandlerSignature> handlerInfo_;
     std::vector<std::unique_ptr<InstructionStrategy>> strategies_;
 };
 

--- a/src/il/verify/InstructionStrategies.cpp
+++ b/src/il/verify/InstructionStrategies.cpp
@@ -1,0 +1,105 @@
+// File: src/il/verify/InstructionStrategies.cpp
+// Purpose: Provide the default instruction verification strategies for FunctionVerifier.
+// Key invariants: Control-flow opcodes are handled separately from generic instruction checking.
+// Ownership/Lifetime: Strategies are allocated per-verifier invocation and owned by the caller.
+// Links: docs/il-guide.md#reference
+
+#include "il/verify/InstructionStrategies.hpp"
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/verify/BranchVerifier.hpp"
+#include "il/verify/FunctionVerifier.hpp"
+#include "il/verify/InstructionChecker.hpp"
+#include "il/verify/TypeInference.hpp"
+
+#include <memory>
+#include <unordered_map>
+
+using namespace il::core;
+
+namespace il::verify
+{
+using il::support::Expected;
+
+Expected<void> verifyInstruction_E(const Function &fn,
+                                   const BasicBlock &bb,
+                                   const Instr &instr,
+                                   const std::unordered_map<std::string, const Extern *> &externs,
+                                   const std::unordered_map<std::string, const Function *> &funcs,
+                                   TypeInference &types,
+                                   DiagSink &sink);
+
+namespace
+{
+
+class ControlFlowStrategy final : public FunctionVerifier::InstructionStrategy
+{
+  public:
+    bool matches(const Instr &instr) const override
+    {
+        return instr.op == Opcode::Br || instr.op == Opcode::CBr || instr.op == Opcode::Ret;
+    }
+
+    Expected<void> verify(const Function &fn,
+                          const BasicBlock &bb,
+                          const Instr &instr,
+                          const std::unordered_map<std::string, const BasicBlock *> &blockMap,
+                          const std::unordered_map<std::string, const Extern *> &externs,
+                          const std::unordered_map<std::string, const Function *> &funcs,
+                          TypeInference &types,
+                          DiagSink &sink) const override
+    {
+        (void)externs;
+        (void)funcs;
+        (void)sink;
+        switch (instr.op)
+        {
+            case Opcode::Br:
+                return verifyBr_E(fn, bb, instr, blockMap, types);
+            case Opcode::CBr:
+                return verifyCBr_E(fn, bb, instr, blockMap, types);
+            case Opcode::Ret:
+                return verifyRet_E(fn, bb, instr, types);
+            default:
+                break;
+        }
+        return {};
+    }
+};
+
+class DefaultInstructionStrategy final : public FunctionVerifier::InstructionStrategy
+{
+  public:
+    bool matches(const Instr &) const override
+    {
+        return true;
+    }
+
+    Expected<void> verify(const Function &fn,
+                          const BasicBlock &bb,
+                          const Instr &instr,
+                          const std::unordered_map<std::string, const BasicBlock *> &blockMap,
+                          const std::unordered_map<std::string, const Extern *> &externs,
+                          const std::unordered_map<std::string, const Function *> &funcs,
+                          TypeInference &types,
+                          DiagSink &sink) const override
+    {
+        (void)blockMap;
+        return verifyInstruction_E(fn, bb, instr, externs, funcs, types, sink);
+    }
+};
+
+} // namespace
+
+std::vector<std::unique_ptr<FunctionVerifier::InstructionStrategy>>
+makeDefaultInstructionStrategies()
+{
+    std::vector<std::unique_ptr<FunctionVerifier::InstructionStrategy>> strategies;
+    strategies.push_back(std::make_unique<ControlFlowStrategy>());
+    strategies.push_back(std::make_unique<DefaultInstructionStrategy>());
+    return strategies;
+}
+
+} // namespace il::verify

--- a/src/il/verify/InstructionStrategies.hpp
+++ b/src/il/verify/InstructionStrategies.hpp
@@ -1,0 +1,20 @@
+// File: src/il/verify/InstructionStrategies.hpp
+// Purpose: Declare factory helpers that register instruction verification strategies.
+// Key invariants: Strategies partition opcode handling between control-flow and generic instruction
+// checks. Ownership/Lifetime: Returns unique_ptr-owned strategies transferred to the caller
+// (FunctionVerifier). Links: docs/il-guide.md#reference
+#pragma once
+
+#include "il/verify/FunctionVerifier.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace il::verify
+{
+
+/// @brief Construct the default set of instruction strategies used by FunctionVerifier.
+std::vector<std::unique_ptr<FunctionVerifier::InstructionStrategy>>
+makeDefaultInstructionStrategies();
+
+} // namespace il::verify

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -120,6 +120,15 @@ function(viper_add_il_core_tests)
   viper_add_test_exe(test_il_control_flow_checker ${_VIPER_IL_UNIT_DIR}/test_il_control_flow_checker.cpp)
   target_link_libraries(test_il_control_flow_checker PRIVATE il_core il_verify ${VIPER_IL_SUPPORT_LIB})
   viper_add_ctest(test_il_control_flow_checker test_il_control_flow_checker)
+
+  viper_add_test_exe(test_il_exception_handler_analysis
+    ${_VIPER_IL_UNIT_DIR}/test_il_exception_handler_analysis.cpp)
+  target_link_libraries(test_il_exception_handler_analysis PRIVATE il_core il_verify ${VIPER_IL_SUPPORT_LIB})
+  viper_add_ctest(test_il_exception_handler_analysis test_il_exception_handler_analysis)
+
+  viper_add_test_exe(test_il_branch_verifier ${_VIPER_IL_UNIT_DIR}/test_il_branch_verifier.cpp)
+  target_link_libraries(test_il_branch_verifier PRIVATE il_core il_verify ${VIPER_IL_SUPPORT_LIB})
+  viper_add_ctest(test_il_branch_verifier test_il_branch_verifier)
 endfunction()
 
 function(viper_add_il_utils_test)

--- a/tests/unit/test_il_branch_verifier.cpp
+++ b/tests/unit/test_il_branch_verifier.cpp
@@ -1,0 +1,86 @@
+// File: tests/unit/test_il_branch_verifier.cpp
+// Purpose: Validate branch verifier helpers catch structural issues and accept correct inputs.
+// Key invariants: Branch argument types, condition operands, and return values are enforced.
+// Ownership/Lifetime: Constructs temporary IL functions for each scenario.
+// Links: docs/il-guide.md#reference
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Type.hpp"
+#include "il/verify/BranchVerifier.hpp"
+#include "il/verify/TypeInference.hpp"
+
+#include <cassert>
+#include <unordered_map>
+#include <unordered_set>
+
+int main()
+{
+    using namespace il::core;
+    using il::verify::TypeInference;
+    using il::verify::verifyBr_E;
+    using il::verify::verifyCBr_E;
+    using il::verify::verifyRet_E;
+
+    Function fn;
+    fn.name = "f";
+
+    BasicBlock source;
+    source.label = "entry";
+
+    BasicBlock target;
+    target.label = "dest";
+    Param destParam;
+    destParam.name = "x";
+    destParam.type = Type(Type::Kind::I64);
+    destParam.id = 10u;
+    target.params.push_back(destParam);
+
+    std::unordered_map<std::string, const BasicBlock *> blockMap;
+    blockMap[target.label] = &target;
+
+    std::unordered_map<unsigned, Type> temps;
+    temps[5] = Type(Type::Kind::I1);
+    std::unordered_set<unsigned> defined = {5};
+    TypeInference types(temps, defined);
+
+    Instr br;
+    br.op = Opcode::Br;
+    br.labels.push_back(target.label);
+    br.brArgs.push_back({Value::temp(5)});
+    auto brResult = verifyBr_E(fn, source, br, blockMap, types);
+    assert(!brResult);
+    assert(brResult.error().message.find("arg type mismatch") != std::string::npos);
+
+    Instr cbr;
+    cbr.op = Opcode::CBr;
+    cbr.operands.push_back(Value::temp(5));
+    cbr.labels = {target.label, target.label};
+    temps[5] = Type(Type::Kind::I64);
+    TypeInference cbrTypes(temps, defined);
+    auto cbrResult = verifyCBr_E(fn, source, cbr, blockMap, cbrTypes);
+    assert(!cbrResult);
+    assert(cbrResult.error().message.find("conditional branch mismatch") != std::string::npos);
+
+    Function retFn;
+    retFn.name = "r";
+    retFn.retType = Type(Type::Kind::I64);
+    BasicBlock retBlock;
+    retBlock.label = "entry";
+    std::unordered_map<unsigned, Type> retTemps;
+    retTemps[1] = Type(Type::Kind::I64);
+    std::unordered_set<unsigned> retDefined = {1};
+    TypeInference retTypes(retTemps, retDefined);
+    Instr retInstr;
+    retInstr.op = Opcode::Ret;
+    auto retMissing = verifyRet_E(retFn, retBlock, retInstr, retTypes);
+    assert(!retMissing);
+    assert(retMissing.error().message.find("ret value type mismatch") != std::string::npos);
+
+    retInstr.operands.push_back(Value::temp(1));
+    auto retOk = verifyRet_E(retFn, retBlock, retInstr, retTypes);
+    assert(retOk);
+
+    return 0;
+}

--- a/tests/unit/test_il_exception_handler_analysis.cpp
+++ b/tests/unit/test_il_exception_handler_analysis.cpp
@@ -1,0 +1,108 @@
+// File: tests/unit/test_il_exception_handler_analysis.cpp
+// Purpose: Exercise exception-handler analysis helpers for success and failure scenarios.
+// Key invariants: Handler signatures and EH stack balance diagnostics behave as expected.
+// Ownership/Lifetime: Uses temporary IL objects constructed in-place.
+// Links: docs/il-guide.md#reference
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Param.hpp"
+#include "il/core/Type.hpp"
+#include "il/verify/ExceptionHandlerAnalysis.hpp"
+
+#include <cassert>
+#include <string>
+#include <unordered_map>
+
+int main()
+{
+    using namespace il::core;
+    using il::verify::analyzeHandlerBlock;
+    using il::verify::checkEhStackBalance;
+    using il::verify::HandlerSignature;
+
+    Function fn;
+    fn.name = "f";
+
+    BasicBlock handler;
+    handler.label = "handler";
+    Param errParam;
+    errParam.name = "err";
+    errParam.type = Type(Type::Kind::Error);
+    errParam.id = 1u;
+    Param tokParam;
+    tokParam.name = "tok";
+    tokParam.type = Type(Type::Kind::ResumeTok);
+    tokParam.id = 2u;
+    handler.params = {errParam, tokParam};
+
+    Instr entry;
+    entry.op = Opcode::EhEntry;
+    handler.instructions.push_back(entry);
+
+    auto handlerSig = analyzeHandlerBlock(fn, handler);
+    assert(handlerSig);
+    auto handlerSigOpt = handlerSig.value();
+    assert(handlerSigOpt.has_value());
+    HandlerSignature sig = *handlerSigOpt;
+    assert(sig.errorParam == errParam.id);
+    assert(sig.resumeTokenParam == tokParam.id);
+
+    BasicBlock malformed;
+    malformed.label = "bad";
+    malformed.params = handler.params;
+    Instr wrongFront;
+    wrongFront.op = Opcode::Ret;
+    malformed.instructions.push_back(wrongFront);
+    malformed.instructions.push_back(entry);
+    auto malformedSig = analyzeHandlerBlock(fn, malformed);
+    assert(!malformedSig);
+    assert(malformedSig.error().message.find("eh.entry only allowed") != std::string::npos);
+
+    BasicBlock nonHandler;
+    nonHandler.label = "body";
+    Instr add;
+    add.op = Opcode::Add;
+    nonHandler.instructions.push_back(add);
+    auto nonHandlerSig = analyzeHandlerBlock(fn, nonHandler);
+    assert(nonHandlerSig);
+    auto nonHandlerOpt = nonHandlerSig.value();
+    assert(!nonHandlerOpt.has_value());
+
+    Function stackFn;
+    stackFn.name = "stack";
+    BasicBlock entryBlock;
+    entryBlock.label = "entry";
+    Instr pop;
+    pop.op = Opcode::EhPop;
+    entryBlock.instructions.push_back(pop);
+    Instr term;
+    term.op = Opcode::Ret;
+    entryBlock.instructions.push_back(term);
+    stackFn.blocks.push_back(entryBlock);
+    std::unordered_map<std::string, const BasicBlock *> blockMap;
+    blockMap[stackFn.blocks.front().label] = &stackFn.blocks.front();
+    auto stackDiag = checkEhStackBalance(stackFn, blockMap);
+    assert(!stackDiag);
+    assert(stackDiag.error().message.find("eh.pop without matching") != std::string::npos);
+
+    Function balancedFn;
+    balancedFn.name = "balanced";
+    BasicBlock balancedEntry;
+    balancedEntry.label = "entry";
+    Instr push;
+    push.op = Opcode::EhPush;
+    balancedEntry.instructions.push_back(push);
+    Instr popOk;
+    popOk.op = Opcode::EhPop;
+    balancedEntry.instructions.push_back(popOk);
+    balancedEntry.instructions.push_back(term);
+    balancedFn.blocks.push_back(balancedEntry);
+    std::unordered_map<std::string, const BasicBlock *> balancedMap;
+    balancedMap[balancedFn.blocks.front().label] = &balancedFn.blocks.front();
+    auto balancedResult = checkEhStackBalance(balancedFn, balancedMap);
+    assert(balancedResult);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extract exception-handler analysis helpers into `ExceptionHandlerAnalysis` and reuse in the function verifier
- split branch/return verification into `BranchVerifier` and move instruction strategy wiring into `InstructionStrategies`
- update control-flow checker, build files, and add focused unit tests for the new helpers

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dcc4b229d48324967b02bee1a586e2