### PR TITLE
fix: avoid self-branch emission in BASIC lowerer

### DIFF
--- a/src/frontends/basic/LowerEmit.cpp
+++ b/src/frontends/basic/LowerEmit.cpp
@@ -354,6 +354,16 @@ Value Lowerer::emitCheckedNeg(Type ty, Value val)
 /// deterministic control-flow stitching.
 void Lowerer::emitBr(BasicBlock *target)
 {
+    BasicBlock *block = context().current();
+    assert(block && "emitBr requires an active block");
+
+    if (block == target)
+    {
+        // Avoid emitting a self-branch when virtual and real lines collapse; the block already
+        // falls through to itself without a terminator.
+        return;
+    }
+
     Instr in;
     in.op = Opcode::Br;
     in.type = Type(Type::Kind::Void);
@@ -361,8 +371,6 @@ void Lowerer::emitBr(BasicBlock *target)
         target->label = nextFallbackBlockLabel();
     in.labels.push_back(target->label);
     in.loc = curLoc;
-    BasicBlock *block = context().current();
-    assert(block && "emitBr requires an active block");
     block->instructions.push_back(in);
     block->terminated = true;
 }


### PR DESCRIPTION
## Summary
- skip emitting unconditional branches when the BASIC lowerer targets the current block to avoid self-loops during line collapsing

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e1f44a03188324abee0923e85c5bfb