### PR TITLE
Add CLS/COLOR/LOCATE keywords to BASIC lexer

### DIFF
--- a/src/frontends/basic/Lexer.cpp
+++ b/src/frontends/basic/Lexer.cpp
@@ -25,7 +25,7 @@ struct KeywordEntry
     TokenKind kind;
 };
 
-constexpr std::array<KeywordEntry, 56> kKeywordTable{{
+constexpr std::array<KeywordEntry, 59> kKeywordTable{{
     {"ABS", TokenKind::KeywordAbs},
     {"AND", TokenKind::KeywordAnd},
     {"ANDALSO", TokenKind::KeywordAndAlso},
@@ -35,6 +35,8 @@ constexpr std::array<KeywordEntry, 56> kKeywordTable{{
     {"BOOLEAN", TokenKind::KeywordBoolean},
     {"CEIL", TokenKind::KeywordCeil},
     {"CLOSE", TokenKind::KeywordClose},
+    {"CLS", TokenKind::KeywordCls},
+    {"COLOR", TokenKind::KeywordColor},
     {"COS", TokenKind::KeywordCos},
     {"DIM", TokenKind::KeywordDim},
     {"DO", TokenKind::KeywordDo},
@@ -54,6 +56,7 @@ constexpr std::array<KeywordEntry, 56> kKeywordTable{{
     {"LBOUND", TokenKind::KeywordLbound},
     {"LET", TokenKind::KeywordLet},
     {"LINE", TokenKind::KeywordLine},
+    {"LOCATE", TokenKind::KeywordLocate},
     {"LOOP", TokenKind::KeywordLoop},
     {"MOD", TokenKind::KeywordMod},
     {"NEXT", TokenKind::KeywordNext},


### PR DESCRIPTION
## Summary
- map the CLS, COLOR, and LOCATE keywords to dedicated token kinds in the BASIC lexer

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e18030b3e483248f144137ff681a42