### PR TITLE
Add runtime float formatting regression test

### DIFF
--- a/tests/runtime/FloatFormattingTests.cpp
+++ b/tests/runtime/FloatFormattingTests.cpp
@@ -1,0 +1,41 @@
+// File: tests/runtime/FloatFormattingTests.cpp
+// Purpose: Verify deterministic runtime formatting for floating-point values.
+// Key invariants: Canonical spellings are produced regardless of special cases.
+// Ownership: Runtime numeric formatting helpers.
+// Links: docs/codemap.md
+
+#include "rt_format.h"
+
+#include <array>
+#include <cassert>
+#include <cstring>
+#include <limits>
+
+int main()
+{
+    struct FormatCase
+    {
+        double value;
+        const char *expected;
+    };
+
+    const std::array<FormatCase, 10> cases = {{{0.0, "0"},
+                                               {-0.0, "-0"},
+                                               {0.5, "0.5"},
+                                               {1.5, "1.5"},
+                                               {2.5, "2.5"},
+                                               {1e20, "1e+20"},
+                                               {1e-20, "1e-20"},
+                                               {std::numeric_limits<double>::quiet_NaN(), "NaN"},
+                                               {std::numeric_limits<double>::infinity(), "Inf"},
+                                               {-std::numeric_limits<double>::infinity(), "-Inf"}}};
+
+    for (const auto &test : cases)
+    {
+        char buffer[64] = {};
+        rt_format_f64(test.value, buffer, sizeof(buffer));
+        assert(std::strcmp(buffer, test.expected) == 0);
+    }
+
+    return 0;
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -55,6 +55,10 @@ function(viper_add_runtime_tests)
   target_link_libraries(test_rt_float_determinism PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_float_determinism test_rt_float_determinism)
 
+  viper_add_test_exe(test_rt_float_formatting ${VIPER_TESTS_DIR}/runtime/FloatFormattingTests.cpp)
+  target_link_libraries(test_rt_float_formatting PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
+  viper_add_ctest(test_rt_FloatFormatting test_rt_float_formatting)
+
   viper_add_test_exe(test_rt_error_plumbing ${VIPER_TESTS_DIR}/runtime/RtErrorPlumbingTests.cpp)
   target_link_libraries(test_rt_error_plumbing PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_error_plumbing test_rt_error_plumbing)


### PR DESCRIPTION
## Summary
- add a runtime test that exercises `rt_format_f64` across standard and special double values
- register the executable with the runtime test suite so it can be targeted via the `FloatFormatting` filter

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build -R FloatFormatting --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68df3b17338c8324b02775aca0fde888