### PR TITLE
refactor: introduce BASIC statement sequencer helper

### DIFF
--- a/src/frontends/basic/CMakeLists.txt
+++ b/src/frontends/basic/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(fe_basic STATIC
   Parser_Stmt.cpp
   Parser_Expr.cpp
   Parser_Token.cpp
+  StatementSequencer.cpp
   NameMangler.cpp
   TypeSuffix.cpp
   TypeRules.cpp

--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -52,198 +52,9 @@ Parser::Parser(std::string_view src, uint32_t file_id, DiagnosticEmitter *emitte
     }
 }
 
-Parser::StatementContext::StatementContext(Parser &parser) : parser_(parser) {}
-
-void Parser::StatementContext::skipLeadingSeparator()
+StatementSequencer Parser::statementSequencer()
 {
-    if (parser_.at(TokenKind::EndOfLine))
-    {
-        parser_.consume();
-        lastSeparator_ = SeparatorKind::LineBreak;
-    }
-    else if (parser_.at(TokenKind::Colon))
-    {
-        parser_.consume();
-        lastSeparator_ = SeparatorKind::Colon;
-    }
-    else
-    {
-        lastSeparator_ = SeparatorKind::None;
-    }
-}
-
-bool Parser::StatementContext::skipLineBreaks()
-{
-    bool consumed = false;
-    while (parser_.at(TokenKind::EndOfLine))
-    {
-        parser_.consume();
-        consumed = true;
-    }
-    if (consumed)
-        lastSeparator_ = SeparatorKind::LineBreak;
-    return consumed;
-}
-
-void Parser::StatementContext::skipStatementSeparator()
-{
-    if (parser_.at(TokenKind::Colon))
-    {
-        parser_.consume();
-        lastSeparator_ = SeparatorKind::Colon;
-    }
-    else if (parser_.at(TokenKind::EndOfLine))
-    {
-        parser_.consume();
-        lastSeparator_ = SeparatorKind::LineBreak;
-    }
-    else
-    {
-        lastSeparator_ = SeparatorKind::None;
-    }
-}
-
-void Parser::StatementContext::withOptionalLineNumber(const std::function<void(int)> &fn)
-{
-    int line = 0;
-    if (pendingLine_ >= 0)
-    {
-        line = pendingLine_;
-        pendingLine_ = -1;
-    }
-    else if (parser_.at(TokenKind::Number))
-    {
-        line = std::atoi(parser_.peek().lexeme.c_str());
-        parser_.consume();
-    }
-    fn(line);
-}
-
-void Parser::StatementContext::stashPendingLine(int line)
-{
-    pendingLine_ = line;
-}
-
-Parser::StatementContext::SeparatorKind Parser::StatementContext::lastSeparator() const
-{
-    return lastSeparator_;
-}
-
-Parser::StatementContext::TerminatorInfo Parser::StatementContext::consumeStatementBody(
-    const TerminatorPredicate &isTerminator,
-    const TerminatorConsumer &onTerminator,
-    std::vector<StmtPtr> &dst)
-{
-    TerminatorInfo info;
-    skipLeadingSeparator();
-    while (!parser_.at(TokenKind::EndOfFile))
-    {
-        skipLineBreaks();
-        if (parser_.at(TokenKind::EndOfFile))
-            break;
-
-        bool done = false;
-        withOptionalLineNumber(
-            [&](int line)
-            {
-                if (isTerminator(line))
-                {
-                    info.line = line;
-                    info.loc = parser_.peek().loc;
-                    onTerminator(line, info);
-                    done = true;
-                    return;
-                }
-                auto stmt = parser_.parseStatement(line);
-                stmt->line = line;
-                dst.push_back(std::move(stmt));
-            });
-        if (done)
-            break;
-        skipStatementSeparator();
-    }
-    return info;
-}
-
-Parser::StatementContext::TerminatorInfo Parser::StatementContext::consumeStatementBody(
-    TokenKind terminator, std::vector<StmtPtr> &dst)
-{
-    auto predicate = [&](int) { return parser_.at(terminator); };
-    auto consumer = [&](int, TerminatorInfo &) { parser_.consume(); };
-    return consumeStatementBody(predicate, consumer, dst);
-}
-
-Parser::StatementContext Parser::statementContext()
-{
-    return StatementContext(*this);
-}
-
-StmtPtr Parser::parseStatementLine(StatementContext &ctx)
-{
-    std::vector<StmtPtr> stmts;
-    int lineNumber = 0;
-    bool haveLine = false;
-    auto predicate = [&](int line)
-    {
-        if (!haveLine)
-        {
-            haveLine = true;
-            lineNumber = line;
-            return false;
-        }
-
-        if (ctx.lastSeparator() == StatementContext::SeparatorKind::LineBreak)
-        {
-            if (line > 0)
-                ctx.stashPendingLine(line);
-            return true;
-        }
-
-        if (ctx.lastSeparator() != StatementContext::SeparatorKind::Colon)
-        {
-            if (line > 0)
-                ctx.stashPendingLine(line);
-            return true;
-        }
-
-        if (line > 0 && line != lineNumber)
-        {
-            ctx.stashPendingLine(line);
-            return true;
-        }
-        return false;
-    };
-    auto consumer = [&](int line, StatementContext::TerminatorInfo &)
-    {
-        if (line > 0)
-            ctx.stashPendingLine(line);
-    };
-
-    ctx.consumeStatementBody(predicate, consumer, stmts);
-
-    if (stmts.empty())
-        return nullptr;
-
-    if (!haveLine && !stmts.empty())
-        lineNumber = stmts.front()->line;
-
-    if (lineNumber != 0)
-    {
-        for (auto &stmt : stmts)
-        {
-            if (stmt)
-                stmt->line = lineNumber;
-        }
-    }
-
-    if (stmts.size() == 1)
-        return std::move(stmts.front());
-
-    auto list = std::make_unique<StmtList>();
-    list->line = lineNumber;
-    list->loc = stmts.front()->loc;
-    list->stmts = std::move(stmts);
-    return list;
+    return StatementSequencer(*this);
 }
 
 /// @brief Parse the entire BASIC program.
