### PR TITLE
refactor(il/verify): introduce instruction verify context

### DIFF
--- a/src/il/verify/FunctionVerifier.cpp
+++ b/src/il/verify/FunctionVerifier.cpp
@@ -18,6 +18,7 @@
 #include "il/verify/InstructionChecker.hpp"
 #include "il/verify/InstructionStrategies.hpp"
 #include "il/verify/TypeInference.hpp"
+#include "il/verify/VerifyCtx.hpp"
 
 #include <algorithm>
 #include <optional>
@@ -69,9 +70,7 @@ Expected<void> validateBlockParams_E(const Function &fn,
                                      TypeInference &types,
                                      std::vector<unsigned> &paramIds);
 Expected<void> checkBlockTerminators_E(const Function &fn, const BasicBlock &bb);
-Expected<void> verifyOpcodeSignature_E(const Function &fn,
-                                       const BasicBlock &bb,
-                                       const Instr &instr);
+Expected<void> verifyOpcodeSignature_E(const VerifyCtx &ctx);
 Expected<void> verifyInstruction_E(const Function &fn,
                                    const BasicBlock &bb,
                                    const Instr &instr,
@@ -308,7 +307,8 @@ Expected<void> FunctionVerifier::verifyInstruction(
     TypeInference &types,
     DiagSink &sink)
 {
-    if (auto result = verifyOpcodeSignature_E(fn, bb, instr); !result)
+    VerifyCtx ctx{sink, types, externs_, functionMap_, fn, bb, instr};
+    if (auto result = verifyOpcodeSignature_E(ctx); !result)
         return result;
 
     for (const auto &strategy : strategies_)

--- a/src/il/verify/InstructionStrategies.cpp
+++ b/src/il/verify/InstructionStrategies.cpp
@@ -13,6 +13,7 @@
 #include "il/verify/FunctionVerifier.hpp"
 #include "il/verify/InstructionChecker.hpp"
 #include "il/verify/TypeInference.hpp"
+#include "il/verify/VerifyCtx.hpp"
 
 #include <memory>
 #include <unordered_map>
@@ -23,13 +24,7 @@ namespace il::verify
 {
 using il::support::Expected;
 
-Expected<void> verifyInstruction_E(const Function &fn,
-                                   const BasicBlock &bb,
-                                   const Instr &instr,
-                                   const std::unordered_map<std::string, const Extern *> &externs,
-                                   const std::unordered_map<std::string, const Function *> &funcs,
-                                   TypeInference &types,
-                                   DiagSink &sink);
+Expected<void> verifyInstruction_E(const VerifyCtx &ctx);
 
 namespace
 {
@@ -90,7 +85,8 @@ class DefaultInstructionStrategy final : public FunctionVerifier::InstructionStr
                           DiagSink &sink) const override
     {
         (void)blockMap;
-        return verifyInstruction_E(fn, bb, instr, externs, funcs, types, sink);
+        VerifyCtx ctx{sink, types, externs, funcs, fn, bb, instr};
+        return verifyInstruction_E(ctx);
     }
 };
 

--- a/src/il/verify/VerifyCtx.hpp
+++ b/src/il/verify/VerifyCtx.hpp
@@ -1,0 +1,36 @@
+// File: src/il/verify/VerifyCtx.hpp
+// Purpose: Defines a shared context structure for verifier routines operating on IL instructions.
+// Key invariants: Context members reference live verifier state scoped to the current instruction.
+// Ownership/Lifetime: Non-owning references valid for the duration of a single verification step.
+// Links: docs/il-guide.md#reference
+#pragma once
+
+#include "il/core/fwd.hpp"
+
+#include <string>
+#include <unordered_map>
+
+namespace il::core
+{
+struct Extern;
+}
+
+namespace il::verify
+{
+
+class DiagSink;
+class TypeInference;
+
+/// @brief Bundles shared verifier state when validating a single instruction.
+struct VerifyCtx
+{
+    DiagSink &diags; ///< Diagnostic sink used for warnings and errors.
+    TypeInference &types; ///< Type inference table tracking temporaries.
+    const std::unordered_map<std::string, const il::core::Extern *> &externs; ///< Known extern signatures.
+    const std::unordered_map<std::string, const il::core::Function *> &functions; ///< Known function definitions.
+    const il::core::Function &fn; ///< Function that owns the instruction.
+    const il::core::BasicBlock &block; ///< Basic block containing the instruction.
+    const il::core::Instr &instr; ///< Instruction under validation.
+};
+
+} // namespace il::verify


### PR DESCRIPTION
## Summary
- add a VerifyCtx helper that collects instruction-level verifier state
- update selected verifier helpers to accept VerifyCtx instead of long parameter lists
- thread VerifyCtx through FunctionVerifier and the default instruction strategy

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e0ae9ba99c8324b19858e59dbeeebf