### PR TITLE
Make il tool CLIs depend on viper::il_full aggregator

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,15 +143,15 @@ add_executable(ilc
   tools/ilc/cli.cpp
   tools/ilc/break_spec.cpp)
 set_target_properties(ilc PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/ilc)
-target_link_libraries(ilc PRIVATE viper_il_full il_vm il_transform fe_basic il_api il_tools_common)
+target_link_libraries(ilc PRIVATE viper::il_full il_vm il_transform fe_basic il_api il_tools_common)
 
 add_executable(il-verify tools/il-verify/il-verify.cpp)
 set_target_properties(il-verify PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/il-verify)
-target_link_libraries(il-verify PRIVATE viper_il_full il_build il_vm il_api il_tools_common)
+target_link_libraries(il-verify PRIVATE viper::il_full il_build il_vm il_api il_tools_common)
 
 add_executable(il-dis tools/il-dis/main.cpp)
 set_target_properties(il-dis PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/il-dis)
-target_link_libraries(il-dis PRIVATE viper_il_full il_build)
+target_link_libraries(il-dis PRIVATE viper::il_full il_build)
 
 add_subdirectory(frontends/basic)
 


### PR DESCRIPTION
## Summary
- update the ilc, il-verify, and il-dis executables to link against the namespaced viper::il_full target

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68df62f26b5c8324a594393fb04a0a02