### PR TITLE
Refactor ProcedureContext into dedicated state components

### DIFF
--- a/src/frontends/basic/LowerExpr.cpp
+++ b/src/frontends/basic/LowerExpr.cpp
@@ -1071,7 +1071,7 @@ Lowerer::RVal Lowerer::lowerBuiltinCall(const BuiltinCallExpr &c)
                 BasicBlock *origin = ctx.current();
                 assert(origin && "conversion lowering requires active block");
                 std::string originLabel = origin->label;
-                BlockNamer *blockNamer = ctx.blockNamer();
+                BlockNamer *blockNamer = ctx.blockNames().namer();
                 std::string contLabel = blockNamer ? blockNamer->generic("conv_ok")
                                                    : mangler.block("conv_ok");
                 std::string trapLabel = blockNamer ? blockNamer->generic("conv_trap")
@@ -1131,7 +1131,7 @@ Lowerer::RVal Lowerer::lowerBuiltinCall(const BuiltinCallExpr &c)
                     BasicBlock *origin = ctx.current();
                     assert(origin && "VAL lowering requires active block");
                     std::string originLabel = origin->label;
-                    BlockNamer *blockNamer = ctx.blockNamer();
+                    BlockNamer *blockNamer = ctx.blockNames().namer();
                     auto labelFor = [&](const char *hint) {
                         if (blockNamer)
                             return blockNamer->generic(hint);

--- a/src/frontends/basic/LoweringPipeline.cpp
+++ b/src/frontends/basic/LoweringPipeline.cpp
@@ -417,7 +417,7 @@ void ProcedureLowering::emit(const std::string &name,
     {
         lowerer.curLoc = {};
         config.emitEmptyBody();
-        ctx.resetBlockNamer();
+        ctx.blockNames().resetNamer();
         return;
     }
 
@@ -430,7 +430,7 @@ void ProcedureLowering::emit(const std::string &name,
     lowerer.curLoc = {};
     config.emitFinalReturn();
 
-    ctx.resetBlockNamer();
+    ctx.blockNames().resetNamer();
 }
 
 StatementLowering::StatementLowering(Lowerer &lowerer) : lowerer(lowerer) {}
@@ -447,7 +447,7 @@ void StatementLowering::lowerSequence(
     auto &ctx = lowerer.context();
     auto *func = ctx.function();
     assert(func && "lowerSequence requires an active function");
-    auto &lineBlocks = ctx.lineBlocks();
+    auto &lineBlocks = ctx.blockNames().lineBlocks();
     lowerer.emitBr(&func->blocks[lineBlocks[stmts.front()->line]]);
 
     for (size_t i = 0; i < stmts.size(); ++i)


### PR DESCRIPTION
## Summary
- split the BASIC ProcedureContext into BlockNameState, LoopState, and ErrorHandlerState helpers
- update lowering helpers and error-handling logic to use the new context components
- adjust the lowering pipeline to rely on the refactored context accessors

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68dcd0ad5fd883249c8df8d399c25acb