### PR TITLE
Refactor BASIC lowering passes to share AST walker

### DIFF
--- a/src/frontends/basic/AstWalker.hpp
+++ b/src/frontends/basic/AstWalker.hpp
@@ -1,0 +1,600 @@
+// File: src/frontends/basic/AstWalker.hpp
+// Purpose: Provides a reusable recursive AST walker for BASIC front-end passes.
+// Key invariants: Traversal order matches the legacy visitors for statements and expressions.
+// Ownership/Lifetime: Walker borrows AST nodes without owning them.
+// Links: docs/codemap.md
+#pragma once
+
+#include "frontends/basic/AST.hpp"
+#include <type_traits>
+
+namespace il::frontends::basic
+{
+
+/// @brief Generic recursive AST walker that forwards traversal hooks to @p Derived.
+/// @tparam Derived Concrete walker implementing optional callbacks.
+/// @details The walker visits statements and expressions in the same order as the
+/// legacy lowering visitors. Derived classes may override `before`,
+/// `after`, `shouldVisitChildren`, `beforeChild`, and `afterChild` for any
+/// node type; the base implementation provides no-op defaults.
+template <typename Derived>
+class BasicAstWalker : public ExprVisitor, public StmtVisitor
+{
+  public:
+    /// @brief Visit an expression subtree.
+    /// @param expr Root expression to walk.
+    void walkExpr(const Expr &expr)
+    {
+        expr.accept(*static_cast<Derived *>(this));
+    }
+
+    /// @brief Visit a statement subtree.
+    /// @param stmt Root statement to walk.
+    void walkStmt(const Stmt &stmt)
+    {
+        stmt.accept(*static_cast<Derived *>(this));
+    }
+
+  protected:
+    BasicAstWalker() = default;
+
+    template <typename Node>
+    void callBefore(const Node &node)
+    {
+        if constexpr (requires(Derived &d, const Node &n) { d.before(n); })
+            static_cast<Derived *>(this)->before(node);
+    }
+
+    template <typename Node>
+    void callAfter(const Node &node)
+    {
+        if constexpr (requires(Derived &d, const Node &n) { d.after(n); })
+            static_cast<Derived *>(this)->after(node);
+    }
+
+    template <typename Node>
+    bool callShouldVisit(const Node &node)
+    {
+        if constexpr (requires(Derived &d, const Node &n) { d.shouldVisitChildren(n); })
+            return static_cast<Derived *>(this)->shouldVisitChildren(node);
+        return true;
+    }
+
+    template <typename Parent, typename Child>
+    void callBeforeChild(const Parent &parent, const Child &child)
+    {
+        if constexpr (requires(Derived &d, const Parent &p, const Child &c) { d.beforeChild(p, c); })
+            static_cast<Derived *>(this)->beforeChild(parent, child);
+    }
+
+    template <typename Parent, typename Child>
+    void callAfterChild(const Parent &parent, const Child &child)
+    {
+        if constexpr (requires(Derived &d, const Parent &p, const Child &c) { d.afterChild(p, c); })
+            static_cast<Derived *>(this)->afterChild(parent, child);
+    }
+
+    // Expression visitors --------------------------------------------------
+
+    void visit(const IntExpr &expr) override
+    {
+        callBefore(expr);
+        callAfter(expr);
+    }
+
+    void visit(const FloatExpr &expr) override
+    {
+        callBefore(expr);
+        callAfter(expr);
+    }
+
+    void visit(const StringExpr &expr) override
+    {
+        callBefore(expr);
+        callAfter(expr);
+    }
+
+    void visit(const BoolExpr &expr) override
+    {
+        callBefore(expr);
+        callAfter(expr);
+    }
+
+    void visit(const VarExpr &expr) override
+    {
+        callBefore(expr);
+        callAfter(expr);
+    }
+
+    void visit(const ArrayExpr &expr) override
+    {
+        callBefore(expr);
+        if (callShouldVisit(expr))
+        {
+            if (expr.index)
+            {
+                callBeforeChild(expr, *expr.index);
+                expr.index->accept(*static_cast<Derived *>(this));
+                callAfterChild(expr, *expr.index);
+            }
+        }
+        callAfter(expr);
+    }
+
+    void visit(const LBoundExpr &expr) override
+    {
+        callBefore(expr);
+        callAfter(expr);
+    }
+
+    void visit(const UBoundExpr &expr) override
+    {
+        callBefore(expr);
+        callAfter(expr);
+    }
+
+    void visit(const UnaryExpr &expr) override
+    {
+        callBefore(expr);
+        if (callShouldVisit(expr))
+        {
+            if (expr.expr)
+            {
+                callBeforeChild(expr, *expr.expr);
+                expr.expr->accept(*static_cast<Derived *>(this));
+                callAfterChild(expr, *expr.expr);
+            }
+        }
+        callAfter(expr);
+    }
+
+    void visit(const BinaryExpr &expr) override
+    {
+        callBefore(expr);
+        if (callShouldVisit(expr))
+        {
+            if (expr.lhs)
+            {
+                callBeforeChild(expr, *expr.lhs);
+                expr.lhs->accept(*static_cast<Derived *>(this));
+                callAfterChild(expr, *expr.lhs);
+            }
+            if (expr.rhs)
+            {
+                callBeforeChild(expr, *expr.rhs);
+                expr.rhs->accept(*static_cast<Derived *>(this));
+                callAfterChild(expr, *expr.rhs);
+            }
+        }
+        callAfter(expr);
+    }
+
+    void visit(const BuiltinCallExpr &expr) override
+    {
+        callBefore(expr);
+        if (callShouldVisit(expr))
+        {
+            for (const auto &arg : expr.args)
+            {
+                if (!arg)
+                    continue;
+                callBeforeChild(expr, *arg);
+                arg->accept(*static_cast<Derived *>(this));
+                callAfterChild(expr, *arg);
+            }
+        }
+        callAfter(expr);
+    }
+
+    void visit(const CallExpr &expr) override
+    {
+        callBefore(expr);
+        if (callShouldVisit(expr))
+        {
+            for (const auto &arg : expr.args)
+            {
+                if (!arg)
+                    continue;
+                callBeforeChild(expr, *arg);
+                arg->accept(*static_cast<Derived *>(this));
+                callAfterChild(expr, *arg);
+            }
+        }
+        callAfter(expr);
+    }
+
+    // Statement visitors ---------------------------------------------------
+
+    void visit(const PrintStmt &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt))
+        {
+            for (const auto &item : stmt.items)
+            {
+                if (item.kind != PrintItem::Kind::Expr || !item.expr)
+                    continue;
+                callBeforeChild(stmt, *item.expr);
+                item.expr->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *item.expr);
+            }
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const PrintChStmt &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt))
+        {
+            if (stmt.channelExpr)
+            {
+                callBeforeChild(stmt, *stmt.channelExpr);
+                stmt.channelExpr->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.channelExpr);
+            }
+            for (const auto &arg : stmt.args)
+            {
+                if (!arg)
+                    continue;
+                callBeforeChild(stmt, *arg);
+                arg->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *arg);
+            }
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const LetStmt &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt))
+        {
+            if (stmt.target)
+            {
+                callBeforeChild(stmt, *stmt.target);
+                stmt.target->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.target);
+            }
+            if (stmt.expr)
+            {
+                callBeforeChild(stmt, *stmt.expr);
+                stmt.expr->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.expr);
+            }
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const DimStmt &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt))
+        {
+            if (stmt.size)
+            {
+                callBeforeChild(stmt, *stmt.size);
+                stmt.size->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.size);
+            }
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const ReDimStmt &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt))
+        {
+            if (stmt.size)
+            {
+                callBeforeChild(stmt, *stmt.size);
+                stmt.size->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.size);
+            }
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const RandomizeStmt &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt) && stmt.seed)
+        {
+            callBeforeChild(stmt, *stmt.seed);
+            stmt.seed->accept(*static_cast<Derived *>(this));
+            callAfterChild(stmt, *stmt.seed);
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const IfStmt &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt))
+        {
+            if (stmt.cond)
+            {
+                callBeforeChild(stmt, *stmt.cond);
+                stmt.cond->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.cond);
+            }
+            if (stmt.then_branch)
+            {
+                callBeforeChild(stmt, *stmt.then_branch);
+                stmt.then_branch->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.then_branch);
+            }
+            for (const auto &elseif : stmt.elseifs)
+            {
+                if (elseif.cond)
+                {
+                    callBeforeChild(stmt, *elseif.cond);
+                    elseif.cond->accept(*static_cast<Derived *>(this));
+                    callAfterChild(stmt, *elseif.cond);
+                }
+                if (elseif.then_branch)
+                {
+                    callBeforeChild(stmt, *elseif.then_branch);
+                    elseif.then_branch->accept(*static_cast<Derived *>(this));
+                    callAfterChild(stmt, *elseif.then_branch);
+                }
+            }
+            if (stmt.else_branch)
+            {
+                callBeforeChild(stmt, *stmt.else_branch);
+                stmt.else_branch->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.else_branch);
+            }
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const WhileStmt &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt))
+        {
+            if (stmt.cond)
+            {
+                callBeforeChild(stmt, *stmt.cond);
+                stmt.cond->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.cond);
+            }
+            for (const auto &bodyStmt : stmt.body)
+            {
+                if (!bodyStmt)
+                    continue;
+                callBeforeChild(stmt, *bodyStmt);
+                bodyStmt->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *bodyStmt);
+            }
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const DoStmt &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt))
+        {
+            if (stmt.cond)
+            {
+                callBeforeChild(stmt, *stmt.cond);
+                stmt.cond->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.cond);
+            }
+            for (const auto &bodyStmt : stmt.body)
+            {
+                if (!bodyStmt)
+                    continue;
+                callBeforeChild(stmt, *bodyStmt);
+                bodyStmt->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *bodyStmt);
+            }
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const ForStmt &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt))
+        {
+            if (stmt.start)
+            {
+                callBeforeChild(stmt, *stmt.start);
+                stmt.start->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.start);
+            }
+            if (stmt.end)
+            {
+                callBeforeChild(stmt, *stmt.end);
+                stmt.end->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.end);
+            }
+            if (stmt.step)
+            {
+                callBeforeChild(stmt, *stmt.step);
+                stmt.step->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.step);
+            }
+            for (const auto &bodyStmt : stmt.body)
+            {
+                if (!bodyStmt)
+                    continue;
+                callBeforeChild(stmt, *bodyStmt);
+                bodyStmt->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *bodyStmt);
+            }
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const NextStmt &stmt) override
+    {
+        callBefore(stmt);
+        callAfter(stmt);
+    }
+
+    void visit(const ExitStmt &stmt) override
+    {
+        callBefore(stmt);
+        callAfter(stmt);
+    }
+
+    void visit(const GotoStmt &stmt) override
+    {
+        callBefore(stmt);
+        callAfter(stmt);
+    }
+
+    void visit(const OpenStmt &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt))
+        {
+            if (stmt.pathExpr)
+            {
+                callBeforeChild(stmt, *stmt.pathExpr);
+                stmt.pathExpr->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.pathExpr);
+            }
+            if (stmt.channelExpr)
+            {
+                callBeforeChild(stmt, *stmt.channelExpr);
+                stmt.channelExpr->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.channelExpr);
+            }
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const CloseStmt &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt) && stmt.channelExpr)
+        {
+            callBeforeChild(stmt, *stmt.channelExpr);
+            stmt.channelExpr->accept(*static_cast<Derived *>(this));
+            callAfterChild(stmt, *stmt.channelExpr);
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const OnErrorGoto &stmt) override
+    {
+        callBefore(stmt);
+        callAfter(stmt);
+    }
+
+    void visit(const Resume &stmt) override
+    {
+        callBefore(stmt);
+        callAfter(stmt);
+    }
+
+    void visit(const EndStmt &stmt) override
+    {
+        callBefore(stmt);
+        callAfter(stmt);
+    }
+
+    void visit(const InputStmt &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt) && stmt.prompt)
+        {
+            callBeforeChild(stmt, *stmt.prompt);
+            stmt.prompt->accept(*static_cast<Derived *>(this));
+            callAfterChild(stmt, *stmt.prompt);
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const LineInputChStmt &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt))
+        {
+            if (stmt.channelExpr)
+            {
+                callBeforeChild(stmt, *stmt.channelExpr);
+                stmt.channelExpr->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.channelExpr);
+            }
+            if (stmt.targetVar)
+            {
+                callBeforeChild(stmt, *stmt.targetVar);
+                stmt.targetVar->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *stmt.targetVar);
+            }
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const ReturnStmt &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt) && stmt.value)
+        {
+            callBeforeChild(stmt, *stmt.value);
+            stmt.value->accept(*static_cast<Derived *>(this));
+            callAfterChild(stmt, *stmt.value);
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const FunctionDecl &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt))
+        {
+            for (const auto &bodyStmt : stmt.body)
+            {
+                if (!bodyStmt)
+                    continue;
+                callBeforeChild(stmt, *bodyStmt);
+                bodyStmt->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *bodyStmt);
+            }
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const SubDecl &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt))
+        {
+            for (const auto &bodyStmt : stmt.body)
+            {
+                if (!bodyStmt)
+                    continue;
+                callBeforeChild(stmt, *bodyStmt);
+                bodyStmt->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *bodyStmt);
+            }
+        }
+        callAfter(stmt);
+    }
+
+    void visit(const StmtList &stmt) override
+    {
+        callBefore(stmt);
+        if (callShouldVisit(stmt))
+        {
+            for (const auto &sub : stmt.stmts)
+            {
+                if (!sub)
+                    continue;
+                callBeforeChild(stmt, *sub);
+                sub->accept(*static_cast<Derived *>(this));
+                callAfterChild(stmt, *sub);
+            }
+        }
+        callAfter(stmt);
+    }
+};
+
+} // namespace il::frontends::basic

