### PR TITLE
fix(il/io): report missing function closing brace

### DIFF
--- a/src/il/io/FunctionParser.cpp
+++ b/src/il/io/FunctionParser.cpp
@@ -307,6 +307,14 @@ Expected<void> parseFunction(std::istream &is, std::string &header, ParserState 
         if (!instr)
             return instr;
     }
+    if (st.curFn)
+    {
+        std::ostringstream oss;
+        oss << "line " << st.lineNo << ": unexpected end of file; missing '}'";
+        st.curFn = nullptr;
+        st.curBB = nullptr;
+        return Expected<void>{makeError({}, oss.str())};
+    }
     if (!st.pendingBrs.empty())
     {
         const auto &unresolved = st.pendingBrs.front();

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -53,6 +53,11 @@ function(viper_add_il_core_tests)
   target_compile_definitions(test_il_parse_unresolved_branch PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
   viper_add_ctest(test_il_parse_unresolved_branch test_il_parse_unresolved_branch)
 
+  viper_add_test_exe(test_il_parse_missing_brace ${_VIPER_IL_UNIT_DIR}/test_il_parse_missing_brace.cpp)
+  target_link_libraries(test_il_parse_missing_brace PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  target_compile_definitions(test_il_parse_missing_brace PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
+  viper_add_ctest(test_il_parse_missing_brace test_il_parse_missing_brace)
+
   viper_add_test_exe(test_il_parse_negative ${_VIPER_IL_UNIT_DIR}/test_il_parse_negative.cpp)
   target_link_libraries(test_il_parse_negative PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   target_compile_definitions(test_il_parse_negative PRIVATE BAD_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse")

--- a/tests/il/parse-roundtrip/missing_brace.il
+++ b/tests/il/parse-roundtrip/missing_brace.il
@@ -1,0 +1,5 @@
+il 0.1.2
+func @unterminated() -> void {
+entry:
+  ret
+// Intentionally missing the closing brace to exercise EOF diagnostics.

--- a/tests/unit/test_il_parse_missing_brace.cpp
+++ b/tests/unit/test_il_parse_missing_brace.cpp
@@ -1,0 +1,39 @@
+// File: tests/unit/test_il_parse_missing_brace.cpp
+// Purpose: Ensure IL parser reports a diagnostic when a function body misses a closing brace.
+// Key invariants: Parser surfaces EOF diagnostics referencing the final line number.
+// Ownership/Lifetime: Test owns module buffers and diagnostics locally.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "support/diagnostics.hpp"
+
+#include <cassert>
+#include <fstream>
+#include <sstream>
+
+#ifndef PARSE_ROUNDTRIP_DIR
+#error "PARSE_ROUNDTRIP_DIR must be defined"
+#endif
+
+int main()
+{
+    const char *path = PARSE_ROUNDTRIP_DIR "/missing_brace.il";
+    std::ifstream in(path);
+    std::stringstream buffer;
+    buffer << in.rdbuf();
+    buffer.seekg(0);
+
+    il::core::Module module;
+    auto parseResult = il::api::v2::parse_text_expected(buffer, module);
+    assert(!parseResult);
+
+    std::ostringstream diag;
+    il::support::printDiag(parseResult.error(), diag);
+    const std::string message = diag.str();
+    assert(message.find("line 5") != std::string::npos);
+    assert(message.find("unexpected end of file") != std::string::npos);
+    assert(message.find("missing '}'") != std::string::npos);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- emit an EOF diagnostic when parseFunction reaches the end of input without a closing brace
- add a parse-roundtrip fixture and unit test that assert the missing-brace error is reported

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dee959665c8324aa09bc3d43a70b93