### PR TITLE
Suppress duplicate-lib warnings on Apple (temporary)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ endif()
 add_compile_options(${IL_COMPILE_FLAGS})
 add_link_options(${IL_LINK_FLAGS})
 
+if(APPLE)
+  add_link_options(-Wl,-no_warn_duplicate_libraries)
+endif()
+
 function(viper_assert_no_directory_link_libraries dir label)
   if("${dir}" STREQUAL ".")
     get_property(_dir_link_libs DIRECTORY PROPERTY LINK_LIBRARIES)


### PR DESCRIPTION
## Summary
- temporarily add an Apple-specific linker flag to suppress duplicate library warnings while structural refactors are in flight

## Testing
- cmake -S . -B build
- cmake --build build -j2
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dfedce1d5083248c542783d59d0170