### PR TITLE
Refactor BASIC AST printer into expression/statement modules

### DIFF
--- a/src/frontends/basic/AstPrint_Expr.cpp
+++ b/src/frontends/basic/AstPrint_Expr.cpp
@@ -1,0 +1,144 @@
+// File: src/frontends/basic/AstPrint_Expr.cpp
+// Purpose: Implements expression printing logic for the BASIC AST printer.
+// Key invariants: All expression node kinds must be handled.
+// Ownership/Lifetime: Operates on non-owning AST references.
+// Notes: Uses BuiltinRegistry metadata for builtin call names.
+// Links: docs/codemap.md
+
+#include "frontends/basic/AstPrinter.hpp"
+#include "frontends/basic/BuiltinRegistry.hpp"
+#include <array>
+#include <sstream>
+
+namespace il::frontends::basic
+{
+
+namespace
+{
+} // namespace
+
+struct AstPrinter::ExprPrinter final : ExprVisitor
+{
+    ExprPrinter(Printer &printer, [[maybe_unused]] PrintStyle &style) : printer(printer) {}
+
+    void print(const Expr &expr)
+    {
+        expr.accept(*this);
+    }
+
+    template <typename NodeT> void visit([[maybe_unused]] const NodeT &)
+    {
+        static_assert(sizeof(NodeT) == 0, "Unhandled expression node in AstPrinter");
+    }
+
+    void visit(const IntExpr &expr) override
+    {
+        printer.os << expr.value;
+    }
+
+    void visit(const FloatExpr &expr) override
+    {
+        std::ostringstream os;
+        os << expr.value;
+        printer.os << os.str();
+    }
+
+    void visit(const StringExpr &expr) override
+    {
+        printer.os << '"' << expr.value << '"';
+    }
+
+    void visit(const BoolExpr &expr) override
+    {
+        printer.os << (expr.value ? "TRUE" : "FALSE");
+    }
+
+    void visit(const VarExpr &expr) override
+    {
+        printer.os << expr.name;
+    }
+
+    void visit(const ArrayExpr &expr) override
+    {
+        printer.os << expr.name << '(';
+        expr.index->accept(*this);
+        printer.os << ')';
+    }
+
+    void visit(const UnaryExpr &expr) override
+    {
+        printer.os << "(NOT ";
+        expr.expr->accept(*this);
+        printer.os << ')';
+    }
+
+    void visit(const BinaryExpr &expr) override
+    {
+        static constexpr std::array<const char *, 17> ops = {"+",
+                                                             "-",
+                                                             "*",
+                                                             "/",
+                                                             "^",
+                                                             "\\",
+                                                             "MOD",
+                                                             "=",
+                                                             "<>",
+                                                             "<",
+                                                             "<=",
+                                                             ">",
+                                                             ">=",
+                                                             "ANDALSO",
+                                                             "ORELSE",
+                                                             "AND",
+                                                             "OR"};
+        printer.os << '(' << ops[static_cast<size_t>(expr.op)] << ' ';
+        expr.lhs->accept(*this);
+        printer.os << ' ';
+        expr.rhs->accept(*this);
+        printer.os << ')';
+    }
+
+    void visit(const BuiltinCallExpr &expr) override
+    {
+        printer.os << '(' << getBuiltinInfo(expr.builtin).name;
+        for (const auto &arg : expr.args)
+        {
+            printer.os << ' ';
+            arg->accept(*this);
+        }
+        printer.os << ')';
+    }
+
+    void visit(const LBoundExpr &expr) override
+    {
+        printer.os << "(LBOUND " << expr.name << ')';
+    }
+
+    void visit(const UBoundExpr &expr) override
+    {
+        printer.os << "(UBOUND " << expr.name << ')';
+    }
+
+    void visit(const CallExpr &expr) override
+    {
+        printer.os << '(' << expr.callee;
+        for (const auto &arg : expr.args)
+        {
+            printer.os << ' ';
+            arg->accept(*this);
+        }
+        printer.os << ')';
+    }
+
+  private:
+    Printer &printer;
+};
+
+void AstPrinter::printExpr(const Expr &expr, Printer &printer, PrintStyle &style)
+{
+    ExprPrinter exprPrinter{printer, style};
+    exprPrinter.print(expr);
+}
+
+} // namespace il::frontends::basic
+

