### PR TITLE
Normalize BASIC boolean IL to -1/0 representation

### DIFF
--- a/src/frontends/basic/LowerEmit.cpp
+++ b/src/frontends/basic/LowerEmit.cpp
@@ -112,6 +112,21 @@ Lowerer::IlValue Lowerer::emitBoolConst(bool v)
     return emitUnary(Opcode::Trunc1, ilBoolTy(), Value::constInt(v ? 1 : 0));
 }
 
+Value Lowerer::emitConstI64(std::int64_t v)
+{
+    return Value::constInt(v);
+}
+
+Value Lowerer::emitZext1ToI64(Value b1)
+{
+    return emitUnary(Opcode::Zext1, Type(Type::Kind::I64), b1);
+}
+
+Value Lowerer::emitISub(Value lhs, Value rhs)
+{
+    return emitBinary(Opcode::Sub, Type(Type::Kind::I64), lhs, rhs);
+}
+
 /// @brief Build a boolean by merging results from synthetic then/else blocks.
 /// @param emitThen Callback that stores the truthy value to the provided slot within the
 /// then block.

--- a/src/frontends/basic/LowerStmt.cpp
+++ b/src/frontends/basic/LowerStmt.cpp
@@ -247,17 +247,24 @@ void Lowerer::lowerLet(const LetStmt &stmt)
         bool isBool = slotInfo.isBoolean;
         if (!isArray)
         {
-            if (!isStr && !isF64 && !isBool && v.type.kind == Type::Kind::I1)
+            if (isBool)
             {
-                v = coerceToI64(std::move(v), stmt.loc);
+                v = coerceToBool(std::move(v), stmt.loc);
             }
-            if (isF64 && v.type.kind == Type::Kind::I64)
+            else
             {
-                v = coerceToF64(std::move(v), stmt.loc);
-            }
-            else if (!isStr && !isF64 && !isBool && v.type.kind == Type::Kind::F64)
-            {
-                v = coerceToI64(std::move(v), stmt.loc);
+                if (!isStr && !isF64 && v.type.kind == Type::Kind::I1)
+                {
+                    v = coerceToI64(std::move(v), stmt.loc);
+                }
+                if (isF64 && v.type.kind == Type::Kind::I64)
+                {
+                    v = coerceToF64(std::move(v), stmt.loc);
+                }
+                else if (!isStr && !isF64 && v.type.kind == Type::Kind::F64)
+                {
+                    v = coerceToI64(std::move(v), stmt.loc);
+                }
             }
         }
         Value slot = Value::temp(*info->slotId);

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -14,6 +14,7 @@
 #include "il/core/Module.hpp"
 #include "il/runtime/RuntimeSignatures.hpp"
 #include <array>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -597,6 +598,18 @@ class Lowerer
 
     /// @brief Emit unary instruction of @p op on @p val producing @p ty.
     Value emitUnary(Opcode op, Type ty, Value val);
+
+    /// @brief Materialize a constant 64-bit integer value.
+    Value emitConstI64(std::int64_t v);
+
+    /// @brief Zero-extend an i1 predicate to BASIC's 64-bit logical form.
+    Value emitZext1ToI64(Value b1);
+
+    /// @brief Emit a 64-bit integer subtraction.
+    Value emitISub(Value lhs, Value rhs);
+
+    /// @brief Convert an i1 predicate into BASIC's -1/0 logical encoding.
+    Value emitBasicLogicalI64(Value b1);
 
     /// @brief Emit checked integer negation for @p val producing type @p ty.
     Value emitCheckedNeg(Type ty, Value val);

--- a/tests/golden/il/boolean_and.il
+++ b/tests/golden/il/boolean_and.il
@@ -48,53 +48,60 @@ L50:
   %t10 = load i64, %t5
   .loc 1 5 16
   %t11 = icmp_ne %t10, 0
+  .loc 1 5 16
+  %t12 = zext1 %t11
+  .loc 1 5 16
+  %t13 = sub 0, %t12
   .loc 1 5 4
