### PR TITLE
Fix BASIC lowering virtual lines for unnumbered statements

### DIFF
--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -378,6 +378,8 @@ class Lowerer
 
     void collectVars(const std::vector<const Stmt *> &stmts);
 
+    int virtualLine(const Stmt &s);
+
     void lowerFunctionDecl(const FunctionDecl &decl);
 
     void lowerSubDecl(const SubDecl &decl);
@@ -672,6 +674,10 @@ class Lowerer
     size_t nextStringId{0};
     size_t nextFallbackBlockId{0};
     std::unordered_map<std::string, ProcedureSignature> procSignatures;
+
+    std::unordered_map<const Stmt *, int> stmtVirtualLines_;
+    int synthLineBase_{-1000000000};
+    int synthSeq_{0};
 
     ProcedureContext context_;
 

--- a/tests/golden/basic_lowering/LowerProgramWithProc.il
+++ b/tests/golden/basic_lowering/LowerProgramWithProc.il
@@ -8,8 +8,8 @@ global const str @.L0 = "
 "
 func @F() -> i64 {
 entry_F:
-  br L0_F
-L0_F:
+  br L-1000000000_F
+L-1000000000_F:
   .loc 1 2 8
   ret 5
 ret_F:
@@ -17,8 +17,8 @@ ret_F:
 }
 func @main() -> i64 {
 entry:
-  br L0
-L0:
+  br L-1000000000
+L-1000000000:
   .loc 1 4 7
   %t0 = call @F()
   .loc 1 4 1

--- a/tests/golden/basic_lowering/ReturnNest.il
+++ b/tests/golden/basic_lowering/ReturnNest.il
@@ -8,8 +8,8 @@ global const str @.L0 = "
 "
 func @F() -> i64 {
 entry_F:
-  br L0_F
-L0_F:
+  br L-1000000000_F
+L-1000000000_F:
   .loc 1 2 1
   br if_test_0_F
 ret_F:
@@ -28,8 +28,8 @@ if_else_0_F:
 }
 func @main() -> i64 {
 entry:
-  br L0
-L0:
+  br L-1000000000
+L-1000000000:
   .loc 1 4 7
   %t0 = call @F()
   .loc 1 4 1

--- a/tests/golden/basic_lowering/SuffixFreeVars.il
+++ b/tests/golden/basic_lowering/SuffixFreeVars.il
@@ -20,18 +20,14 @@ entry:
   store ptr, %t0, null
   %t1 = alloca 8
   %t2 = alloca 8
-  br L08
-L0:
-L01:
-L02:
-L03:
-L04:
-L05:
-L06:
-L07:
-L08:
+  br L-1000000000
+L-1000000000:
   .loc 1 1 1
-  br L08
+  br L-999999999
+L-999999999:
+  .loc 1 2 1
+  br L-999999998
+L-999999998:
   .loc 1 3 1
   %t3 = call @rt_arr_i32_new(2)
   .loc 1 3 1
@@ -42,12 +38,21 @@ L08:
   call @rt_arr_i32_release(%t4)
   .loc 1 3 1
   store ptr, %t0, %t3
+  .loc 1 3 1
+  br L-999999997
+L-999999997:
   .loc 1 4 15
   %t5 = const_str @.L0
   .loc 1 4 1
   store str, %t2, %t5
+  .loc 1 4 1
+  br L-999999996
+L-999999996:
   .loc 1 5 1
   store i64, %t1, 5
+  .loc 1 5 1
+  br L-999999995
+L-999999995:
   .loc 1 6 17
   %t6 = load i64, %t1
   .loc 1 6 17
@@ -68,6 +73,7 @@ L08:
   %t14 = scmp_gt %t13, 0
   .loc 1 6 5
   cbr %t14, bc_oob0, bc_ok0
+L-999999994:
   .loc 1 7 7
   %t15 = load str, %t2
   .loc 1 7 1
@@ -76,6 +82,9 @@ L08:
   %t16 = const_str @.L1
   .loc 1 7 1
   call @rt_print_str(%t16)
+  .loc 1 7 1
+  br L-999999993
+L-999999993:
   .loc 1 8 7
   %t17 = load i64, %t1
   .loc 1 8 1
@@ -84,6 +93,9 @@ L08:
   %t18 = const_str @.L1
   .loc 1 8 1
   call @rt_print_str(%t18)
+  .loc 1 8 1
+  br L-999999992
+L-999999992:
   .loc 1 9 7
   %t19 = load ptr, %t0
   .loc 1 9 7
@@ -111,7 +123,7 @@ bc_ok0:
   .loc 1 6 1
   call @rt_arr_i32_set(%t7, 0, %t6)
   .loc 1 6 1
-  br L08
+  br L-999999994
 bc_oob0:
   .loc 1 6 5
   call @rt_arr_oob_panic(0, %t8)

--- a/tests/golden/basic_lowering/labels_proc_loops.il
+++ b/tests/golden/basic_lowering/labels_proc_loops.il
@@ -7,16 +7,16 @@ extern @rt_substr(str, i64, i64) -> str
 func @F() -> i64 {
 entry_F:
   %t0 = alloca 8
-  br L0_F
-L0_F:
-L0_F:
-L0_F:
+  br L-1000000000_F
+L-1000000000_F:
   .loc 1 2 1
   br while_head_0_F
+L-999999999_F:
   .loc 1 4 1
   store i64, %t0, 1
   .loc 1 4 1
   br for_head_1_F
+L-999999998_F:
   .loc 1 6 8
   ret 0
 ret_F:
@@ -31,7 +31,7 @@ while_body_0_F:
   br while_head_0_F
 while_end_0_F:
   .loc 1 2 1
-  br L0_F
+  br L-999999999_F
 for_head_1_F:
   .loc 1 4 1
   %t2 = load i64, %t0
@@ -53,7 +53,7 @@ for_inc_1_F:
   br for_head_1_F
 for_end_1_F:
   .loc 1 4 1
-  br L0_F
+  br L-999999998_F
 }
 func @main() -> i64 {
 entry:

--- a/tests/golden/basic_to_il/calls_lowering.il
+++ b/tests/golden/basic_to_il/calls_lowering.il
@@ -12,8 +12,8 @@ func @F#(f64 %X#) -> f64 {
 entry_F#:
   %t1 = alloca 8
   store f64, %t1, %t0
-  br L0_F#
-L0_F#:
+  br L-1000000000_F#
+L-1000000000_F#:
   .loc 1 2 8
   %t2 = load f64, %t1
   .loc 1 2 8
@@ -25,8 +25,8 @@ func @ID$(str %S$) -> str {
 entry_ID$:
   %t1 = alloca 8
   store str, %t1, %t0
-  br L0_ID$
-L0_ID$:
+  br L-1000000000_ID$
+L-1000000000_ID$:
   .loc 1 5 8
   %t2 = load str, %t1
   .loc 1 5 8
@@ -39,11 +39,11 @@ func @FIRST#(i64 %N) -> f64 {
 entry_FIRST#:
   %t1 = alloca 8
   store i64, %t1, %t0
-  br L0_FIRST#
-L0_FIRST#:
-L0_FIRST#:
+  br L-1000000000_FIRST#
+L-1000000000_FIRST#:
   .loc 1 8 1
   br if_test_0_FIRST#
+L-999999999_FIRST#:
   .loc 1 9 16
   %t7 = load i64, %t1
   .loc 1 9 8
@@ -75,17 +75,17 @@ if_else_0_FIRST#:
   br if_end_0_FIRST#
 if_end_0_FIRST#:
   .loc 1 8 1
-  br L0_FIRST#
+  br L-999999999_FIRST#
 }
 func @SECOND#(f64 %N#) -> f64 {
 entry_SECOND#:
   %t1 = alloca 8
   store f64, %t1, %t0
-  br L0_SECOND#
-L0_SECOND#:
-L0_SECOND#:
+  br L-1000000000_SECOND#
+L-1000000000_SECOND#:
   .loc 1 12 1
   br if_test_0_SECOND#
+L-999999999_SECOND#:
   .loc 1 13 15
   %t8 = load f64, %t1
   .loc 1 13 18
@@ -123,7 +123,7 @@ if_else_0_SECOND#:
   br if_end_0_SECOND#
 if_end_0_SECOND#:
   .loc 1 12 1
-  br L0_SECOND#
+  br L-999999999_SECOND#
 }
 func @main() -> i64 {
 entry:

--- a/tests/golden/basic_to_il/loc_add.il
+++ b/tests/golden/basic_to_il/loc_add.il
@@ -8,8 +8,8 @@ global const str @.L0 = "
 "
 func @main() -> i64 {
 entry:
-  br L0
-L0:
+  br L-1000000000
+L-1000000000:
   .loc 1 1 1
   call @rt_print_i64(3)
   .loc 1 1 1

--- a/tests/golden/basic_to_il/lower_funcdef_only.il
+++ b/tests/golden/basic_to_il/lower_funcdef_only.il
@@ -8,8 +8,8 @@ global const str @.L0 = "
 "
 func @F() -> i64 {
 entry_F:
-  br L0_F
-L0_F:
+  br L-1000000000_F
+L-1000000000_F:
   .loc 1 2 8
   ret 5
 ret_F:
@@ -17,8 +17,8 @@ ret_F:
 }
 func @S() -> void {
 entry_S:
-  br L0_S
-L0_S:
+  br L-1000000000_S
+L-1000000000_S:
   .loc 1 5 1
   call @rt_print_i64(1)
   .loc 1 5 1


### PR DESCRIPTION
## Summary
- synthesize virtual line numbers for unnumbered BASIC statements and use them for block lookup during lowering
- reset numbering for program lowering and refresh BASIC to IL golden fixtures with the new block labels

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e1ea846428832489ae203de119f42c