### PR TITLE
feat: add shared path normalization utility

### DIFF
--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(support STATIC
   arena.cpp
   diag_expected.cpp
   diag_capture.cpp
+  path_utils.cpp
 )
 
 target_include_directories(support PUBLIC

--- a/src/support/path_utils.cpp
+++ b/src/support/path_utils.cpp
@@ -1,0 +1,85 @@
+// File: src/support/path_utils.cpp
+// Purpose: Implement helpers for normalizing and caching source file paths.
+// Key invariants: Normalization always yields forward slashes and resolves dot
+// segments; cache entries remain valid for the lifetime of the cache object.
+// Ownership/Lifetime: PathCache stores cached strings for reuse across calls.
+// Links: docs/codemap.md
+
+#include "support/path_utils.hpp"
+
+#include "support/source_manager.hpp"
+
+#include <algorithm>
+#include <filesystem>
+
+namespace il::support
+{
+namespace
+{
+[[nodiscard]] std::string normalizeImpl(std::string_view path)
+{
+    std::string key(path);
+    std::string sanitized = key;
+    std::replace(sanitized.begin(), sanitized.end(), '\\', '/');
+
+    if (sanitized.empty())
+        return std::string{"."};
+
+    std::filesystem::path fsPath(sanitized);
+    std::string generic = fsPath.lexically_normal().generic_string();
+
+    if (generic.empty())
+        generic = sanitized.front() == '/' ? std::string{"/"} : std::string{"."};
+
+    return generic;
+}
+} // namespace
+
+std::string PathCache::normalize(std::string_view path) const
+{
+    std::string key(path);
+    auto it = stringCache_.find(key);
+    if (it != stringCache_.end())
+        return it->second;
+
+    std::string normalized = normalizeImpl(path);
+    auto [pos, inserted] = stringCache_.emplace(std::move(key), std::move(normalized));
+    (void)inserted;
+    return pos->second;
+}
+
+const std::string &
+PathCache::getOrNormalize(const SourceManager &sm, uint32_t fileId, std::string_view fallback) const
+{
+    static const std::string kEmpty;
+    if (fileId == 0)
+        return kEmpty;
+
+    auto [it, inserted] = fileIdCache_.try_emplace(fileId);
+    if (!inserted)
+        return it->second;
+
+    std::string raw;
+    if (!fallback.empty())
+        raw.assign(fallback);
+    else
+        raw.assign(sm.getPath(fileId));
+
+    it->second = normalize(raw);
+    return it->second;
+}
+
+std::string basename(std::string_view path)
+{
+    if (path.empty())
+        return {};
+    size_t pos = path.find_last_of('/');
+    if (pos == std::string_view::npos)
+        return std::string(path);
+    if (pos + 1 >= path.size())
+        return {};
+    return std::string(path.substr(pos + 1));
+}
+
+} // namespace il::support
+

--- a/src/support/path_utils.hpp
+++ b/src/support/path_utils.hpp
@@ -1,0 +1,50 @@
+// File: src/support/path_utils.hpp
+// Purpose: Declare helpers for normalizing and caching source file paths.
+// Key invariants: Normalized paths always use forward slashes and have dot
+// segments resolved; cache entries stay consistent for the lifetime of the
+// cache instance.
+// Ownership/Lifetime: PathCache owns cached strings and must outlive
+// references returned by getOrNormalize().
+// Links: docs/codemap.md
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace il::support
+{
+class SourceManager;
+
+/// @brief Cache that normalizes file system paths and remembers results.
+/// @invariant Returned normalized paths always use forward slashes.
+/// @ownership Owns cached strings for both raw paths and file identifiers.
+class PathCache
+{
+  public:
+    /// @brief Normalize @p path and cache the result for reuse.
+    /// @param path Arbitrary file system path, possibly using backslashes.
+    /// @return Normalized path with dot segments collapsed and forward slashes.
+    [[nodiscard]] std::string normalize(std::string_view path) const;
+
+    /// @brief Retrieve normalized path for @p fileId from @p sm, caching it on demand.
+    /// @param sm Source manager providing canonical file paths.
+    /// @param fileId Identifier assigned by the source manager.
+    /// @param fallback Optional raw path to avoid redundant lookups.
+    /// @return Reference to the cached normalized path or an empty string when unavailable.
+    [[nodiscard]] const std::string &
+    getOrNormalize(const SourceManager &sm, uint32_t fileId, std::string_view fallback = {}) const;
+
+  private:
+    mutable std::unordered_map<std::string, std::string> stringCache_; ///< Raw -> normalized cache.
+    mutable std::unordered_map<uint32_t, std::string> fileIdCache_;    ///< File id -> normalized cache.
+};
+
+/// @brief Compute basename component of @p path after normalization.
+/// @param path Path expressed with forward slashes.
+/// @return Last path component or empty string when none exists.
+[[nodiscard]] std::string basename(std::string_view path);
+
+} // namespace il::support
+

--- a/src/vm/Debug.hpp
+++ b/src/vm/Debug.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "il/core/Type.hpp"
+#include "support/path_utils.hpp"
 #include "support/string_interner.hpp"
 #include "support/symbol.hpp"
 #include <optional>
@@ -68,11 +69,6 @@ class DebugCtrl
     /// @brief Retrieve associated source manager.
     const il::support::SourceManager *getSourceManager() const;
 
-    /// @brief Normalize @p p by canonicalizing separators and dot segments.
-    /// Uses std::filesystem::path::lexically_normal() after converting
-    /// backslashes to forward slashes to ensure stable breakpoint comparisons.
-    static std::string normalizePath(std::string p);
-
     /// @brief Register a watch on variable @p name.
     void addWatch(std::string_view name);
 
@@ -115,6 +111,7 @@ class DebugCtrl
     };
 
     std::unordered_map<il::support::Symbol, WatchEntry> watches_; ///< Watched variables
