### PR TITLE
Create interface target for shared tool/test options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ option(IL_SANITIZE_ADDRESS "Enable address sanitizer" OFF)
 option(IL_SANITIZE_UNDEFINED "Enable undefined behavior sanitizer" OFF)
 
 set(IL_COMPILE_FLAGS -Wall -Wextra -Wpedantic)
-set(IL_LINK_FLAGS "")
+set(IL_LINK_FLAGS)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   list(APPEND IL_COMPILE_FLAGS -Wno-unused-parameter -Wno-unused-private-field -Wno-mismatched-tags)
@@ -55,11 +55,20 @@ if(IL_USE_LIBCXX AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT APPLE)
   list(APPEND IL_LINK_FLAGS -stdlib=libc++)
 endif()
 
-add_compile_options(${IL_COMPILE_FLAGS})
-add_link_options(${IL_LINK_FLAGS})
+add_library(viper_common_opts INTERFACE)
+target_compile_features(viper_common_opts INTERFACE cxx_std_20)
+if(IL_COMPILE_FLAGS)
+  target_compile_options(viper_common_opts INTERFACE ${IL_COMPILE_FLAGS})
+endif()
+
+set(_viper_link_opts ${IL_LINK_FLAGS})
+list(FILTER _viper_link_opts EXCLUDE REGEX "^$")
+if(_viper_link_opts)
+  target_link_options(viper_common_opts INTERFACE ${_viper_link_opts})
+endif()
 
 if(APPLE)
-  add_link_options(-Wl,-no_warn_duplicate_libraries)
+  target_link_options(viper_common_opts INTERFACE -Wl,-no_warn_duplicate_libraries)
 endif()
 
 function(viper_assert_no_directory_link_libraries dir label)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -158,17 +158,36 @@ add_executable(ilc
   tools/ilc/cli.cpp
   tools/ilc/break_spec.cpp)
 set_target_properties(ilc PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/ilc)
-target_link_libraries(ilc PRIVATE viper::il_full il_vm il_transform fe_basic il_api il_tools_common)
+target_link_libraries(ilc
+  PRIVATE
+    viper_common_opts
+    viper::il_full
+    il_vm
+    il_transform
+    fe_basic
+    il_api
+    il_tools_common)
 get_target_property(ILC_LINK_LIBS ilc LINK_LIBRARIES)
 message(STATUS "ilc LINK_LIBRARIES: ${ILC_LINK_LIBS}")
 
 add_executable(il-verify tools/il-verify/il-verify.cpp)
 set_target_properties(il-verify PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/il-verify)
-target_link_libraries(il-verify PRIVATE viper::il_full il_build il_vm il_api il_tools_common)
+target_link_libraries(il-verify
+  PRIVATE
+    viper_common_opts
+    viper::il_full
+    il_build
+    il_vm
+    il_api
+    il_tools_common)
 
 add_executable(il-dis tools/il-dis/main.cpp)
 set_target_properties(il-dis PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/il-dis)
-target_link_libraries(il-dis PRIVATE viper::il_full il_build)
+target_link_libraries(il-dis
+  PRIVATE
+    viper_common_opts
+    viper::il_full
+    il_build)
 
 add_subdirectory(frontends/basic)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
 endif()
 
 add_library(viper_testing INTERFACE)
-target_link_libraries(viper_testing INTERFACE viper::il_full ${_viper_testing_gtest_targets})
+target_link_libraries(viper_testing INTERFACE viper_common_opts viper::il_full ${_viper_testing_gtest_targets})
 
 if(IL_ENABLE_DOCS_LINT)
   find_package(Python3 COMPONENTS Interpreter REQUIRED)


### PR DESCRIPTION
## Summary
- add a `viper_common_opts` INTERFACE library to centralize common compile features, warnings, and link flags
- link the IL tooling executables and the `viper_testing` interface library against the shared options target

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dff1071fd0832481efc00e80b6537c