### PR TITLE
fix(vm): trap unmapped opcode with diagnostic mnemonic

### DIFF
--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -45,9 +45,13 @@ struct ActiveVMGuard
 
 std::string opcodeMnemonic(Opcode op)
 {
-    const auto &info = getOpcodeInfo(op);
-    if (info.name && info.name[0] != '\0')
-        return info.name;
+    const size_t index = static_cast<size_t>(op);
+    if (index < kNumOpcodes)
+    {
+        const auto &info = getOpcodeInfo(op);
+        if (info.name && info.name[0] != '\0')
+            return info.name;
+    }
     return std::string("opcode#") + std::to_string(static_cast<int>(op));
 }
 
@@ -149,7 +153,8 @@ VM::ExecResult VM::executeOpcode(Frame &fr,
                                  size_t &ip)
 {
     const auto &table = getOpcodeHandlers();
-    OpcodeHandler handler = table[static_cast<size_t>(in.op)];
+    const size_t index = static_cast<size_t>(in.op);
+    OpcodeHandler handler = index < table.size() ? table[index] : nullptr;
     if (!handler)
     {
         RuntimeBridge::trap(TrapKind::InvalidOperation,

--- a/tests/vm/UnknownOpcodeTests.cpp
+++ b/tests/vm/UnknownOpcodeTests.cpp
@@ -1,15 +1,52 @@
 // File: tests/vm/UnknownOpcodeTests.cpp
-// Purpose: Ensure the VM handles previously unimplemented opcodes once handlers land.
-// Key invariants: Executing `const_null` completes without raising a trap.
-// Ownership/Lifetime: Builds a small module and executes it directly.
+// Purpose: Verify the VM traps gracefully when encountering unmapped opcodes.
+// Key invariants: Unknown opcode dispatch produces InvalidOperation traps with mnemonic text.
+// Ownership/Lifetime: Builds an ephemeral module executed in a forked child to capture stderr.
 // Links: docs/il-guide.md#reference
 
 #include "il/build/IRBuilder.hpp"
 #include "vm/VM.hpp"
 
 #include <cassert>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
 
 using namespace il::core;
+
+namespace
+{
+std::string captureTrap(Module &module)
+{
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        il::vm::VM vm(module);
+        vm.run();
+        _exit(0);
+    }
+    close(fds[1]);
+    char buffer[512];
+    ssize_t n = read(fds[0], buffer, sizeof(buffer) - 1);
+    if (n < 0)
+        n = 0;
+    buffer[n] = '\0';
+    close(fds[0]);
+    int status = 0;
+    waitpid(pid, &status, 0);
+    assert(WIFEXITED(status) && WEXITSTATUS(status) == 1);
+    return std::string(buffer);
+}
+
+constexpr int kBogusOpcodeValue = static_cast<int>(Opcode::Count) + 17;
+constexpr Opcode kBogusOpcode = static_cast<Opcode>(kBogusOpcodeValue);
+
+} // namespace
 
 int main()
 {
@@ -19,23 +56,31 @@ int main()
     auto &bb = builder.addBlock(fn, "entry");
     builder.setInsertPoint(bb);
 
-    Instr bad;
-    bad.result = builder.reserveTempId();
-    bad.op = Opcode::ConstNull;
-    bad.type = Type(Type::Kind::Ptr);
-    bad.loc = {1, 1, 1};
-    bb.instructions.push_back(bad);
+    const il::support::SourceLoc loc{1, 1, 1};
+
+    Instr invalid;
+    invalid.result = builder.reserveTempId();
+    invalid.op = kBogusOpcode;
+    invalid.type = Type(Type::Kind::I64);
+    invalid.loc = loc;
+    bb.instructions.push_back(invalid);
 
     Instr ret;
     ret.op = Opcode::Ret;
     ret.type = Type(Type::Kind::Void);
-    ret.loc = {1, 1, 1};
-    ret.operands.push_back(Value::constInt(0));
+    ret.loc = loc;
     bb.instructions.push_back(ret);
 
-    il::vm::VM vm(module);
-    const int64_t exitCode = vm.run();
-    assert(exitCode == 0 && "const_null execution should not raise a trap");
+    const std::string diag = captureTrap(module);
+    const bool hasTrapKind = diag.find("Trap @main#0 line 1: InvalidOperation (code=0)") != std::string::npos;
+    assert(hasTrapKind && "expected InvalidOperation trap for unmapped opcode");
+
+    const bool hasPrefix = diag.find("unimplemented opcode:") != std::string::npos;
+    assert(hasPrefix && "expected diagnostic prefix for unmapped opcode");
+
+    const std::string mnemonic = "opcode#" + std::to_string(kBogusOpcodeValue);
+    const bool hasMnemonic = diag.find(mnemonic) != std::string::npos;
+    assert(hasMnemonic && "expected diagnostic to mention opcode mnemonic");
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- guard the VM opcode dispatch table against out-of-range IDs and fall back to an opcode#N mnemonic for unknown handlers
- add a regression test that injects a bogus opcode and asserts the InvalidOperation trap includes the mnemonic text

## Testing
- cmake --build build
- ctest --test-dir build --output-on-failure -R unknown_opcode

------
https://chatgpt.com/codex/tasks/task_e_68df3ece91748324b7a4ddb9be3604fe