### PR TITLE
Refactor: generate opcode name mapping from Opcode.def

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(support)
 
 add_library(viper_il_core STATIC
   il/core/OpcodeInfo.cpp
+  il/core/OpcodeNames.cpp
   il/core/Type.cpp
   il/core/Value.cpp
   il/core/Instr.cpp

--- a/src/il/core/Opcode.hpp
+++ b/src/il/core/Opcode.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <cstddef>
-#include <string>
 
 namespace il::core
 {
@@ -27,6 +26,6 @@ constexpr size_t kNumOpcodes = static_cast<size_t>(Opcode::Count);
 /// @brief Convert opcode @p op to its mnemonic string.
 /// @param op Opcode to stringify.
 /// @return Lowercase mnemonic defined by the IL spec.
-std::string toString(Opcode op);
+const char *toString(Opcode op);
 
 } // namespace il::core

--- a/src/il/core/OpcodeInfo.cpp
+++ b/src/il/core/OpcodeInfo.cpp
@@ -68,14 +68,6 @@ std::vector<Opcode> all_opcodes()
     return ops;
 }
 
-std::string opcode_mnemonic(Opcode op)
-{
-    const size_t idx = static_cast<size_t>(op);
-    if (idx >= kOpcodeTable.size())
-        return "";
-    return kOpcodeTable[idx].name;
-}
-
 bool isVariadicOperandCount(uint8_t value)
 {
     return value == kVariadicOperandCount;
@@ -89,15 +81,15 @@ bool isVariadicSuccessorCount(uint8_t value)
 /**
  * @brief Returns the mnemonic associated with the provided opcode.
  *
- * Performs a direct lookup into the opcode metadata table and treats any opcode whose
- * numerical value falls outside the table bounds as invalid.
+ * Delegates to the generated opcode name table and treats out-of-range opcodes
+ * as invalid.
  *
  * @param op Opcode enumeration value to translate into a mnemonic string.
  * @returns The mnemonic string if the opcode is within range; otherwise an empty string.
  */
-std::string toString(Opcode op)
+std::string opcode_mnemonic(Opcode op)
 {
-    return opcode_mnemonic(op);
+    return toString(op);
 }
 
 } // namespace il::core

--- a/src/il/core/OpcodeInfo.hpp
+++ b/src/il/core/OpcodeInfo.hpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <cstdint>
 #include <limits>
+#include <string>
 #include <vector>
 
 namespace il::core

--- a/src/il/core/OpcodeNames.cpp
+++ b/src/il/core/OpcodeNames.cpp
@@ -1,0 +1,32 @@
+// File: src/il/core/OpcodeNames.cpp
+// Purpose: Provide lightweight mnemonic lookups for IL opcodes.
+// Key invariants: Table entries align exactly with the order of il::core::Opcode.
+// Ownership/Lifetime: Static storage duration for shared string literals.
+// Links: docs/il-guide.md#reference
+
+#include "il/core/Opcode.hpp"
+
+#include <array>
+
+namespace il::core
+{
+namespace
+{
+constexpr std::array<const char *, kNumOpcodes> kOpcodeNames = {
+#define IL_OPCODE(NAME, MNEMONIC, ...) MNEMONIC,
+#include "il/core/Opcode.def"
+#undef IL_OPCODE
+};
+
+static_assert(kOpcodeNames.size() == kNumOpcodes, "Opcode name table must match enum count");
+} // namespace
+
+const char *toString(Opcode op)
+{
+    const size_t index = static_cast<size_t>(op);
+    if (index < kOpcodeNames.size())
+        return kOpcodeNames[index];
+    return "";
+}
+
+} // namespace il::core


### PR DESCRIPTION
## Summary
- add a generated opcode name table sourced from Opcode.def and expose il::core::toString as a const char* helper
- have OpcodeInfo reuse the shared name table for opcode mnemonics and register the new source with viper_il_core

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e0aeb4e04883248af803c5395e1999