@@ -254,13 +65,13 @@ std::unique_ptr<Program> Parser::parseProgram()
     auto prog = std::make_unique<Program>();
     prog->loc = peek().loc;
     bool inMain = false;
-    auto ctx = statementContext();
+    auto seq = statementSequencer();
     while (!at(TokenKind::EndOfFile))
     {
-        ctx.skipLineBreaks();
+        seq.skipLineBreaks();
         if (at(TokenKind::EndOfFile))
             break;
-        auto root = parseStatementLine(ctx);
+        auto root = seq.parseStatementLine();
         if (!root)
             continue;
         if (!inMain &&

--- a/src/frontends/basic/StatementSequencer.cpp
+++ b/src/frontends/basic/StatementSequencer.cpp
@@ -1,0 +1,207 @@
+// File: src/frontends/basic/StatementSequencer.cpp
+// Purpose: Implements BASIC statement sequencing helper shared by parser routines.
+// Key invariants: Delegates token access to Parser while owning separator state.
+// Ownership/Lifetime: Operates on borrowed Parser; no additional resources allocated.
+// License: MIT (see LICENSE).
+// Links: docs/codemap.md
+
+#include "frontends/basic/StatementSequencer.hpp"
+
+#include "frontends/basic/Parser.hpp"
+#include <cstdlib>
+
+namespace il::frontends::basic
+{
+StatementSequencer::StatementSequencer(Parser &parser) : parser_(parser) {}
+
+void StatementSequencer::skipLeadingSeparator()
+{
+    if (parser_.at(TokenKind::EndOfLine))
+    {
+        parser_.consume();
+        lastSeparator_ = SeparatorKind::LineBreak;
+    }
+    else if (parser_.at(TokenKind::Colon))
+    {
+        parser_.consume();
+        lastSeparator_ = SeparatorKind::Colon;
+    }
+    else
+    {
+        lastSeparator_ = SeparatorKind::None;
+    }
+}
+
+bool StatementSequencer::skipLineBreaks()
+{
+    bool consumed = false;
+    while (parser_.at(TokenKind::EndOfLine))
+    {
+        parser_.consume();
+        consumed = true;
+    }
+    if (consumed)
+        lastSeparator_ = SeparatorKind::LineBreak;
+    return consumed;
+}
+
+void StatementSequencer::skipStatementSeparator()
+{
+    if (parser_.at(TokenKind::Colon))
+    {
+        parser_.consume();
+        lastSeparator_ = SeparatorKind::Colon;
+    }
+    else if (parser_.at(TokenKind::EndOfLine))
+    {
+        parser_.consume();
+        lastSeparator_ = SeparatorKind::LineBreak;
+    }
+    else
+    {
+        lastSeparator_ = SeparatorKind::None;
+    }
+}
+
+void StatementSequencer::withOptionalLineNumber(const std::function<void(int)> &fn)
+{
+    int line = 0;
+    if (pendingLine_ >= 0)
+    {
+        line = pendingLine_;
+        pendingLine_ = -1;
+    }
+    else if (parser_.at(TokenKind::Number))
+    {
+        line = std::atoi(parser_.peek().lexeme.c_str());
+        parser_.consume();
+    }
+    fn(line);
+}
+
+void StatementSequencer::stashPendingLine(int line)
+{
+    pendingLine_ = line;
+}
+
+StatementSequencer::SeparatorKind StatementSequencer::lastSeparator() const
+{
+    return lastSeparator_;
+}
+
+StatementSequencer::TerminatorInfo StatementSequencer::collectStatements(
+    const TerminatorPredicate &isTerminator,
+    const TerminatorConsumer &onTerminator,
+    std::vector<StmtPtr> &dst)
+{
+    TerminatorInfo info;
+    skipLeadingSeparator();
+    while (!parser_.at(TokenKind::EndOfFile))
+    {
+        skipLineBreaks();
+        if (parser_.at(TokenKind::EndOfFile))
+            break;
+
+        bool done = false;
+        withOptionalLineNumber(
+            [&](int line)
+            {
+                if (isTerminator(line))
+                {
+                    info.line = line;
+                    info.loc = parser_.peek().loc;
+                    onTerminator(line, info);
+                    done = true;
+                    return;
+                }
+                auto stmt = parser_.parseStatement(line);
+                if (stmt)
+                {
+                    stmt->line = line;
+                    dst.push_back(std::move(stmt));
+                }
+            });
+        if (done)
+            break;
+        skipStatementSeparator();
+    }
+    return info;
+}
+
+StatementSequencer::TerminatorInfo StatementSequencer::collectStatements(
+    TokenKind terminator, std::vector<StmtPtr> &dst)
+{
+    auto predicate = [&](int) { return parser_.at(terminator); };
+    auto consumer = [&](int, TerminatorInfo &) { parser_.consume(); };
+    return collectStatements(predicate, consumer, dst);
+}
+
+StmtPtr StatementSequencer::parseStatementLine()
+{
+    std::vector<StmtPtr> stmts;
+    int lineNumber = 0;
+    bool haveLine = false;
+    auto predicate = [&](int line)
+    {
+        if (!haveLine)
+        {
+            haveLine = true;
+            lineNumber = line;
+            return false;
+        }
+
+        if (lastSeparator() == SeparatorKind::LineBreak)
+        {
+            if (line > 0)
+                stashPendingLine(line);
+            return true;
+        }
+
+        if (lastSeparator() != SeparatorKind::Colon)
+        {
+            if (line > 0)
+                stashPendingLine(line);
+            return true;
+        }
+
+        if (line > 0 && line != lineNumber)
+        {
+            stashPendingLine(line);
+            return true;
+        }
+        return false;
+    };
+    auto consumer = [&](int line, TerminatorInfo &)
+    {
+        if (line > 0)
+            stashPendingLine(line);
+    };
+
+    collectStatements(predicate, consumer, stmts);
+
+    if (stmts.empty())
+        return nullptr;
+
+    if (!haveLine && !stmts.empty())
+        lineNumber = stmts.front()->line;
+
+    if (lineNumber != 0)
+    {
+        for (auto &stmt : stmts)
+        {
+            if (stmt)
+                stmt->line = lineNumber;
+        }
+    }
+
+    if (stmts.size() == 1)
+        return std::move(stmts.front());
+
+    auto list = std::make_unique<StmtList>();
+    list->line = lineNumber;
+    list->loc = stmts.front()->loc;
+    list->stmts = std::move(stmts);
+    return list;
+}
+
+} // namespace il::frontends::basic

--- a/src/frontends/basic/StatementSequencer.hpp
+++ b/src/frontends/basic/StatementSequencer.hpp
@@ -1,0 +1,82 @@
+// File: src/frontends/basic/StatementSequencer.hpp
+// Purpose: Declares helper coordinating BASIC statement sequencing semantics.
+// Key invariants: Maintains separator classification and pending line labels.
+// Ownership/Lifetime: Helper borrows Parser token stream; no ownership transfer.
+// Links: docs/codemap.md
+#pragma once
+
+#include "frontends/basic/AST.hpp"
+#include "frontends/basic/Token.hpp"
+#include "support/source_location.hpp"
+#include <functional>
+#include <vector>
+
+namespace il::frontends::basic
+{
+class Parser;
+
+/// @brief Helper that manages separators, labels, and statement iteration.
+class StatementSequencer
+{
+  public:
+    /// @brief Aggregated information about a terminating keyword.
+    struct TerminatorInfo
+    {
+        int line = 0;                 ///< Optional line number preceding terminator.
+        il::support::SourceLoc loc{}; ///< Location where terminator keyword appeared.
+    };
+
+    /// @brief Classification of the most recently consumed separator.
+    enum class SeparatorKind
+    {
+        None,      ///< No separator observed since last statement.
+        Colon,     ///< Colon separated adjacent statements.
+        LineBreak, ///< Line break separated adjacent statements.
+    };
+
+    using TerminatorPredicate = std::function<bool(int)>; ///< Identifies terminator tokens.
+    using TerminatorConsumer =
+        std::function<void(int, TerminatorInfo &)>; ///< Consumes terminator tokens.
+
+    /// @brief Construct a sequencer bound to a parser instance.
+    explicit StatementSequencer(Parser &parser);
+
+    /// @brief Consume a single leading colon or newline if present.
+    void skipLeadingSeparator();
+
+    /// @brief Consume consecutive newline tokens.
+    /// @return True when at least one newline token was consumed.
+    bool skipLineBreaks();
+
+    /// @brief Consume either a colon or newline separator when present.
+    void skipStatementSeparator();
+
+    /// @brief Invoke @p fn with an optional numeric line label.
+    void withOptionalLineNumber(const std::function<void(int)> &fn);
+
+    /// @brief Remember a pending line label for the next statement.
+    void stashPendingLine(int line);
+
+    /// @brief Inspect the last consumed separator classification.
+    SeparatorKind lastSeparator() const;
+
+    /// @brief Populate @p dst with statements until @p isTerminator fires.
+    TerminatorInfo collectStatements(const TerminatorPredicate &isTerminator,
+                                     const TerminatorConsumer &onTerminator,
+                                     std::vector<StmtPtr> &dst);
+
+    /// @brief Populate @p dst until the specified terminator token is encountered.
+    TerminatorInfo collectStatements(TokenKind terminator, std::vector<StmtPtr> &dst);
+
+    /// @brief Parse and coalesce statements that share a logical source line.
+    /// @return Either a single statement or a StmtList representing the line.
+    StmtPtr parseStatementLine();
+
+  private:
+    Parser &parser_;             ///< Underlying parser providing token access.
+    int pendingLine_ = -1;       ///< Deferred numeric line label for next statement.
+    SeparatorKind lastSeparator_ =
+        SeparatorKind::LineBreak; ///< Default to line break at start of file.
+};
+
+} // namespace il::frontends::basic


### PR DESCRIPTION
## Summary
- add a StatementSequencer helper that centralizes separator and line-label handling for BASIC statements
- refactor parser statement routines to consume the helper instead of manipulating StatementContext directly
- extend parser statement tests to cover multiline, colon-separated, and labeled lines to confirm semantics

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dcc88431048324b43820e0c9f0ae8c