--- a/src/frontends/basic/LowerScan.hpp
+++ b/src/frontends/basic/LowerScan.hpp
@@ -16,13 +16,6 @@ enum class ExprType
 
 private:
 ExprType scanExpr(const Expr &e);
-ExprType scanUnaryExpr(const UnaryExpr &u);
-ExprType scanBinaryExpr(const BinaryExpr &b);
-ExprType scanArrayExpr(const ArrayExpr &arr);
-ExprType scanLBoundExpr(const LBoundExpr &expr);
-ExprType scanUBoundExpr(const UBoundExpr &expr);
-
-public:
 ExprType scanBuiltinCallExpr(const BuiltinCallExpr &c);
 
 private:

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -28,8 +28,7 @@ namespace il::frontends::basic
 
 class LowererExprVisitor;
 class LowererStmtVisitor;
-class ScanExprVisitor;
-class ScanStmtVisitor;
+class ScanWalker;
 struct ProgramLowering;
 struct ProcedureLowering;
 struct StatementLowering;
@@ -57,8 +56,7 @@ class Lowerer
   private:
     friend class LowererExprVisitor;
     friend class LowererStmtVisitor;
-    friend class ScanExprVisitor;
-    friend class ScanStmtVisitor;
+    friend class ScanWalker;
     friend struct ProgramLowering;
     friend struct ProcedureLowering;
     friend struct StatementLowering;

