### PR TITLE
Add invalid EH coverage for resume tokens on join paths

### DIFF
--- a/src/il/verify/EhVerifier.cpp
+++ b/src/il/verify/EhVerifier.cpp
@@ -10,6 +10,7 @@
 
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
 #include "il/core/Module.hpp"
 #include "il/verify/ExceptionHandlerAnalysis.hpp"
 
@@ -26,6 +27,35 @@ il::support::Expected<void> EhVerifier::run(const Module &module, DiagSink &sink
     (void)sink;
     for (const auto &fn : module.functions)
     {
+        bool hasEhOps = false;
+        for (const auto &bb : fn.blocks)
+        {
+            for (const auto &instr : bb.instructions)
+            {
+                switch (instr.op)
+                {
+                    case Opcode::EhPush:
+                    case Opcode::EhPop:
+                    case Opcode::Trap:
+                    case Opcode::TrapFromErr:
+                    case Opcode::ResumeSame:
+                    case Opcode::ResumeNext:
+                    case Opcode::ResumeLabel:
+                        hasEhOps = true;
+                        break;
+                    default:
+                        break;
+                }
+                if (hasEhOps)
+                    break;
+            }
+            if (hasEhOps)
+                break;
+        }
+
+        if (!hasEhOps)
+            continue;
+
         std::unordered_map<std::string, const BasicBlock *> blockMap;
         blockMap.reserve(fn.blocks.size());
         for (const auto &bb : fn.blocks)

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -331,6 +331,24 @@ function(viper_add_il_invalid_tests)
     -DFILE=${_VIPER_INVALID_EH_DIR}/resume_label_without_token.il
     -DEXPECT_FILE=${_VIPER_INVALID_EH_DIR}/resume_label_without_token.expected
     -P ${_VIPER_NEGATIVE_DIR}/check_negative.cmake)
+  viper_add_ctest(il_verify_invalid_eh_resume_same_join_no_token
+    ${CMAKE_COMMAND}
+    -DIL_VERIFY=${IL_VERIFY}
+    -DFILE=${_VIPER_INVALID_EH_DIR}/resume_same_join_without_token.il
+    -DEXPECT_FILE=${_VIPER_INVALID_EH_DIR}/resume_same_join_without_token.expected
+    -P ${_VIPER_NEGATIVE_DIR}/check_negative.cmake)
+  viper_add_ctest(il_verify_invalid_eh_resume_next_join_no_token
+    ${CMAKE_COMMAND}
+    -DIL_VERIFY=${IL_VERIFY}
+    -DFILE=${_VIPER_INVALID_EH_DIR}/resume_next_join_without_token.il
+    -DEXPECT_FILE=${_VIPER_INVALID_EH_DIR}/resume_next_join_without_token.expected
+    -P ${_VIPER_NEGATIVE_DIR}/check_negative.cmake)
+  viper_add_ctest(il_verify_invalid_eh_resume_label_join_no_token
+    ${CMAKE_COMMAND}
+    -DIL_VERIFY=${IL_VERIFY}
+    -DFILE=${_VIPER_INVALID_EH_DIR}/resume_label_join_without_token.il
+    -DEXPECT_FILE=${_VIPER_INVALID_EH_DIR}/resume_label_join_without_token.expected
+    -P ${_VIPER_NEGATIVE_DIR}/check_negative.cmake)
 endfunction()
 
 function(viper_add_il_liveness_tests)

--- a/tests/il/invalid_eh/resume_label_join_without_token.expected
+++ b/tests/il/invalid_eh/resume_label_join_without_token.expected
@@ -1,0 +1,1 @@
+error: verify.eh.resume_token_missing: resume_label_join_without_token:handler: resume.label %t4 label after: resume.* requires active resume token; path: entry -> handler

--- a/tests/il/invalid_eh/resume_label_join_without_token.il
+++ b/tests/il/invalid_eh/resume_label_join_without_token.il
@@ -1,0 +1,17 @@
+il 0.1.2
+
+func @resume_label_join_without_token(i1 %flag, Error %err, ResumeTok %tok) -> void {
+entry:
+  eh.push ^handler
+  cbr %flag, handler(%err, %tok), trap_block
+
+trap_block:
+  trap
+
+handler ^handler(%err:Error, %tok:ResumeTok):
+  eh.entry
+  resume.label %tok, ^after(%err)
+
+after(%forward_err:Error):
+  ret
+}

--- a/tests/il/invalid_eh/resume_next_join_without_token.expected
+++ b/tests/il/invalid_eh/resume_next_join_without_token.expected
@@ -1,0 +1,1 @@
+error: verify.eh.resume_token_missing: resume_next_join_without_token:handler: resume.next %t4: resume.* requires active resume token; path: entry -> handler

--- a/tests/il/invalid_eh/resume_next_join_without_token.il
+++ b/tests/il/invalid_eh/resume_next_join_without_token.il
@@ -1,0 +1,14 @@
+il 0.1.2
+
+func @resume_next_join_without_token(i1 %flag, Error %err, ResumeTok %tok) -> void {
+entry:
+  eh.push ^handler
+  cbr %flag, handler(%err, %tok), trap_block
+
+trap_block:
+  trap
+
+handler ^handler(%err:Error, %tok:ResumeTok):
+  eh.entry
+  resume.next %tok
+}

--- a/tests/il/invalid_eh/resume_same_join_without_token.expected
+++ b/tests/il/invalid_eh/resume_same_join_without_token.expected
@@ -1,0 +1,1 @@
+error: verify.eh.resume_token_missing: resume_same_join_without_token:handler: resume.same %t4: resume.* requires active resume token; path: entry -> handler

--- a/tests/il/invalid_eh/resume_same_join_without_token.il
+++ b/tests/il/invalid_eh/resume_same_join_without_token.il
@@ -1,0 +1,14 @@
+il 0.1.2
+
+func @resume_same_join_without_token(i1 %flag, Error %err, ResumeTok %tok) -> void {
+entry:
+  eh.push ^handler
+  cbr %flag, handler(%err, %tok), trap_block
+
+trap_block:
+  trap
+
+handler ^handler(%err:Error, %tok:ResumeTok):
+  eh.entry
+  resume.same %tok
+}


### PR DESCRIPTION
## Summary
- short-circuit the EH verifier when a function contains no EH-related operations before consulting the stack analysis
- add invalid IL fixtures that branch around a trap and confirm resume.same/next/label require an active resume token
- register the new fixtures with the existing negative il-verify suite

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68de9a7b5fe083249f6ff35fe43f6200