### PR TITLE
Add terminal control comment to runtime header

### DIFF
--- a/src/runtime/rt.hpp
+++ b/src/runtime/rt.hpp
@@ -54,6 +54,8 @@ extern "C" {
     /// @return Pointer to zeroed block or trap on failure.
     void *rt_alloc(int64_t bytes);
 
+    // Terminal control + single-key input
+
     /// @brief Clear the terminal when stdout is a TTY.
     void rt_term_cls(void);
 


### PR DESCRIPTION
## Summary
- group the terminal control and key input declarations in `rt.hpp` under a shared comment so the APIs are easy to discover

## Testing
- `cmake -S . -B build`
- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68e0c21e401c832491f7129d4ca35891