--- a/tests/basic/CMakeLists.txt
+++ b/tests/basic/CMakeLists.txt
@@ -46,6 +46,10 @@ function(viper_add_basic_main_tests)
   target_link_libraries(test_basic_lowerer_conversions PRIVATE ${VIPER_BASIC_LIBS})
   viper_add_ctest(test_basic_lowerer_conversions test_basic_lowerer_conversions)
 
+  viper_add_test_exe(test_basic_lowerer_runtime_helpers ${_VIPER_BASIC_UNIT_DIR}/test_basic_lowerer_runtime_helpers.cpp)
+  target_link_libraries(test_basic_lowerer_runtime_helpers PRIVATE ${VIPER_BASIC_LIBS})
+  viper_add_ctest(test_basic_lowerer_runtime_helpers test_basic_lowerer_runtime_helpers)
+
   viper_add_test_exe(test_basic_semantic_components ${_VIPER_BASIC_UNIT_DIR}/test_basic_semantic_components.cpp)
   target_link_libraries(test_basic_semantic_components PRIVATE ${VIPER_BASIC_LIBS})
   viper_add_ctest(test_basic_semantic_components test_basic_semantic_components)

--- a/tests/unit/test_basic_lowerer_runtime_helpers.cpp
+++ b/tests/unit/test_basic_lowerer_runtime_helpers.cpp
@@ -1,0 +1,64 @@
+// File: tests/unit/test_basic_lowerer_runtime_helpers.cpp
+// Purpose: Verify BASIC lowering requests runtime helpers via the shared AST walker.
+// Key invariants: Array assignment, PRINT #, and INPUT trigger their respective helpers.
+// Ownership: Test constructs AST via parser and owns emitted module.
+// Links: docs/codemap.md
+
+#include "frontends/basic/Lowerer.hpp"
+#include "frontends/basic/Parser.hpp"
+#include "support/source_manager.hpp"
+#include <cassert>
+#include <string>
+#include <unordered_set>
+
+using namespace il::frontends::basic;
+using namespace il::support;
+
+namespace
+{
+
+std::unordered_set<std::string> collectExternNames(const il::core::Module &module)
+{
+    std::unordered_set<std::string> names;
+    for (const auto &ext : module.externs)
+        names.insert(ext.name);
+    return names;
+}
+
+} // namespace
+
+int main()
+{
+    SourceManager sm;
+    uint32_t fid = sm.addFile("runtime_walk.bas");
+    const std::string src =
+        "10 DIM A(3)\n"
+        "20 LET A(1) = 5\n"
+        "30 OPEN \"out.dat\" FOR OUTPUT AS #1\n"
+        "40 PRINT #1, 42\n"
+        "50 INPUT X\n"
+        "60 CLOSE #1\n";
+
+    Parser parser(src, fid);
+    auto program = parser.parseProgram();
+    assert(program);
+
+    Lowerer lowerer;
+    il::core::Module module = lowerer.lowerProgram(*program);
+
+    auto names = collectExternNames(module);
+    assert(names.count("rt_arr_i32_set") == 1);
+    assert(names.count("rt_to_int") == 1);
+
+    const std::string stringHelpers[] = {
+        "rt_str_i16_alloc",
+        "rt_str_i32_alloc",
+        "rt_str_f_alloc",
+        "rt_str_d_alloc",
+    };
+    bool foundStringHelper = false;
+    for (const auto &helper : stringHelpers)
+        foundStringHelper = foundStringHelper || names.count(helper) == 1;
+    assert(foundStringHelper);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- introduce `BasicAstWalker` to centralize BASIC AST traversal
- adapt variable collection and scan stages to run on the shared walker callbacks
- add a regression test asserting runtime helper tracking after the refactor

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dcd0a53688832485b8017a805dc5e4