### PR TITLE
fix: force C numeric locale at startup

### DIFF
--- a/docs/runtime-vm.md
+++ b/docs/runtime-vm.md
@@ -75,6 +75,9 @@ Trace output is identical across platforms. All numbers use the C locale with
 booleans printed as `0` or `1`, integers in base‑10, and floating-point values
 formatted using `%.17g`. Line endings are normalized to `\n` even on Windows.
 
+At process start the runtime sets `LC_NUMERIC` to `"C"` to ensure numeric
+parsing and printing stay deterministic regardless of the host locale.
+
 ### Recursion
 
 The interpreter allocates a fresh frame for each call. Recursive functions thus

--- a/src/vm/VMInit.cpp
+++ b/src/vm/VMInit.cpp
@@ -11,12 +11,28 @@
 #include "il/core/Module.hpp"
 
 #include <cassert>
+#include <clocale>
 #include <utility>
 
 using namespace il::core;
 
 namespace il::vm
 {
+
+namespace
+{
+
+struct NumericLocaleInitializer
+{
+    NumericLocaleInitializer()
+    {
+        std::setlocale(LC_NUMERIC, "C");
+    }
+};
+
+[[maybe_unused]] const NumericLocaleInitializer kNumericLocaleInitializer{};
+
+} // namespace
 
 /// Construct a VM instance bound to a specific IL @p Module.
 /// The constructor wires the tracing and debugging subsystems and pre-populates


### PR DESCRIPTION
## Summary
- force the VM library to set LC_NUMERIC to the C locale during process startup
- document the locale requirement in the runtime/VM guide

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68ddf992d2cc8324baa23a4d76c41736