### PR TITLE
Fix BASIC constant folder float formatting determinism

### DIFF
--- a/src/frontends/basic/ConstFolder.cpp
+++ b/src/frontends/basic/ConstFolder.cpp
@@ -8,6 +8,10 @@
 
 #include "frontends/basic/ConstFolder.hpp"
 #include "frontends/basic/ConstFoldHelpers.hpp"
+
+extern "C" {
+#include "runtime/rt_format.h"
+}
 #include <cctype>
 #include <cmath>
 #include <cstdint>
@@ -627,11 +631,15 @@ private:
                     auto n = detail::asNumeric(*expr.args[0]);
                     if (n)
                     {
-                        char buf[32];
+                        char buf[64];
                         if (n->isFloat)
-                            snprintf(buf, sizeof(buf), "%g", n->f);
+                        {
+                            rt_format_f64(n->f, buf, sizeof(buf));
+                        }
                         else
+                        {
                             snprintf(buf, sizeof(buf), "%lld", n->i);
+                        }
                         replaceWithStr(buf, expr.loc);
                     }
                 }


### PR DESCRIPTION
## Summary
- include the runtime formatting helper in the BASIC constant folder
- switch float constant folding to rt_format_f64 with a larger buffer to ensure deterministic strings

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68df3222fc888324bd0fe154b9a47d54