### PR TITLE
fix(fe_basic): require array runtime helpers for lowered accesses

### DIFF
--- a/src/frontends/basic/LowerEmit.cpp
+++ b/src/frontends/basic/LowerEmit.cpp
@@ -176,8 +176,15 @@ Lowerer::IlValue Lowerer::emitBoolFromBranches(const std::function<void(Value)> 
 /// current block identified by @c cur. When bounds checking is active, additional ok/fail blocks
 /// are created through @c builder and named with @c blockNamer (falling back to @c mangler) so the
 /// failing path can trap via the runtime helper before control resumes at the success block.
-Lowerer::ArrayAccess Lowerer::lowerArrayAccess(const ArrayExpr &expr)
+Lowerer::ArrayAccess Lowerer::lowerArrayAccess(const ArrayExpr &expr, ArrayAccessKind kind)
 {
+    requireArrayI32Len();
+    requireArrayOobPanic();
+    if (kind == ArrayAccessKind::Load)
+        requireArrayI32Get();
+    else
+        requireArrayI32Set();
+
     ProcedureContext &ctx = context();
     const auto *info = findSymbol(expr.name);
     assert(info && info->slotId);

--- a/src/frontends/basic/LowerEmit.hpp
+++ b/src/frontends/basic/LowerEmit.hpp
@@ -169,5 +169,5 @@ void emitRet(Value v);
 void emitRetVoid();
 std::string getStringLabel(const std::string &s);
 unsigned nextTempId();
-ArrayAccess lowerArrayAccess(const ArrayExpr &expr);
+ArrayAccess lowerArrayAccess(const ArrayExpr &expr, ArrayAccessKind kind);
 void emitProgram(const Program &prog);

--- a/src/frontends/basic/LowerExpr.cpp
+++ b/src/frontends/basic/LowerExpr.cpp
@@ -94,7 +94,8 @@ class LowererExprVisitor final : public ExprVisitor
 
     void visit(const ArrayExpr &expr) override
     {
-        Lowerer::ArrayAccess access = lowerer_.lowerArrayAccess(expr);
+        Lowerer::ArrayAccess access =
+            lowerer_.lowerArrayAccess(expr, Lowerer::ArrayAccessKind::Load);
         lowerer_.curLoc = expr.loc;
         Value val = lowerer_.emitCallRet(il::core::Type(il::core::Type::Kind::I64),
                                          "rt_arr_i32_get",

--- a/src/frontends/basic/LowerStmt.cpp
+++ b/src/frontends/basic/LowerStmt.cpp
@@ -324,7 +324,7 @@ void Lowerer::lowerLet(const LetStmt &stmt)
         {
             v = coerceToI64(std::move(v), stmt.loc);
         }
-        ArrayAccess access = lowerArrayAccess(*arr);
+        ArrayAccess access = lowerArrayAccess(*arr, ArrayAccessKind::Store);
         curLoc = stmt.loc;
         emitCall("rt_arr_i32_set", {access.base, access.index, v.value});
     }

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -100,6 +100,13 @@ class Lowerer
         Value index; ///< Zero-based element index, coerced to i64.
     };
 
+    /// @brief Classify how an array access will be consumed.
+    enum class ArrayAccessKind
+    {
+        Load,  ///< The caller will read from the computed element.
+        Store, ///< The caller will write to the computed element.
+    };
+
     /// @brief Aggregated metadata for a BASIC symbol.
     struct SymbolInfo
     {
@@ -657,7 +664,7 @@ class Lowerer
 
     std::string nextFallbackBlockLabel();
 
-    ArrayAccess lowerArrayAccess(const ArrayExpr &expr);
+    ArrayAccess lowerArrayAccess(const ArrayExpr &expr, ArrayAccessKind kind);
 
     void emitProgram(const Program &prog);
 


### PR DESCRIPTION
## Summary
- require the BASIC array runtime helpers before lowering element accesses
- thread through an access kind so loads request `rt_arr_i32_get` and stores request `rt_arr_i32_set`

## Testing
- cmake -S . -B build
- cmake --build build -j2
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e1fbb040d4832495edd1c55dbdf8d5