### PR TITLE
Refactor operand parsing into OperandParser

### DIFF
--- a/src/il/io/CMakeLists.txt
+++ b/src/il/io/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(viper_il_io STATIC
   FunctionParser.cpp
   InstrParser.cpp
+  OperandParser.cpp
   ModuleParser.cpp
   Parser.cpp
   ParserState.cpp

--- a/src/il/io/InstrParser.cpp
+++ b/src/il/io/InstrParser.cpp
@@ -13,12 +13,11 @@
 #include "il/core/Opcode.hpp"
 #include "il/core/OpcodeInfo.hpp"
 #include "il/core/Value.hpp"
+#include "il/io/OperandParser.hpp"
 #include "il/io/ParserUtil.hpp"
 #include "il/io/TypeParser.hpp"
 #include "support/diag_expected.hpp"
 
-#include <cctype>
-#include <exception>
 #include <optional>
 #include <sstream>
 #include <unordered_map>
@@ -42,78 +41,6 @@ using il::core::Value;
 using il::support::Expected;
 using il::support::makeError;
 using il::support::printDiag;
-
-/// @brief Parses a textual operand token into an IL value.
-///
-/// Supports temporaries, globals, string constants, and immediates. An empty
-/// token yields a zero integer, matching textual defaults for optional
-/// operands.
-///
-/// @param tok Token extracted from the instruction body.
-/// @param st Parser state providing temporary mappings and diagnostic context.
-/// @return Parsed value or an error anchored to @p st.curLoc.
-Expected<Value> parseValue_E(const std::string &tok, ParserState &st)
-{
-    if (tok.empty())
-        return Value::constInt(0);
-    if (tok[0] == '%')
-    {
-        std::string name = tok.substr(1);
-        auto it = st.tempIds.find(name);
-        if (it != st.tempIds.end())
-            return Value::temp(it->second);
-        if (name.size() > 1 && name[0] == 't')
-        {
-            bool digits = true;
-            for (size_t i = 1; i < name.size(); ++i)
-            {
-                if (!std::isdigit(static_cast<unsigned char>(name[i])))
-                {
-                    digits = false;
-                    break;
-                }
-            }
-            if (digits)
-            {
-                try
-                {
-                    return Value::temp(static_cast<unsigned>(std::stoul(name.substr(1))));
-                }
-                catch (const std::exception &)
-                {
-                    std::ostringstream oss;
-                    oss << "Line " << st.lineNo << ": invalid temp id '" << tok << "'";
-                    return Expected<Value>{makeError(st.curLoc, oss.str())};
-                }
-            }
-        }
-        std::ostringstream oss;
-        oss << "Line " << st.lineNo << ": unknown temp '" << tok << "'";
-        return Expected<Value>{makeError(st.curLoc, oss.str())};
-    }
-    if (tok[0] == '@')
-        return Value::global(tok.substr(1));
-    if (tok == "null")
-        return Value::null();
-    if (tok.size() >= 2 && tok.front() == '"' && tok.back() == '"')
-        return Value::constStr(tok.substr(1, tok.size() - 2));
-    if (tok.find('.') != std::string::npos || tok.find('e') != std::string::npos ||
-        tok.find('E') != std::string::npos)
-    {
-        double value = 0.0;
-        if (parseFloatLiteral(tok, value))
-            return Value::constFloat(value);
-        std::ostringstream oss;
-        oss << "Line " << st.lineNo << ": invalid floating literal '" << tok << "'";
-        return Expected<Value>{makeError(st.curLoc, oss.str())};
-    }
-    long long intValue = 0;
-    if (parseIntegerLiteral(tok, intValue))
-        return Value::constInt(intValue);
-    std::ostringstream oss;
-    oss << "Line " << st.lineNo << ": invalid integer literal '" << tok << "'";
-    return Expected<Value>{makeError(st.curLoc, oss.str())};
-}
 
 /// @brief Parses a textual type token and validates it against the IL type set.
 ///
@@ -264,30 +191,6 @@ Expected<void> validateShape_E(const Instr &in, ParserState &st)
 /// @param label Target block label being referenced.
 /// @param argCount Number of arguments supplied in the branch.
 /// @return Empty on success; otherwise, a diagnostic referencing @p in.loc.
-Expected<void> checkBlockArgCount(const Instr &in,
-                                  ParserState &st,
-                                  const std::string &label,
-                                  size_t argCount)
-{
-    if (in.op == Opcode::EhPush)
-        return {};
-    auto it = st.blockParamCount.find(label);
-    if (it != st.blockParamCount.end())
-    {
-        if (it->second != argCount)
-        {
-            std::ostringstream oss;
-            oss << "line " << st.lineNo << ": bad arg count";
-            return Expected<void>{makeError(in.loc, oss.str())};
-        }
-    }
-    else
-    {
-        st.pendingBrs.push_back({label, argCount, st.lineNo});
-    }
-    return {};
-}
-
 /// @brief Lazily build a lookup from opcode mnemonics to Opcode enumerators.
 const std::unordered_map<std::string, Opcode> &mnemonicTable()
 {
@@ -345,265 +248,6 @@ void applyDefaultType(const OpcodeInfo &info, Instr &in)
 }
 
 /// @brief Parse the call operand syntax `<callee>(args...)`.
-Expected<void> parseCallBody(const std::string &rest, Instr &in, ParserState &st)
-{
-    const size_t at = rest.find('@');
-    const size_t lp = rest.find('(', at);
-    const size_t rp = rest.find(')', lp);
-    if (at == std::string::npos || lp == std::string::npos || rp == std::string::npos)
-    {
-        std::ostringstream oss;
-        oss << "line " << st.lineNo << ": malformed call";
-        return Expected<void>{makeError(in.loc, oss.str())};
-    }
-    in.callee = trim(rest.substr(at + 1, lp - at - 1));
-    std::string args = rest.substr(lp + 1, rp - lp - 1);
-    std::stringstream as(args);
-    std::string a;
-    while (std::getline(as, a, ','))
-    {
-        a = trim(a);
-        if (a.empty())
-            continue;
-        auto argVal = parseValue_E(a, st);
-        if (!argVal)
-            return Expected<void>{argVal.error()};
-        in.operands.push_back(std::move(argVal.value()));
-    }
-    in.type = Type(Type::Kind::Void);
-    return {};
-}
-
-/// @brief Parse a branch target `<label>(args...)` fragment.
-Expected<void> parseBranchTarget(
-    const std::string &part, Instr &in, ParserState &st, std::string &lbl, std::vector<Value> &args)
-{
-    std::string text = trim(part);
-    if (text.rfind("label ", 0) == 0)
-        text = trim(text.substr(6));
-    if (!text.empty() && text[0] == '^')
-        text = text.substr(1);
-    const size_t lp = text.find('(');
-    if (lp == std::string::npos)
-    {
-        lbl = trim(text);
-        return {};
-    }
-    const size_t rp = text.find(')', lp);
-    if (rp == std::string::npos)
-    {
-        std::ostringstream oss;
-        oss << "line " << st.lineNo << ": mismatched ')";
-        return Expected<void>{makeError(in.loc, oss.str())};
-    }
-    lbl = trim(text.substr(0, lp));
-    std::string argsStr = text.substr(lp + 1, rp - lp - 1);
-    std::stringstream as(argsStr);
-    std::string token;
-    while (std::getline(as, token, ','))
-    {
-        token = trim(token);
-        if (token.empty())
-            continue;
-        auto val = parseValue_E(token, st);
-        if (!val)
-            return Expected<void>{val.error()};
-        args.push_back(std::move(val.value()));
-    }
-    return {};
-}
-
-/// @brief Parse the list of branch targets for control-flow opcodes.
-Expected<void> parseBranchTargetsFromString(const std::string &text,
-                                            size_t expectedTargets,
-                                            Instr &in,
-                                            ParserState &st)
-{
-    std::string remaining = trim(text);
-    const char *mnemonic = getOpcodeInfo(in.op).name;
-    for (size_t idx = 0; idx < expectedTargets; ++idx)
-    {
-        if (remaining.empty())
-        {
-            std::ostringstream oss;
-            oss << "line " << st.lineNo << ": malformed " << mnemonic;
-            return Expected<void>{makeError(in.loc, oss.str())};
-        }
-
-        size_t split = remaining.size();
-        size_t depth = 0;
-        for (size_t pos = 0; pos < remaining.size(); ++pos)
-        {
-            char c = remaining[pos];
-            if (c == '(')
-                ++depth;
-            else if (c == ')')
-            {
-                if (depth == 0)
-                {
-                    std::ostringstream oss;
-                    oss << "line " << st.lineNo << ": mismatched ')";
-                    return Expected<void>{makeError(in.loc, oss.str())};
-                }
-                --depth;
-            }
-            else if (c == ',' && depth == 0)
-            {
-                split = pos;
-                break;
-            }
-        }
-
-        std::string segment = trim(remaining.substr(0, split));
-        if (segment.empty())
-        {
-            std::ostringstream oss;
-            oss << "line " << st.lineNo << ": malformed " << mnemonic;
-            return Expected<void>{makeError(in.loc, oss.str())};
-        }
-
-        std::vector<Value> args;
-        std::string label;
-        auto parsed = parseBranchTarget(segment, in, st, label, args);
-        if (!parsed)
-            return parsed;
-        in.labels.push_back(label);
-        in.brArgs.push_back(args);
-        auto check = checkBlockArgCount(in, st, label, args.size());
-        if (!check)
-            return check;
-
-        if (split < remaining.size())
-            remaining = trim(remaining.substr(split + 1));
-        else
-            remaining.clear();
-    }
-
-    if (!trim(remaining).empty())
-    {
-        std::ostringstream oss;
-        oss << "line " << st.lineNo << ": malformed " << mnemonic;
-        return Expected<void>{makeError(in.loc, oss.str())};
-    }
-
-    in.type = Type(Type::Kind::Void);
-    return {};
-}
-
-Expected<void> parseSwitchI32Operands(const std::string &text, Instr &in, ParserState &st)
-{
-    std::string remaining = trim(text);
-    const char *mnemonic = getOpcodeInfo(in.op).name;
-    if (remaining.empty())
-    {
-        std::ostringstream oss;
-        oss << "line " << st.lineNo << ": malformed " << mnemonic;
-        return Expected<void>{makeError(in.loc, oss.str())};
-    }
-
-    bool parsingDefault = true;
-    while (!remaining.empty())
-    {
-        size_t split = remaining.size();
-        size_t depth = 0;
-        for (size_t pos = 0; pos < remaining.size(); ++pos)
-        {
-            char c = remaining[pos];
-            if (c == '(')
-                ++depth;
-            else if (c == ')')
-            {
-                if (depth == 0)
-                {
-                    std::ostringstream oss;
-                    oss << "line " << st.lineNo << ": mismatched ')";
-                    return Expected<void>{makeError(in.loc, oss.str())};
-                }
-                --depth;
-            }
-            else if (c == ',' && depth == 0)
-            {
-                split = pos;
-                break;
-            }
-        }
-
-        std::string segment = trim(remaining.substr(0, split));
-        if (segment.empty())
-        {
-            std::ostringstream oss;
-            oss << "line " << st.lineNo << ": malformed " << mnemonic;
-            return Expected<void>{makeError(in.loc, oss.str())};
-        }
-
-        if (parsingDefault)
-        {
-            std::vector<Value> args;
-            std::string label;
-            auto parsed = parseBranchTarget(segment, in, st, label, args);
-            if (!parsed)
-                return parsed;
-            size_t argCount = args.size();
-            in.labels.push_back(label);
-            in.brArgs.push_back(std::move(args));
-            auto check = checkBlockArgCount(in, st, label, argCount);
-            if (!check)
-                return check;
-            parsingDefault = false;
-        }
-        else
-        {
-            const size_t arrow = segment.find("->");
-            if (arrow == std::string::npos)
-            {
-                std::ostringstream oss;
-                oss << "line " << st.lineNo << ": malformed " << mnemonic;
-                return Expected<void>{makeError(in.loc, oss.str())};
-            }
-            std::string valueText = trim(segment.substr(0, arrow));
-            std::string targetText = trim(segment.substr(arrow + 2));
-            if (valueText.empty() || targetText.empty())
-            {
-                std::ostringstream oss;
-                oss << "line " << st.lineNo << ": malformed " << mnemonic;
-                return Expected<void>{makeError(in.loc, oss.str())};
-            }
-
-            auto caseValue = parseValue_E(valueText, st);
-            if (!caseValue)
-                return Expected<void>{caseValue.error()};
-            in.operands.push_back(std::move(caseValue.value()));
-
-            std::vector<Value> args;
-            std::string label;
-            auto parsed = parseBranchTarget(targetText, in, st, label, args);
-            if (!parsed)
-                return parsed;
-            size_t argCount = args.size();
-            in.labels.push_back(label);
-            in.brArgs.push_back(std::move(args));
-            auto check = checkBlockArgCount(in, st, label, argCount);
-            if (!check)
-                return check;
-        }
-
-        if (split < remaining.size())
-            remaining = trim(remaining.substr(split + 1));
-        else
-            break;
-    }
-
-    if (parsingDefault)
-    {
-        std::ostringstream oss;
-        oss << "line " << st.lineNo << ": malformed " << mnemonic;
-        return Expected<void>{makeError(in.loc, oss.str())};
-    }
-
-    in.type = Type(Type::Kind::Void);
-    return {};
-}
-
 /// @brief Parse operands based on opcode metadata-driven descriptions.
 Expected<void> parseWithMetadata(Opcode opcode, const std::string &rest, Instr &in, ParserState &st)
 {
@@ -613,6 +257,7 @@ Expected<void> parseWithMetadata(Opcode opcode, const std::string &rest, Instr &
 
     std::istringstream ss(rest);
     const std::string original = rest;
+    OperandParser operandParser{st, in};
 
     for (size_t idx = 0; idx < info.parse.size(); ++idx)
     {
@@ -660,7 +305,7 @@ Expected<void> parseWithMetadata(Opcode opcode, const std::string &rest, Instr &
                         break;
                     }
                 }
-                auto value = parseValue_E(token, st);
+                auto value = operandParser.parseValueToken(token);
                 if (!value)
                     return Expected<void>{value.error()};
                 in.operands.push_back(std::move(value.value()));
@@ -668,7 +313,7 @@ Expected<void> parseWithMetadata(Opcode opcode, const std::string &rest, Instr &
             }
             case OperandParseKind::Call:
             {
-                auto parsed = parseCallBody(original, in, st);
+                auto parsed = operandParser.parseCallOperands(original);
                 if (!parsed)
                     return parsed;
                 return {};
@@ -684,7 +329,7 @@ Expected<void> parseWithMetadata(Opcode opcode, const std::string &rest, Instr &
                 std::string remainder;
                 std::getline(ss, remainder);
                 remainder = trim(remainder);
-                auto parsed = parseBranchTargetsFromString(remainder, branchCount, in, st);
+                auto parsed = operandParser.parseBranchTargets(remainder, branchCount);
                 if (!parsed)
                     return parsed;
                 return {};
@@ -694,7 +339,7 @@ Expected<void> parseWithMetadata(Opcode opcode, const std::string &rest, Instr &
                 std::string remainder;
                 std::getline(ss, remainder);
                 remainder = trim(remainder);
-                auto parsed = parseSwitchI32Operands(remainder, in, st);
+                auto parsed = operandParser.parseSwitchTargets(remainder);
                 if (!parsed)
                     return parsed;
                 return {};

--- a/src/il/io/OperandParser.cpp
+++ b/src/il/io/OperandParser.cpp
@@ -1,0 +1,371 @@
+// File: src/il/io/OperandParser.cpp
+// Purpose: Implements helpers for parsing IL instruction operands.
+// Key invariants: Operates on instructions tied to the current parser state.
+// Ownership/Lifetime: Mutates instructions owned by the parser caller.
+// Links: docs/il-guide.md#reference
+
+#include "il/io/OperandParser.hpp"
+
+#include "il/core/Instr.hpp"
+#include "il/core/OpcodeInfo.hpp"
+#include "il/core/Value.hpp"
+#include "il/io/ParserUtil.hpp"
+
+#include "support/diag_expected.hpp"
+
+#include <cctype>
+#include <exception>
+#include <sstream>
+#include <utility>
+
+namespace il::io::detail
+{
+
+using il::core::Instr;
+using il::core::Value;
+using il::support::Expected;
+using il::support::makeError;
+
+OperandParser::OperandParser(ParserState &state, Instr &instr) : state_(state), instr_(instr) {}
+
+Expected<Value> OperandParser::parseValueToken(const std::string &tok) const
+{
+    if (tok.empty())
+        return Value::constInt(0);
+    if (tok[0] == '%')
+    {
+        std::string name = tok.substr(1);
+        auto it = state_.tempIds.find(name);
+        if (it != state_.tempIds.end())
+            return Value::temp(it->second);
+        if (name.size() > 1 && name[0] == 't')
+        {
+            bool digits = true;
+            for (size_t i = 1; i < name.size(); ++i)
+            {
+                if (!std::isdigit(static_cast<unsigned char>(name[i])))
+                {
+                    digits = false;
+                    break;
+                }
+            }
+            if (digits)
+            {
+                try
+                {
+                    return Value::temp(static_cast<unsigned>(std::stoul(name.substr(1))));
+                }
+                catch (const std::exception &)
+                {
+                    std::ostringstream oss;
+                    oss << "Line " << state_.lineNo << ": invalid temp id '" << tok << "'";
+                    return Expected<Value>{makeError(state_.curLoc, oss.str())};
+                }
+            }
+        }
+        std::ostringstream oss;
+        oss << "Line " << state_.lineNo << ": unknown temp '" << tok << "'";
+        return Expected<Value>{makeError(state_.curLoc, oss.str())};
+    }
+    if (tok[0] == '@')
+        return Value::global(tok.substr(1));
+    if (tok == "null")
+        return Value::null();
+    if (tok.size() >= 2 && tok.front() == '"' && tok.back() == '"')
+        return Value::constStr(tok.substr(1, tok.size() - 2));
+    if (tok.find('.') != std::string::npos || tok.find('e') != std::string::npos ||
+        tok.find('E') != std::string::npos)
+    {
+        double value = 0.0;
+        if (parseFloatLiteral(tok, value))
+            return Value::constFloat(value);
+        std::ostringstream oss;
+        oss << "Line " << state_.lineNo << ": invalid floating literal '" << tok << "'";
+        return Expected<Value>{makeError(state_.curLoc, oss.str())};
+    }
+    long long intValue = 0;
+    if (parseIntegerLiteral(tok, intValue))
+        return Value::constInt(intValue);
+    std::ostringstream oss;
+    oss << "Line " << state_.lineNo << ": invalid integer literal '" << tok << "'";
+    return Expected<Value>{makeError(state_.curLoc, oss.str())};
+}
+
+Expected<void> OperandParser::parseCallOperands(const std::string &text)
+{
+    const size_t at = text.find('@');
+    const size_t lp = text.find('(', at);
+    const size_t rp = text.find(')', lp);
+    if (at == std::string::npos || lp == std::string::npos || rp == std::string::npos)
+    {
+        std::ostringstream oss;
+        oss << "line " << state_.lineNo << ": malformed call";
+        return Expected<void>{makeError(instr_.loc, oss.str())};
+    }
+    instr_.callee = trim(text.substr(at + 1, lp - at - 1));
+    std::string args = text.substr(lp + 1, rp - lp - 1);
+    std::stringstream as(args);
+    std::string a;
+    while (std::getline(as, a, ','))
+    {
+        a = trim(a);
+        if (a.empty())
+            continue;
+        auto argVal = parseValueToken(a);
+        if (!argVal)
+            return Expected<void>{argVal.error()};
+        instr_.operands.push_back(std::move(argVal.value()));
+    }
+    instr_.type = il::core::Type(il::core::Type::Kind::Void);
+    return {};
+}
+
+Expected<void> OperandParser::parseBranchTarget(const std::string &segment,
+                                                std::string &label,
+                                                std::vector<Value> &args) const
+{
+    std::string text = trim(segment);
+    if (text.rfind("label ", 0) == 0)
+        text = trim(text.substr(6));
+    if (!text.empty() && text[0] == '^')
+        text = text.substr(1);
+    const size_t lp = text.find('(');
+    if (lp == std::string::npos)
+    {
+        label = trim(text);
+        return {};
+    }
+    const size_t rp = text.find(')', lp);
+    if (rp == std::string::npos)
+    {
+        std::ostringstream oss;
+        oss << "line " << state_.lineNo << ": mismatched ')";
+        return Expected<void>{makeError(instr_.loc, oss.str())};
+    }
+    label = trim(text.substr(0, lp));
+    std::string argsStr = text.substr(lp + 1, rp - lp - 1);
+    std::stringstream as(argsStr);
+    std::string token;
+    while (std::getline(as, token, ','))
+    {
+        token = trim(token);
+        if (token.empty())
+            continue;
+        auto val = parseValueToken(token);
+        if (!val)
+            return Expected<void>{val.error()};
+        args.push_back(std::move(val.value()));
+    }
+    return {};
+}
+
+Expected<void> OperandParser::checkBranchArgCount(const std::string &label,
+                                                  size_t argCount) const
+{
+    if (instr_.op == il::core::Opcode::EhPush)
+        return {};
+    auto it = state_.blockParamCount.find(label);
+    if (it != state_.blockParamCount.end())
+    {
+        if (it->second != argCount)
+        {
+            std::ostringstream oss;
+            oss << "line " << state_.lineNo << ": bad arg count";
+            return Expected<void>{makeError(instr_.loc, oss.str())};
+        }
+    }
+    else
+    {
+        state_.pendingBrs.push_back({label, argCount, state_.lineNo});
+    }
+    return {};
+}
+
+Expected<void> OperandParser::parseBranchTargets(const std::string &text, size_t expectedTargets)
+{
+    std::string remaining = trim(text);
+    const char *mnemonic = il::core::getOpcodeInfo(instr_.op).name;
+    for (size_t idx = 0; idx < expectedTargets; ++idx)
+    {
+        if (remaining.empty())
+        {
+            std::ostringstream oss;
+            oss << "line " << state_.lineNo << ": malformed " << mnemonic;
+            return Expected<void>{makeError(instr_.loc, oss.str())};
+        }
+
+        size_t split = remaining.size();
+        size_t depth = 0;
+        for (size_t pos = 0; pos < remaining.size(); ++pos)
+        {
+            char c = remaining[pos];
+            if (c == '(')
+                ++depth;
+            else if (c == ')')
+            {
+                if (depth == 0)
+                {
+                    std::ostringstream oss;
+                    oss << "line " << state_.lineNo << ": mismatched ')";
+                    return Expected<void>{makeError(instr_.loc, oss.str())};
+                }
+                --depth;
+            }
+            else if (c == ',' && depth == 0)
+            {
+                split = pos;
+                break;
+            }
+        }
+
+        std::string segment = trim(remaining.substr(0, split));
+        if (segment.empty())
+        {
+            std::ostringstream oss;
+            oss << "line " << state_.lineNo << ": malformed " << mnemonic;
+            return Expected<void>{makeError(instr_.loc, oss.str())};
+        }
+
+        std::vector<Value> args;
+        std::string label;
+        auto parsed = parseBranchTarget(segment, label, args);
+        if (!parsed)
+            return parsed;
+        instr_.labels.push_back(label);
+        instr_.brArgs.push_back(args);
+        auto check = checkBranchArgCount(label, args.size());
+        if (!check)
+            return check;
+
+        if (split < remaining.size())
+            remaining = trim(remaining.substr(split + 1));
+        else
+            remaining.clear();
+    }
+
+    if (!trim(remaining).empty())
+    {
+        std::ostringstream oss;
+        oss << "line " << state_.lineNo << ": malformed " << mnemonic;
+        return Expected<void>{makeError(instr_.loc, oss.str())};
+    }
+
+    instr_.type = il::core::Type(il::core::Type::Kind::Void);
+    return {};
+}
+
+Expected<void> OperandParser::parseSwitchTargets(const std::string &text)
+{
+    std::string remaining = trim(text);
+    const char *mnemonic = il::core::getOpcodeInfo(instr_.op).name;
+    if (remaining.empty())
+    {
+        std::ostringstream oss;
+        oss << "line " << state_.lineNo << ": malformed " << mnemonic;
+        return Expected<void>{makeError(instr_.loc, oss.str())};
+    }
+
+    bool parsingDefault = true;
+    while (!remaining.empty())
+    {
+        size_t split = remaining.size();
+        size_t depth = 0;
+        for (size_t pos = 0; pos < remaining.size(); ++pos)
+        {
+            char c = remaining[pos];
+            if (c == '(')
+                ++depth;
+            else if (c == ')')
+            {
+                if (depth == 0)
+                {
+                    std::ostringstream oss;
+                    oss << "line " << state_.lineNo << ": mismatched ')";
+                    return Expected<void>{makeError(instr_.loc, oss.str())};
+                }
+                --depth;
+            }
+            else if (c == ',' && depth == 0)
+            {
+                split = pos;
+                break;
+            }
+        }
+
+        std::string segment = trim(remaining.substr(0, split));
+        if (segment.empty())
+        {
+            std::ostringstream oss;
+            oss << "line " << state_.lineNo << ": malformed " << mnemonic;
+            return Expected<void>{makeError(instr_.loc, oss.str())};
+        }
+
+        if (parsingDefault)
+        {
+            std::vector<Value> args;
+            std::string label;
+            auto parsed = parseBranchTarget(segment, label, args);
+            if (!parsed)
+                return parsed;
+            size_t argCount = args.size();
+            instr_.labels.push_back(label);
+            instr_.brArgs.push_back(std::move(args));
+            auto check = checkBranchArgCount(label, argCount);
+            if (!check)
+                return check;
+            parsingDefault = false;
+        }
+        else
+        {
+            const size_t arrow = segment.find("->");
+            if (arrow == std::string::npos)
+            {
+                std::ostringstream oss;
+                oss << "line " << state_.lineNo << ": malformed " << mnemonic;
+                return Expected<void>{makeError(instr_.loc, oss.str())};
+            }
+            std::string valueText = trim(segment.substr(0, arrow));
+            std::string targetText = trim(segment.substr(arrow + 2));
+            if (valueText.empty() || targetText.empty())
+            {
+                std::ostringstream oss;
+                oss << "line " << state_.lineNo << ": malformed " << mnemonic;
+                return Expected<void>{makeError(instr_.loc, oss.str())};
+            }
+
+            auto caseValue = parseValueToken(valueText);
+            if (!caseValue)
+                return Expected<void>{caseValue.error()};
+            instr_.operands.push_back(std::move(caseValue.value()));
+
+            std::vector<Value> args;
+            std::string label;
+            auto parsed = parseBranchTarget(targetText, label, args);
+            if (!parsed)
+                return parsed;
+            size_t argCount = args.size();
+            instr_.labels.push_back(label);
+            instr_.brArgs.push_back(std::move(args));
+            auto check = checkBranchArgCount(label, argCount);
+            if (!check)
+                return check;
+        }
+
+        if (split < remaining.size())
+            remaining = trim(remaining.substr(split + 1));
+        else
+            break;
+    }
+
+    if (parsingDefault)
+    {
+        std::ostringstream oss;
+        oss << "line " << state_.lineNo << ": malformed " << mnemonic;
+        return Expected<void>{makeError(instr_.loc, oss.str())};
+    }
+
+    instr_.type = il::core::Type(il::core::Type::Kind::Void);
+    return {};
+}
+
+} // namespace il::io::detail

--- a/src/il/io/OperandParser.hpp
+++ b/src/il/io/OperandParser.hpp
@@ -1,0 +1,60 @@
+// File: src/il/io/OperandParser.hpp
+// Purpose: Declares a helper for parsing textual IL operands.
+// Key invariants: Requires ParserState to supply SSA mappings and diagnostics.
+// Ownership/Lifetime: Operates on instructions owned by the parser caller.
+// Links: docs/il-guide.md#reference
+#pragma once
+
+#include "il/core/fwd.hpp"
+#include "il/io/ParserState.hpp"
+#include "support/diag_expected.hpp"
+
+#include <string>
+#include <vector>
+
+namespace il::io::detail
+{
+
+/// @brief Parses operand tokens for an instruction currently under construction.
+class OperandParser
+{
+  public:
+    /// @brief Construct an operand parser bound to the current parser state and instruction.
+    /// @param state Parser state supplying temporary mappings and diagnostics.
+    /// @param instr Instruction receiving parsed operands.
+    OperandParser(ParserState &state, il::core::Instr &instr);
+
+    /// @brief Parse a single value token (temporary, global, literal, etc.).
+    /// @param token Token extracted from the instruction text.
+    /// @return Parsed IL value or a diagnostic on failure.
+    il::support::Expected<il::core::Value> parseValueToken(const std::string &token) const;
+
+    /// @brief Parse the call operand syntax and append results to the instruction.
+    /// @param text Remainder of the instruction line starting at the callee token.
+    /// @return Empty on success; otherwise, a diagnostic describing the malformed call.
+    il::support::Expected<void> parseCallOperands(const std::string &text);
+
+    /// @brief Parse branch target lists of the form `label(args), label(args)`.
+    /// @param text Textual segment containing the branch targets.
+    /// @param expectedTargets Number of targets dictated by the opcode metadata.
+    /// @return Empty on success; otherwise, a diagnostic describing the malformed targets.
+    il::support::Expected<void> parseBranchTargets(const std::string &text, size_t expectedTargets);
+
+    /// @brief Parse switch operand payloads consisting of a default target followed by cases.
+    /// @param text Textual segment beginning with the default target.
+    /// @return Empty on success; otherwise, a diagnostic describing the malformed switch payload.
+    il::support::Expected<void> parseSwitchTargets(const std::string &text);
+
+  private:
+    il::support::Expected<void> parseBranchTarget(const std::string &segment,
+                                                  std::string &label,
+                                                  std::vector<il::core::Value> &args) const;
+
+    il::support::Expected<void> checkBranchArgCount(const std::string &label,
+                                                    size_t argCount) const;
+
+    ParserState &state_;
+    il::core::Instr &instr_;
+};
+
+} // namespace il::io::detail


### PR DESCRIPTION
## Summary
- extract operand parsing helpers into a dedicated `OperandParser` under `il/io`
- update instruction parsing to delegate value, call, branch, and switch operands through the new helper and add the file to the build

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e09c636570832490e5b8b085cd6171