### PR TITLE
test(vm): ensure opcode handlers cover all opcodes

### DIFF
--- a/tests/vm/CMakeLists.txt
+++ b/tests/vm/CMakeLists.txt
@@ -169,6 +169,10 @@ function(viper_add_vm_unit_tests)
   target_link_libraries(test_vm_dispatch_handlers PRIVATE ${VIPER_VM_LIB})
   viper_add_ctest(test_vm_dispatch_handlers test_vm_dispatch_handlers)
 
+  viper_add_test_exe(test_vm_opcode_coverage ${_VIPER_VM_DIR}/OpcodeCoverageTests.cpp)
+  target_link_libraries(test_vm_opcode_coverage PRIVATE ${VIPER_VM_LIB})
+  viper_add_ctest(test_vm_opcode_coverage test_vm_opcode_coverage)
+
   viper_add_test_exe(test_vm_opcode_dispatch ${VIPER_TESTS_DIR}/unit/test_vm_opcode_dispatch.cpp)
   target_link_libraries(test_vm_opcode_dispatch PRIVATE il_io ${VIPER_VM_LIB} il_api)
   viper_add_ctest(test_vm_opcode_dispatch test_vm_opcode_dispatch)

--- a/tests/vm/OpcodeCoverageTests.cpp
+++ b/tests/vm/OpcodeCoverageTests.cpp
@@ -1,0 +1,45 @@
+// File: tests/vm/OpcodeCoverageTests.cpp
+// Purpose: Ensure every opcode declared in Opcode.def has an executable VM handler.
+// Key invariants: Handler table entries are non-null for all non-whitelisted opcodes.
+// Ownership/Lifetime: Test inspects static opcode metadata and dispatch table.
+// Links: docs/il-guide.md#reference
+
+#include "il/core/OpcodeInfo.hpp"
+#include "vm/VM.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+
+using il::core::Opcode;
+
+namespace
+{
+/// @brief Opcodes intentionally lacking VM handlers.
+/// @details Empty by default; populate when the VM is expected not to execute
+/// specific opcodes (e.g., pseudo ops used only during lowering).
+constexpr std::array<Opcode, 0> kWhitelistedOpcodes{};
+
+bool isWhitelisted(Opcode opcode)
+{
+    return std::find(kWhitelistedOpcodes.begin(), kWhitelistedOpcodes.end(), opcode) !=
+           kWhitelistedOpcodes.end();
+}
+} // namespace
+
+int main()
+{
+    const auto &handlers = il::vm::VM::getOpcodeHandlers();
+    const auto opcodes = il::core::all_opcodes();
+
+    for (const auto opcode : opcodes)
+    {
+        if (isWhitelisted(opcode))
+            continue;
+
+        const auto index = static_cast<size_t>(opcode);
+        assert(handlers[index] != nullptr && "opcode missing VM handler");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a VM opcode coverage test that asserts every opcode defined in Opcode.def has a non-null handler unless explicitly whitelisted
- register the coverage test with the VM test suite so it runs with the existing dispatch checks

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68ddee9989108324a6a0d99a87387e24