### PR TITLE
basic: lower CLS/COLOR/LOCATE to runtime helpers

### DIFF
--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -520,6 +520,12 @@ class Lowerer
 
     void lowerReturn(const ReturnStmt &stmt);
 
+    void visit(const ClsStmt &stmt);
+
+    void visit(const ColorStmt &stmt);
+
+    void visit(const LocateStmt &stmt);
+
     void lowerOpen(const OpenStmt &stmt);
 
     void lowerClose(const CloseStmt &stmt);


### PR DESCRIPTION
## Summary
- add lowering visitors for CLS, COLOR, and LOCATE that request terminal runtime helpers
- coerce BASIC arguments to 32-bit integers before calling the new runtime entry points

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e1c49a5a00832499c0827ee32dc1e9