### PR TITLE
Refactor VM run loop helper structure

### DIFF
--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -112,6 +112,7 @@ class VM
     friend class RuntimeBridge; ///< Runtime bridge accesses trap formatting helpers
     friend void vm_raise(TrapKind kind, int32_t code);
     friend void vm_raise_from_error(const VmError &error);
+    friend struct VMTestHook; ///< Unit tests access interpreter internals
 
     /// @brief Result of executing one opcode.
     struct ExecResult
@@ -328,6 +329,15 @@ class VM
     std::optional<Slot> processDebugControl(ExecState &st,
                                             const il::core::Instr *in,
                                             bool postExec);
+
+    /// @brief Forward to debug control logic for pause decisions.
+    std::optional<Slot> shouldPause(ExecState &st, const il::core::Instr *in, bool postExec);
+
+    /// @brief Execute a single interpreter step.
+    std::optional<Slot> stepOnce(ExecState &st);
+
+    /// @brief Handle a trap dispatch signal raised during interpretation.
+    bool handleTrapDispatch(const TrapDispatchSignal &signal, ExecState &st);
 
     /// @brief Run the main interpreter loop.
     /// @param st Prepared execution state.

--- a/tests/unit/test_vm_run_loop_helpers.cpp
+++ b/tests/unit/test_vm_run_loop_helpers.cpp
@@ -1,0 +1,124 @@
+// File: tests/unit/test_vm_run_loop_helpers.cpp
+// Purpose: Validate VM run loop helper behaviour for debug pauses and trap dispatch.
+// Key invariants: stepOnce honours breakpoints and trap dispatch clears context.
+// Ownership: Test constructs IL module and runs helper wrappers.
+// Links: docs/codemap.md
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Module.hpp"
+#include "il/core/Opcode.hpp"
+#include "il/core/Type.hpp"
+#include "il/core/Value.hpp"
+#include "vm/VM.hpp"
+
+#include <cassert>
+#include <optional>
+
+namespace il::vm
+{
+/// @brief Grant unit tests access to VM private helpers.
+struct VMTestHook
+{
+    using State = VM::ExecState;
+    using TrapSignal = VM::TrapDispatchSignal;
+
+    static State prepare(VM &vm, const il::core::Function &fn)
+    {
+        return vm.prepareExecution(fn, {});
+    }
+
+    static State clone(const State &st)
+    {
+        return st;
+    }
+
+    static std::optional<Slot> step(VM &vm, State &st)
+    {
+        return vm.stepOnce(st);
+    }
+
+    static TrapSignal makeTrap(State &st)
+    {
+        return TrapSignal(&st);
+    }
+
+    static bool handleTrap(VM &vm, const TrapSignal &signal, State &st)
+    {
+        return vm.handleTrapDispatch(signal, st);
+    }
+
+    static void setContext(VM &vm,
+                           Frame &fr,
+                           const il::core::BasicBlock *bb,
+                           size_t ip,
+                           const il::core::Instr &in)
+    {
+        vm.setCurrentContext(fr, bb, ip, in);
+    }
+
+    static bool hasInstruction(const VM &vm)
+    {
+        return vm.currentContext.hasInstruction;
+    }
+};
+} // namespace il::vm
+
+int main()
+{
+    using namespace il::core;
+
+    Module m;
+    Function fn;
+    fn.name = "main";
+    fn.retType = Type(Type::Kind::I64);
+
+    BasicBlock bb;
+    bb.label = "entry";
+
+    Instr ret;
+    ret.op = Opcode::Ret;
+    ret.type = Type(Type::Kind::Void);
+    ret.operands.push_back(Value::constInt(7));
+    bb.instructions.push_back(ret);
+    bb.terminated = true;
+
+    fn.blocks.push_back(bb);
+    m.functions.push_back(fn);
+
+    auto &mainFn = m.functions.front();
+
+    il::vm::DebugCtrl dbg;
+    auto sym = dbg.internLabel("entry");
+    dbg.addBreak(sym);
+
+    il::vm::VM vm(m, {}, 0, dbg);
+
+    il::vm::VMTestHook::State state = il::vm::VMTestHook::prepare(vm, mainFn);
+
+    auto pause = il::vm::VMTestHook::step(vm, state);
+    assert(pause.has_value());
+    assert(pause->i64 == 10);
+
+    state.skipBreakOnce = true;
+    auto result = il::vm::VMTestHook::step(vm, state);
+    assert(result.has_value());
+    assert(result->i64 == 7);
+
+    const auto &instr = mainFn.blocks.front().instructions.front();
+    il::vm::VMTestHook::setContext(vm, state.fr, state.bb, state.ip, instr);
+    auto targeted = il::vm::VMTestHook::makeTrap(state);
+    bool handled = il::vm::VMTestHook::handleTrap(vm, targeted, state);
+    assert(handled);
+    assert(!il::vm::VMTestHook::hasInstruction(vm));
+
+    il::vm::VMTestHook::setContext(vm, state.fr, state.bb, state.ip, instr);
+    auto other = il::vm::VMTestHook::clone(state);
+    auto otherSignal = il::vm::VMTestHook::makeTrap(other);
+    handled = il::vm::VMTestHook::handleTrap(vm, otherSignal, state);
+    assert(!handled);
+    assert(il::vm::VMTestHook::hasInstruction(vm));
+
+    return 0;
+}

--- a/tests/vm/CMakeLists.txt
+++ b/tests/vm/CMakeLists.txt
@@ -160,6 +160,10 @@ function(viper_add_vm_unit_tests)
   viper_add_test_exe(test_vm_opcode_dispatch ${VIPER_TESTS_DIR}/unit/test_vm_opcode_dispatch.cpp)
   target_link_libraries(test_vm_opcode_dispatch PRIVATE il_io ${VIPER_VM_LIB} il_api)
   viper_add_ctest(test_vm_opcode_dispatch test_vm_opcode_dispatch)
+
+  viper_add_test_exe(test_vm_run_loop_helpers ${VIPER_TESTS_DIR}/unit/test_vm_run_loop_helpers.cpp)
+  target_link_libraries(test_vm_run_loop_helpers PRIVATE ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
+  viper_add_ctest(test_vm_run_loop_helpers test_vm_run_loop_helpers)
 endfunction()
 
 function(viper_add_vm_path_tests)


### PR DESCRIPTION
## Summary
- extract shouldPause, stepOnce, and handleTrapDispatch helpers from `VM::runFunctionLoop`
- simplify the interpreter loop to rely on the new helpers for clearer control flow
- add a targeted unit test and register it with the VM test suite to cover debug resume and trap dispatch

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68dcd0bae3588324ad88df212a881dd1