### PR TITLE
feat(il/core): expose opcode enumeration helpers

### DIFF
--- a/src/il/core/OpcodeInfo.cpp
+++ b/src/il/core/OpcodeInfo.cpp
@@ -8,6 +8,7 @@
 #include "il/core/OpcodeInfo.hpp"
 
 #include <string>
+#include <vector>
 
 namespace il::core
 {
@@ -58,6 +59,23 @@ const OpcodeInfo &getOpcodeInfo(Opcode op)
     return kOpcodeTable[static_cast<size_t>(op)];
 }
 
+std::vector<Opcode> all_opcodes()
+{
+    std::vector<Opcode> ops;
+    ops.reserve(kNumOpcodes);
+    for (size_t index = 0; index < kNumOpcodes; ++index)
+        ops.push_back(static_cast<Opcode>(index));
+    return ops;
+}
+
+std::string opcode_mnemonic(Opcode op)
+{
+    const size_t idx = static_cast<size_t>(op);
+    if (idx >= kOpcodeTable.size())
+        return "";
+    return kOpcodeTable[idx].name;
+}
+
 bool isVariadicOperandCount(uint8_t value)
 {
     return value == kVariadicOperandCount;
@@ -74,10 +92,7 @@ bool isVariadicOperandCount(uint8_t value)
  */
 std::string toString(Opcode op)
 {
-    const size_t idx = static_cast<size_t>(op);
-    if (idx >= kOpcodeTable.size())
-        return "";
-    return kOpcodeTable[idx].name;
+    return opcode_mnemonic(op);
 }
 
 } // namespace il::core

--- a/src/il/core/OpcodeInfo.hpp
+++ b/src/il/core/OpcodeInfo.hpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <cstdint>
 #include <limits>
+#include <vector>
 
 namespace il::core
 {
@@ -168,6 +169,15 @@ extern const std::array<OpcodeInfo, kNumOpcodes> kOpcodeTable;
 /// @param op Opcode to query.
 /// @return Reference to the metadata entry for @p op.
 const OpcodeInfo &getOpcodeInfo(Opcode op);
+
+/// @brief Enumerate all opcodes defined by the IL in declaration order.
+/// @return Vector containing every opcode exactly once.
+std::vector<Opcode> all_opcodes();
+
+/// @brief Retrieve the canonical mnemonic string for an opcode.
+/// @param op Opcode to translate into text.
+/// @return Lowercase mnemonic defined by the IL spec, empty if invalid.
+std::string opcode_mnemonic(Opcode op);
 
 /// @brief Determine whether @p value denotes a variadic operand upper bound.
 bool isVariadicOperandCount(uint8_t value);

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -140,6 +140,10 @@ function(viper_add_il_utils_test)
   viper_add_test_exe(test_il_utils ${_VIPER_IL_DIR}/UtilsTests.cpp)
   target_link_libraries(test_il_utils PRIVATE il_utils)
   viper_add_ctest(test_il_utils test_il_utils)
+
+  viper_add_test_exe(test_il_opcode_info ${_VIPER_IL_DIR}/OpcodeInfoTests.cpp)
+  target_link_libraries(test_il_opcode_info PRIVATE il_core)
+  viper_add_ctest(test_il_opcode_info test_il_opcode_info)
 endfunction()
 
 function(viper_add_il_analysis_tests)

--- a/tests/il/OpcodeInfoTests.cpp
+++ b/tests/il/OpcodeInfoTests.cpp
@@ -1,0 +1,32 @@
+// File: tests/il/OpcodeInfoTests.cpp
+// Purpose: Exercise opcode metadata enumeration helpers for stability.
+// Key invariants: Enumeration covers every opcode exactly once in declaration order.
+// Ownership/Lifetime: Uses read-only metadata from il::core.
+// Links: docs/il-guide.md#reference
+
+#include "il/core/OpcodeInfo.hpp"
+
+#include <cassert>
+
+int main()
+{
+    using namespace il::core;
+
+    const auto ops = all_opcodes();
+    assert(!ops.empty());
+
+    const auto again = all_opcodes();
+    assert(ops == again);
+
+    for (size_t index = 0; index < ops.size(); ++index)
+    {
+        const Opcode op = ops[index];
+        assert(static_cast<size_t>(op) == index);
+
+        const auto mnemonic = opcode_mnemonic(op);
+        assert(!mnemonic.empty());
+        assert(mnemonic == getOpcodeInfo(op).name);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add helpers to enumerate opcodes and expose canonical mnemonics from the metadata table
- reuse the shared mnemonic lookup for the existing toString helper
- introduce an OpcodeInfo unit test and register it with the IL test suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ddebedc948832487119104bd3e03b2