### PR TITLE
Fix BASIC StatementSequencer initial separator state

### DIFF
--- a/src/frontends/basic/StatementSequencer.hpp
+++ b/src/frontends/basic/StatementSequencer.hpp
@@ -76,7 +76,7 @@ class StatementSequencer
     Parser &parser_;             ///< Underlying parser providing token access.
     int pendingLine_ = -1;       ///< Deferred numeric line label for next statement.
     SeparatorKind lastSeparator_ =
-        SeparatorKind::LineBreak; ///< Default to line break at start of file.
+        SeparatorKind::None; ///< Treat start-of-file as neutral separator state.
 };
 
 } // namespace il::frontends::basic

--- a/tests/frontends/basic/ParserStatementContextTests.cpp
+++ b/tests/frontends/basic/ParserStatementContextTests.cpp
@@ -15,6 +15,22 @@ using namespace il::support;
 int main()
 {
     {
+        std::string src = "PRINT 123\nEND\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("single_line.bas");
+        Parser p(src, fid);
+        StatementSequencer seq(p);
+        assert(seq.lastSeparator() == StatementSequencer::SeparatorKind::None);
+        seq.skipLineBreaks();
+        assert(seq.lastSeparator() == StatementSequencer::SeparatorKind::None);
+        auto prog = p.parseProgram();
+        assert(prog);
+        assert(prog->main.size() == 2);
+        assert(dynamic_cast<PrintStmt *>(prog->main[0].get()));
+        assert(dynamic_cast<EndStmt *>(prog->main[1].get()));
+    }
+
+    {
         std::string src = "PRINT 1\nPRINT 2: PRINT 3\nEND\n";
         SourceManager sm;
         uint32_t fid = sm.addFile("multiline.bas");


### PR DESCRIPTION
## Summary
- default the BASIC statement sequencer to report `None` before consuming any separators so the beginning of the stream is neutral
- add a parser regression test to cover an unnumbered single-line program and validate the neutral separator state

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e1f81fe6d08324990a0a279d8e9f7d