### PR TITLE
fix(basic): lower boolean literals to BASIC truth values

### DIFF
--- a/src/frontends/basic/LowerExpr.cpp
+++ b/src/frontends/basic/LowerExpr.cpp
@@ -85,15 +85,7 @@ class LowererExprVisitor final : public ExprVisitor
     void visit(const BoolExpr &expr) override
     {
         lowerer_.curLoc = expr.loc;
-        if (lowerer_.context().current() == nullptr)
-        {
-            Value logical = Value::constInt(expr.value ? -1 : 0);
-            result_ = Lowerer::RVal{logical, il::core::Type(il::core::Type::Kind::I64)};
-            return;
-        }
-        Value raw = lowerer_.emitBoolConst(expr.value);
-        lowerer_.curLoc = expr.loc;
-        Value logical = lowerer_.emitBasicLogicalI64(raw);
+        Value logical = lowerer_.emitConstI64(expr.value ? -1 : 0);
         result_ = Lowerer::RVal{logical, il::core::Type(il::core::Type::Kind::I64)};
     }
 

--- a/tests/golden/il/boolean_branch_join_skeleton.il
+++ b/tests/golden/il/boolean_branch_join_skeleton.il
@@ -16,45 +16,33 @@ L10:
   .loc 1 1 4
   br L20
 L20:
-  .loc 1 2 12
-  %t2 = trunc1 1
-  .loc 1 2 12
-  %t3 = zext1 %t2
-  .loc 1 2 12
-  %t4 = isub.ovf 0, %t3
   .loc 1 2 4
-  %t5 = trunc1 %t4
+  %t2 = trunc1 -1
   .loc 1 2 4
-  store i1, %t0, %t5
+  store i1, %t0, %t2
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 10
-  %t6 = load i1, %t0
-  .loc 1 3 15
-  %t7 = trunc1 0
-  .loc 1 3 15
-  %t8 = zext1 %t7
-  .loc 1 3 15
-  %t9 = isub.ovf 0, %t8
+  %t3 = load i1, %t0
   .loc 1 3 12
-  %t10 = trunc1 %t9
+  %t4 = trunc1 0
   .loc 1 3 12
-  %t11 = zext1 %t6
+  %t5 = zext1 %t3
   .loc 1 3 12
-  %t12 = isub.ovf 0, %t11
+  %t6 = isub.ovf 0, %t5
   .loc 1 3 12
-  %t13 = zext1 %t10
+  %t7 = zext1 %t4
   .loc 1 3 12
-  %t14 = isub.ovf 0, %t13
+  %t8 = isub.ovf 0, %t7
   .loc 1 3 12
-  %t15 = or %t12, %t14
+  %t9 = or %t6, %t8
   .loc 1 3 4
-  call @rt_print_i64(%t15)
+  call @rt_print_i64(%t9)
   .loc 1 3 4
-  %t16 = const_str @.L0
+  %t10 = const_str @.L0
   .loc 1 3 4
-  call @rt_print_str(%t16)
+  call @rt_print_str(%t10)
   .loc 1 3 4
   br exit
 exit:

--- a/tests/golden/il/boolean_dim_and_assign.il
+++ b/tests/golden/il/boolean_dim_and_assign.il
@@ -16,16 +16,10 @@ L10:
   .loc 1 1 4
   br L20
 L20:
-  .loc 1 2 12
-  %t2 = trunc1 1
-  .loc 1 2 12
-  %t3 = zext1 %t2
-  .loc 1 2 12
-  %t4 = isub.ovf 0, %t3
   .loc 1 2 4
-  %t5 = trunc1 %t4
+  %t2 = trunc1 -1
   .loc 1 2 4
-  store i1, %t0, %t5
+  store i1, %t0, %t2
   .loc 1 2 4
   br L30
 L30:
@@ -33,33 +27,33 @@ L30:
   br if_test_0
 L40:
   .loc 1 4 10
-  %t8 = load i1, %t0
+  %t5 = load i1, %t0
   .loc 1 4 4
