### PR TITLE
fix(il/io): report unresolved branch targets

### DIFF
--- a/src/il/io/FunctionParser.cpp
+++ b/src/il/io/FunctionParser.cpp
@@ -280,7 +280,7 @@ Expected<void> parseFunction(std::istream &is, std::string &header, ParserState 
         {
             st.curFn = nullptr;
             st.curBB = nullptr;
-            return {};
+            break;
         }
         if (line.back() == ':')
         {
@@ -306,6 +306,13 @@ Expected<void> parseFunction(std::istream &is, std::string &header, ParserState 
         auto instr = parseInstructionShim_E(line, st);
         if (!instr)
             return instr;
+    }
+    if (!st.pendingBrs.empty())
+    {
+        const auto &unresolved = st.pendingBrs.front();
+        std::ostringstream oss;
+        oss << "line " << unresolved.line << ": unknown block '" << unresolved.label << "'";
+        return Expected<void>{makeError({}, oss.str())};
     }
     return {};
 }

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -48,6 +48,11 @@ function(viper_add_il_core_tests)
   target_compile_definitions(test_il_parse_roundtrip PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip" SWITCH_GOLDEN="${CMAKE_SOURCE_DIR}/tests/golden/il_opt/switch_basic.il")
   viper_add_ctest(test_il_parse_roundtrip test_il_parse_roundtrip)
 
+  viper_add_test_exe(test_il_parse_unresolved_branch ${_VIPER_IL_UNIT_DIR}/test_il_parse_unresolved_branch.cpp)
+  target_link_libraries(test_il_parse_unresolved_branch PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  target_compile_definitions(test_il_parse_unresolved_branch PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
+  viper_add_ctest(test_il_parse_unresolved_branch test_il_parse_unresolved_branch)
+
   viper_add_test_exe(test_il_parse_negative ${_VIPER_IL_UNIT_DIR}/test_il_parse_negative.cpp)
   target_link_libraries(test_il_parse_negative PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   target_compile_definitions(test_il_parse_negative PRIVATE BAD_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse")

--- a/tests/il/parse-roundtrip/missing_block.il
+++ b/tests/il/parse-roundtrip/missing_block.il
@@ -1,0 +1,6 @@
+il 0.1.2
+func @unresolved() -> void {
+entry:
+  // Branch to an undefined block; parser should report "unknown block".
+  br missing()
+}

--- a/tests/unit/test_il_parse_unresolved_branch.cpp
+++ b/tests/unit/test_il_parse_unresolved_branch.cpp
@@ -1,0 +1,38 @@
+// File: tests/unit/test_il_parse_unresolved_branch.cpp
+// Purpose: Ensure parser rejects branches targeting undefined blocks.
+// Key invariants: Parsing fails with an "unknown block" diagnostic referencing the label/line.
+// Ownership/Lifetime: Test constructs modules and diagnostic buffers locally.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "support/diagnostics.hpp"
+
+#include <cassert>
+#include <fstream>
+#include <sstream>
+
+#ifndef PARSE_ROUNDTRIP_DIR
+#error "PARSE_ROUNDTRIP_DIR must be defined"
+#endif
+
+int main()
+{
+    const char *path = PARSE_ROUNDTRIP_DIR "/missing_block.il";
+    std::ifstream in(path);
+    std::stringstream buf;
+    buf << in.rdbuf();
+    buf.seekg(0);
+
+    il::core::Module m;
+    auto parse = il::api::v2::parse_text_expected(buf, m);
+    assert(!parse);
+
+    std::ostringstream diag;
+    il::support::printDiag(parse.error(), diag);
+    const std::string message = diag.str();
+    assert(message.find("unknown block 'missing'") != std::string::npos);
+    assert(message.find("line 5") != std::string::npos);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ensure parseFunction reports diagnostics when forward branches target missing blocks
- add a negative parse fixture and unit test exercising the unresolved branch diagnostic
- register the new test with CMake and document the fixture's intent

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68dee12966b08324a5ca7315b2924fc1