### PR TITLE
Add terminal terminal_demo BASIC example

### DIFF
--- a/examples/terminal_demo.bas
+++ b/examples/terminal_demo.bas
@@ -1,0 +1,8 @@
+COLOR 14,1
+CLS
+LOCATE 3, 10
+PRINT "Press any key..."
+k$ = INKEY$()
+IF k$ = "" THEN k$ = GETKEY$()
+COLOR 7,0
+PRINT "You pressed code "; ASC(k$)


### PR DESCRIPTION
## Summary
- add a terminal input demo BASIC program under `examples`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1e4643f8c832484ac6e4cf1d46062