### PR TITLE
basic: parser support for CLS/COLOR/LOCATE

### DIFF
--- a/src/frontends/basic/Parser.cpp
+++ b/src/frontends/basic/Parser.cpp
@@ -22,7 +22,7 @@ Parser::Parser(std::string_view src, uint32_t file_id, DiagnosticEmitter *emitte
     : lexer_(src, file_id), emitter_(emitter)
 {
     tokens_.push_back(lexer_.next());
-    static constexpr std::array<std::pair<TokenKind, StmtHandler>, 22> kStatementHandlers = {{
+    static constexpr std::array<std::pair<TokenKind, StmtHandler>, 25> kStatementHandlers = {{
         {TokenKind::KeywordPrint, {&Parser::parsePrint, nullptr}},
         {TokenKind::KeywordLet, {&Parser::parseLet, nullptr}},
         {TokenKind::KeywordIf, {nullptr, &Parser::parseIf}},
@@ -34,11 +34,14 @@ Parser::Parser(std::string_view src, uint32_t file_id, DiagnosticEmitter *emitte
         {TokenKind::KeywordGoto, {&Parser::parseGoto, nullptr}},
         {TokenKind::KeywordOpen, {&Parser::parseOpen, nullptr}},
         {TokenKind::KeywordClose, {&Parser::parseClose, nullptr}},
+        {TokenKind::KeywordCls, {&Parser::parseCls, nullptr}},
+        {TokenKind::KeywordColor, {&Parser::parseColor, nullptr}},
         {TokenKind::KeywordOn, {&Parser::parseOnErrorGoto, nullptr}},
         {TokenKind::KeywordResume, {&Parser::parseResume, nullptr}},
         {TokenKind::KeywordEnd, {&Parser::parseEnd, nullptr}},
         {TokenKind::KeywordInput, {&Parser::parseInput, nullptr}},
         {TokenKind::KeywordLine, {&Parser::parseLineInput, nullptr}},
+        {TokenKind::KeywordLocate, {&Parser::parseLocate, nullptr}},
         {TokenKind::KeywordDim, {&Parser::parseDim, nullptr}},
         {TokenKind::KeywordRedim, {&Parser::parseReDim, nullptr}},
         {TokenKind::KeywordRandomize, {&Parser::parseRandomize, nullptr}},

--- a/src/frontends/basic/Parser.hpp
+++ b/src/frontends/basic/Parser.hpp
@@ -159,6 +159,18 @@ class Parser
     /// @return RANDOMIZE statement node.
     StmtPtr parseRandomize();
 
+    /// @brief Parse a CLS statement clearing the display.
+    /// @return CLS statement node.
+    StmtPtr parseCls();
+
+    /// @brief Parse a COLOR statement adjusting the palette.
+    /// @return COLOR statement node.
+    StmtPtr parseColor();
+
+    /// @brief Parse a LOCATE statement moving the cursor.
+    /// @return LOCATE statement node.
+    StmtPtr parseLocate();
+
     /// @brief Parse a FUNCTION definition including body.
     /// @return FUNCTION statement node.
     StmtPtr parseFunction();

--- a/src/frontends/basic/Parser_Stmt.cpp
+++ b/src/frontends/basic/Parser_Stmt.cpp
@@ -661,6 +661,48 @@ StmtPtr Parser::parseRandomize()
     return stmt;
 }
 
+/// @brief Parse a CLS statement clearing the screen.
+/// @return ClsStmt node without additional operands.
+StmtPtr Parser::parseCls()
+{
+    auto loc = consume().loc; // CLS
+    auto n = std::make_unique<ClsStmt>();
+    n->loc = loc;
+    return n;
+}
+
+/// @brief Parse a COLOR statement configuring foreground/background colors.
+/// @return ColorStmt capturing optional background expression.
+StmtPtr Parser::parseColor()
+{
+    auto loc = consume().loc; // COLOR
+    auto n = std::make_unique<ColorStmt>();
+    n->loc = loc;
+    n->fg = parseExpression();
+    if (at(TokenKind::Comma))
+    {
+        consume();
+        n->bg = parseExpression();
+    }
+    return n;
+}
+
+/// @brief Parse a LOCATE statement positioning the cursor.
+/// @return LocateStmt capturing row and optional column expressions.
+StmtPtr Parser::parseLocate()
+{
+    auto loc = consume().loc; // LOCATE
+    auto n = std::make_unique<LocateStmt>();
+    n->loc = loc;
+    n->row = parseExpression();
+    if (at(TokenKind::Comma))
+    {
+        consume();
+        n->col = parseExpression();
+    }
+    return n;
+}
+
 /// @brief Derive a BASIC type from an identifier suffix.
 /// @param name Identifier to inspect.
 /// @return Corresponding BASIC type; defaults to I64.


### PR DESCRIPTION
## Summary
- add parser entry points for CLS, COLOR, and LOCATE statements and populate statement handlers
- implement BASIC parser support for CLS, COLOR (with optional background), and LOCATE (with optional column)

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e1ba298d2c8324b614bffd3dd97281