### PR TITLE
Wire new VM runtime and IL tests into CTest

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -57,7 +57,7 @@ function(viper_add_runtime_tests)
 
   viper_add_test_exe(test_rt_float_formatting ${VIPER_TESTS_DIR}/runtime/FloatFormattingTests.cpp)
   target_link_libraries(test_rt_float_formatting PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
-  viper_add_ctest(test_rt_FloatFormatting test_rt_float_formatting)
+  viper_add_ctest(runtime_FloatFormattingTests test_rt_float_formatting)
 
   viper_add_test_exe(test_rt_error_plumbing ${VIPER_TESTS_DIR}/runtime/RtErrorPlumbingTests.cpp)
   target_link_libraries(test_rt_error_plumbing PRIVATE ${VIPER_RUNTIME_TEST_LIBS})

--- a/tests/vm/CMakeLists.txt
+++ b/tests/vm/CMakeLists.txt
@@ -104,7 +104,7 @@ function(viper_add_vm_unit_tests)
   viper_add_test_exe(test_vm_switch ${_VIPER_VM_DIR}/SwitchTests.cpp)
   target_link_libraries(test_vm_switch PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   target_compile_definitions(test_vm_switch PRIVATE TESTS_DIR="${CMAKE_SOURCE_DIR}/tests")
-  viper_add_ctest(test_vm_switch test_vm_switch)
+  viper_add_ctest(vm_SwitchTests test_vm_switch)
 
   viper_add_test_exe(test_vm_trap_invalid_cast ${_VIPER_VM_DIR}/TrapInvalidCastTests.cpp)
   target_link_libraries(test_vm_trap_invalid_cast PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
@@ -112,7 +112,7 @@ function(viper_add_vm_unit_tests)
 
   viper_add_test_exe(test_vm_unknown_opcode ${_VIPER_VM_DIR}/UnknownOpcodeTests.cpp)
   target_link_libraries(test_vm_unknown_opcode PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
-  viper_add_ctest(test_vm_unknown_opcode test_vm_unknown_opcode)
+  viper_add_ctest(vm_UnknownOpcodeTests test_vm_unknown_opcode)
 
   viper_add_test_exe(test_vm_trap_loc ${VIPER_TESTS_DIR}/unit/test_vm_trap_loc.cpp)
   target_link_libraries(test_vm_trap_loc PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})


### PR DESCRIPTION
## Summary
- register the runtime FloatFormatting test suite under a descriptive CTest name
- expose the VM Switch and UnknownOpcode suites via CTest entries that match CI filters

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build -R "(UnknownOpcode|SwitchTests|FloatFormatting|InvalidEh)"


------
https://chatgpt.com/codex/tasks/task_e_68df4833e23483248181a0dd21eceacd