### PR TITLE
Print resolved link items for ilc (diagnostic only)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,6 +159,8 @@ add_executable(ilc
   tools/ilc/break_spec.cpp)
 set_target_properties(ilc PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/ilc)
 target_link_libraries(ilc PRIVATE viper::il_full il_vm il_transform fe_basic il_api il_tools_common)
+get_target_property(ILC_LINK_LIBS ilc LINK_LIBRARIES)
+message(STATUS "ilc LINK_LIBRARIES: ${ILC_LINK_LIBS}")
 
 add_executable(il-verify tools/il-verify/il-verify.cpp)
 set_target_properties(il-verify PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/il-verify)


### PR DESCRIPTION
## Summary
- emit the ilc target's resolved LINK_LIBRARIES during configuration to help spot duplicate link entries

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68dfeafb42908324891894d2817429c4