-  store i1, %t2, %t11
+  %t14 = trunc1 %t13
+  .loc 1 5 4
+  store i1, %t2, %t14
   .loc 1 5 4
   br L60
 L60:
   .loc 1 6 17
-  %t12 = load i1, %t2
-  .loc 1 6 26
-  %t13 = load i64, %t4
-  .loc 1 6 28
-  %t14 = icmp_ne %t13, 0
-  .loc 1 6 28
-  %t15 = alloca 1
+  %t15 = load i1, %t2
   .loc 1 6 21
-  cbr %t12, bool_then, bool_else
+  %t16 = zext1 %t15
+  .loc 1 6 21
+  %t17 = sub 0, %t16
+  .loc 1 6 26
+  %t18 = load i64, %t4
+  .loc 1 6 28
+  %t19 = icmp_ne %t18, 0
+  .loc 1 6 28
+  %t20 = zext1 %t19
+  .loc 1 6 28
+  %t21 = sub 0, %t20
+  .loc 1 6 21
+  %t22 = trunc1 %t21
+  .loc 1 6 21
+  %t23 = zext1 %t22
+  .loc 1 6 21
+  %t24 = sub 0, %t23
+  .loc 1 6 21
+  %t25 = and %t17, %t24
+  .loc 1 6 4
+  %t26 = trunc1 %t25
+  .loc 1 6 4
+  store i1, %t0, %t26
+  .loc 1 6 4
+  br L70
 L70:
   .loc 1 7 10
-  %t18 = load i1, %t0
+  %t27 = load i1, %t0
   .loc 1 7 4
-  %t19 = zext1 %t18
+  %t28 = zext1 %t27
   .loc 1 7 4
-  call @rt_print_i64(%t19)
+  %t29 = sub 0, %t28
   .loc 1 7 4
-  %t20 = const_str @.L0
+  call @rt_print_i64(%t29)
   .loc 1 7 4
-  call @rt_print_str(%t20)
+  %t30 = const_str @.L0
+  .loc 1 7 4
+  call @rt_print_str(%t30)
   .loc 1 7 4
   br exit
 exit:
   ret 0
-bool_then:
-  .loc 1 6 21
-  store i1, %t15, %t14
-  .loc 1 6 21
-  br bool_join
-bool_else:
-  .loc 1 6 21
-  %t16 = trunc1 0
-  .loc 1 6 21
-  store i1, %t15, %t16
-  .loc 1 6 21
-  br bool_join
-bool_join:
-  .loc 1 6 21
-  %t17 = load i1, %t15
-  .loc 1 6 4
-  store i1, %t0, %t17
-  .loc 1 6 4
-  br L70
 }

--- a/tests/golden/il/boolean_andalso.il
+++ b/tests/golden/il/boolean_andalso.il
@@ -48,53 +48,73 @@ L50:
   %t10 = load i64, %t5
   .loc 1 5 16
   %t11 = icmp_ne %t10, 0
+  .loc 1 5 16
+  %t12 = zext1 %t11
+  .loc 1 5 16
+  %t13 = sub 0, %t12
   .loc 1 5 4
-  store i1, %t2, %t11
+  %t14 = trunc1 %t13
+  .loc 1 5 4
+  store i1, %t2, %t14
   .loc 1 5 4
   br L60
 L60:
   .loc 1 6 17
-  %t12 = load i1, %t2
+  %t15 = load i1, %t2
   .loc 1 6 21
-  %t13 = alloca 1
+  %t16 = alloca 1
   .loc 1 6 21
-  cbr %t12, and_rhs, and_false
+  cbr %t15, and_rhs, and_false
 L70:
   .loc 1 7 10
-  %t18 = load i1, %t0
+  %t27 = load i1, %t0
   .loc 1 7 4
-  %t19 = zext1 %t18
+  %t28 = zext1 %t27
   .loc 1 7 4
