### PR TITLE
fix(il/verify): enforce resume token availability

### DIFF
--- a/src/il/verify/DiagSink.cpp
+++ b/src/il/verify/DiagSink.cpp
@@ -21,6 +21,8 @@ std::string_view diagCodeToPrefix(il::verify::VerifyDiagCode code)
             return "verify.eh.underflow";
         case VerifyDiagCode::EhStackLeak:
             return "verify.eh.unreleased";
+        case VerifyDiagCode::EhResumeTokenMissing:
+            return "verify.eh.resume_token_missing";
     }
     return {};
 }

--- a/src/il/verify/DiagSink.hpp
+++ b/src/il/verify/DiagSink.hpp
@@ -19,7 +19,8 @@ enum class VerifyDiagCode
 {
     Unknown = 0,           ///< Unclassified diagnostic.
     EhStackUnderflow,      ///< Encountered eh.pop with an empty handler stack.
-    EhStackLeak            ///< Execution left a function with handlers still active.
+    EhStackLeak,           ///< Execution left a function with handlers still active.
+    EhResumeTokenMissing   ///< Handler attempted to resume without a trap token.
 };
 
 /// @brief Convert a verifier diagnostic code to its textual prefix.

--- a/tests/golden/errors_map/from_err.il
+++ b/tests/golden/errors_map/from_err.il
@@ -6,6 +6,7 @@ entry:
   eh.push ^H
   trap.from_err i32 1
 exit:
+  eh.pop
   ret
 handler ^H(%err:Error, %tok:ResumeTok):
   eh.entry

--- a/tests/golden/errors_map/from_err_fnf.il
+++ b/tests/golden/errors_map/from_err_fnf.il
@@ -6,6 +6,7 @@ entry:
   eh.push ^H
   trap.from_err i32 1
 exit:
+  eh.pop
   ret
 handler ^H(%err:Error, %tok:ResumeTok):
   eh.entry

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -313,6 +313,27 @@ function(viper_add_il_invalid_tests)
     -DFILE=${_VIPER_INVALID_EH_DIR}/push_leak_branch.il
     -DEXPECT_FILE=${_VIPER_INVALID_EH_DIR}/push_leak_branch.expected
     -P ${_VIPER_NEGATIVE_DIR}/check_negative.cmake)
+
+  viper_add_ctest(il_verify_invalid_eh_resume_same_no_token
+    ${CMAKE_COMMAND}
+    -DIL_VERIFY=${IL_VERIFY}
+    -DFILE=${_VIPER_INVALID_EH_DIR}/resume_same_missing_token.il
+    -DEXPECT_FILE=${_VIPER_INVALID_EH_DIR}/resume_same_missing_token.expected
+    -P ${_VIPER_NEGATIVE_DIR}/check_negative.cmake)
+
+  viper_add_ctest(il_verify_invalid_eh_resume_next_no_token
+    ${CMAKE_COMMAND}
+    -DIL_VERIFY=${IL_VERIFY}
+    -DFILE=${_VIPER_INVALID_EH_DIR}/resume_next_missing_token.il
+    -DEXPECT_FILE=${_VIPER_INVALID_EH_DIR}/resume_next_missing_token.expected
+    -P ${_VIPER_NEGATIVE_DIR}/check_negative.cmake)
+
+  viper_add_ctest(il_verify_invalid_eh_resume_label_no_token
+    ${CMAKE_COMMAND}
+    -DIL_VERIFY=${IL_VERIFY}
+    -DFILE=${_VIPER_INVALID_EH_DIR}/resume_label_missing_token.il
+    -DEXPECT_FILE=${_VIPER_INVALID_EH_DIR}/resume_label_missing_token.expected
+    -P ${_VIPER_NEGATIVE_DIR}/check_negative.cmake)
 endfunction()
 
 function(viper_add_il_liveness_tests)

