### PR TITLE
docs: document diag capture helpers

### DIFF
--- a/src/support/diag_capture.cpp
+++ b/src/support/diag_capture.cpp
@@ -1,3 +1,4 @@
+// MIT License. See LICENSE in the project root for full license information.
 // File: src/support/diag_capture.cpp
 // Purpose: Provide out-of-line definitions for DiagCapture helper methods.
 // Key invariants: The stored string stream contents are preserved when converting
@@ -9,17 +10,28 @@
 
 namespace il::support
 {
+/// Print the diagnostic object to the provided output stream.
+///
+/// @param out Stream that receives the formatted diagnostic text.
+/// @param diag Diagnostic value to serialize.
 void DiagCapture::printTo(std::ostream &out, const Diag &diag)
 {
     printDiag(diag, out);
 }
 
+/// Translate the captured buffer into a Diagnostic instance.
+///
+/// @return A Diagnostic populated with the captured message and an empty location.
 Diag DiagCapture::toDiag() const
 {
     return makeError({}, ss.str());
 }
 
-/// @brief Convert the legacy call result into an Expected<void> diagnostic outcome.
+/// Convert the legacy boolean status into an Expected<void> diagnostic outcome.
+///
+/// @param ok Indicates whether the original operation succeeded.
+/// @param capture Diagnostic capture used to materialize errors when @p ok is false.
+/// @return An empty Expected when @p ok is true; otherwise contains the captured diagnostic.
 Expected<void> capture_to_expected_impl(bool ok, DiagCapture &capture)
 {
     if (ok)


### PR DESCRIPTION
## Summary
- add the MIT license notice to src/support/diag_capture.cpp
- document DiagCapture helper functions with Doxygen comments and parameter/return notes

## Testing
- not run (comment-only change)


------
https://chatgpt.com/codex/tasks/task_e_68df3f6dabd08324b0007b712fd0ecdd