### PR TITLE
Add IL stack aggregator target to dedupe link lines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,13 +132,14 @@ add_custom_target(distclean
 )
 
 set(VIPER_PUBLIC_LIB_TARGETS
-  support
+  viper_support
   viper_runtime
-  il_core
+  viper_il_core
   il_runtime
   il_build
-  il_io
-  il_verify
+  viper_il_io
+  viper_il_verify
+  viper_il_full
   il_analysis
   il_transform
   il_utils

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(support)
 
-add_library(il_core STATIC
+add_library(viper_il_core STATIC
   il/core/OpcodeInfo.cpp
   il/core/Type.cpp
   il/core/Value.cpp
@@ -11,20 +11,21 @@ add_library(il_core STATIC
   il/core/Extern.cpp
   il/core/Module.cpp
 )
-target_include_directories(il_core PUBLIC
+target_include_directories(viper_il_core PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
 )
+target_link_libraries(viper_il_core PRIVATE viper_support)
 
 add_library(il_runtime STATIC il/runtime/RuntimeSignatures.cpp)
-target_link_libraries(il_runtime PUBLIC il_core viper_runtime)
+target_link_libraries(il_runtime PUBLIC viper_il_core viper_runtime)
 target_include_directories(il_runtime PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
 )
 
 add_library(il_build STATIC il/build/IRBuilder.cpp)
-target_link_libraries(il_build PUBLIC il_core support)
+target_link_libraries(il_build PUBLIC viper_il_core viper_support)
 target_include_directories(il_build PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
@@ -32,7 +33,7 @@ target_include_directories(il_build PUBLIC
 
 add_subdirectory(il/io)
 
-add_library(il_verify STATIC
+add_library(viper_il_verify STATIC
   il/verify/DiagFormat.cpp
   il/verify/DiagSink.cpp
   il/verify/EhVerifier.cpp
@@ -46,15 +47,29 @@ add_library(il_verify STATIC
   il/verify/BranchVerifier.cpp
   il/verify/ControlFlowChecker.cpp
   il/verify/TypeInference.cpp)
-target_link_libraries(il_verify PUBLIC il_core il_runtime)
-target_include_directories(il_verify PUBLIC
+target_link_libraries(viper_il_verify PRIVATE viper_il_core il_runtime)
+target_include_directories(viper_il_verify PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
 )
 
+add_library(viper_il_full INTERFACE)
+target_link_libraries(viper_il_full INTERFACE
+  viper_il_core
+  viper_il_verify
+  viper_il_io
+  viper_support
+)
+
+add_library(viper::support   ALIAS viper_support)
+add_library(viper::il_core   ALIAS viper_il_core)
+add_library(viper::il_verify ALIAS viper_il_verify)
+add_library(viper::il_io     ALIAS viper_il_io)
+add_library(viper::il_full   ALIAS viper_il_full)
+
 add_library(il_api STATIC il/api/expected_api.cpp)
 target_link_libraries(il_api
-  PUBLIC support il_io il_verify)
+  PUBLIC viper_il_full)
 target_include_directories(il_api PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
@@ -63,7 +78,7 @@ target_include_directories(il_api PUBLIC
 add_library(il_analysis STATIC
   il/analysis/CFG.cpp
   il/analysis/Dominators.cpp)
-target_link_libraries(il_analysis PUBLIC il_core)
+target_link_libraries(il_analysis PUBLIC viper_il_core)
 target_include_directories(il_analysis PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
@@ -75,21 +90,21 @@ add_library(il_transform STATIC
   il/transform/ConstFold.cpp
   il/transform/DCE.cpp
   il/transform/Mem2Reg.cpp)
-target_link_libraries(il_transform PUBLIC il_core il_verify il_analysis)
+target_link_libraries(il_transform PUBLIC viper_il_core viper_il_verify il_analysis)
 target_include_directories(il_transform PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
 )
 
 add_library(il_utils STATIC il/utils/Utils.cpp)
-target_link_libraries(il_utils PUBLIC il_core)
+target_link_libraries(il_utils PUBLIC viper_il_core)
 target_include_directories(il_utils PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
 )
 
 add_library(il_tools_common STATIC tools/common/module_loader.cpp)
-target_link_libraries(il_tools_common PUBLIC il_api support)
+target_link_libraries(il_tools_common PUBLIC il_api)
 target_include_directories(il_tools_common PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
@@ -115,7 +130,7 @@ target_include_directories(il_vm PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
 )
-target_link_libraries(il_vm PUBLIC il_core il_runtime viper_runtime support)
+target_link_libraries(il_vm PUBLIC viper_il_core il_runtime viper_runtime viper_support)
 
 add_library(il_codegen_x86_64 STATIC codegen/x86_64/placeholder.cpp)
 set_target_properties(il_codegen_x86_64 PROPERTIES LINKER_LANGUAGE CXX)
@@ -128,15 +143,15 @@ add_executable(ilc
   tools/ilc/cli.cpp
   tools/ilc/break_spec.cpp)
 set_target_properties(ilc PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/ilc)
-target_link_libraries(ilc PRIVATE il_core il_io il_vm il_verify il_transform fe_basic il_api support il_tools_common)
+target_link_libraries(ilc PRIVATE viper_il_full il_vm il_transform fe_basic il_api il_tools_common)
 
 add_executable(il-verify tools/il-verify/il-verify.cpp)
 set_target_properties(il-verify PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/il-verify)
-target_link_libraries(il-verify PRIVATE support il_core il_build il_io il_vm il_verify il_api il_tools_common)
+target_link_libraries(il-verify PRIVATE viper_il_full il_build il_vm il_api il_tools_common)
 
 add_executable(il-dis tools/il-dis/main.cpp)
 set_target_properties(il-dis PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/il-dis)
-target_link_libraries(il-dis PRIVATE support il_core il_build il_io)
+target_link_libraries(il-dis PRIVATE viper_il_full il_build)
 
 add_subdirectory(frontends/basic)
 
@@ -144,13 +159,13 @@ add_executable(basic-ast-dump
   tools/basic-ast-dump/main.cpp
   tools/basic/common.cpp)
 set_target_properties(basic-ast-dump PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/basic-ast-dump)
-target_link_libraries(basic-ast-dump PRIVATE fe_basic support)
+target_link_libraries(basic-ast-dump PRIVATE fe_basic)
 target_compile_definitions(basic-ast-dump PRIVATE VIPER_BASIC_TOOL_USAGE="Usage: basic-ast-dump <file.bas>\\n")
 add_executable(basic-lex-dump
   tools/basic-lex-dump/main.cpp
   tools/basic/common.cpp)
 set_target_properties(basic-lex-dump PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/basic-lex-dump)
-target_link_libraries(basic-lex-dump PRIVATE fe_basic support)
+target_link_libraries(basic-lex-dump PRIVATE fe_basic)
 target_compile_definitions(basic-lex-dump PRIVATE VIPER_BASIC_TOOL_USAGE="Usage: basic-lex-dump <file.bas>\\n")
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/support/

--- a/src/frontends/basic/CMakeLists.txt
+++ b/src/frontends/basic/CMakeLists.txt
@@ -34,7 +34,7 @@ add_library(fe_basic STATIC
   SemanticDiagnostics.cpp
 )
 
-target_link_libraries(fe_basic PUBLIC support il_build il_core il_runtime)
+target_link_libraries(fe_basic PUBLIC viper_il_full il_build il_runtime)
 target_include_directories(fe_basic PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>

--- a/src/il/io/CMakeLists.txt
+++ b/src/il/io/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(il_io STATIC
+add_library(viper_il_io STATIC
   FunctionParser.cpp
   InstrParser.cpp
   ModuleParser.cpp
@@ -9,9 +9,9 @@ add_library(il_io STATIC
   TypeParser.cpp
 )
 
-target_link_libraries(il_io PUBLIC il_core)
+target_link_libraries(viper_il_io PRIVATE viper_il_core)
 
-target_include_directories(il_io PUBLIC
+target_include_directories(viper_il_io PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
 )

--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(support STATIC
+add_library(viper_support STATIC
   string_interner.cpp
   source_manager.cpp
   source_location.cpp
@@ -9,7 +9,7 @@ add_library(support STATIC
   diag_capture.cpp
 )
 
-target_include_directories(support PUBLIC
+target_include_directories(viper_support PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
 )

--- a/tests/basic/CMakeLists.txt
+++ b/tests/basic/CMakeLists.txt
@@ -2,7 +2,7 @@
 # File: tests/basic/CMakeLists.txt
 # Purpose: BASIC frontend unit and golden tests.
 
-set(VIPER_BASIC_LIBS fe_basic support)
+set(VIPER_BASIC_LIBS fe_basic)
 set(VIPER_BASIC_LIBS ${VIPER_BASIC_LIBS} PARENT_SCOPE)
 
 function(viper_add_basic_early_tests)
@@ -27,7 +27,7 @@ function(viper_add_basic_main_tests)
   viper_add_ctest(test_basic_lexer test_basic_lexer)
 
   viper_add_test_exe(test_basic_loc ${_VIPER_BASIC_UNIT_DIR}/test_basic_loc.cpp)
-  target_link_libraries(test_basic_loc PRIVATE fe_basic il_build il_core support)
+  target_link_libraries(test_basic_loc PRIVATE fe_basic il_build viper_il_full)
   viper_add_ctest(test_basic_loc test_basic_loc)
 
   viper_add_test_exe(test_basic_expr_loc ${_VIPER_BASIC_UNIT_DIR}/test_basic_expr_loc.cpp)

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -2,10 +2,8 @@
 # File: tests/il/CMakeLists.txt
 # Purpose: IL parser, verifier, and analysis tests.
 
-set(VIPER_IL_CORE_IO_LIBS il_core il_io)
+set(VIPER_IL_CORE_IO_LIBS viper_il_full)
 set(VIPER_IL_CORE_IO_LIBS ${VIPER_IL_CORE_IO_LIBS} PARENT_SCOPE)
-set(VIPER_IL_SUPPORT_LIB support)
-set(VIPER_IL_SUPPORT_LIB ${VIPER_IL_SUPPORT_LIB} PARENT_SCOPE)
 set(VIPER_IL_ANALYSIS_LIBS il_analysis il_build)
 set(VIPER_IL_ANALYSIS_LIBS ${VIPER_IL_ANALYSIS_LIBS} PARENT_SCOPE)
 
@@ -17,29 +15,29 @@ function(viper_add_il_core_tests)
   set(_VIPER_IL_UNIT_DIR ${VIPER_TESTS_DIR}/unit)
 
   viper_add_test_exe(test_il_serialize ${_VIPER_IL_UNIT_DIR}/test_il_serialize.cpp)
-  target_link_libraries(test_il_serialize PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_build ${VIPER_IL_SUPPORT_LIB})
+  target_link_libraries(test_il_serialize PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_build)
   target_compile_definitions(test_il_serialize PRIVATE TESTS_DIR="${VIPER_TESTS_DIR}")
   viper_add_ctest(test_il_serialize test_il_serialize)
 
   viper_add_test_exe(test_il_serialize_opcodes ${_VIPER_IL_UNIT_DIR}/test_il_serialize_opcodes.cpp)
-  target_link_libraries(test_il_serialize_opcodes PRIVATE ${VIPER_IL_CORE_IO_LIBS} ${VIPER_IL_SUPPORT_LIB})
+  target_link_libraries(test_il_serialize_opcodes PRIVATE ${VIPER_IL_CORE_IO_LIBS})
   target_compile_definitions(test_il_serialize_opcodes PRIVATE TESTS_DIR="${VIPER_TESTS_DIR}")
   viper_add_ctest(test_il_serialize_opcodes test_il_serialize_opcodes)
 
   viper_add_test_exe(test_il_malformed_cbr ${_VIPER_IL_UNIT_DIR}/test_il_malformed_cbr.cpp)
-  target_link_libraries(test_il_malformed_cbr PRIVATE ${VIPER_IL_CORE_IO_LIBS} ${VIPER_IL_SUPPORT_LIB})
+  target_link_libraries(test_il_malformed_cbr PRIVATE ${VIPER_IL_CORE_IO_LIBS})
   viper_add_ctest(test_il_malformed_cbr test_il_malformed_cbr)
 
   viper_add_test_exe(test_irbuilder_call_ret ${_VIPER_IL_UNIT_DIR}/test_irbuilder_call_ret.cpp)
-  target_link_libraries(test_irbuilder_call_ret PRIVATE il_core il_build ${VIPER_IL_SUPPORT_LIB})
+  target_link_libraries(test_irbuilder_call_ret PRIVATE il_build ${VIPER_IL_CORE_IO_LIBS})
   viper_add_ctest(test_irbuilder_call_ret test_irbuilder_call_ret)
 
   viper_add_test_exe(test_irbuilder_call_unknown ${_VIPER_IL_UNIT_DIR}/test_irbuilder_call_unknown.cpp)
-  target_link_libraries(test_irbuilder_call_unknown PRIVATE il_core il_build ${VIPER_IL_SUPPORT_LIB})
+  target_link_libraries(test_irbuilder_call_unknown PRIVATE il_build ${VIPER_IL_CORE_IO_LIBS})
   viper_add_ctest(test_irbuilder_call_unknown test_irbuilder_call_unknown)
 
   viper_add_test_exe(test_il_roundtrip ${_VIPER_IL_UNIT_DIR}/test_il_roundtrip.cpp)
-  target_link_libraries(test_il_roundtrip PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_verify il_api)
+  target_link_libraries(test_il_roundtrip PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   target_compile_definitions(test_il_roundtrip PRIVATE EXAMPLES_DIR="${CMAKE_SOURCE_DIR}/examples" ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/roundtrip")
   viper_add_ctest(test_il_roundtrip test_il_roundtrip)
 
@@ -54,7 +52,7 @@ function(viper_add_il_core_tests)
   viper_add_ctest(test_il_parse_unresolved_branch test_il_parse_unresolved_branch)
 
   viper_add_test_exe(test_il_parse_param_prefix ${_VIPER_IL_UNIT_DIR}/test_il_parse_param_prefix.cpp)
-  target_link_libraries(test_il_parse_param_prefix PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api ${VIPER_IL_SUPPORT_LIB})
+  target_link_libraries(test_il_parse_param_prefix PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   target_compile_definitions(test_il_parse_param_prefix PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
   viper_add_ctest(test_il_parse_param_prefix test_il_parse_param_prefix)
 
@@ -107,7 +105,7 @@ function(viper_add_il_core_tests)
   viper_add_ctest(test_il_parse_misc_instructions test_il_parse_misc_instructions)
 
   viper_add_test_exe(test_il_function_parser_errors ${_VIPER_IL_UNIT_DIR}/test_il_function_parser_errors.cpp)
-  target_link_libraries(test_il_function_parser_errors PRIVATE ${VIPER_IL_CORE_IO_LIBS} ${VIPER_IL_SUPPORT_LIB})
+  target_link_libraries(test_il_function_parser_errors PRIVATE ${VIPER_IL_CORE_IO_LIBS})
   viper_add_ctest(test_il_function_parser_errors test_il_function_parser_errors)
 
   viper_add_test_exe(test_expected_api_build ${_VIPER_IL_UNIT_DIR}/test_expected_api_build.cpp)
@@ -115,19 +113,19 @@ function(viper_add_il_core_tests)
   viper_add_ctest(test_expected_api_build test_expected_api_build)
 
   viper_add_test_exe(test_il_verify_trap ${_VIPER_IL_UNIT_DIR}/test_il_verify_trap.cpp)
-  target_link_libraries(test_il_verify_trap PRIVATE il_core il_verify il_api)
+  target_link_libraries(test_il_verify_trap PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   viper_add_ctest(test_il_verify_trap test_il_verify_trap)
 
   viper_add_test_exe(test_il_verify_forward_call ${_VIPER_IL_UNIT_DIR}/test_il_verify_forward_call.cpp)
-  target_link_libraries(test_il_verify_forward_call PRIVATE il_core il_verify il_api)
+  target_link_libraries(test_il_verify_forward_call PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   viper_add_ctest(test_il_verify_forward_call test_il_verify_forward_call)
 
   viper_add_test_exe(test_il_verify_release_lifetime ${_VIPER_IL_UNIT_DIR}/test_il_verify_release_lifetime.cpp)
-  target_link_libraries(test_il_verify_release_lifetime PRIVATE il_core il_verify il_api)
+  target_link_libraries(test_il_verify_release_lifetime PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   viper_add_ctest(test_il_verify_release_lifetime test_il_verify_release_lifetime)
 
   viper_add_test_exe(test_il_type_inference ${_VIPER_IL_UNIT_DIR}/test_il_type_inference.cpp)
-  target_link_libraries(test_il_type_inference PRIVATE il_core il_verify ${VIPER_IL_SUPPORT_LIB})
+  target_link_libraries(test_il_type_inference PRIVATE ${VIPER_IL_CORE_IO_LIBS})
   viper_add_ctest(test_il_type_inference test_il_type_inference)
 
   viper_add_test_exe(test_runtime_registry ${_VIPER_IL_UNIT_DIR}/test_runtime_registry.cpp)
@@ -135,24 +133,24 @@ function(viper_add_il_core_tests)
   viper_add_ctest(test_runtime_registry test_runtime_registry)
 
   viper_add_test_exe(test_il_instruction_checker ${_VIPER_IL_UNIT_DIR}/test_il_instruction_checker.cpp)
-  target_link_libraries(test_il_instruction_checker PRIVATE il_core il_verify ${VIPER_IL_SUPPORT_LIB})
+  target_link_libraries(test_il_instruction_checker PRIVATE ${VIPER_IL_CORE_IO_LIBS})
   viper_add_ctest(test_il_instruction_checker test_il_instruction_checker)
 
   viper_add_test_exe(test_il_error_resume_ir ${_VIPER_IL_UNIT_DIR}/test_il_error_resume_ir.cpp)
-  target_link_libraries(test_il_error_resume_ir PRIVATE il_core)
+  target_link_libraries(test_il_error_resume_ir PRIVATE ${VIPER_IL_CORE_IO_LIBS})
   viper_add_ctest(test_il_error_resume_ir test_il_error_resume_ir)
 
   viper_add_test_exe(test_il_control_flow_checker ${_VIPER_IL_UNIT_DIR}/test_il_control_flow_checker.cpp)
-  target_link_libraries(test_il_control_flow_checker PRIVATE il_core il_verify ${VIPER_IL_SUPPORT_LIB})
+  target_link_libraries(test_il_control_flow_checker PRIVATE ${VIPER_IL_CORE_IO_LIBS})
   viper_add_ctest(test_il_control_flow_checker test_il_control_flow_checker)
 
   viper_add_test_exe(test_il_exception_handler_analysis
     ${_VIPER_IL_UNIT_DIR}/test_il_exception_handler_analysis.cpp)
-  target_link_libraries(test_il_exception_handler_analysis PRIVATE il_core il_verify ${VIPER_IL_SUPPORT_LIB})
+  target_link_libraries(test_il_exception_handler_analysis PRIVATE ${VIPER_IL_CORE_IO_LIBS})
   viper_add_ctest(test_il_exception_handler_analysis test_il_exception_handler_analysis)
 
   viper_add_test_exe(test_il_branch_verifier ${_VIPER_IL_UNIT_DIR}/test_il_branch_verifier.cpp)
-  target_link_libraries(test_il_branch_verifier PRIVATE il_core il_verify ${VIPER_IL_SUPPORT_LIB})
+  target_link_libraries(test_il_branch_verifier PRIVATE ${VIPER_IL_CORE_IO_LIBS})
   viper_add_ctest(test_il_branch_verifier test_il_branch_verifier)
 endfunction()
 
@@ -167,11 +165,11 @@ function(viper_add_il_utils_test)
   viper_add_ctest(test_il_utils test_il_utils)
 
   viper_add_test_exe(test_il_opcode_info ${_VIPER_IL_DIR}/OpcodeInfoTests.cpp)
-  target_link_libraries(test_il_opcode_info PRIVATE il_core)
+  target_link_libraries(test_il_opcode_info PRIVATE ${VIPER_IL_CORE_IO_LIBS})
   viper_add_ctest(test_il_opcode_info test_il_opcode_info)
 
   viper_add_test_exe(test_il_invalid_eh ${_VIPER_IL_DIR}/InvalidEhTests.cpp)
-  target_link_libraries(test_il_invalid_eh PRIVATE il_core il_io il_verify il_api ${VIPER_IL_SUPPORT_LIB})
+  target_link_libraries(test_il_invalid_eh PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   target_compile_definitions(
     test_il_invalid_eh PRIVATE INVALID_EH_DIR="${CMAKE_SOURCE_DIR}/tests/il/invalid_eh")
   viper_add_ctest(il_InvalidEhTests test_il_invalid_eh)
@@ -396,10 +394,10 @@ function(viper_add_il_liveness_tests)
   set(_VIPER_IL_UNIT_DIR ${VIPER_TESTS_DIR}/unit)
 
   viper_add_test_exe(test_il_liveness ${_VIPER_IL_UNIT_DIR}/test_il_liveness.cpp)
-  target_link_libraries(test_il_liveness PRIVATE il_io il_transform il_api)
+  target_link_libraries(test_il_liveness PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_transform il_api)
   viper_add_ctest(test_il_liveness test_il_liveness)
 
   viper_add_test_exe(test_il_pass_manager ${_VIPER_IL_UNIT_DIR}/test_il_pass_manager.cpp)
-  target_link_libraries(test_il_pass_manager PRIVATE il_io il_transform il_api)
+  target_link_libraries(test_il_pass_manager PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_transform il_api)
   viper_add_ctest(test_il_pass_manager test_il_pass_manager)
 endfunction()

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -2,7 +2,7 @@
 # File: tests/tools/CMakeLists.txt
 # Purpose: CLI and tool-specific smoke tests.
 
-set(VIPER_TOOLS_LIBS il_vm il_api support il_tools_common)
+set(VIPER_TOOLS_LIBS viper_il_full il_vm il_api il_tools_common)
 set(VIPER_TOOLS_LIBS ${VIPER_TOOLS_LIBS} PARENT_SCOPE)
 
 function(viper_add_tools_tests)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,7 +2,7 @@
 # File: tests/unit/CMakeLists.txt
 # Purpose: Build standalone unit test executables.
 
-set(VIPER_UNIT_SUPPORT_LIBS support)
+set(VIPER_UNIT_SUPPORT_LIBS viper_support)
 set(VIPER_UNIT_SUPPORT_LIBS ${VIPER_UNIT_SUPPORT_LIBS} PARENT_SCOPE)
 set(VIPER_RUNTIME_TEST_LIBS viper_runtime)
 set(VIPER_RUNTIME_TEST_LIBS ${VIPER_RUNTIME_TEST_LIBS} PARENT_SCOPE)

--- a/tests/vm/CMakeLists.txt
+++ b/tests/vm/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 set(VIPER_VM_LIB il_vm)
 set(VIPER_VM_LIB ${VIPER_VM_LIB} PARENT_SCOPE)
-set(VIPER_VM_SUPPORT_LIB support)
+set(VIPER_VM_SUPPORT_LIB viper_support)
 set(VIPER_VM_SUPPORT_LIB ${VIPER_VM_SUPPORT_LIB} PARENT_SCOPE)
 
 function(viper_add_vm_debug_tests)
@@ -167,7 +167,7 @@ function(viper_add_vm_unit_tests)
   viper_add_ctest(test_vm_many_temps test_vm_many_temps)
 
   viper_add_test_exe(test_vm_addr_of ${VIPER_TESTS_DIR}/unit/test_vm_addr_of.cpp)
-  target_link_libraries(test_vm_addr_of PRIVATE il_io ${VIPER_VM_LIB} il_api)
+  target_link_libraries(test_vm_addr_of PRIVATE viper_il_full ${VIPER_VM_LIB} il_api)
   viper_add_ctest(test_vm_addr_of test_vm_addr_of)
 
   viper_add_test_exe(test_vm_dispatch_handlers ${VIPER_TESTS_DIR}/unit/test_vm_dispatch_handlers.cpp)
@@ -179,7 +179,7 @@ function(viper_add_vm_unit_tests)
   viper_add_ctest(test_vm_opcode_coverage test_vm_opcode_coverage)
 
   viper_add_test_exe(test_vm_opcode_dispatch ${VIPER_TESTS_DIR}/unit/test_vm_opcode_dispatch.cpp)
-  target_link_libraries(test_vm_opcode_dispatch PRIVATE il_io ${VIPER_VM_LIB} il_api)
+  target_link_libraries(test_vm_opcode_dispatch PRIVATE viper_il_full ${VIPER_VM_LIB} il_api)
   viper_add_ctest(test_vm_opcode_dispatch test_vm_opcode_dispatch)
 
   viper_add_test_exe(test_vm_run_loop_helpers ${VIPER_TESTS_DIR}/unit/test_vm_run_loop_helpers.cpp)


### PR DESCRIPTION
## Summary
- rename the IL and support static libraries to viper_* and add the viper_il_full interface aggregator
- update executables and tests to consume the aggregated IL stack and remove repeated support/core/io link entries
- export the new targets so the consolidated IL stack is available to downstream consumers

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68df49a31b2c8324b38a26ba6e3f83f3