--- a/src/frontends/basic/AstPrint_Stmt.cpp
+++ b/src/frontends/basic/AstPrint_Stmt.cpp
@@ -1,0 +1,453 @@
+// File: src/frontends/basic/AstPrint_Stmt.cpp
+// Purpose: Implements statement printing logic for the BASIC AST printer.
+// Key invariants: All statement node kinds must be handled.
+// Ownership/Lifetime: Operates on non-owning AST references.
+// Notes: Relies on PrintStyle to manage spacing and body formatting.
+// Links: docs/codemap.md
+
+#include "frontends/basic/AstPrinter.hpp"
+
+namespace il::frontends::basic
+{
+
+namespace
+{
+
+const char *typeToString(Type ty)
+{
+    switch (ty)
+    {
+        case Type::I64:
+            return "I64";
+        case Type::F64:
+            return "F64";
+        case Type::Str:
+            return "STR";
+        case Type::Bool:
+            return "BOOLEAN";
+    }
+    return "I64";
+}
+
+const char *openModeToString(OpenStmt::Mode mode)
+{
+    switch (mode)
+    {
+        case OpenStmt::Mode::Input:
+            return "INPUT";
+        case OpenStmt::Mode::Output:
+            return "OUTPUT";
+        case OpenStmt::Mode::Append:
+            return "APPEND";
+        case OpenStmt::Mode::Binary:
+            return "BINARY";
+        case OpenStmt::Mode::Random:
+            return "RANDOM";
+    }
+    return "INPUT";
+}
+
+} // namespace
+
+struct AstPrinter::StmtPrinter final : StmtVisitor
+{
+    StmtPrinter(Printer &printer, PrintStyle &style) : printer(printer), style(style) {}
+
+    void print(const Stmt &stmt)
+    {
+        stmt.accept(*this);
+    }
+
+    template <typename NodeT> void visit([[maybe_unused]] const NodeT &)
+    {
+        static_assert(sizeof(NodeT) == 0, "Unhandled statement node in AstPrinter");
+    }
+
+    void visit(const PrintStmt &stmt) override
+    {
+        printer.os << "(PRINT";
+        for (const auto &item : stmt.items)
+        {
+            printer.os << ' ';
+            switch (item.kind)
+            {
+                case PrintItem::Kind::Expr:
+                    AstPrinter::printExpr(*item.expr, printer, style);
+                    break;
+                case PrintItem::Kind::Comma:
+                    printer.os << ',';
+                    break;
+                case PrintItem::Kind::Semicolon:
+                    printer.os << ';';
+                    break;
+            }
+        }
+        printer.os << ')';
+    }
+
+    void visit(const PrintChStmt &stmt) override
+    {
+        printer.os << "(PRINT#";
+        style.writeChannelPrefix();
+        if (stmt.channelExpr)
+        {
+            AstPrinter::printExpr(*stmt.channelExpr, printer, style);
+        }
+        else
+        {
+            style.writeNull();
+        }
+        style.writeArgsPrefix();
+        bool first = true;
+        for (const auto &arg : stmt.args)
+        {
+            style.separate(first);
+            if (arg)
+            {
+                AstPrinter::printExpr(*arg, printer, style);
+            }
+            else
+            {
+                style.writeNull();
+            }
+        }
+        style.writeArgsSuffix();
+        if (!stmt.trailingNewline)
+            style.writeNoNewlineTag();
+        printer.os << ')';
+    }
+
+    void visit(const LetStmt &stmt) override
+    {
+        printer.os << "(LET ";
+        AstPrinter::printExpr(*stmt.target, printer, style);
+        printer.os << ' ';
+        AstPrinter::printExpr(*stmt.expr, printer, style);
+        printer.os << ')';
+    }
+
+    void visit(const DimStmt &stmt) override
+    {
+        printer.os << "(DIM " << stmt.name;
+        if (stmt.isArray)
+        {
+            if (stmt.size)
+            {
+                printer.os << ' ';
+                AstPrinter::printExpr(*stmt.size, printer, style);
+            }
+            if (stmt.type != Type::I64)
+                printer.os << " AS " << typeToString(stmt.type);
+        }
+        else
+        {
+            printer.os << " AS " << typeToString(stmt.type);
+        }
+        printer.os << ')';
+    }
+
+    void visit(const ReDimStmt &stmt) override
+    {
+        printer.os << "(REDIM " << stmt.name;
+        if (stmt.size)
+        {
+            printer.os << ' ';
+            AstPrinter::printExpr(*stmt.size, printer, style);
+        }
+        printer.os << ')';
+    }
+
+    void visit(const RandomizeStmt &stmt) override
+    {
+        printer.os << "(RANDOMIZE ";
+        AstPrinter::printExpr(*stmt.seed, printer, style);
+        printer.os << ')';
+    }
+
+    void visit(const IfStmt &stmt) override
+    {
+        printer.os << "(IF ";
+        AstPrinter::printExpr(*stmt.cond, printer, style);
+        printer.os << " THEN ";
+        stmt.then_branch->accept(*this);
+        for (const auto &elseif : stmt.elseifs)
+        {
+            printer.os << " ELSEIF ";
+            AstPrinter::printExpr(*elseif.cond, printer, style);
+            printer.os << " THEN ";
+            elseif.then_branch->accept(*this);
+        }
+        if (stmt.else_branch)
+        {
+            printer.os << " ELSE ";
+            stmt.else_branch->accept(*this);
+        }
+        printer.os << ')';
+    }
+
+    void visit(const WhileStmt &stmt) override
+    {
+        printer.os << "(WHILE ";
+        AstPrinter::printExpr(*stmt.cond, printer, style);
+        printNumberedBody(stmt.body);
+    }
+
+    void visit(const DoStmt &stmt) override
+    {
+        printer.os << "(DO "
+                    << (stmt.testPos == DoStmt::TestPos::Pre ? "pre" : "post") << ' ';
+        switch (stmt.condKind)
+        {
+            case DoStmt::CondKind::None:
+                printer.os << "NONE";
+                break;
+            case DoStmt::CondKind::While:
+                printer.os << "WHILE";
+                break;
+            case DoStmt::CondKind::Until:
+                printer.os << "UNTIL";
+                break;
+        }
+        if (stmt.condKind != DoStmt::CondKind::None && stmt.cond)
+        {
+            printer.os << ' ';
+            AstPrinter::printExpr(*stmt.cond, printer, style);
+        }
+        printNumberedBody(stmt.body);
+    }
+
+    void visit(const ForStmt &stmt) override
+    {
+        printer.os << "(FOR " << stmt.var << " = ";
+        AstPrinter::printExpr(*stmt.start, printer, style);
+        printer.os << " TO ";
+        AstPrinter::printExpr(*stmt.end, printer, style);
+        if (stmt.step)
+        {
+            printer.os << " STEP ";
+            AstPrinter::printExpr(*stmt.step, printer, style);
+        }
+        printNumberedBody(stmt.body);
+    }
+
+    void visit(const NextStmt &stmt) override
+    {
+        printer.os << "(NEXT " << stmt.var << ')';
+    }
+
+    void visit(const ExitStmt &stmt) override
+    {
+        printer.os << "(EXIT ";
+        switch (stmt.kind)
+        {
+            case ExitStmt::LoopKind::For:
+                printer.os << "FOR";
+                break;
+            case ExitStmt::LoopKind::While:
+                printer.os << "WHILE";
+                break;
+            case ExitStmt::LoopKind::Do:
+                printer.os << "DO";
+                break;
+        }
+        printer.os << ')';
+    }
+
+    void visit(const GotoStmt &stmt) override
+    {
+        printer.os << "(GOTO " << stmt.target << ')';
+    }
+
+    void visit(const OpenStmt &stmt) override
+    {
+        printer.os << "(OPEN mode=" << openModeToString(stmt.mode) << '('
+                    << static_cast<int>(stmt.mode) << ") path=";
+        if (stmt.pathExpr)
+        {
+            AstPrinter::printExpr(*stmt.pathExpr, printer, style);
+        }
+        else
+        {
+            style.writeNull();
+        }
+        style.writeChannelPrefix();
+        if (stmt.channelExpr)
+        {
+            AstPrinter::printExpr(*stmt.channelExpr, printer, style);
+        }
+        else
+        {
+            style.writeNull();
+        }
+        printer.os << ')';
+    }
+
+    void visit(const CloseStmt &stmt) override
+    {
+        printer.os << "(CLOSE";
+        style.writeChannelPrefix();
+        if (stmt.channelExpr)
+        {
+            AstPrinter::printExpr(*stmt.channelExpr, printer, style);
+        }
+        else
+        {
+            style.writeNull();
+        }
+        printer.os << ')';
+    }
+
+    void visit(const OnErrorGoto &stmt) override
+    {
+        printer.os << "(ON-ERROR GOTO ";
+        if (stmt.toZero)
+        {
+            printer.os << '0';
+        }
+        else
+        {
+            printer.os << stmt.target;
+        }
+        printer.os << ')';
+    }
+
+    void visit(const Resume &stmt) override
+    {
+        printer.os << "(RESUME";
+        switch (stmt.mode)
+        {
+            case Resume::Mode::Same:
+                break;
+            case Resume::Mode::Next:
+                printer.os << " NEXT";
+                break;
+            case Resume::Mode::Label:
+                printer.os << ' ' << stmt.target;
+                break;
+        }
+        printer.os << ')';
+    }
+
+    void visit(const EndStmt &) override
+    {
+        printer.os << "(END)";
+    }
+
+    void visit(const InputStmt &stmt) override
+    {
+        printer.os << "(INPUT";
+        if (stmt.prompt)
+        {
+            printer.os << ' ';
+            AstPrinter::printExpr(*stmt.prompt, printer, style);
+            printer.os << ',';
+        }
+        printer.os << ' ' << stmt.var << ')';
+    }
+
+    void visit(const LineInputChStmt &stmt) override
+    {
+        printer.os << "(LINE-INPUT#";
+        style.writeChannelPrefix();
+        if (stmt.channelExpr)
+        {
+            AstPrinter::printExpr(*stmt.channelExpr, printer, style);
+        }
+        else
+        {
+            style.writeNull();
+        }
+        printer.os << " target=";
+        if (stmt.targetVar)
+        {
+            AstPrinter::printExpr(*stmt.targetVar, printer, style);
+        }
+        else
+        {
+            style.writeNull();
+        }
+        printer.os << ')';
+    }
+
+    void visit(const ReturnStmt &stmt) override
+    {
+        printer.os << "(RETURN";
+        if (stmt.value)
+        {
+            printer.os << ' ';
+            AstPrinter::printExpr(*stmt.value, printer, style);
+        }
+        printer.os << ')';
+    }
+
+    void visit(const FunctionDecl &stmt) override
+    {
+        printer.os << "(FUNCTION " << stmt.name << " RET " << typeToString(stmt.ret) << " (";
+        bool firstParam = true;
+        for (const auto &param : stmt.params)
+        {
+            if (!firstParam)
+                printer.os << ' ';
+            firstParam = false;
+            printer.os << param.name;
+            if (param.is_array)
+                printer.os << "()";
+        }
+        printer.os << ")";
+        printNumberedBody(stmt.body);
+    }
+
+    void visit(const SubDecl &stmt) override
+    {
+        printer.os << "(SUB " << stmt.name << " (";
+        bool firstParam = true;
+        for (const auto &param : stmt.params)
+        {
+            if (!firstParam)
+                printer.os << ' ';
+            firstParam = false;
+            printer.os << param.name;
+            if (param.is_array)
+                printer.os << "()";
+        }
+        printer.os << ")";
+        printNumberedBody(stmt.body);
+    }
+
+    void visit(const StmtList &stmt) override
+    {
+        printer.os << "(SEQ";
+        for (const auto &subStmt : stmt.stmts)
+        {
+            printer.os << ' ';
+            subStmt->accept(*this);
+        }
+        printer.os << ')';
+    }
+
+  private:
+    void printNumberedBody(const std::vector<std::unique_ptr<Stmt>> &body)
+    {
+        style.openBody();
+        bool first = true;
+        for (const auto &bodyStmt : body)
+        {
+            style.separate(first);
+            style.writeLineNumber(bodyStmt->line);
+            bodyStmt->accept(*this);
+        }
+        style.closeBody();
+    }
+
+    Printer &printer;
+    PrintStyle &style;
+};
+
+void AstPrinter::printStmt(const Stmt &stmt, Printer &printer, PrintStyle &style)
+{
+    StmtPrinter stmtPrinter{printer, style};
+    stmtPrinter.print(stmt);
+}
+
+} // namespace il::frontends::basic
+