+    il::support::PathCache pathCache_; ///< Cached normalized paths for breakpoint checks
 };
 
 } // namespace il::vm

--- a/src/vm/Trace.hpp
+++ b/src/vm/Trace.hpp
@@ -12,6 +12,8 @@
 #include <utility>
 #include <vector>
 
+#include "support/path_utils.hpp"
+
 namespace il::core
 {
 struct Instr;
@@ -71,20 +73,20 @@ class TraceSink
     /// @brief Cache entry describing a traced source file.
     struct FileCacheEntry
     {
-        std::string path;               ///< Canonical file path.
+        std::string normalizedPath;     ///< Normalized file path for display.
         std::vector<std::string> lines; ///< File contents split into lines.
     };
 
     /// @brief Retrieve cached file for @p file_id, loading it on first access.
     /// @param file_id Source file identifier.
-    /// @param path_hint Optional canonical path to avoid redundant lookups.
     /// @return Pointer to cache entry or nullptr if unavailable.
-    const FileCacheEntry *getOrLoadFile(uint32_t file_id, std::string path_hint = {});
+    const FileCacheEntry *getOrLoadFile(uint32_t file_id);
 
     TraceConfig cfg; ///< Active configuration
     std::unordered_map<const il::core::Function *, std::unordered_map<const il::core::Instr *, InstrLocation>>
         instrLocations; ///< Per-function instruction location cache.
     std::unordered_map<uint32_t, FileCacheEntry> fileCache; ///< Cached source text.
+    il::support::PathCache pathCache; ///< Normalized path cache shared across trace lookups.
 };
 
 } // namespace il::vm

--- a/tests/unit/PathNormalizeTests.cpp
+++ b/tests/unit/PathNormalizeTests.cpp
@@ -4,16 +4,15 @@
 // basename extracted from normalized path.
 // Ownership: Standalone executable.
 // Links: docs/codemap.md
-#include "vm/Debug.hpp"
+#include "support/path_utils.hpp"
 #include <cassert>
 
 int main()
 {
-    using il::vm::DebugCtrl;
-    std::string norm = DebugCtrl::normalizePath("a/b/../c\\file.bas");
+    il::support::PathCache cache;
+    std::string norm = cache.normalize("a/b/../c\\file.bas");
     assert(norm == "a/c/file.bas");
-    size_t pos = norm.find_last_of('/');
-    std::string base = (pos == std::string::npos) ? norm : norm.substr(pos + 1);
+    std::string base = il::support::basename(norm);
     assert(base == "file.bas");
     return 0;
 }

