### PR TITLE
fix(fe_basic): align BASIC boolean literals with logical semantics

### DIFF
--- a/src/frontends/basic/LowerExpr.cpp
+++ b/src/frontends/basic/LowerExpr.cpp
@@ -85,15 +85,7 @@ class LowererExprVisitor final : public ExprVisitor
     void visit(const BoolExpr &expr) override
     {
         lowerer_.curLoc = expr.loc;
-        if (lowerer_.context().current() == nullptr)
-        {
-            Value logical = Value::constInt(expr.value ? -1 : 0);
-            result_ = Lowerer::RVal{logical, il::core::Type(il::core::Type::Kind::I64)};
-            return;
-        }
-        Value raw = lowerer_.emitBoolConst(expr.value);
-        lowerer_.curLoc = expr.loc;
-        Value logical = lowerer_.emitBasicLogicalI64(raw);
+        Value logical = lowerer_.emitConstI64(expr.value ? -1 : 0);
         result_ = Lowerer::RVal{logical, il::core::Type(il::core::Type::Kind::I64)};
     }
 

--- a/tests/golden/il/boolean_literals.il
+++ b/tests/golden/il/boolean_literals.il
@@ -45,59 +45,47 @@ L30:
 L40:
   .loc 1 4 10
   %t10 = load i1, %t0
-  .loc 1 4 15
-  %t11 = trunc1 1
-  .loc 1 4 15
-  %t12 = zext1 %t11
-  .loc 1 4 15
+  .loc 1 4 12
+  %t11 = trunc1 -1
+  .loc 1 4 12
+  %t12 = zext1 %t10
+  .loc 1 4 12
   %t13 = isub.ovf 0, %t12
   .loc 1 4 12
-  %t14 = trunc1 %t13
+  %t14 = zext1 %t11
   .loc 1 4 12
-  %t15 = zext1 %t10
+  %t15 = isub.ovf 0, %t14
   .loc 1 4 12
-  %t16 = isub.ovf 0, %t15
-  .loc 1 4 12
-  %t17 = zext1 %t14
-  .loc 1 4 12
-  %t18 = isub.ovf 0, %t17
-  .loc 1 4 12
-  %t19 = or %t16, %t18
+  %t16 = or %t13, %t15
   .loc 1 4 4
-  call @rt_print_i64(%t19)
+  call @rt_print_i64(%t16)
   .loc 1 4 4
-  %t20 = const_str @.L0
+  %t17 = const_str @.L0
   .loc 1 4 4
-  call @rt_print_str(%t20)
+  call @rt_print_str(%t17)
   .loc 1 4 4
   br L50
 L50:
-  .loc 1 5 10
-  %t21 = trunc1 0
-  .loc 1 5 10
-  %t22 = zext1 %t21
-  .loc 1 5 10
+  .loc 1 5 16
+  %t18 = trunc1 0
+  .loc 1 5 20
+  %t19 = load i1, %t0
+  .loc 1 5 16
+  %t20 = zext1 %t18
+  .loc 1 5 16
+  %t21 = isub.ovf 0, %t20
+  .loc 1 5 16
+  %t22 = zext1 %t19
+  .loc 1 5 16
   %t23 = isub.ovf 0, %t22
   .loc 1 5 16
-  %t24 = trunc1 %t23
-  .loc 1 5 20
-  %t25 = load i1, %t0
-  .loc 1 5 16
-  %t26 = zext1 %t24
-  .loc 1 5 16
-  %t27 = isub.ovf 0, %t26
-  .loc 1 5 16
-  %t28 = zext1 %t25
-  .loc 1 5 16
-  %t29 = isub.ovf 0, %t28
-  .loc 1 5 16
-  %t30 = and %t27, %t29
+  %t24 = and %t21, %t23
   .loc 1 5 4
-  call @rt_print_i64(%t30)
+  call @rt_print_i64(%t24)
   .loc 1 5 4
-  %t31 = const_str @.L0
+  %t25 = const_str @.L0
   .loc 1 5 4
-  call @rt_print_str(%t31)
+  call @rt_print_str(%t25)
   .loc 1 5 4
   br exit
 exit:


### PR DESCRIPTION
## Summary
- lower BASIC boolean literals directly to -1/0 i64 constants
- refresh the boolean_literals golden to reflect BASIC logical words

## Testing
- cmake --build build --target fe_basic
- ctest --test-dir build -R basic_to_il_boolean_literals --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e031b1b80483249afb3e38bc5e6734