-  call @rt_print_i64(%t19)
+  %t29 = sub 0, %t28
   .loc 1 7 4
-  %t20 = const_str @.L0
+  call @rt_print_i64(%t29)
   .loc 1 7 4
-  call @rt_print_str(%t20)
+  %t30 = const_str @.L0
+  .loc 1 7 4
+  call @rt_print_str(%t30)
   .loc 1 7 4
   br exit
 exit:
   ret 0
 and_rhs:
   .loc 1 6 30
-  %t14 = load i64, %t4
+  %t17 = load i64, %t4
   .loc 1 6 32
-  %t15 = icmp_ne %t14, 0
+  %t18 = icmp_ne %t17, 0
+  .loc 1 6 32
+  %t19 = zext1 %t18
+  .loc 1 6 32
+  %t20 = sub 0, %t19
   .loc 1 6 21
-  store i1, %t13, %t15
+  %t21 = trunc1 %t20
+  .loc 1 6 21
+  store i1, %t16, %t21
   .loc 1 6 21
   br and_done
 and_false:
   .loc 1 6 21
-  %t16 = trunc1 0
+  %t22 = trunc1 0
   .loc 1 6 21
-  store i1, %t13, %t16
+  store i1, %t16, %t22
   .loc 1 6 21
   br and_done
 and_done:
   .loc 1 6 21
-  %t17 = load i1, %t13
+  %t23 = load i1, %t16
+  .loc 1 6 21
+  %t24 = zext1 %t23
+  .loc 1 6 21
+  %t25 = sub 0, %t24
   .loc 1 6 4
-  store i1, %t0, %t17
+  %t26 = trunc1 %t25
+  .loc 1 6 4
+  store i1, %t0, %t26
   .loc 1 6 4
   br L70
 }

--- a/tests/golden/il/boolean_literals.il
+++ b/tests/golden/il/boolean_literals.il
@@ -32,70 +32,62 @@ L30:
   %t5 = load i64, %t2
   .loc 1 3 14
   %t6 = icmp_ne %t5, 0
+  .loc 1 3 14
+  %t7 = zext1 %t6
+  .loc 1 3 14
+  %t8 = sub 0, %t7
   .loc 1 3 4
-  store i1, %t0, %t6
+  %t9 = trunc1 %t8
+  .loc 1 3 4
+  store i1, %t0, %t9
   .loc 1 3 4
   br L40
 L40:
   .loc 1 4 10
-  %t7 = load i1, %t0
-  .loc 1 4 15
-  %t8 = trunc1 1
-  .loc 1 4 15
-  %t9 = alloca 1
-L50:
-  .loc 1 5 10
-  %t14 = trunc1 0
-  .loc 1 5 20
-  %t15 = load i1, %t0
-  .loc 1 5 20
-  %t16 = alloca 1
-  .loc 1 5 16
-  cbr %t14, bool_then1, bool_else1
-exit:
-  ret 0
-bool_then:
-bool_else:
+  %t10 = load i1, %t0
   .loc 1 4 12
-  store i1, %t9, %t8
+  %t11 = zext1 %t10
   .loc 1 4 12
-  br bool_join
-bool_join:
+  %t12 = sub 0, %t11
   .loc 1 4 12
-  %t11 = load i1, %t9
+  %t13 = trunc1 -1
+  .loc 1 4 12
+  %t14 = zext1 %t13
+  .loc 1 4 12
+  %t15 = sub 0, %t14
+  .loc 1 4 12
+  %t16 = or %t12, %t15
   .loc 1 4 4
-  %t12 = zext1 %t11
+  call @rt_print_i64(%t16)
   .loc 1 4 4
-  call @rt_print_i64(%t12)
+  %t17 = const_str @.L0
   .loc 1 4 4
-  %t13 = const_str @.L0
-  .loc 1 4 4
-  call @rt_print_str(%t13)
+  call @rt_print_str(%t17)
   .loc 1 4 4
   br L50
-bool_then1:
+L50:
   .loc 1 5 16
