### PR TITLE
fix(il/io): validate function parameter identifiers

### DIFF
--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -53,6 +53,11 @@ function(viper_add_il_core_tests)
   target_compile_definitions(test_il_parse_unresolved_branch PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
   viper_add_ctest(test_il_parse_unresolved_branch test_il_parse_unresolved_branch)
 
+  viper_add_test_exe(test_il_parse_param_prefix ${_VIPER_IL_UNIT_DIR}/test_il_parse_param_prefix.cpp)
+  target_link_libraries(test_il_parse_param_prefix PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api ${VIPER_IL_SUPPORT_LIB})
+  target_compile_definitions(test_il_parse_param_prefix PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
+  viper_add_ctest(test_il_parse_param_prefix test_il_parse_param_prefix)
+
   viper_add_test_exe(test_il_parse_negative ${_VIPER_IL_UNIT_DIR}/test_il_parse_negative.cpp)
   target_link_libraries(test_il_parse_negative PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   target_compile_definitions(test_il_parse_negative PRIVATE BAD_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse")

--- a/tests/il/negatives/narrow_cast_nochk.expected
+++ b/tests/il/negatives/narrow_cast_nochk.expected
@@ -1,1 +1,1 @@
-error: narrow_cast:entry: %1 = fptosi %t0: fp to integer narrowing must use cast.fp_to_si.rte.chk (rounds to nearest-even and traps on overflow)
+error: narrow_cast:entry: %2 = fptosi %t1: fp to integer narrowing must use cast.fp_to_si.rte.chk (rounds to nearest-even and traps on overflow)

--- a/tests/il/negatives/unchecked_srem.expected
+++ b/tests/il/negatives/unchecked_srem.expected
@@ -1,1 +1,1 @@
-error: unchecked_srem:entry: %2 = srem %t0 %t1: signed remainder must use srem.chk0 (traps on divide-by-zero; matches BASIC MOD semantics)
+error: unchecked_srem:entry: %4 = srem %t2 %t3: signed remainder must use srem.chk0 (traps on divide-by-zero; matches BASIC MOD semantics)

--- a/tests/il/parse-roundtrip/bad_param_prefix.il
+++ b/tests/il/parse-roundtrip/bad_param_prefix.il
@@ -1,0 +1,5 @@
+il 0.1.2
+func @missing_percent(i32 arg) -> i32 {
+entry:
+  ret 0
+}

--- a/tests/unit/test_il_parse_param_prefix.cpp
+++ b/tests/unit/test_il_parse_param_prefix.cpp
@@ -1,0 +1,38 @@
+// File: tests/unit/test_il_parse_param_prefix.cpp
+// Purpose: Ensure function headers reject parameters missing the '%' prefix.
+// Key invariants: Parser reports descriptive diagnostics for malformed names.
+// Ownership/Lifetime: Test constructs modules and diagnostic buffers locally.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "support/diagnostics.hpp"
+
+#include <cassert>
+#include <fstream>
+#include <sstream>
+
+#ifndef PARSE_ROUNDTRIP_DIR
+#error "PARSE_ROUNDTRIP_DIR must be defined"
+#endif
+
+int main()
+{
+    const char *path = PARSE_ROUNDTRIP_DIR "/bad_param_prefix.il";
+    std::ifstream in(path);
+    std::stringstream buffer;
+    buffer << in.rdbuf();
+    buffer.seekg(0);
+
+    il::core::Module m;
+    auto parse = il::api::v2::parse_text_expected(buffer, m);
+    assert(!parse);
+
+    std::ostringstream diag;
+    il::support::printDiag(parse.error(), diag);
+    const std::string message = diag.str();
+    assert(message.find("parameter name must start with '%'") != std::string::npos);
+    assert(message.find("line 2") != std::string::npos);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- validate function header parameters by rejecting missing `%` prefixes and malformed name/type tokens
- add a parse failure fixture and unit test covering a function header with `i32 arg`
- refresh IL negative expectation files for updated temporary numbering after stricter header parsing

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68df0e93b1ac8324b1b39c7efc09aa92