### PR TITLE
Tighten IL link visibility in build system

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,11 @@ target_include_directories(il_runtime PUBLIC
 )
 
 add_library(il_build STATIC il/build/IRBuilder.cpp)
-target_link_libraries(il_build PUBLIC viper_il_core viper_support)
+target_link_libraries(il_build
+  PUBLIC
+    viper_il_core
+  PRIVATE
+    viper_support)
 target_include_directories(il_build PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
@@ -90,7 +94,12 @@ add_library(il_transform STATIC
   il/transform/ConstFold.cpp
   il/transform/DCE.cpp
   il/transform/Mem2Reg.cpp)
-target_link_libraries(il_transform PUBLIC viper_il_core viper_il_verify il_analysis)
+target_link_libraries(il_transform
+  PUBLIC
+    viper_il_core
+  PRIVATE
+    viper_il_verify
+    il_analysis)
 target_include_directories(il_transform PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
@@ -130,7 +139,13 @@ target_include_directories(il_vm PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/viper>
 )
-target_link_libraries(il_vm PUBLIC viper_il_core il_runtime viper_runtime viper_support)
+target_link_libraries(il_vm
+  PUBLIC
+    viper_il_core
+    il_runtime
+    viper_runtime
+  PRIVATE
+    viper_support)
 
 add_library(il_codegen_x86_64 STATIC codegen/x86_64/placeholder.cpp)
 set_target_properties(il_codegen_x86_64 PROPERTIES LINKER_LANGUAGE CXX)

--- a/tests/vm/CMakeLists.txt
+++ b/tests/vm/CMakeLists.txt
@@ -147,7 +147,7 @@ function(viper_add_vm_unit_tests)
   viper_add_ctest(test_vm_runtime_concurrency test_vm_runtime_concurrency)
 
   viper_add_test(test_vm_runtime_bridge_marshalling ${VIPER_TESTS_DIR}/unit/test_vm_runtime_bridge_marshalling.cpp)
-  target_link_libraries(test_vm_runtime_bridge_marshalling PRIVATE ${VIPER_VM_LIB})
+  target_link_libraries(test_vm_runtime_bridge_marshalling PRIVATE ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   viper_add_ctest(test_vm_runtime_bridge_marshalling test_vm_runtime_bridge_marshalling)
 
   viper_add_test(test_vm_alloca_negative ${VIPER_TESTS_DIR}/unit/test_vm_alloca_negative.cpp)
@@ -175,11 +175,11 @@ function(viper_add_vm_unit_tests)
   viper_add_ctest(test_vm_addr_of test_vm_addr_of)
 
   viper_add_test(test_vm_dispatch_handlers ${VIPER_TESTS_DIR}/unit/test_vm_dispatch_handlers.cpp)
-  target_link_libraries(test_vm_dispatch_handlers PRIVATE ${VIPER_VM_LIB})
+  target_link_libraries(test_vm_dispatch_handlers PRIVATE ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   viper_add_ctest(test_vm_dispatch_handlers test_vm_dispatch_handlers)
 
   viper_add_test(test_vm_opcode_coverage ${_VIPER_VM_DIR}/OpcodeCoverageTests.cpp)
-  target_link_libraries(test_vm_opcode_coverage PRIVATE ${VIPER_VM_LIB})
+  target_link_libraries(test_vm_opcode_coverage PRIVATE ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   viper_add_ctest(test_vm_opcode_coverage test_vm_opcode_coverage)
 
   viper_add_test(test_vm_opcode_dispatch ${VIPER_TESTS_DIR}/unit/test_vm_opcode_dispatch.cpp)
@@ -197,10 +197,10 @@ function(viper_add_vm_path_tests)
   endif()
 
   viper_add_test(test_vm_normalize_path ${VIPER_TESTS_DIR}/unit/test_vm_normalize_path.cpp)
-  target_link_libraries(test_vm_normalize_path PRIVATE ${VIPER_VM_LIB})
+  target_link_libraries(test_vm_normalize_path PRIVATE ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   viper_add_ctest(test_vm_normalize_path test_vm_normalize_path)
 
   viper_add_test(test_path_normalize ${VIPER_TESTS_DIR}/unit/PathNormalizeTests.cpp)
-  target_link_libraries(test_path_normalize PRIVATE ${VIPER_VM_LIB})
+  target_link_libraries(test_path_normalize PRIVATE ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   viper_add_ctest(test_path_normalize test_path_normalize)
 endfunction()


### PR DESCRIPTION
## Summary
- limit il_build, il_transform, and il_vm to expose only the dependencies their consumers need
- update VM unit test targets to link viper_support explicitly now that il_vm no longer publishes it

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68dfe7120d9883249cb1bebf0ea2cffe