### PR TITLE
Add INKEY$ and GETKEY$ built-in registrations

### DIFF
--- a/src/frontends/basic/AST.hpp
+++ b/src/frontends/basic/AST.hpp
@@ -340,7 +340,9 @@ struct BuiltinCallExpr : Expr
         Ucase,
         Lcase,
         Chr,
-        Asc
+        Asc,
+        InKey,
+        GetKey
     } builtin;
 
     /// Argument expressions passed to the builtin; owned.

--- a/src/frontends/basic/BuiltinRegistry.cpp
+++ b/src/frontends/basic/BuiltinRegistry.cpp
@@ -31,7 +31,7 @@ using TransformKind = LowerRule::ArgTransform::Kind;
 using Feature = LowerRule::Feature;
 using FeatureAction = LowerRule::Feature::Action;
 
-constexpr std::size_t kBuiltinCount = static_cast<std::size_t>(B::Asc) + 1;
+constexpr std::size_t kBuiltinCount = static_cast<std::size_t>(B::GetKey) + 1;
 
 constexpr std::size_t idx(B b) noexcept
 {
@@ -275,6 +275,8 @@ static const std::array<BuiltinInfo, kBuiltinCount> kBuiltins = [] {
     infos[idx(B::Lcase)] = {"LCASE$", nullptr};
     infos[idx(B::Chr)] = {"CHR$", nullptr};
     infos[idx(B::Asc)] = {"ASC", nullptr};
+    infos[idx(B::InKey)] = {"INKEY$", nullptr};
+    infos[idx(B::GetKey)] = {"GETKEY$", nullptr};
 
     return infos;
 }();
@@ -498,6 +500,7 @@ static const std::unordered_map<std::string_view, B> kByName = {
     {"COS", B::Cos},      {"POW", B::Pow},      {"RND", B::Rnd},    {"INSTR", B::Instr},
     {"LTRIM$", B::Ltrim}, {"RTRIM$", B::Rtrim}, {"TRIM$", B::Trim}, {"UCASE$", B::Ucase},
     {"LCASE$", B::Lcase}, {"CHR$", B::Chr},     {"ASC", B::Asc},
+    {"INKEY$", B::InKey}, {"GETKEY$", B::GetKey},
 };
 } // namespace
 


### PR DESCRIPTION
## Summary
- extend `BuiltinCallExpr::Builtin` with enumerators for INKEY$ and GETKEY$
- register the new built-in names and metadata in the BASIC front-end registry

## Testing
- `cmake -S . -B build`
- `cmake --build build -j4`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68e1cc76042c8324b40328bd3c159868