### PR TITLE
Fix array bounds check to use boolean or

### DIFF
--- a/tests/golden/basic_lowering/SuffixFreeVars.il
+++ b/tests/golden/basic_lowering/SuffixFreeVars.il
@@ -68,9 +68,9 @@ L-999999995:
   .loc 1 6 5
   %t12 = zext1 %t10
   .loc 1 6 5
-  %t13 = iadd.ovf %t11, %t12
+  %t13 = or %t11, %t12
   .loc 1 6 5
-  %t14 = scmp_gt %t13, 0
+  %t14 = icmp_ne %t13, 0
   .loc 1 6 5
   cbr %t14, bc_oob0, bc_ok0
 L-999999994:
@@ -109,9 +109,9 @@ L-999999992:
   .loc 1 9 7
   %t24 = zext1 %t22
   .loc 1 9 7
-  %t25 = iadd.ovf %t23, %t24
+  %t25 = or %t23, %t24
   .loc 1 9 7
-  %t26 = scmp_gt %t25, 0
+  %t26 = icmp_ne %t25, 0
   .loc 1 9 7
   cbr %t26, bc_oob1, bc_ok1
 exit:

--- a/tests/golden/basic_to_il/array_dim_runtime.il
+++ b/tests/golden/basic_to_il/array_dim_runtime.il
@@ -80,9 +80,9 @@ L40:
   .loc 1 4 8
   %t19 = zext1 %t17
   .loc 1 4 8
-  %t20 = iadd.ovf %t18, %t19
+  %t20 = or %t18, %t19
   .loc 1 4 8
-  %t21 = scmp_gt %t20, 0
+  %t21 = icmp_ne %t20, 0
   .loc 1 4 8
   cbr %t21, bc_oob0, bc_ok0
 L50:
@@ -101,9 +101,9 @@ L50:
   .loc 1 5 12
   %t28 = zext1 %t26
   .loc 1 5 12
-  %t29 = iadd.ovf %t27, %t28
+  %t29 = or %t27, %t28
   .loc 1 5 12
-  %t30 = scmp_gt %t29, 0
+  %t30 = icmp_ne %t29, 0
   .loc 1 5 12
   cbr %t30, bc_oob1, bc_ok1
 L60:

--- a/tests/golden/basic_to_il/bounds_check.il
+++ b/tests/golden/basic_to_il/bounds_check.il
@@ -48,9 +48,9 @@ L20:
   .loc 1 2 10
   %t9 = zext1 %t7
   .loc 1 2 10
-  %t10 = iadd.ovf %t8, %t9
+  %t10 = or %t8, %t9
   .loc 1 2 10
-  %t11 = scmp_gt %t10, 0
+  %t11 = icmp_ne %t10, 0
   .loc 1 2 10
   cbr %t11, bc_oob0, bc_ok0
 exit:

--- a/tests/golden/basic_to_il/ex6_array_sum.il
+++ b/tests/golden/basic_to_il/ex6_array_sum.il
@@ -116,9 +116,9 @@ loop_body:
   .loc 1 6 10
   %t24 = zext1 %t22
   .loc 1 6 10
-  %t25 = iadd.ovf %t23, %t24
+  %t25 = or %t23, %t24
   .loc 1 6 10
-  %t26 = scmp_gt %t25, 0
+  %t26 = icmp_ne %t25, 0
   .loc 1 6 10
   cbr %t26, bc_oob0, bc_ok0
 done:
@@ -144,9 +144,9 @@ bc_ok0:
   .loc 1 7 18
   %t34 = zext1 %t32
   .loc 1 7 18
-  %t35 = iadd.ovf %t33, %t34
+  %t35 = or %t33, %t34
   .loc 1 7 18
-  %t36 = scmp_gt %t35, 0
+  %t36 = icmp_ne %t35, 0
   .loc 1 7 18
   cbr %t36, bc_oob1, bc_ok1
 bc_oob0:


### PR DESCRIPTION
## Summary
- ensure BASIC array bounds checks consider both negative and oversized indices explicitly
- refresh BASIC-to-IL golden files for the updated out-of-bounds predicate

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68e1fefc3c4c8324ad04b8eb8a14591d