### PR TITLE
feat(vm): add isub handler and boolean materialisation test

### DIFF
--- a/src/il/core/OpcodeInfo.hpp
+++ b/src/il/core/OpcodeInfo.hpp
@@ -54,6 +54,7 @@ enum class VMDispatch : uint8_t
     GEP,
     Add,
     Sub,
+    ISub,
     Mul,
     IAddOvf,
     ISubOvf,

--- a/src/vm/OpHandlers.hpp
+++ b/src/vm/OpHandlers.hpp
@@ -48,6 +48,13 @@ struct OpHandlers
                                     const il::core::BasicBlock *&bb,
                                     size_t &ip);
 
+    static VM::ExecResult handleISub(VM &vm,
+                                     Frame &fr,
+                                     const il::core::Instr &in,
+                                     const VM::BlockMap &blocks,
+                                     const il::core::BasicBlock *&bb,
+                                     size_t &ip);
+
     static VM::ExecResult handleMul(VM &vm,
                                     Frame &fr,
                                     const il::core::Instr &in,

--- a/src/vm/int_ops.cpp
+++ b/src/vm/int_ops.cpp
@@ -447,6 +447,19 @@ VM::ExecResult OpHandlers::handleSub(VM &vm,
                             { out.i64 = lhsVal.i64 - rhsVal.i64; });
 }
 
+/// @brief Interpret the `isub` opcode for 64-bit integers.
+/// @note Routes to @ref OpHandlers::handleSub to share two's complement semantics with
+///       the general subtraction handler.
+VM::ExecResult OpHandlers::handleISub(VM &vm,
+                                      Frame &fr,
+                                      const Instr &in,
+                                      const VM::BlockMap &blocks,
+                                      const BasicBlock *&bb,
+                                      size_t &ip)
+{
+    return handleSub(vm, fr, in, blocks, bb, ip);
+}
+
 /// @brief Interpret the `mul` opcode for 64-bit integers.
 /// @note Multiplication uses the same operand handling helpers as addition, wraps
 ///       modulo 2^64 per docs/il-guide.md#reference §Integer Arithmetic, and stores the

--- a/tests/unit/test_vm_zext1_isub.cpp
+++ b/tests/unit/test_vm_zext1_isub.cpp
@@ -1,0 +1,51 @@
+// File: tests/unit/test_vm_zext1_isub.cpp
+// Purpose: Ensure the VM handles boolean materialisation via zext1 and isub.
+// Key invariants: Zero-extension results are canonical 0/1 and subtraction yields -1/0 without
+// traps.
+// Ownership: Parses IL text at runtime and executes it through the VM interpreter.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "vm/VM.hpp"
+
+#include <cassert>
+#include <sstream>
+#include <string>
+
+int main()
+{
+    const char *il = R"(il 0.1
+
+func @materialize(i1 %flag) -> i64 {
+entry(%flag0: i1):
+  %z = zext1 %flag0
+  %neg = sub 0, %z
+  ret %neg
+}
+
+func @main() -> i64 {
+entry:
+  %true_flag = icmp_eq 1, 1
+  %false_flag = icmp_eq 0, 1
+  %neg_true = call @materialize(%true_flag)
+  %neg_false = call @materialize(%false_flag)
+  %true_ok = icmp_eq %neg_true, -1
+  %false_ok = icmp_eq %neg_false, 0
+  %true_i64 = zext1 %true_ok
+  %false_i64 = zext1 %false_ok
+  %sum = add %true_i64, %false_i64
+  ret %sum
+}
+)";
+
+    il::core::Module m;
+    std::istringstream is(il);
+    auto parse = il::api::v2::parse_text_expected(is, m);
+    assert(parse);
+
+    il::vm::VM vm(m);
+    int64_t rv = vm.run();
+    assert(rv == 2);
+    return 0;
+}

--- a/tests/vm/CMakeLists.txt
+++ b/tests/vm/CMakeLists.txt
@@ -186,6 +186,10 @@ function(viper_add_vm_unit_tests)
   target_link_libraries(test_vm_opcode_dispatch PRIVATE viper_il_full ${VIPER_VM_LIB} il_api)
   viper_add_ctest(test_vm_opcode_dispatch test_vm_opcode_dispatch)
 
+  viper_add_test(test_vm_zext1_isub ${VIPER_TESTS_DIR}/unit/test_vm_zext1_isub.cpp)
+  target_link_libraries(test_vm_zext1_isub PRIVATE viper_il_full ${VIPER_VM_LIB} il_api)
+  viper_add_ctest(test_vm_zext1_isub test_vm_zext1_isub)
+
   viper_add_test(test_vm_run_loop_helpers ${VIPER_TESTS_DIR}/unit/test_vm_run_loop_helpers.cpp)
   target_link_libraries(test_vm_run_loop_helpers PRIVATE ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   viper_add_ctest(test_vm_run_loop_helpers test_vm_run_loop_helpers)


### PR DESCRIPTION
## Summary
- add a dedicated dispatch slot for `Opcode::ISub` that reuses the existing subtraction semantics
- cover the frontend's boolean materialisation path with a new VM unit test and wire it into the build

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e0351036e48324871f77b2b7c222f0