### PR TITLE
Add regression test for runtime int64 formatting

### DIFF
--- a/tests/runtime/Int64ToStringTests.cpp
+++ b/tests/runtime/Int64ToStringTests.cpp
@@ -1,0 +1,49 @@
+// File: tests/runtime/Int64ToStringTests.cpp
+// Purpose: Lock down runtime formatting for critical 64-bit integer values.
+// Key invariants: Decimal spellings are canonical and portable across toolchains.
+// Ownership: Runtime integer formatting helpers.
+// Links: docs/codemap.md
+
+#include "rt_int_format.h"
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
+int main()
+{
+    struct FormatCase
+    {
+        int64_t value;
+        const char *expected;
+    };
+
+    const std::array<FormatCase, 7> cases = {{{0, "0"},
+                                              {1, "1"},
+                                              {-1, "-1"},
+                                              {std::numeric_limits<int64_t>::max(), "9223372036854775807"},
+                                              {std::numeric_limits<int64_t>::min(), "-9223372036854775808"},
+                                              {static_cast<int64_t>(1000000000000000000LL), "1000000000000000000"},
+                                              {static_cast<int64_t>(-1000000000000000000LL), "-1000000000000000000"}}};
+
+    for (const auto &test : cases)
+    {
+        char buffer[64] = {};
+        const size_t written = rt_i64_to_cstr(test.value, buffer, sizeof(buffer));
+        assert(written == std::strlen(test.expected));
+        assert(std::strcmp(buffer, test.expected) == 0);
+
+        if (test.value >= 0)
+        {
+            char unsigned_buffer[64] = {};
+            const size_t unsigned_written =
+                rt_u64_to_cstr(static_cast<uint64_t>(test.value), unsigned_buffer, sizeof(unsigned_buffer));
+            assert(unsigned_written == std::strlen(test.expected));
+            assert(std::strcmp(unsigned_buffer, test.expected) == 0);
+        }
+    }
+
+    return 0;
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -61,6 +61,12 @@ function(viper_add_runtime_tests)
     TEST_NAME runtime_FloatFormattingTests)
   target_link_libraries(test_rt_float_formatting PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
 
+  viper_add_test(
+    test_rt_int64_to_string
+    ${VIPER_TESTS_DIR}/runtime/Int64ToStringTests.cpp
+    TEST_NAME runtime_Int64ToStringTests)
+  target_link_libraries(test_rt_int64_to_string PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
+
   viper_add_test(test_rt_error_plumbing ${VIPER_TESTS_DIR}/runtime/RtErrorPlumbingTests.cpp)
   target_link_libraries(test_rt_error_plumbing PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_error_plumbing test_rt_error_plumbing)


### PR DESCRIPTION
## Summary
- add a runtime test that exercises rt_i64_to_cstr/rt_u64_to_cstr across boundary 64-bit values
- register the test in the runtime suite so it participates in ctest runs

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build -R Int64ToString --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e01e56c5d48324ac1b01ab3bad3f4d