### PR TITLE
docs: document diag capture helpers

### DIFF
--- a/src/support/diag_capture.cpp
+++ b/src/support/diag_capture.cpp
@@ -3,17 +3,24 @@
 // Key invariants: The stored string stream contents are preserved when converting
 //                 to a Diagnostic; print operations delegate to printDiag.
 // Ownership/Lifetime: DiagCapture owns its string buffer; diagnostics copy the text.
+// License: MIT License (see LICENSE).
 // Links: docs/codemap.md
 
 #include "support/diag_capture.hpp"
 
 namespace il::support
 {
+/// @brief Write the given diagnostic to the supplied stream.
+/// @param out Destination stream that receives the formatted diagnostic text.
+/// @param diag Diagnostic instance to serialize.
+/// @note Writes to @p out but does not mutate the capture state.
 void DiagCapture::printTo(std::ostream &out, const Diag &diag)
 {
     printDiag(diag, out);
 }
 
+/// @brief Convert the captured message into a Diagnostic value.
+/// @return Diagnostic containing a copy of the captured text.
 Diag DiagCapture::toDiag() const
 {
     return makeError({}, ss.str());


### PR DESCRIPTION
## Summary
- add MIT license attribution to the diag capture implementation header comment
- document DiagCapture::printTo and DiagCapture::toDiag with Doxygen-style summaries and notes

## Testing
- cmake -S . -B build
- cmake --build build -j2
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68df3cfa8348832497de84094e70ef5c