-  store i1, %t16, %t15
+  %t18 = trunc1 0
   .loc 1 5 16
-  br bool_join1
-bool_else1:
-  .loc 1 5 16
-  %t17 = trunc1 0
-  .loc 1 5 16
-  store i1, %t16, %t17
-  .loc 1 5 16
-  br bool_join1
-bool_join1:
-  .loc 1 5 16
-  %t18 = load i1, %t16
-  .loc 1 5 4
   %t19 = zext1 %t18
+  .loc 1 5 16
+  %t20 = sub 0, %t19
+  .loc 1 5 20
+  %t21 = load i1, %t0
+  .loc 1 5 16
+  %t22 = zext1 %t21
+  .loc 1 5 16
+  %t23 = sub 0, %t22
+  .loc 1 5 16
+  %t24 = and %t20, %t23
   .loc 1 5 4
-  call @rt_print_i64(%t19)
+  call @rt_print_i64(%t24)
   .loc 1 5 4
-  %t20 = const_str @.L0
+  %t25 = const_str @.L0
   .loc 1 5 4
-  call @rt_print_str(%t20)
+  call @rt_print_str(%t25)
   .loc 1 5 4
   br exit
+exit:
+  ret 0
 }

--- a/tests/golden/il/boolean_or.il
+++ b/tests/golden/il/boolean_or.il
@@ -48,53 +48,60 @@ L50:
   %t10 = load i64, %t5
   .loc 1 5 16
   %t11 = icmp_ne %t10, 0
+  .loc 1 5 16
+  %t12 = zext1 %t11
+  .loc 1 5 16
+  %t13 = sub 0, %t12
   .loc 1 5 4
-  store i1, %t2, %t11
+  %t14 = trunc1 %t13
+  .loc 1 5 4
+  store i1, %t2, %t14
   .loc 1 5 4
   br L60
 L60:
   .loc 1 6 17
-  %t12 = load i1, %t2
-  .loc 1 6 25
-  %t13 = load i64, %t4
-  .loc 1 6 27
-  %t14 = icmp_ne %t13, 0
-  .loc 1 6 27
-  %t15 = alloca 1
+  %t15 = load i1, %t2
   .loc 1 6 21
-  cbr %t12, bool_then, bool_else
+  %t16 = zext1 %t15
+  .loc 1 6 21
+  %t17 = sub 0, %t16
+  .loc 1 6 25
+  %t18 = load i64, %t4
+  .loc 1 6 27
+  %t19 = icmp_ne %t18, 0
+  .loc 1 6 27
+  %t20 = zext1 %t19
+  .loc 1 6 27
+  %t21 = sub 0, %t20
+  .loc 1 6 21
+  %t22 = trunc1 %t21
+  .loc 1 6 21
+  %t23 = zext1 %t22
+  .loc 1 6 21
+  %t24 = sub 0, %t23
+  .loc 1 6 21
+  %t25 = or %t17, %t24
+  .loc 1 6 4
+  %t26 = trunc1 %t25
+  .loc 1 6 4
+  store i1, %t0, %t26
+  .loc 1 6 4
+  br L70
 L70:
   .loc 1 7 10
-  %t18 = load i1, %t0
+  %t27 = load i1, %t0
   .loc 1 7 4
-  %t19 = zext1 %t18
+  %t28 = zext1 %t27
   .loc 1 7 4
-  call @rt_print_i64(%t19)
+  %t29 = sub 0, %t28
   .loc 1 7 4
-  %t20 = const_str @.L0
+  call @rt_print_i64(%t29)
   .loc 1 7 4
-  call @rt_print_str(%t20)
+  %t30 = const_str @.L0
+  .loc 1 7 4
+  call @rt_print_str(%t30)
   .loc 1 7 4
   br exit
 exit:
   ret 0
