### PR TITLE
Add BASIC tokens for CLS/COLOR/LOCATE

### DIFF
--- a/src/frontends/basic/TokenKinds.def
+++ b/src/frontends/basic/TokenKinds.def
@@ -59,6 +59,9 @@ TOKEN(KeywordReturn, "RETURN")
 TOKEN(KeywordLbound, "LBOUND")
 TOKEN(KeywordUbound, "UBOUND")
 TOKEN(KeywordUntil, "UNTIL")
+TOKEN(KeywordCls, "CLS")
+TOKEN(KeywordColor, "COLOR")
+TOKEN(KeywordLocate, "LOCATE")
 
 // Operators ----------------------------------------------------------------
 TOKEN(Plus, "+")


### PR DESCRIPTION
## Summary
- add keyword token kinds for CLS, COLOR, and LOCATE in the BASIC frontend

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68e179f571608324bcf24f245244d8de