--- a/tests/il/invalid_eh/resume_label_missing_token.expected
+++ b/tests/il/invalid_eh/resume_label_missing_token.expected
@@ -1,0 +1,1 @@
+error: verify.eh.resume_token_missing: resume_label_missing_token:handler: resume.label

--- a/tests/il/invalid_eh/resume_label_missing_token.il
+++ b/tests/il/invalid_eh/resume_label_missing_token.il
@@ -1,0 +1,13 @@
+il 0.1.2
+
+func @resume_label_missing_token(%err:Error, %tok:ResumeTok) -> void {
+entry(%err:Error, %tok:ResumeTok):
+  br ^handler(%err, %tok)
+
+handler ^handler(%err:Error, %tok:ResumeTok):
+  eh.entry
+  resume.label %tok, ^after
+
+after:
+  ret
+}

--- a/tests/il/invalid_eh/resume_next_missing_token.expected
+++ b/tests/il/invalid_eh/resume_next_missing_token.expected
@@ -1,0 +1,1 @@
+error: verify.eh.resume_token_missing: resume_next_missing_token:handler: resume.next

--- a/tests/il/invalid_eh/resume_next_missing_token.il
+++ b/tests/il/invalid_eh/resume_next_missing_token.il
@@ -1,0 +1,10 @@
+il 0.1.2
+
+func @resume_next_missing_token(%err:Error, %tok:ResumeTok) -> void {
+entry(%err:Error, %tok:ResumeTok):
+  br ^handler(%err, %tok)
+
+handler ^handler(%err:Error, %tok:ResumeTok):
+  eh.entry
+  resume.next %tok
+}

--- a/tests/il/invalid_eh/resume_same_missing_token.expected
+++ b/tests/il/invalid_eh/resume_same_missing_token.expected
@@ -1,0 +1,1 @@
+error: verify.eh.resume_token_missing: resume_same_missing_token:handler: resume.same

--- a/tests/il/invalid_eh/resume_same_missing_token.il
+++ b/tests/il/invalid_eh/resume_same_missing_token.il
@@ -1,0 +1,10 @@
+il 0.1.2
+
+func @resume_same_missing_token(%err:Error, %tok:ResumeTok) -> void {
+entry(%err:Error, %tok:ResumeTok):
+  br ^handler(%err, %tok)
+
+handler ^handler(%err:Error, %tok:ResumeTok):
+  eh.entry
+  resume.same %tok
+}

--- a/tests/unit/test_il_exception_handler_analysis.cpp
+++ b/tests/unit/test_il_exception_handler_analysis.cpp
@@ -93,14 +93,19 @@ int main()
     balancedEntry.label = "entry";
     Instr push;
     push.op = Opcode::EhPush;
+    push.labels.push_back("handler");
     balancedEntry.instructions.push_back(push);
     Instr popOk;
     popOk.op = Opcode::EhPop;
     balancedEntry.instructions.push_back(popOk);
     balancedEntry.instructions.push_back(term);
     balancedFn.blocks.push_back(balancedEntry);
+    BasicBlock balancedHandler;
+    balancedHandler.label = "handler";
+    balancedFn.blocks.push_back(balancedHandler);
     std::unordered_map<std::string, const BasicBlock *> balancedMap;
-    balancedMap[balancedFn.blocks.front().label] = &balancedFn.blocks.front();
+    balancedMap[balancedFn.blocks[0].label] = &balancedFn.blocks[0];
+    balancedMap[balancedHandler.label] = &balancedFn.blocks[1];
     auto balancedResult = checkEhStackBalance(balancedFn, balancedMap);
     assert(balancedResult);
 


### PR DESCRIPTION
## Summary
- track exception handler resume tokens in checkEhStackBalance and report a new verifier diagnostic when resume.* executes without an active token
- add the new verify.eh.resume_token_missing code and extend existing unit tests to cover the updated handler analysis
- add invalid IL cases for resume.same/next/label without tokens and update golden programs to pop handlers after resume

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68de9361f5c88324bf550e0e00433720