### PR TITLE
test(il): add invalid EH verifier diagnostics

### DIFF
--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -169,6 +169,12 @@ function(viper_add_il_utils_test)
   viper_add_test_exe(test_il_opcode_info ${_VIPER_IL_DIR}/OpcodeInfoTests.cpp)
   target_link_libraries(test_il_opcode_info PRIVATE il_core)
   viper_add_ctest(test_il_opcode_info test_il_opcode_info)
+
+  viper_add_test_exe(test_il_invalid_eh ${_VIPER_IL_DIR}/InvalidEhTests.cpp)
+  target_link_libraries(test_il_invalid_eh PRIVATE il_core il_io il_verify il_api ${VIPER_IL_SUPPORT_LIB})
+  target_compile_definitions(
+    test_il_invalid_eh PRIVATE INVALID_EH_DIR="${CMAKE_SOURCE_DIR}/tests/il/invalid_eh")
+  viper_add_ctest(il_InvalidEhTests test_il_invalid_eh)
 endfunction()
 
 function(viper_add_il_analysis_tests)

--- a/tests/il/InvalidEhTests.cpp
+++ b/tests/il/InvalidEhTests.cpp
@@ -1,0 +1,93 @@
+// File: tests/il/InvalidEhTests.cpp
+// Purpose: Ensure EH verifier reports clear diagnostics for invalid handler patterns.
+// Key invariants: Parsing succeeds but verification fails with targeted error substrings.
+// Ownership/Lifetime: Test owns loaded modules and input streams.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "support/diag_expected.hpp"
+
+#include <array>
+#include <cassert>
+#include <cstdio>
+#include <fstream>
+#include <initializer_list>
+#include <sstream>
+#include <string>
+
+namespace
+{
+struct InvalidCase
+{
+    const char *fileName;
+    std::initializer_list<const char *> expectedSubstrings;
+};
+} // namespace
+
+int main()
+{
+    using il::api::v2::parse_text_expected;
+    using il::api::v2::verify_module_expected;
+
+    const std::array<InvalidCase, 3> cases = {{
+        {"unbalanced_push_pop.il", {"verify.eh.unreleased", "unmatched eh.push depth"}},
+        {"resume_without_token.il",
+         {"verify.eh.resume_token_missing", "resume.* requires active resume token"}},
+        {"resume_label_not_postdom.il",
+         {"verify.eh.resume_label_target", "must postdominate block"}},
+    }};
+
+    for (const auto &testCase : cases)
+    {
+        const std::string path = std::string(INVALID_EH_DIR) + "/" + testCase.fileName;
+        std::ifstream in(path);
+        if (!in)
+        {
+            std::fprintf(stderr, "failed to open %s\n", path.c_str());
+            return 1;
+        }
+
+        il::core::Module module;
+        auto parseResult = parse_text_expected(in, module);
+        if (!parseResult)
+        {
+            std::ostringstream diag;
+            il::support::printDiag(parseResult.error(), diag);
+            std::fprintf(
+                stderr, "unexpected parse failure for %s: %s\n", path.c_str(), diag.str().c_str());
+            return 1;
+        }
+
+        auto verifyResult = verify_module_expected(module);
+        if (verifyResult)
+        {
+            std::fprintf(stderr, "expected verifier to fail for %s\n", path.c_str());
+            return 1;
+        }
+
+        std::ostringstream diag;
+        il::support::printDiag(verifyResult.error(), diag);
+        const std::string diagText = diag.str();
+        if (diagText.empty())
+        {
+            std::fprintf(stderr, "expected diagnostic text for %s\n", path.c_str());
+            return 1;
+        }
+
+        for (const char *expected : testCase.expectedSubstrings)
+        {
+            if (diagText.find(expected) == std::string::npos)
+            {
+                std::fprintf(stderr,
+                             "diagnostic for %s missing substring '%s': %s\n",
+                             path.c_str(),
+                             expected,
+                             diagText.c_str());
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}

--- a/tests/il/invalid_eh/resume_label_not_postdom.il
+++ b/tests/il/invalid_eh/resume_label_not_postdom.il
@@ -1,0 +1,23 @@
+il 0.1.2
+
+func @resume_label_not_postdom(i1 %flag, Error %err, ResumeTok %tok) -> void {
+entry:
+  eh.push ^handler
+  cbr %flag, ^left, ^right
+
+left:
+  eh.pop
+  br exit
+
+right:
+  %tmp:i64 = sdiv.chk0 1, 1
+  eh.pop
+  br exit
+
+exit:
+  ret
+
+handler ^handler(%err:Error, %tok:ResumeTok):
+  eh.entry
+  resume.label %tok, ^left
+}

--- a/tests/il/invalid_eh/resume_without_token.il
+++ b/tests/il/invalid_eh/resume_without_token.il
@@ -1,0 +1,10 @@
+il 0.1.2
+
+func @resume_without_token(Error %err, ResumeTok %tok) -> void {
+entry:
+  br ^handler(%err, %tok)
+
+handler ^handler(%err:Error, %tok:ResumeTok):
+  eh.entry
+  resume.same %tok
+}

--- a/tests/il/invalid_eh/unbalanced_push_pop.il
+++ b/tests/il/invalid_eh/unbalanced_push_pop.il
@@ -1,0 +1,13 @@
+il 0.1.2
+
+func @unbalanced_push_pop() -> void {
+entry:
+  eh.push ^handler
+  eh.push ^handler
+  eh.pop
+  ret
+
+handler ^handler(%err:Error, %tok:ResumeTok):
+  eh.entry
+  resume.next %tok
+}


### PR DESCRIPTION
## Summary
- add negative IL fixtures for EH stack imbalance, resume without token, and invalid resume.label targets
- add InvalidEhTests harness to parse fixtures, invoke the verifier, and check diagnostic substrings
- wire the harness into the IL test suite via CMake

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68df4371c9bc83248cb34443f156bdd2