### PR TITLE
docs: document global verifier interfaces

### DIFF
--- a/src/il/verify/GlobalVerifier.cpp
+++ b/src/il/verify/GlobalVerifier.cpp
@@ -2,6 +2,7 @@
 // Purpose: Implements global declaration verification ensuring uniqueness within a module.
 // Key invariants: Global definitions may not share a name; lookup table mirrors module globals.
 // Ownership/Lifetime: Stores pointers to module-owned globals for later lookups.
+// License: MIT (see LICENSE).
 // Links: docs/il-guide.md#reference
 
 #include "il/verify/GlobalVerifier.hpp"
@@ -19,11 +20,14 @@ using il::support::Expected;
 using il::support::makeError;
 }
 
+/// @brief Exposes the cached map from global names to module-owned definitions.
 [[nodiscard]] const GlobalVerifier::GlobalMap &GlobalVerifier::globals() const
 {
     return globals_;
 }
 
+/// @brief Builds the global lookup map and reports duplicate declarations via the result.
+/// @returns An empty result on success or an error when duplicate globals are detected.
 Expected<void> GlobalVerifier::run(const Module &module, DiagSink &)
 {
     globals_.clear();


### PR DESCRIPTION
## Summary
- note the MIT license in the global verifier implementation header block
- add doxygen comments that describe the global map accessors and duplicate detection

## Testing
- not run (comments only)


------
https://chatgpt.com/codex/tasks/task_e_68df3d2c71048324b7ad37945acf1aee