-  %t9 = zext1 %t8
+  %t6 = zext1 %t5
   .loc 1 4 4
-  %t10 = isub.ovf 0, %t9
+  %t7 = isub.ovf 0, %t6
   .loc 1 4 4
-  call @rt_print_i64(%t10)
+  call @rt_print_i64(%t7)
   .loc 1 4 4
-  %t11 = const_str @.L0
+  %t8 = const_str @.L0
   .loc 1 4 4
-  call @rt_print_str(%t11)
+  call @rt_print_str(%t8)
   .loc 1 4 4
   br exit
 exit:
   ret 0
 if_test_0:
   .loc 1 3 7
-  %t6 = load i1, %t0
+  %t3 = load i1, %t0
   .loc 1 3 7
-  cbr %t6, if_then_0, if_else
+  cbr %t3, if_then_0, if_else
 if_then_0:
   .loc 1 3 14
   call @rt_print_i64(1)
   .loc 1 3 14
-  %t7 = const_str @.L0
+  %t4 = const_str @.L0
   .loc 1 3 14
-  call @rt_print_str(%t7)
+  call @rt_print_str(%t4)
   .loc 1 3 4
   br if_exit
 if_else:

--- a/tests/golden/il/boolean_literals.il
+++ b/tests/golden/il/boolean_literals.il
@@ -45,59 +45,47 @@ L30:
 L40:
   .loc 1 4 10
   %t10 = load i1, %t0
-  .loc 1 4 15
-  %t11 = trunc1 1
-  .loc 1 4 15
-  %t12 = zext1 %t11
-  .loc 1 4 15
+  .loc 1 4 12
+  %t11 = trunc1 -1
+  .loc 1 4 12
+  %t12 = zext1 %t10
+  .loc 1 4 12
   %t13 = isub.ovf 0, %t12
   .loc 1 4 12
-  %t14 = trunc1 %t13
+  %t14 = zext1 %t11
   .loc 1 4 12
-  %t15 = zext1 %t10
+  %t15 = isub.ovf 0, %t14
   .loc 1 4 12
-  %t16 = isub.ovf 0, %t15
-  .loc 1 4 12
-  %t17 = zext1 %t14
-  .loc 1 4 12
-  %t18 = isub.ovf 0, %t17
-  .loc 1 4 12
-  %t19 = or %t16, %t18
+  %t16 = or %t13, %t15
   .loc 1 4 4
-  call @rt_print_i64(%t19)
+  call @rt_print_i64(%t16)
   .loc 1 4 4
-  %t20 = const_str @.L0
+  %t17 = const_str @.L0
   .loc 1 4 4
-  call @rt_print_str(%t20)
+  call @rt_print_str(%t17)
   .loc 1 4 4
   br L50
 L50:
-  .loc 1 5 10
-  %t21 = trunc1 0
-  .loc 1 5 10
-  %t22 = zext1 %t21
-  .loc 1 5 10
+  .loc 1 5 16
+  %t18 = trunc1 0
+  .loc 1 5 20
+  %t19 = load i1, %t0
+  .loc 1 5 16
+  %t20 = zext1 %t18
+  .loc 1 5 16
+  %t21 = isub.ovf 0, %t20
+  .loc 1 5 16
+  %t22 = zext1 %t19
+  .loc 1 5 16
   %t23 = isub.ovf 0, %t22
   .loc 1 5 16
-  %t24 = trunc1 %t23
-  .loc 1 5 20
-  %t25 = load i1, %t0
-  .loc 1 5 16
-  %t26 = zext1 %t24
-  .loc 1 5 16
-  %t27 = isub.ovf 0, %t26
-  .loc 1 5 16
-  %t28 = zext1 %t25
-  .loc 1 5 16
-  %t29 = isub.ovf 0, %t28
-  .loc 1 5 16
-  %t30 = and %t27, %t29
+  %t24 = and %t21, %t23
   .loc 1 5 4
-  call @rt_print_i64(%t30)
+  call @rt_print_i64(%t24)
   .loc 1 5 4
