### PR TITLE
Add guard for assert(false) usage in BASIC frontend

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,11 @@ add_subdirectory(basic)
 add_subdirectory(golden)
 add_subdirectory(e2e)
 
+viper_add_ctest(NoAssertFalseGuard
+  ${CMAKE_COMMAND}
+  -DVIPER_SOURCE_DIR=${CMAKE_SOURCE_DIR}
+  -P ${CMAKE_SOURCE_DIR}/tests/tools/NoAssertFalseTest.cmake)
+
 viper_add_unit_support_tests()
 viper_add_il_core_tests()
 viper_add_basic_early_tests()

--- a/tests/tools/NoAssertFalseTest.cmake
+++ b/tests/tools/NoAssertFalseTest.cmake
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.20)
+
+if(NOT DEFINED VIPER_SOURCE_DIR)
+  message(FATAL_ERROR "VIPER_SOURCE_DIR must be provided to NoAssertFalseTest.cmake")
+endif()
+
+set(_no_assert_false_globs
+  "${VIPER_SOURCE_DIR}/src/frontends/basic/*.cpp"
+  "${VIPER_SOURCE_DIR}/src/frontends/basic/*.hpp"
+  "${VIPER_SOURCE_DIR}/src/vm/RuntimeBridge.cpp"
+)
+
+set(_no_assert_false_offenders)
+
+set(_no_assert_false_allow_strings
+  "string default values are not supported"
+  "builtin lowering referenced missing argument without default"
+  "unsupported custom builtin conversion"
+)
+
+foreach(_pattern IN LISTS _no_assert_false_globs)
+  file(GLOB _no_assert_false_files LIST_DIRECTORIES FALSE ${_pattern})
+  foreach(_file IN LISTS _no_assert_false_files)
+    file(STRINGS "${_file}" _no_assert_false_lines REGEX "assert\\s*\\(\\s*false")
+    foreach(_line IN LISTS _no_assert_false_lines)
+      set(_line_allowed FALSE)
+      foreach(_allowed IN LISTS _no_assert_false_allow_strings)
+        string(FIND "${_line}" "${_allowed}" _found_index)
+        if(NOT _found_index EQUAL -1)
+          set(_line_allowed TRUE)
+          break()
+        endif()
+      endforeach()
+      if(NOT _line_allowed)
+        list(APPEND _no_assert_false_offenders "${_file}")
+        break()
+      endif()
+    endforeach()
+  endforeach()
+endforeach()
+
+if(_no_assert_false_offenders)
+  list(REMOVE_DUPLICATES _no_assert_false_offenders)
+  list(SORT _no_assert_false_offenders)
+  list(JOIN _no_assert_false_offenders "\n  " _no_assert_false_message)
+  message(FATAL_ERROR "Found forbidden 'assert(false)' usage in:\n  ${_no_assert_false_message}\nReplace with appropriate error handling before committing.")
+else()
+  message(STATUS "No forbidden assert(false) occurrences detected.")
+endif()


### PR DESCRIPTION
## Summary
- add a CMake script that scans the BASIC frontend sources and RuntimeBridge for forbidden `assert(false)`
- register the script as the `NoAssertFalseGuard` ctest so the pattern is checked automatically

## Testing
- cmake --build build -j4
- ctest --test-dir build -R NoAssertFalse -V

------
https://chatgpt.com/codex/tasks/task_e_68df4a5e6a9c8324b45280e34c8b2f43