-bool_then:
-  .loc 1 6 21
-  %t16 = trunc1 1
-  .loc 1 6 21
-  store i1, %t15, %t16
-  .loc 1 6 21
-  br bool_join
-bool_else:
-  .loc 1 6 21
-  store i1, %t15, %t14
-  .loc 1 6 21
-  br bool_join
-bool_join:
-  .loc 1 6 21
-  %t17 = load i1, %t15
-  .loc 1 6 4
-  store i1, %t0, %t17
-  .loc 1 6 4
-  br L70
 }

--- a/tests/golden/il/boolean_orelse.il
+++ b/tests/golden/il/boolean_orelse.il
@@ -48,53 +48,73 @@ L50:
   %t10 = load i64, %t5
   .loc 1 5 16
   %t11 = icmp_ne %t10, 0
+  .loc 1 5 16
+  %t12 = zext1 %t11
+  .loc 1 5 16
+  %t13 = sub 0, %t12
   .loc 1 5 4
-  store i1, %t2, %t11
+  %t14 = trunc1 %t13
+  .loc 1 5 4
+  store i1, %t2, %t14
   .loc 1 5 4
   br L60
 L60:
   .loc 1 6 17
-  %t12 = load i1, %t2
+  %t15 = load i1, %t2
   .loc 1 6 21
-  %t13 = alloca 1
+  %t16 = alloca 1
   .loc 1 6 21
-  cbr %t12, or_true, or_rhs
+  cbr %t15, or_true, or_rhs
 L70:
   .loc 1 7 10
-  %t18 = load i1, %t0
+  %t27 = load i1, %t0
   .loc 1 7 4
-  %t19 = zext1 %t18
+  %t28 = zext1 %t27
   .loc 1 7 4
-  call @rt_print_i64(%t19)
+  %t29 = sub 0, %t28
   .loc 1 7 4
-  %t20 = const_str @.L0
+  call @rt_print_i64(%t29)
   .loc 1 7 4
-  call @rt_print_str(%t20)
+  %t30 = const_str @.L0
+  .loc 1 7 4
+  call @rt_print_str(%t30)
   .loc 1 7 4
   br exit
 exit:
   ret 0
 or_true:
   .loc 1 6 21
-  %t14 = trunc1 1
+  %t17 = trunc1 1
   .loc 1 6 21
-  store i1, %t13, %t14
+  store i1, %t16, %t17
   .loc 1 6 21
   br or_done
 or_rhs:
   .loc 1 6 29
-  %t15 = load i64, %t4
+  %t18 = load i64, %t4
   .loc 1 6 31
-  %t16 = icmp_ne %t15, 0
+  %t19 = icmp_ne %t18, 0
+  .loc 1 6 31
+  %t20 = zext1 %t19
+  .loc 1 6 31
+  %t21 = sub 0, %t20
   .loc 1 6 21
-  store i1, %t13, %t16
+  %t22 = trunc1 %t21
+  .loc 1 6 21
+  store i1, %t16, %t22
   .loc 1 6 21
   br or_done
 or_done:
   .loc 1 6 21
-  %t17 = load i1, %t13
+  %t23 = load i1, %t16
+  .loc 1 6 21
+  %t24 = zext1 %t23
+  .loc 1 6 21
+  %t25 = sub 0, %t24
   .loc 1 6 4
-  store i1, %t0, %t17
+  %t26 = trunc1 %t25
+  .loc 1 6 4
+  store i1, %t0, %t26
   .loc 1 6 4
   br L70
 }


### PR DESCRIPTION
## Summary
- add a helper to map i1 predicates into BASIC’s -1/0 logical I64 form and apply it across literal, comparison, and logical expression lowering
- update boolean coercion paths, builtin handling, and assignments to respect the new logical encoding
- refresh BASIC boolean golden IL fixtures to match the normalized representation

## Testing
- cmake -S . -B build
- cmake --build build --target fe_basic
- ctest --test-dir build --output-on-failure -R "basic_to_il_boolean_(literals|and|or|andalso|orelse)"

------
https://chatgpt.com/codex/tasks/task_e_68e021adcc9483249c047b4602552d36