### PR TITLE
refactor(vm): centralize runtime marshalling helpers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,6 +125,7 @@ add_library(il_vm STATIC
   vm/VMInit.cpp
   vm/VMDebug.cpp
   vm/RuntimeBridge.cpp
+  vm/Marshal.cpp
   vm/OpHandlers.cpp
   vm/OpHandlerUtils.cpp
   vm/Trap.cpp

--- a/src/vm/Marshal.cpp
+++ b/src/vm/Marshal.cpp
@@ -1,0 +1,72 @@
+// File: src/vm/Marshal.cpp
+// Purpose: Implements helpers for converting between VM and runtime representations.
+// Key invariants: Conversions mirror existing manual code paths to avoid behavior changes.
+// Ownership/Lifetime: Returned string views remain valid only while underlying storage lives.
+// Links: docs/il-guide.md#reference
+
+#include "vm/Marshal.hpp"
+
+#include "rt_string.h"
+
+#include <cassert>
+
+namespace il::vm
+{
+
+ViperString toViperString(StringRef text)
+{
+    if (text.data() == nullptr)
+        return nullptr;
+    if (text.empty())
+        return rt_const_cstr("");
+    return rt_const_cstr(text.data());
+}
+
+StringRef fromViperString(const ViperString &str)
+{
+    if (!str)
+        return {};
+    const char *data = rt_string_cstr(str);
+    if (!data)
+        return {};
+    const int64_t length = rt_len(str);
+    if (length <= 0)
+        return {};
+    return StringRef{data, static_cast<size_t>(length)};
+}
+
+int64_t toI64(const il::core::Value &value)
+{
+    using Kind = il::core::Value::Kind;
+    switch (value.kind)
+    {
+        case Kind::ConstInt:
+            return static_cast<int64_t>(value.i64);
+        case Kind::ConstFloat:
+            return static_cast<int64_t>(value.f64);
+        case Kind::NullPtr:
+            return 0;
+        default:
+            assert(false && "value kind is not convertible to i64");
+            return 0;
+    }
+}
+
+double toF64(const il::core::Value &value)
+{
+    using Kind = il::core::Value::Kind;
+    switch (value.kind)
+    {
+        case Kind::ConstFloat:
+            return value.f64;
+        case Kind::ConstInt:
+            return static_cast<double>(value.i64);
+        case Kind::NullPtr:
+            return 0.0;
+        default:
+            assert(false && "value kind is not convertible to f64");
+            return 0.0;
+    }
+}
+
+} // namespace il::vm

--- a/src/vm/Marshal.hpp
+++ b/src/vm/Marshal.hpp
@@ -1,0 +1,25 @@
+// File: src/vm/Marshal.hpp
+// Purpose: Declares helpers for converting between VM and runtime data types.
+// Key invariants: Conversion helpers preserve existing runtime encodings.
+// Ownership/Lifetime: Views returned do not extend the lifetime of underlying data.
+// Links: docs/il-guide.md#reference
+#pragma once
+
+#include "il/core/Value.hpp"
+#include "rt_string.h"
+
+#include <cstdint>
+#include <string_view>
+
+namespace il::vm
+{
+
+using StringRef = std::string_view;
+using ViperString = ::rt_string;
+
+ViperString toViperString(StringRef text);
+StringRef fromViperString(const ViperString &str);
+int64_t toI64(const il::core::Value &value);
+double toF64(const il::core::Value &value);
+
+} // namespace il::vm

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -13,6 +13,7 @@
 #include "il/core/OpcodeInfo.hpp"
 #include "il/core/Value.hpp"
 #include "vm/RuntimeBridge.hpp"
+#include "vm/Marshal.hpp"
 #include <algorithm>
 #include <exception>
 #include <iostream>
@@ -106,13 +107,13 @@ Slot VM::eval(Frame &fr, const Value &v)
                 return fr.regs[v.id];
             return s;
         case Value::Kind::ConstInt:
-            s.i64 = v.i64;
+            s.i64 = toI64(v);
             return s;
         case Value::Kind::ConstFloat:
-            s.f64 = v.f64;
+            s.f64 = toF64(v);
             return s;
         case Value::Kind::ConstStr:
-            s.str = rt_const_cstr(v.str.c_str());
+            s.str = toViperString(v.str);
             return s;
         case Value::Kind::GlobalAddr:
         {

--- a/src/vm/VMInit.cpp
+++ b/src/vm/VMInit.cpp
@@ -5,6 +5,7 @@
 // Links: docs/il-guide.md#reference
 
 #include "vm/VM.hpp"
+#include "vm/Marshal.hpp"
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Function.hpp"
 #include "il/core/Global.hpp"
@@ -58,7 +59,7 @@ VM::VM(const Module &m, TraceConfig tc, uint64_t ms, DebugCtrl dbg, DebugScript 
     for (const auto &f : m.functions)
         fnMap[f.name] = &f;
     for (const auto &g : m.globals)
-        strMap[g.name] = rt_const_cstr(g.init.c_str());
+        strMap[g.name] = toViperString(g.init);
 }
 
 /// Initialise a fresh @c Frame for executing function @p fn.

--- a/src/vm/control_flow.cpp
+++ b/src/vm/control_flow.cpp
@@ -13,9 +13,9 @@
 #include "il/core/Value.hpp"
 #include "vm/OpHandlerUtils.hpp"
 #include "vm/RuntimeBridge.hpp"
+#include "vm/Marshal.hpp"
 #include "vm/Trap.hpp"
 #include "vm/err_bridge.hpp"
-#include "rt_string.h"
 #include <string>
 #include <algorithm>
 #include <cassert>
@@ -524,7 +524,10 @@ VM::ExecResult OpHandlers::handleTrapErr(VM &vm,
     {
         Slot textSlot = vm.eval(fr, in.operands[1]);
         if (textSlot.str != nullptr)
-            message = rt_string_cstr(textSlot.str);
+        {
+            auto view = fromViperString(textSlot.str);
+            message.assign(view.begin(), view.end());
+        }
     }
 
     VmError *token = vm_acquire_trap_token();


### PR DESCRIPTION
## Summary
- add vm::Marshal helpers for converting between runtime strings, values, and IL primitives
- refactor VM initialization and control flow to use the shared marshalling utilities
- register the new source file with the il_vm target

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e0a43b84748324b5d2d02ade7ab3ee