--- a/src/frontends/basic/AstPrinter.hpp
+++ b/src/frontends/basic/AstPrinter.hpp
@@ -55,11 +55,54 @@ class AstPrinter
         Indent push();
     };
 
+    /// @brief Holds formatting preferences for AST emission.
+    struct PrintStyle
+    {
+        /// @brief Create a style bound to @p printer.
+        explicit PrintStyle(Printer &printer);
+
+        /// @brief Emit the opening delimiter for a statement body.
+        void openBody() const;
+
+        /// @brief Emit the closing delimiter for a statement body.
+        void closeBody() const;
+
+        /// @brief Ensure elements printed with @p first are separated.
+        void separate(bool &first) const;
+
+        /// @brief Write a numbered label prefix for a statement.
+        void writeLineNumber(int line) const;
+
+        /// @brief Emit the placeholder used for null optional nodes.
+        void writeNull() const;
+
+        /// @brief Emit the prefix used before channel expressions.
+        void writeChannelPrefix() const;
+
+        /// @brief Emit the prefix used before argument lists.
+        void writeArgsPrefix() const;
+
+        /// @brief Emit the suffix used after argument lists.
+        void writeArgsSuffix() const;
+
+        /// @brief Emit the marker indicating trailing newline suppression.
+        void writeNoNewlineTag() const;
+
+      private:
+        Printer *printer;
+    };
+
     /// @brief Expression visitor producing textual representations.
     struct ExprPrinter;
 
     /// @brief Statement visitor producing textual representations.
     struct StmtPrinter;
+
+    /// @brief Helper invoked by visitors to serialize expressions.
+    static void printExpr(const Expr &expr, Printer &p, PrintStyle &style);
+
+    /// @brief Helper invoked by the dispatcher to serialize statements.
+    static void printStmt(const Stmt &stmt, Printer &p, PrintStyle &style);
 
     /// @brief Dump a statement node to the printer.
     /// @param stmt Statement to serialize.

--- a/src/frontends/basic/CMakeLists.txt
+++ b/src/frontends/basic/CMakeLists.txt
@@ -3,6 +3,8 @@ add_library(fe_basic STATIC
   Lexer.cpp
   AST.cpp
   AstPrinter.cpp
+  AstPrint_Expr.cpp
+  AstPrint_Stmt.cpp
   Parser.cpp
   Parser_Stmt.cpp
   Parser_Expr.cpp


### PR DESCRIPTION
## Summary
- add a PrintStyle helper in AstPrinter to centralize formatting behavior
- move expression printing into the new AstPrint_Expr.cpp implementation unit
- move statement printing into AstPrint_Stmt.cpp and update the build to compile the new sources

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e097d1f98c83249cb0c37a0c9d8e17