### PR TITLE
feat(il/verify): add EH stack verifier pass

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ add_subdirectory(il/io)
 add_library(il_verify STATIC
   il/verify/DiagFormat.cpp
   il/verify/DiagSink.cpp
+  il/verify/EhVerifier.cpp
   il/verify/Verifier.cpp
   il/verify/ExternVerifier.cpp
   il/verify/GlobalVerifier.cpp

--- a/src/il/verify/DiagSink.hpp
+++ b/src/il/verify/DiagSink.hpp
@@ -7,10 +7,45 @@
 
 #include "support/diag_expected.hpp"
 
+#include <string>
+#include <string_view>
 #include <vector>
 
 namespace il::verify
 {
+
+/// @brief Identifier for structured verifier diagnostics.
+enum class VerifyDiagCode
+{
+    Unknown = 0,           ///< Unclassified diagnostic.
+    EhStackUnderflow,      ///< Encountered eh.pop with an empty handler stack.
+    EhStackLeak            ///< Execution left a function with handlers still active.
+};
+
+/// @brief Convert a verifier diagnostic code to its textual prefix.
+/// @param code Diagnostic code to translate.
+/// @return Stable string view describing @p code.
+std::string_view toString(VerifyDiagCode code);
+
+/// @brief Construct a diagnostic tagged with a verifier code.
+/// @param code Structured diagnostic code.
+/// @param severity Diagnostic severity classification.
+/// @param loc Optional source location associated with the diagnostic.
+/// @param message Human readable payload appended after the code prefix.
+/// @return Diagnostic ready for reporting through sinks or Expected values.
+il::support::Diag makeVerifierDiag(VerifyDiagCode code,
+                                   il::support::Severity severity,
+                                   il::support::SourceLoc loc,
+                                   std::string message);
+
+/// @brief Convenience wrapper that constructs an error diagnostic for verifier failures.
+/// @param code Structured diagnostic code.
+/// @param loc Optional source location associated with the diagnostic.
+/// @param message Human readable description appended after the code prefix.
+/// @return Error severity diagnostic referencing the provided verifier code.
+il::support::Diag makeVerifierError(VerifyDiagCode code,
+                                    il::support::SourceLoc loc,
+                                    std::string message);
 
 /// @brief Interface for verifier components to report diagnostics without coupling to storage.
 class DiagSink

--- a/src/il/verify/EhVerifier.cpp
+++ b/src/il/verify/EhVerifier.cpp
@@ -1,0 +1,41 @@
+// File: src/il/verify/EhVerifier.cpp
+// Purpose: Implements the verifier pass that validates EH stack balance per function.
+// Key invariants: Control-flow is explored to ensure every execution path maintains
+// balanced eh.push/eh.pop pairs, delegating to ExceptionHandlerAnalysis helpers.
+// Ownership/Lifetime: Operates on caller-owned modules; no allocations outlive
+// verification. Diagnostics are returned via Expected or forwarded through sinks.
+// Links: docs/il-guide.md#reference
+
+#include "il/verify/EhVerifier.hpp"
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Module.hpp"
+#include "il/verify/ExceptionHandlerAnalysis.hpp"
+
+#include <unordered_map>
+
+using namespace il::core;
+
+namespace il::verify
+{
+using il::support::Expected;
+
+il::support::Expected<void> EhVerifier::run(const Module &module, DiagSink &sink) const
+{
+    (void)sink;
+    for (const auto &fn : module.functions)
+    {
+        std::unordered_map<std::string, const BasicBlock *> blockMap;
+        blockMap.reserve(fn.blocks.size());
+        for (const auto &bb : fn.blocks)
+            blockMap[bb.label] = &bb;
+
+        if (auto result = checkEhStackBalance(fn, blockMap); !result)
+            return result;
+    }
+
+    return {};
+}
+
+} // namespace il::verify

--- a/src/il/verify/EhVerifier.hpp
+++ b/src/il/verify/EhVerifier.hpp
@@ -1,0 +1,33 @@
+// File: src/il/verify/EhVerifier.hpp
+// Purpose: Declares the verifier pass responsible for checking EH stack balance.
+// Key invariants: Each function is inspected independently; analysis relies on
+// control-flow reachability to ensure eh.push/eh.pop pairs nest properly.
+// Ownership/Lifetime: The pass borrows module references without taking
+// ownership. Diagnostics are reported through the provided sink or Expected.
+// Links: docs/il-guide.md#reference
+#pragma once
+
+#include "il/verify/DiagSink.hpp"
+
+#include "support/diag_expected.hpp"
+
+namespace il::core
+{
+struct Module;
+}
+
+namespace il::verify
+{
+
+/// @brief Verifier pass that ensures eh.push/eh.pop usage remains balanced.
+class EhVerifier
+{
+  public:
+    /// @brief Analyse all functions within @p module for balanced EH stacks.
+    /// @param module Module whose functions are analysed.
+    /// @param sink Diagnostic sink receiving auxiliary diagnostics.
+    /// @return Success or the first diagnostic describing an imbalance.
+    il::support::Expected<void> run(const il::core::Module &module, DiagSink &sink) const;
+};
+
+} // namespace il::verify

--- a/src/il/verify/FunctionVerifier.cpp
+++ b/src/il/verify/FunctionVerifier.cpp
@@ -147,9 +147,6 @@ Expected<void> FunctionVerifier::verifyFunction(const Function &fn, DiagSink &si
         if (auto result = verifyBlock(fn, bb, blockMap, temps, sink); !result)
             return result;
 
-    if (auto result = checkEhStackBalance(fn, blockMap); !result)
-        return result;
-
     for (const auto &bb : fn.blocks)
     {
         for (const auto &instr : bb.instructions)

--- a/src/il/verify/Verifier.cpp
+++ b/src/il/verify/Verifier.cpp
@@ -9,6 +9,7 @@
 #include "il/core/Module.hpp"
 #include "il/verify/DiagSink.hpp"
 #include "il/verify/ExternVerifier.hpp"
+#include "il/verify/EhVerifier.hpp"
 #include "il/verify/FunctionVerifier.hpp"
 #include "il/verify/GlobalVerifier.hpp"
 #include "support/diag_expected.hpp"
@@ -56,6 +57,10 @@ Expected<void> Verifier::verify(const Module &m)
 
     FunctionVerifier functionVerifier(externVerifier.externs());
     if (auto result = functionVerifier.run(m, sink); !result)
+        return appendWarnings(result, sink);
+
+    EhVerifier ehVerifier;
+    if (auto result = ehVerifier.run(m, sink); !result)
         return appendWarnings(result, sink);
 
     return {};

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -297,6 +297,22 @@ function(viper_add_il_invalid_tests)
     -DFILE=${_VIPER_NEGATIVE_DIR}/narrow_cast_nochk.il
     -DEXPECT_FILE=${_VIPER_NEGATIVE_DIR}/narrow_cast_nochk.expected
     -P ${_VIPER_NEGATIVE_DIR}/check_negative.cmake)
+
+  set(_VIPER_INVALID_EH_DIR ${CMAKE_SOURCE_DIR}/tests/il/invalid_eh)
+
+  viper_add_ctest(il_verify_invalid_eh_underflow
+    ${CMAKE_COMMAND}
+    -DIL_VERIFY=${IL_VERIFY}
+    -DFILE=${_VIPER_INVALID_EH_DIR}/pop_underflow.il
+    -DEXPECT_FILE=${_VIPER_INVALID_EH_DIR}/pop_underflow.expected
+    -P ${_VIPER_NEGATIVE_DIR}/check_negative.cmake)
+
+  viper_add_ctest(il_verify_invalid_eh_leak
+    ${CMAKE_COMMAND}
+    -DIL_VERIFY=${IL_VERIFY}
+    -DFILE=${_VIPER_INVALID_EH_DIR}/push_leak_branch.il
+    -DEXPECT_FILE=${_VIPER_INVALID_EH_DIR}/push_leak_branch.expected
+    -P ${_VIPER_NEGATIVE_DIR}/check_negative.cmake)
 endfunction()
 
 function(viper_add_il_liveness_tests)

--- a/tests/il/invalid_eh/pop_underflow.expected
+++ b/tests/il/invalid_eh/pop_underflow.expected
@@ -1,0 +1,1 @@
+error: verify.eh.underflow: main:second: eh.pop: eh.pop without matching eh.push; path: entry -> first -> second

--- a/tests/il/invalid_eh/pop_underflow.il
+++ b/tests/il/invalid_eh/pop_underflow.il
@@ -1,0 +1,19 @@
+il 0.1.2
+
+func @main() -> void {
+entry:
+  eh.push ^handler
+  br ^first
+
+first:
+  eh.pop
+  br ^second
+
+second:
+  eh.pop
+  ret
+
+handler ^handler(%err:Error, %tok:ResumeTok):
+  eh.entry
+  resume.next %tok
+}

--- a/tests/il/invalid_eh/push_leak_branch.expected
+++ b/tests/il/invalid_eh/push_leak_branch.expected
@@ -1,0 +1,1 @@
+error: verify.eh.unreleased: main:leak: ret: unmatched eh.push depth 1; path: entry -> leak

--- a/tests/il/invalid_eh/push_leak_branch.il
+++ b/tests/il/invalid_eh/push_leak_branch.il
@@ -1,0 +1,18 @@
+il 0.1.2
+
+func @main(i1 %flag) -> void {
+entry:
+  eh.push ^handler
+  cbr %flag, leak, safe
+
+safe:
+  eh.pop
+  ret
+
+leak:
+  ret
+
+handler ^handler(%err:Error, %tok:ResumeTok):
+  eh.entry
+  resume.next %tok
+}

--- a/tests/il/negatives/unbalanced_eh.expected
+++ b/tests/il/negatives/unbalanced_eh.expected
@@ -1,1 +1,1 @@
-error: main:entry: ret: unmatched eh.push depth 1; path: entry
+error: verify.eh.unreleased: main:entry: ret: unmatched eh.push depth 1; path: entry


### PR DESCRIPTION
## Summary
- add an EhVerifier pass that checks each function for balanced eh.push/eh.pop usage and hook it into the verifier pipeline
- extend verifier diagnostics with structured EH stack codes and reuse them from the existing exception handler analysis
- add negative IL tests for EH stack underflow and leak scenarios and update expectations accordingly

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68de8c94a2ac8324871c7d9a702d9017