### PR TITLE
Add CI check for CMake anti-patterns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Configure
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+      - name: Check CMake anti-patterns
+        run: tools/ci/check_cmake.sh
       - name: Build ilc
         run: cmake --build build --target ilc -j2
       - name: Run basic string tests
@@ -45,6 +47,8 @@ jobs:
         run: sudo apt-get install -y clang lld
       - name: Configure
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DIL_WARN_AS_ERROR=ON -DIL_USE_LLD=ON
+      - name: Check CMake anti-patterns
+        run: tools/ci/check_cmake.sh
       - name: Build
         run: cmake --build build -j2
       - name: Test

--- a/tools/ci/check_cmake.sh
+++ b/tools/ci/check_cmake.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+fail=0
+grep -R --line-number -E 'link_libraries\s*\(' . && { echo "Do not use link_libraries()"; fail=1; }
+grep -R --line-number -E 'target_link_libraries\([^)]*\\.a\b' . && { echo "Do not link .a directly; use targets/IMPORTED"; fail=1; }
+exit $fail


### PR DESCRIPTION
## Summary
- add a CI helper script that fails on link_libraries() or direct .a linkage usage
- run the helper after the configure step in both workflows

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dff811f2148324a8088b97659be8df