### PR TITLE
Fix extern parsing diagnostics for missing parentheses

### DIFF
--- a/src/il/io/ModuleParser.cpp
+++ b/src/il/io/ModuleParser.cpp
@@ -41,8 +41,26 @@ using il::support::makeError;
 Expected<void> parseExtern_E(const std::string &line, ParserState &st)
 {
     size_t at = line.find('@');
+    if (at == std::string::npos)
+    {
+        std::ostringstream oss;
+        oss << "line " << st.lineNo << ": missing '@'";
+        return Expected<void>{makeError({}, oss.str())};
+    }
     size_t lp = line.find('(', at);
+    if (lp == std::string::npos)
+    {
+        std::ostringstream oss;
+        oss << "line " << st.lineNo << ": missing '('";
+        return Expected<void>{makeError({}, oss.str())};
+    }
     size_t rp = line.find(')', lp);
+    if (rp == std::string::npos)
+    {
+        std::ostringstream oss;
+        oss << "line " << st.lineNo << ": missing ')'";
+        return Expected<void>{makeError({}, oss.str())};
+    }
     size_t arr = line.find("->", rp);
     if (arr == std::string::npos)
     {

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -63,6 +63,11 @@ function(viper_add_il_core_tests)
   target_compile_definitions(test_il_parse_missing_brace PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
   viper_add_ctest(test_il_parse_missing_brace test_il_parse_missing_brace)
 
+  viper_add_test_exe(test_il_parse_missing_paren ${_VIPER_IL_UNIT_DIR}/test_il_parse_missing_paren.cpp)
+  target_link_libraries(test_il_parse_missing_paren PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  target_compile_definitions(test_il_parse_missing_paren PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
+  viper_add_ctest(test_il_parse_missing_paren test_il_parse_missing_paren)
+
   viper_add_test_exe(test_il_parse_negative ${_VIPER_IL_UNIT_DIR}/test_il_parse_negative.cpp)
   target_link_libraries(test_il_parse_negative PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   target_compile_definitions(test_il_parse_negative PRIVATE BAD_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse")

--- a/tests/il/parse-roundtrip/missing_paren.il
+++ b/tests/il/parse-roundtrip/missing_paren.il
@@ -1,0 +1,7 @@
+il 0.1.2
+extern @no_paren -> i32
+
+func @main() -> i32 {
+entry:
+  ret 0
+}

--- a/tests/unit/test_il_parse_missing_paren.cpp
+++ b/tests/unit/test_il_parse_missing_paren.cpp
@@ -1,0 +1,38 @@
+// File: tests/unit/test_il_parse_missing_paren.cpp
+// Purpose: Ensure extern declarations without parentheses are rejected.
+// Key invariants: Parser diagnostics include the missing token reference and line number.
+// Ownership/Lifetime: Test owns module buffers and diagnostics.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "support/diagnostics.hpp"
+
+#include <cassert>
+#include <fstream>
+#include <sstream>
+
+#ifndef PARSE_ROUNDTRIP_DIR
+#error "PARSE_ROUNDTRIP_DIR must be defined"
+#endif
+
+int main()
+{
+    const char *path = PARSE_ROUNDTRIP_DIR "/missing_paren.il";
+    std::ifstream in(path);
+    std::stringstream buffer;
+    buffer << in.rdbuf();
+    buffer.seekg(0);
+
+    il::core::Module module;
+    auto parseResult = il::api::v2::parse_text_expected(buffer, module);
+    assert(!parseResult);
+
+    std::ostringstream diag;
+    il::support::printDiag(parseResult.error(), diag);
+    const std::string message = diag.str();
+    assert(message.find("line 2") != std::string::npos);
+    assert(message.find("missing '('") != std::string::npos);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- report missing '@', '(' and ')' tokens when parsing extern declarations
- add a negative parse-roundtrip fixture and unit test for a missing parameter list

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68df38773eb48324a31495805ce7e1be