### PR TITLE
fix: diagnose BASIC unknown logical operators

### DIFF
--- a/src/frontends/basic/LowerExpr.cpp
+++ b/src/frontends/basic/LowerExpr.cpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <functional>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -393,7 +394,14 @@ Lowerer::RVal Lowerer::lowerLogicalBinary(const BinaryExpr &b)
         std::string_view opText = logicalOperatorDisplayName(b.op);
         std::string message = "unsupported logical operator '";
         message.append(opText);
-        message.append("'; assuming FALSE");
+        message.push_back('\'');
+        if (opText == std::string_view("<logical>"))
+        {
+            message.append(" (enum value ");
+            message.append(std::to_string(static_cast<int>(b.op)));
+            message.push_back(')');
+        }
+        message.append("; assuming FALSE");
         emitter->emit(il::support::Severity::Error,
                       std::string(kDiagUnsupportedLogicalOperator),
                       b.loc,


### PR DESCRIPTION
## Summary
- report a BASIC frontend diagnostic when lowering encounters an unknown logical operator
- include the enum value in the diagnostic text and continue with a FALSE fallback to keep lowering alive

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68df1d70a2c4832480b3aa71e72eec78