### PR TITLE
fix(frontends/basic): report recoverable type errors

### DIFF
--- a/src/frontends/basic/Lowerer.cpp
+++ b/src/frontends/basic/Lowerer.cpp
@@ -8,6 +8,7 @@
 // Links: docs/codemap.md
 
 #include "frontends/basic/Lowerer.hpp"
+#include "frontends/basic/DiagnosticEmitter.hpp"
 #include "frontends/basic/TypeSuffix.hpp"
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Function.hpp"
@@ -596,6 +597,20 @@ Module Lowerer::lower(const Program &prog)
 void Lowerer::setDiagnosticEmitter(DiagnosticEmitter *emitter) noexcept
 {
     diagnosticEmitter_ = emitter;
+    if (emitter)
+    {
+        TypeRules::setTypeErrorSink([emitter](const TypeRules::TypeError &error) {
+            emitter->emit(il::support::Severity::Error,
+                          error.code,
+                          il::support::SourceLoc{},
+                          0,
+                          error.message);
+        });
+    }
+    else
+    {
+        TypeRules::setTypeErrorSink({});
+    }
 }
 
 DiagnosticEmitter *Lowerer::diagnosticEmitter() const noexcept

--- a/src/frontends/basic/TypeRules.hpp
+++ b/src/frontends/basic/TypeRules.hpp
@@ -5,6 +5,8 @@
 // Links: docs/codemap.md
 #pragma once
 
+#include <functional>
+#include <string>
 #include <string_view>
 
 namespace il::frontends::basic
@@ -24,6 +26,16 @@ class TypeRules
         Double,  ///< 64-bit IEEE-754 floating-point.
     };
 
+    /// @brief Structured information describing a numeric type error.
+    struct TypeError
+    {
+        std::string code;    ///< Project-defined diagnostic code.
+        std::string message; ///< Human-readable explanation.
+    };
+
+    /// @brief Callback invoked when recoverable type errors occur.
+    using TypeErrorSink = std::function<void(const TypeError &error)>;
+
     /// @brief Determine the binary operator result type.
     /// @param op Operator token ("+", "-", "*", "/", "\\", "MOD", "^").
     /// @param lhs Left operand numeric type.
@@ -38,6 +50,9 @@ class TypeRules
     /// @param op Unary operator (currently only '-').
     /// @param operand Operand numeric type.
     static NumericType unaryResultType(char op, NumericType operand) noexcept;
+
+    /// @brief Install a callback used to report recoverable type errors.
+    static void setTypeErrorSink(TypeErrorSink sink) noexcept;
 };
 
 } // namespace il::frontends::basic


### PR DESCRIPTION
## Summary
- add a recoverable diagnostic sink to `TypeRules` so unsupported operators no longer abort
- forward the BASIC lowerer's diagnostic emitter to the new sink to surface structured errors
- return safe operand-based fallbacks for unknown unary and binary operators while reporting diagnostics

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 16`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68df2a546d44832484baee7697f6b166