--- a/tests/unit/test_vm_debug_trace_paths.cpp
+++ b/tests/unit/test_vm_debug_trace_paths.cpp
@@ -1,0 +1,64 @@
+// File: tests/unit/test_vm_debug_trace_paths.cpp
+// Purpose: Ensure debugger breakpoints and trace sink agree on normalized paths.
+// Key invariants: Normalized filenames use forward slashes and match between components.
+// Ownership: Standalone executable.
+// Links: docs/codemap.md
+
+#include "support/source_manager.hpp"
+#include "vm/Debug.hpp"
+#include "vm/Trace.hpp"
+#include "vm/VM.hpp"
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Opcode.hpp"
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+int main()
+{
+    il::support::SourceManager sm;
+    uint32_t fileId = sm.addFile(R"(C:\project\src\trace_src.bas)");
+
+    il::vm::DebugCtrl debug;
+    debug.setSourceManager(&sm);
+    debug.addBreakSrcLine(R"(C:\project\src\trace_src.bas)", 5);
+
+    il::core::Instr inst{};
+    inst.op = il::core::Opcode::Add;
+    inst.loc.file_id = fileId;
+    inst.loc.line = 5;
+    inst.loc.column = 3;
+
+    il::core::BasicBlock block;
+    block.label = "entry";
+    block.instructions.push_back(inst);
+
+    il::core::Function fn;
+    fn.name = "main";
+    fn.blocks.push_back(block);
+
+    il::vm::Frame frame{};
+    frame.func = &fn;
+
+    assert(debug.shouldBreakOn(fn.blocks[0].instructions[0]));
+
+    il::vm::TraceConfig cfg;
+    cfg.mode = il::vm::TraceConfig::SRC;
+    cfg.sm = &sm;
+    il::vm::TraceSink sink(cfg);
+    sink.onFramePrepared(frame);
+
+    std::ostringstream capture;
+    auto *oldBuf = std::cerr.rdbuf(capture.rdbuf());
+    sink.onStep(fn.blocks[0].instructions[0], frame);
+    std::cerr.rdbuf(oldBuf);
+
+    std::string output = capture.str();
+    assert(output.find("trace_src.bas:5:3") != std::string::npos);
+    assert(output.find('\\') == std::string::npos);
+    return 0;
+}
+

--- a/tests/unit/test_vm_normalize_path.cpp
+++ b/tests/unit/test_vm_normalize_path.cpp
@@ -3,19 +3,19 @@
 // Key invariants: Backslashes become slashes; './' removed; 'dir/../' collapsed.
 // Ownership: Standalone executable.
 // Links: docs/codemap.md
-#include "vm/Debug.hpp"
+#include "support/path_utils.hpp"
 #include <cassert>
 #include <string>
 
 int main()
 {
-    using il::vm::DebugCtrl;
-    assert(DebugCtrl::normalizePath(R"(a\b\c)") == "a/b/c");
-    assert(DebugCtrl::normalizePath(R"(C:\project\src\..\main.bas)") == "C:/project/main.bas");
-    assert(DebugCtrl::normalizePath("./a/./b") == "a/b");
-    assert(DebugCtrl::normalizePath("../foo/../bar") == "../bar");
-    assert(DebugCtrl::normalizePath("dir/../file") == "file");
-    assert(DebugCtrl::normalizePath("/foo/../") == "/");
-    assert(DebugCtrl::normalizePath("") == ".");
+    il::support::PathCache cache;
+    assert(cache.normalize(R"(a\b\c)") == "a/b/c");
+    assert(cache.normalize(R"(C:\project\src\..\main.bas)") == "C:/project/main.bas");
+    assert(cache.normalize("./a/./b") == "a/b");
+    assert(cache.normalize("../foo/../bar") == "../bar");
+    assert(cache.normalize("dir/../file") == "file");
+    assert(cache.normalize("/foo/../") == "/");
+    assert(cache.normalize("") == ".");
     return 0;
 }

--- a/tests/vm/CMakeLists.txt
+++ b/tests/vm/CMakeLists.txt
@@ -174,4 +174,8 @@ function(viper_add_vm_path_tests)
   viper_add_test_exe(test_path_normalize ${VIPER_TESTS_DIR}/unit/PathNormalizeTests.cpp)
   target_link_libraries(test_path_normalize PRIVATE ${VIPER_VM_LIB})
   viper_add_ctest(test_path_normalize test_path_normalize)
+
+  viper_add_test_exe(test_vm_debug_trace_paths ${VIPER_TESTS_DIR}/unit/test_vm_debug_trace_paths.cpp)
+  target_link_libraries(test_vm_debug_trace_paths PRIVATE ${VIPER_VM_LIB})
+  viper_add_ctest(test_vm_debug_trace_paths test_vm_debug_trace_paths)
 endfunction()


### PR DESCRIPTION
## Summary
- add a support::PathCache helper to normalize and cache source file paths
- update DebugCtrl and TraceSink to consume the shared path normalization
- extend unit coverage to verify debugger and trace path formatting remains consistent

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dcd0c222ec83248ca59db821c69868