-  %t31 = const_str @.L0
+  %t25 = const_str @.L0
   .loc 1 5 4
-  call @rt_print_str(%t31)
+  call @rt_print_str(%t25)
   .loc 1 5 4
   br exit
 exit:

--- a/tests/golden/il/boolean_not.il
+++ b/tests/golden/il/boolean_not.il
@@ -16,54 +16,48 @@ L10:
   .loc 1 1 4
   br L20
 L20:
-  .loc 1 2 12
-  %t2 = trunc1 1
-  .loc 1 2 12
-  %t3 = zext1 %t2
-  .loc 1 2 12
-  %t4 = isub.ovf 0, %t3
   .loc 1 2 4
-  %t5 = trunc1 %t4
+  %t2 = trunc1 -1
   .loc 1 2 4
-  store i1, %t0, %t5
+  store i1, %t0, %t2
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 14
-  %t6 = load i1, %t0
+  %t3 = load i1, %t0
   .loc 1 3 10
-  %t7 = alloca 1
+  %t4 = alloca 1
   .loc 1 3 10
-  cbr %t6, bool_then, bool_else
+  cbr %t3, bool_then, bool_else
 exit:
   ret 0
 bool_then:
   .loc 1 3 10
-  %t8 = trunc1 0
+  %t5 = trunc1 0
   .loc 1 3 10
-  store i1, %t7, %t8
+  store i1, %t4, %t5
   .loc 1 3 10
   br bool_join
 bool_else:
   .loc 1 3 10
-  %t9 = trunc1 1
+  %t6 = trunc1 1
   .loc 1 3 10
-  store i1, %t7, %t9
+  store i1, %t4, %t6
   .loc 1 3 10
   br bool_join
 bool_join:
   .loc 1 3 10
-  %t10 = load i1, %t7
+  %t7 = load i1, %t4
   .loc 1 3 10
-  %t11 = zext1 %t10
+  %t8 = zext1 %t7
   .loc 1 3 10
-  %t12 = isub.ovf 0, %t11
+  %t9 = isub.ovf 0, %t8
   .loc 1 3 4
-  call @rt_print_i64(%t12)
+  call @rt_print_i64(%t9)
   .loc 1 3 4
-  %t13 = const_str @.L0
+  %t10 = const_str @.L0
   .loc 1 3 4
-  call @rt_print_str(%t13)
+  call @rt_print_str(%t10)
   .loc 1 3 4
   br exit
 }

--- a/tests/unit/test_basic_lowerer_conversions.cpp
+++ b/tests/unit/test_basic_lowerer_conversions.cpp
@@ -58,7 +58,6 @@ int main()
 
     std::vector<int> castChkLines;
     std::vector<int> sitofpLines;
-    std::vector<int> zextLines;
     std::vector<int> truncLines;
 
     for (const auto &block : mainFn->blocks)
@@ -73,9 +72,6 @@ int main()
                 case il::core::Opcode::Sitofp:
                     sitofpLines.push_back(instr.loc.line);
                     break;
-                case il::core::Opcode::Zext1:
-                    zextLines.push_back(instr.loc.line);
-                    break;
                 case il::core::Opcode::Trunc1:
                     truncLines.push_back(instr.loc.line);
                     break;
@@ -88,8 +84,6 @@ int main()
     assert(hasLine(castChkLines, 2));  // LET I = 3.14
     assert(hasLine(sitofpLines, 3));  // LET D# = 1
     assert(hasLine(sitofpLines, 7));  // INPUT "?", D#
-    assert(hasLine(zextLines, 4));    // LET I = TRUE
-    assert(hasLine(zextLines, 5));    // PRINT TRUE
     assert(hasLine(truncLines, 6));   // INPUT "?", FLAG
 
     return 0;


### PR DESCRIPTION
## Summary
- lower BASIC boolean literals directly to -1/0 I64 constants
- refresh BASIC boolean IL golden outputs for literal, dim/assign, branch join, and NOT cases
- update the lowerer conversion unit test expectations now that zexts are no longer emitted

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e031b1b80483249afb3e38bc5e6734