### PR TITLE
Add BASIC INKEY$/GETKEY$ scan and lowering rules

### DIFF
--- a/src/frontends/basic/BuiltinRegistry.cpp
+++ b/src/frontends/basic/BuiltinRegistry.cpp
@@ -248,6 +248,22 @@ static const std::array<LowerRule, kBuiltinCount> kBuiltinLoweringRules = [] {
                              .features = {Feature{.action = FeatureAction::Request,
                                                   .feature = il::runtime::RuntimeFeature::Asc}}}}};
 
+    rules[idx(B::InKey)] = LowerRule{
+        .result = {.kind = ResultSpec::Kind::Fixed, .type = Lowerer::ExprType::Str},
+        .variants = {Variant{.condition = Condition::Always,
+                             .kind = VariantKind::CallRuntime,
+                             .runtime = "rt_inkey_str",
+                             .features = {Feature{.action = FeatureAction::Request,
+                                                  .feature = il::runtime::RuntimeFeature::InKey}}}}};
+
+    rules[idx(B::GetKey)] = LowerRule{
+        .result = {.kind = ResultSpec::Kind::Fixed, .type = Lowerer::ExprType::Str},
+        .variants = {Variant{.condition = Condition::Always,
+                             .kind = VariantKind::CallRuntime,
+                             .runtime = "rt_getkey_str",
+                             .features = {Feature{.action = FeatureAction::Request,
+                                                  .feature = il::runtime::RuntimeFeature::GetKey}}}}};
+
     return rules;
 }();
 
@@ -485,6 +501,24 @@ static const std::array<BuiltinScanRule, kBuiltinCount> kBuiltinScanRules = [] {
                                                                    il::runtime::RuntimeFeature::Asc,
                                                                    0,
                                                                    Lowerer::ExprType::I64}}};
+
+    rules[idx(B::InKey)] = BuiltinScanRule{BuiltinScanRule::ResultSpec{BuiltinScanRule::ResultSpec::Kind::Fixed,
+                                                                       Lowerer::ExprType::Str,
+                                                                       0},
+                                           BuiltinScanRule::ArgTraversal::Explicit,
+                                           {},
+                                           {BuiltinScanRule::Feature{BuiltinScanRule::Feature::Action::Request,
+                                                                     BuiltinScanRule::Feature::Condition::Always,
+                                                                     il::runtime::RuntimeFeature::InKey}}};
+
+    rules[idx(B::GetKey)] = BuiltinScanRule{BuiltinScanRule::ResultSpec{BuiltinScanRule::ResultSpec::Kind::Fixed,
+                                                                        Lowerer::ExprType::Str,
+                                                                        0},
+                                            BuiltinScanRule::ArgTraversal::Explicit,
+                                            {},
+                                            {BuiltinScanRule::Feature{BuiltinScanRule::Feature::Action::Request,
+                                                                      BuiltinScanRule::Feature::Condition::Always,
+                                                                      il::runtime::RuntimeFeature::GetKey}}};
 
     return rules;
 }();


### PR DESCRIPTION
## Summary
- add scan rules for the zero-argument INKEY$ and GETKEY$ BASIC built-ins that request their runtime features
- add lowering rules so INKEY$/GETKEY$ calls invoke rt_inkey_str/rt_getkey_str with the appropriate runtime feature requests

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e1d2d944e08324a484b5b8722c4702