### PR TITLE
fix(frontends/basic): treat DIM upper bounds as inclusive

### DIFF
--- a/tests/e2e/CMakeLists.txt
+++ b/tests/e2e/CMakeLists.txt
@@ -187,7 +187,7 @@ function(viper_add_e2e_vm_suite)
     ${CMAKE_COMMAND}
     -DILC=$<TARGET_FILE:ilc>
     -DBAS_FILE=${CMAKE_SOURCE_DIR}/tests/e2e/basic_array_oob.bas
-    "-DEXPECT_SUBSTR=rt_arr_i32: index 3 out of bounds (len=3)"
+    "-DEXPECT_SUBSTR=rt_arr_i32: index 4 out of bounds (len=4)"
     -P ${_VIPER_E2E_DIR}/test_basic_array_oob.cmake)
   set_tests_properties(basic_array_oob PROPERTIES LABELS VM)
 

--- a/tests/e2e/basic_array_oob.bas
+++ b/tests/e2e/basic_array_oob.bas
@@ -1,4 +1,4 @@
 10 LET N = 3
 20 DIM A(N)
-30 LET A(N) = 1
+30 LET A(N + 1) = 1
 40 END

--- a/tests/golden/basic_lowering/SuffixFreeVars.il
+++ b/tests/golden/basic_lowering/SuffixFreeVars.il
@@ -29,22 +29,16 @@ L-999999999:
   br L-999999998
 L-999999998:
   .loc 1 3 1
-  %t3 = call @rt_arr_i32_new(2)
+  %t3 = iadd.ovf 2, 1
   .loc 1 3 1
-  call @rt_arr_i32_retain(%t3)
+  %t4 = scmp_lt %t3, 0
   .loc 1 3 1
-  %t4 = load ptr, %t0
-  .loc 1 3 1
-  call @rt_arr_i32_release(%t4)
-  .loc 1 3 1
-  store ptr, %t0, %t3
-  .loc 1 3 1
-  br L-999999997
+  cbr %t4, dim_len_fail, dim_len_cont
 L-999999997:
   .loc 1 4 15
-  %t5 = const_str @.L0
+  %t7 = const_str @.L0
   .loc 1 4 1
-  store str, %t2, %t5
+  store str, %t2, %t7
   .loc 1 4 1
   br L-999999996
 L-999999996:
@@ -54,95 +48,111 @@ L-999999996:
   br L-999999995
 L-999999995:
   .loc 1 6 17
-  %t6 = load i64, %t1
+  %t8 = load i64, %t1
   .loc 1 6 17
-  %t7 = load ptr, %t0
+  %t9 = load ptr, %t0
   .loc 1 6 5
-  %t8 = call @rt_arr_i32_len(%t7)
+  %t10 = call @rt_arr_i32_len(%t9)
   .loc 1 6 5
-  %t9 = scmp_lt 0, 0
+  %t11 = scmp_lt 0, 0
   .loc 1 6 5
-  %t10 = scmp_ge 0, %t8
+  %t12 = scmp_ge 0, %t10
   .loc 1 6 5
-  %t11 = zext1 %t9
+  %t13 = zext1 %t11
   .loc 1 6 5
-  %t12 = zext1 %t10
+  %t14 = zext1 %t12
   .loc 1 6 5
-  %t13 = or %t11, %t12
+  %t15 = or %t13, %t14
   .loc 1 6 5
-  %t14 = icmp_ne %t13, 0
+  %t16 = icmp_ne %t15, 0
   .loc 1 6 5
-  cbr %t14, bc_oob0, bc_ok0
+  cbr %t16, bc_oob0, bc_ok0
 L-999999994:
   .loc 1 7 7
-  %t15 = load str, %t2
+  %t17 = load str, %t2
   .loc 1 7 1
-  call @rt_print_str(%t15)
+  call @rt_print_str(%t17)
   .loc 1 7 1
-  %t16 = const_str @.L1
+  %t18 = const_str @.L1
   .loc 1 7 1
-  call @rt_print_str(%t16)
+  call @rt_print_str(%t18)
   .loc 1 7 1
   br L-999999993
 L-999999993:
   .loc 1 8 7
-  %t17 = load i64, %t1
+  %t19 = load i64, %t1
   .loc 1 8 1
-  call @rt_print_i64(%t17)
+  call @rt_print_i64(%t19)
   .loc 1 8 1
-  %t18 = const_str @.L1
+  %t20 = const_str @.L1
   .loc 1 8 1
-  call @rt_print_str(%t18)
+  call @rt_print_str(%t20)
   .loc 1 8 1
   br L-999999992
 L-999999992:
   .loc 1 9 7
-  %t19 = load ptr, %t0
+  %t21 = load ptr, %t0
   .loc 1 9 7
-  %t20 = call @rt_arr_i32_len(%t19)
+  %t22 = call @rt_arr_i32_len(%t21)
   .loc 1 9 7
-  %t21 = scmp_lt 0, 0
+  %t23 = scmp_lt 0, 0
   .loc 1 9 7
-  %t22 = scmp_ge 0, %t20
+  %t24 = scmp_ge 0, %t22
   .loc 1 9 7
-  %t23 = zext1 %t21
+  %t25 = zext1 %t23
   .loc 1 9 7
-  %t24 = zext1 %t22
+  %t26 = zext1 %t24
   .loc 1 9 7
-  %t25 = or %t23, %t24
+  %t27 = or %t25, %t26
   .loc 1 9 7
-  %t26 = icmp_ne %t25, 0
+  %t28 = icmp_ne %t27, 0
   .loc 1 9 7
-  cbr %t26, bc_oob1, bc_ok1
+  cbr %t28, bc_oob1, bc_ok1
 exit:
-  %t29 = load ptr, %t0
-  call @rt_arr_i32_release(%t29)
+  %t31 = load ptr, %t0
+  call @rt_arr_i32_release(%t31)
   store ptr, %t0, null
   ret 0
+dim_len_fail:
+  .loc 1 3 1
+  trap
+dim_len_cont:
+  .loc 1 3 1
+  %t5 = call @rt_arr_i32_new(%t3)
+  .loc 1 3 1
+  call @rt_arr_i32_retain(%t5)
+  .loc 1 3 1
+  %t6 = load ptr, %t0
+  .loc 1 3 1
+  call @rt_arr_i32_release(%t6)
+  .loc 1 3 1
+  store ptr, %t0, %t5
+  .loc 1 3 1
+  br L-999999997
 bc_ok0:
   .loc 1 6 1
-  call @rt_arr_i32_set(%t7, 0, %t6)
+  call @rt_arr_i32_set(%t9, 0, %t8)
   .loc 1 6 1
   br L-999999994
 bc_oob0:
   .loc 1 6 5
-  call @rt_arr_oob_panic(0, %t8)
+  call @rt_arr_oob_panic(0, %t10)
   .loc 1 6 5
   trap
 bc_ok1:
   .loc 1 9 7
-  %t27 = call @rt_arr_i32_get(%t19, 0)
+  %t29 = call @rt_arr_i32_get(%t21, 0)
   .loc 1 9 1
-  call @rt_print_i64(%t27)
+  call @rt_print_i64(%t29)
   .loc 1 9 1
-  %t28 = const_str @.L1
+  %t30 = const_str @.L1
   .loc 1 9 1
-  call @rt_print_str(%t28)
+  call @rt_print_str(%t30)
   .loc 1 9 1
   br exit
 bc_oob1:
   .loc 1 9 7
-  call @rt_arr_oob_panic(0, %t20)
+  call @rt_arr_oob_panic(0, %t22)
   .loc 1 9 7
   trap
 }

--- a/tests/golden/basic_to_il/array_dim_redim.il
+++ b/tests/golden/basic_to_il/array_dim_redim.il
@@ -15,38 +15,58 @@ entry:
   br L10
 L10:
   .loc 1 1 4
-  %t1 = call @rt_arr_i32_new(3)
+  %t1 = iadd.ovf 3, 1
   .loc 1 1 4
-  call @rt_arr_i32_retain(%t1)
+  %t2 = scmp_lt %t1, 0
   .loc 1 1 4
-  %t2 = load ptr, %t0
-  .loc 1 1 4
-  call @rt_arr_i32_release(%t2)
-  .loc 1 1 4
-  store ptr, %t0, %t1
-  .loc 1 1 4
-  br L20
+  cbr %t2, dim_len_fail, dim_len_cont
 L20:
   .loc 1 2 4
-  %t3 = load ptr, %t0
+  %t5 = iadd.ovf 5, 1
   .loc 1 2 4
-  %t4 = call @rt_arr_i32_resize(%t3, 5)
+  %t6 = scmp_lt %t5, 0
   .loc 1 2 4
-  call @rt_arr_i32_retain(%t4)
-  .loc 1 2 4
-  %t5 = load ptr, %t0
-  .loc 1 2 4
-  call @rt_arr_i32_release(%t5)
-  .loc 1 2 4
-  store ptr, %t0, %t4
-  .loc 1 2 4
-  br L30
+  cbr %t6, redim_len_fail, redim_len_cont
 L30:
   .loc 1 3 4
   br exit
 exit:
-  %t6 = load ptr, %t0
-  call @rt_arr_i32_release(%t6)
+  %t10 = load ptr, %t0
+  call @rt_arr_i32_release(%t10)
   store ptr, %t0, null
   ret 0
+dim_len_fail:
+  .loc 1 1 4
+  trap
+dim_len_cont:
+  .loc 1 1 4
+  %t3 = call @rt_arr_i32_new(%t1)
+  .loc 1 1 4
+  call @rt_arr_i32_retain(%t3)
+  .loc 1 1 4
+  %t4 = load ptr, %t0
+  .loc 1 1 4
+  call @rt_arr_i32_release(%t4)
+  .loc 1 1 4
+  store ptr, %t0, %t3
+  .loc 1 1 4
+  br L20
+redim_len_fail:
+  .loc 1 2 4
+  trap
+redim_len_cont:
+  .loc 1 2 4
+  %t7 = load ptr, %t0
+  .loc 1 2 4
+  %t8 = call @rt_arr_i32_resize(%t7, %t5)
+  .loc 1 2 4
+  call @rt_arr_i32_retain(%t8)
+  .loc 1 2 4
+  %t9 = load ptr, %t0
+  .loc 1 2 4
+  call @rt_arr_i32_release(%t9)
+  .loc 1 2 4
+  store ptr, %t0, %t8
+  .loc 1 2 4
+  br L30
 }

--- a/tests/golden/basic_to_il/array_dim_runtime.il
+++ b/tests/golden/basic_to_il/array_dim_runtime.il
@@ -23,139 +23,159 @@ entry:
   br L10
 L10:
   .loc 1 1 4
-  %t3 = call @rt_arr_i32_new(1)
+  %t3 = iadd.ovf 1, 1
   .loc 1 1 4
-  call @rt_arr_i32_retain(%t3)
+  %t4 = scmp_lt %t3, 0
   .loc 1 1 4
-  %t4 = load ptr, %t2
-  .loc 1 1 4
-  call @rt_arr_i32_release(%t4)
-  .loc 1 1 4
-  store ptr, %t2, %t3
-  .loc 1 1 4
-  br L20
+  cbr %t4, dim_len_fail, dim_len_cont
 L20:
   .loc 1 2 13
-  %t5 = load ptr, %t2
+  %t7 = load ptr, %t2
   .loc 1 2 13
-  %t6 = call @rt_arr_i32_len(%t5)
+  %t8 = call @rt_arr_i32_len(%t7)
   .loc 1 2 13
-  %t7 = isub.ovf %t6, 1
+  %t9 = isub.ovf %t8, 1
   .loc 1 2 4
-  store i64, %t1, %t7
+  store i64, %t1, %t9
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 12
-  %t8 = load i64, %t1
+  %t10 = load i64, %t1
   .loc 1 3 15
-  %t9 = iadd.ovf %t8, 2
+  %t11 = iadd.ovf %t10, 2
   .loc 1 3 4
-  %t10 = load ptr, %t2
+  %t12 = iadd.ovf %t11, 1
   .loc 1 3 4
-  %t11 = call @rt_arr_i32_resize(%t10, %t9)
+  %t13 = scmp_lt %t12, 0
   .loc 1 3 4
-  call @rt_arr_i32_retain(%t11)
-  .loc 1 3 4
-  %t12 = load ptr, %t2
-  .loc 1 3 4
-  call @rt_arr_i32_release(%t12)
-  .loc 1 3 4
-  store ptr, %t2, %t11
-  .loc 1 3 4
-  br L40
+  cbr %t13, redim_len_fail, redim_len_cont
 L40:
   .loc 1 4 16
-  %t13 = load ptr, %t2
+  %t17 = load ptr, %t2
   .loc 1 4 10
-  %t14 = load i64, %t1
+  %t18 = load i64, %t1
   .loc 1 4 8
-  %t15 = call @rt_arr_i32_len(%t13)
+  %t19 = call @rt_arr_i32_len(%t17)
   .loc 1 4 8
-  %t16 = scmp_lt %t14, 0
+  %t20 = scmp_lt %t18, 0
   .loc 1 4 8
-  %t17 = scmp_ge %t14, %t15
+  %t21 = scmp_ge %t18, %t19
   .loc 1 4 8
-  %t18 = zext1 %t16
+  %t22 = zext1 %t20
   .loc 1 4 8
-  %t19 = zext1 %t17
+  %t23 = zext1 %t21
   .loc 1 4 8
-  %t20 = or %t18, %t19
+  %t24 = or %t22, %t23
   .loc 1 4 8
-  %t21 = icmp_ne %t20, 0
+  %t25 = icmp_ne %t24, 0
   .loc 1 4 8
-  cbr %t21, bc_oob0, bc_ok0
+  cbr %t25, bc_oob0, bc_ok0
 L50:
   .loc 1 5 12
-  %t22 = load ptr, %t2
+  %t26 = load ptr, %t2
   .loc 1 5 14
-  %t23 = load i64, %t1
+  %t27 = load i64, %t1
   .loc 1 5 12
-  %t24 = call @rt_arr_i32_len(%t22)
+  %t28 = call @rt_arr_i32_len(%t26)
   .loc 1 5 12
-  %t25 = scmp_lt %t23, 0
+  %t29 = scmp_lt %t27, 0
   .loc 1 5 12
-  %t26 = scmp_ge %t23, %t24
+  %t30 = scmp_ge %t27, %t28
   .loc 1 5 12
-  %t27 = zext1 %t25
+  %t31 = zext1 %t29
   .loc 1 5 12
-  %t28 = zext1 %t26
+  %t32 = zext1 %t30
   .loc 1 5 12
-  %t29 = or %t27, %t28
+  %t33 = or %t31, %t32
   .loc 1 5 12
-  %t30 = icmp_ne %t29, 0
+  %t34 = icmp_ne %t33, 0
   .loc 1 5 12
-  cbr %t30, bc_oob1, bc_ok1
+  cbr %t34, bc_oob1, bc_ok1
 L60:
   .loc 1 6 10
-  %t32 = load i64, %t1
+  %t36 = load i64, %t1
   .loc 1 6 4
-  call @rt_print_i64(%t32)
+  call @rt_print_i64(%t36)
   .loc 1 6 4
-  %t33 = const_str @.L0
+  %t37 = const_str @.L0
   .loc 1 6 4
-  call @rt_print_str(%t33)
+  call @rt_print_str(%t37)
   .loc 1 6 4
   br L70
 L70:
   .loc 1 7 10
-  %t34 = load i64, %t0
+  %t38 = load i64, %t0
   .loc 1 7 4
-  call @rt_print_i64(%t34)
+  call @rt_print_i64(%t38)
   .loc 1 7 4
-  %t35 = const_str @.L0
+  %t39 = const_str @.L0
   .loc 1 7 4
-  call @rt_print_str(%t35)
+  call @rt_print_str(%t39)
   .loc 1 7 4
   br L80
 L80:
   .loc 1 8 4
   br exit
 exit:
-  %t36 = load ptr, %t2
-  call @rt_arr_i32_release(%t36)
+  %t40 = load ptr, %t2
+  call @rt_arr_i32_release(%t40)
   store ptr, %t2, null
   ret 0
+dim_len_fail:
+  .loc 1 1 4
+  trap
+dim_len_cont:
+  .loc 1 1 4
+  %t5 = call @rt_arr_i32_new(%t3)
+  .loc 1 1 4
+  call @rt_arr_i32_retain(%t5)
+  .loc 1 1 4
+  %t6 = load ptr, %t2
+  .loc 1 1 4
+  call @rt_arr_i32_release(%t6)
+  .loc 1 1 4
+  store ptr, %t2, %t5
+  .loc 1 1 4
+  br L20
+redim_len_fail:
+  .loc 1 3 4
+  trap
+redim_len_cont:
+  .loc 1 3 4
+  %t14 = load ptr, %t2
+  .loc 1 3 4
+  %t15 = call @rt_arr_i32_resize(%t14, %t12)
+  .loc 1 3 4
+  call @rt_arr_i32_retain(%t15)
+  .loc 1 3 4
+  %t16 = load ptr, %t2
+  .loc 1 3 4
+  call @rt_arr_i32_release(%t16)
+  .loc 1 3 4
+  store ptr, %t2, %t15
+  .loc 1 3 4
+  br L40
 bc_ok0:
   .loc 1 4 4
-  call @rt_arr_i32_set(%t13, %t14, 7)
+  call @rt_arr_i32_set(%t17, %t18, 7)
   .loc 1 4 4
   br L50
 bc_oob0:
   .loc 1 4 8
-  call @rt_arr_oob_panic(%t14, %t15)
+  call @rt_arr_oob_panic(%t18, %t19)
   .loc 1 4 8
   trap
 bc_ok1:
   .loc 1 5 12
-  %t31 = call @rt_arr_i32_get(%t22, %t23)
+  %t35 = call @rt_arr_i32_get(%t26, %t27)
   .loc 1 5 4
-  store i64, %t0, %t31
+  store i64, %t0, %t35
   .loc 1 5 4
   br L60
 bc_oob1:
   .loc 1 5 12
-  call @rt_arr_oob_panic(%t23, %t24)
+  call @rt_arr_oob_panic(%t27, %t28)
   .loc 1 5 12
   trap
 }

--- a/tests/golden/basic_to_il/bounds_check.il
+++ b/tests/golden/basic_to_il/bounds_check.il
@@ -21,57 +21,67 @@ entry:
   br L10
 L10:
   .loc 1 1 4
-  %t2 = call @rt_arr_i32_new(2)
+  %t2 = iadd.ovf 2, 1
   .loc 1 1 4
-  call @rt_arr_i32_retain(%t2)
+  %t3 = scmp_lt %t2, 0
   .loc 1 1 4
-  %t3 = load ptr, %t0
-  .loc 1 1 4
-  call @rt_arr_i32_release(%t3)
-  .loc 1 1 4
-  store ptr, %t0, %t2
-  .loc 1 1 4
-  store i64, %t1, 2
-  .loc 1 1 4
-  br L20
+  cbr %t3, dim_len_fail, dim_len_cont
 L20:
   .loc 1 2 10
-  %t4 = load ptr, %t0
+  %t6 = load ptr, %t0
   .loc 1 2 10
-  %t5 = call @rt_arr_i32_len(%t4)
+  %t7 = call @rt_arr_i32_len(%t6)
   .loc 1 2 10
-  %t6 = scmp_lt 1, 0
+  %t8 = scmp_lt 1, 0
   .loc 1 2 10
-  %t7 = scmp_ge 1, %t5
+  %t9 = scmp_ge 1, %t7
   .loc 1 2 10
-  %t8 = zext1 %t6
+  %t10 = zext1 %t8
   .loc 1 2 10
-  %t9 = zext1 %t7
+  %t11 = zext1 %t9
   .loc 1 2 10
-  %t10 = or %t8, %t9
+  %t12 = or %t10, %t11
   .loc 1 2 10
-  %t11 = icmp_ne %t10, 0
+  %t13 = icmp_ne %t12, 0
   .loc 1 2 10
-  cbr %t11, bc_oob0, bc_ok0
+  cbr %t13, bc_oob0, bc_ok0
 exit:
-  %t14 = load ptr, %t0
-  call @rt_arr_i32_release(%t14)
+  %t16 = load ptr, %t0
+  call @rt_arr_i32_release(%t16)
   store ptr, %t0, null
   ret 0
+dim_len_fail:
+  .loc 1 1 4
+  trap
+dim_len_cont:
+  .loc 1 1 4
+  %t4 = call @rt_arr_i32_new(%t2)
+  .loc 1 1 4
+  call @rt_arr_i32_retain(%t4)
+  .loc 1 1 4
+  %t5 = load ptr, %t0
+  .loc 1 1 4
+  call @rt_arr_i32_release(%t5)
+  .loc 1 1 4
+  store ptr, %t0, %t4
+  .loc 1 1 4
+  store i64, %t1, %t2
+  .loc 1 1 4
+  br L20
 bc_ok0:
   .loc 1 2 10
-  %t12 = call @rt_arr_i32_get(%t4, 1)
+  %t14 = call @rt_arr_i32_get(%t6, 1)
   .loc 1 2 4
-  call @rt_print_i64(%t12)
+  call @rt_print_i64(%t14)
   .loc 1 2 4
-  %t13 = const_str @.L0
+  %t15 = const_str @.L0
   .loc 1 2 4
-  call @rt_print_str(%t13)
+  call @rt_print_str(%t15)
   .loc 1 2 4
   br exit
 bc_oob0:
   .loc 1 2 10
-  call @rt_arr_oob_panic(1, %t5)
+  call @rt_arr_oob_panic(1, %t7)
   .loc 1 2 10
   trap
 }

--- a/tests/golden/basic_to_il/ex6_array_sum.il
+++ b/tests/golden/basic_to_il/ex6_array_sum.il
@@ -36,17 +36,11 @@ L20:
   .loc 1 2 10
   %t6 = load i64, %t3
   .loc 1 2 4
-  %t7 = call @rt_arr_i32_new(%t6)
+  %t7 = iadd.ovf %t6, 1
   .loc 1 2 4
-  call @rt_arr_i32_retain(%t7)
+  %t8 = scmp_lt %t7, 0
   .loc 1 2 4
-  %t8 = load ptr, %t2
-  .loc 1 2 4
-  call @rt_arr_i32_release(%t8)
-  .loc 1 2 4
-  store ptr, %t2, %t7
-  .loc 1 2 4
-  br L30
+  cbr %t8, dim_len_fail, dim_len_cont
 L30:
   .loc 1 3 4
   store i64, %t1, 0
@@ -62,116 +56,132 @@ L50:
   br loop_head
 L100:
   .loc 1 10 11
-  %t41 = load i64, %t0
+  %t43 = load i64, %t0
   .loc 1 10 5
-  call @rt_print_i64(%t41)
+  call @rt_print_i64(%t43)
   .loc 1 10 5
-  %t42 = const_str @.L0
+  %t44 = const_str @.L0
   .loc 1 10 5
-  call @rt_print_str(%t42)
+  call @rt_print_str(%t44)
   .loc 1 10 5
   br L110
 L110:
   .loc 1 11 5
   br exit
 exit:
-  %t43 = load ptr, %t2
-  call @rt_arr_i32_release(%t43)
+  %t45 = load ptr, %t2
+  call @rt_arr_i32_release(%t45)
   store ptr, %t2, null
   ret 0
+dim_len_fail:
+  .loc 1 2 4
+  trap
+dim_len_cont:
+  .loc 1 2 4
+  %t9 = call @rt_arr_i32_new(%t7)
+  .loc 1 2 4
+  call @rt_arr_i32_retain(%t9)
+  .loc 1 2 4
+  %t10 = load ptr, %t2
+  .loc 1 2 4
+  call @rt_arr_i32_release(%t10)
+  .loc 1 2 4
+  store ptr, %t2, %t9
+  .loc 1 2 4
+  br L30
 loop_head:
   .loc 1 5 10
-  %t9 = load i64, %t1
+  %t11 = load i64, %t1
   .loc 1 5 14
-  %t10 = load i64, %t3
+  %t12 = load i64, %t3
   .loc 1 5 12
-  %t11 = scmp_lt %t9, %t10
+  %t13 = scmp_lt %t11, %t12
   .loc 1 5 12
-  %t12 = zext1 %t11
+  %t14 = zext1 %t13
   .loc 1 5 12
-  %t13 = isub.ovf 0, %t12
+  %t15 = isub.ovf 0, %t14
   .loc 1 5 4
-  %t14 = trunc1 %t13
+  %t16 = trunc1 %t15
   .loc 1 5 4
-  cbr %t14, loop_body, done
+  cbr %t16, loop_body, done
 loop_body:
   .loc 1 6 17
-  %t15 = load i64, %t1
+  %t17 = load i64, %t1
   .loc 1 6 21
-  %t16 = load i64, %t1
+  %t18 = load i64, %t1
   .loc 1 6 19
-  %t17 = imul.ovf %t15, %t16
+  %t19 = imul.ovf %t17, %t18
   .loc 1 6 19
-  %t18 = load ptr, %t2
+  %t20 = load ptr, %t2
   .loc 1 6 12
-  %t19 = load i64, %t1
+  %t21 = load i64, %t1
   .loc 1 6 10
-  %t20 = call @rt_arr_i32_len(%t18)
+  %t22 = call @rt_arr_i32_len(%t20)
   .loc 1 6 10
-  %t21 = scmp_lt %t19, 0
+  %t23 = scmp_lt %t21, 0
   .loc 1 6 10
-  %t22 = scmp_ge %t19, %t20
+  %t24 = scmp_ge %t21, %t22
   .loc 1 6 10
-  %t23 = zext1 %t21
+  %t25 = zext1 %t23
   .loc 1 6 10
-  %t24 = zext1 %t22
+  %t26 = zext1 %t24
   .loc 1 6 10
-  %t25 = or %t23, %t24
+  %t27 = or %t25, %t26
   .loc 1 6 10
-  %t26 = icmp_ne %t25, 0
+  %t28 = icmp_ne %t27, 0
   .loc 1 6 10
-  cbr %t26, bc_oob0, bc_ok0
+  cbr %t28, bc_oob0, bc_ok0
 done:
   .loc 1 5 4
   br L100
 bc_ok0:
   .loc 1 6 6
-  call @rt_arr_i32_set(%t18, %t19, %t17)
+  call @rt_arr_i32_set(%t20, %t21, %t19)
   .loc 1 7 14
-  %t27 = load i64, %t0
+  %t29 = load i64, %t0
   .loc 1 7 18
-  %t28 = load ptr, %t2
+  %t30 = load ptr, %t2
   .loc 1 7 20
-  %t29 = load i64, %t1
+  %t31 = load i64, %t1
   .loc 1 7 18
-  %t30 = call @rt_arr_i32_len(%t28)
+  %t32 = call @rt_arr_i32_len(%t30)
   .loc 1 7 18
-  %t31 = scmp_lt %t29, 0
+  %t33 = scmp_lt %t31, 0
   .loc 1 7 18
-  %t32 = scmp_ge %t29, %t30
+  %t34 = scmp_ge %t31, %t32
   .loc 1 7 18
-  %t33 = zext1 %t31
+  %t35 = zext1 %t33
   .loc 1 7 18
-  %t34 = zext1 %t32
+  %t36 = zext1 %t34
   .loc 1 7 18
-  %t35 = or %t33, %t34
+  %t37 = or %t35, %t36
   .loc 1 7 18
-  %t36 = icmp_ne %t35, 0
+  %t38 = icmp_ne %t37, 0
   .loc 1 7 18
-  cbr %t36, bc_oob1, bc_ok1
+  cbr %t38, bc_oob1, bc_ok1
 bc_oob0:
   .loc 1 6 10
-  call @rt_arr_oob_panic(%t19, %t20)
+  call @rt_arr_oob_panic(%t21, %t22)
   .loc 1 6 10
   trap
 bc_ok1:
   .loc 1 7 18
-  %t37 = call @rt_arr_i32_get(%t28, %t29)
+  %t39 = call @rt_arr_i32_get(%t30, %t31)
   .loc 1 7 16
-  %t38 = iadd.ovf %t27, %t37
+  %t40 = iadd.ovf %t29, %t39
   .loc 1 7 6
-  store i64, %t0, %t38
+  store i64, %t0, %t40
   .loc 1 8 14
-  %t39 = load i64, %t1
+  %t41 = load i64, %t1
   .loc 1 8 16
-  %t40 = iadd.ovf %t39, 1
+  %t42 = iadd.ovf %t41, 1
   .loc 1 8 6
-  store i64, %t1, %t40
+  store i64, %t1, %t42
   .loc 1 5 4
   br loop_head
 bc_oob1:
   .loc 1 7 18
-  call @rt_arr_oob_panic(%t29, %t30)
+  call @rt_arr_oob_panic(%t31, %t32)
   .loc 1 7 18
   trap
 }

--- a/tests/golden/basic_to_il/ubound.il
+++ b/tests/golden/basic_to_il/ubound.il
@@ -17,35 +17,45 @@ entry:
   br L10
 L10:
   .loc 1 1 4
-  %t1 = call @rt_arr_i32_new(0)
+  %t1 = iadd.ovf 0, 1
   .loc 1 1 4
-  call @rt_arr_i32_retain(%t1)
+  %t2 = scmp_lt %t1, 0
   .loc 1 1 4
-  %t2 = load ptr, %t0
-  .loc 1 1 4
-  call @rt_arr_i32_release(%t2)
-  .loc 1 1 4
-  store ptr, %t0, %t1
-  .loc 1 1 4
-  br L20
+  cbr %t2, dim_len_fail, dim_len_cont
 L20:
   .loc 1 2 10
-  %t3 = load ptr, %t0
+  %t5 = load ptr, %t0
   .loc 1 2 10
-  %t4 = call @rt_arr_i32_len(%t3)
+  %t6 = call @rt_arr_i32_len(%t5)
   .loc 1 2 10
-  %t5 = isub.ovf %t4, 1
+  %t7 = isub.ovf %t6, 1
   .loc 1 2 4
-  call @rt_print_i64(%t5)
+  call @rt_print_i64(%t7)
   .loc 1 2 4
-  %t6 = const_str @.L0
+  %t8 = const_str @.L0
   .loc 1 2 4
-  call @rt_print_str(%t6)
+  call @rt_print_str(%t8)
   .loc 1 2 4
   br exit
 exit:
-  %t7 = load ptr, %t0
-  call @rt_arr_i32_release(%t7)
+  %t9 = load ptr, %t0
+  call @rt_arr_i32_release(%t9)
   store ptr, %t0, null
   ret 0
+dim_len_fail:
+  .loc 1 1 4
+  trap
+dim_len_cont:
+  .loc 1 1 4
+  %t3 = call @rt_arr_i32_new(%t1)
+  .loc 1 1 4
+  call @rt_arr_i32_retain(%t3)
+  .loc 1 1 4
+  %t4 = load ptr, %t0
+  .loc 1 1 4
+  call @rt_arr_i32_release(%t4)
+  .loc 1 1 4
+  store ptr, %t0, %t3
+  .loc 1 1 4
+  br L20
 }


### PR DESCRIPTION
## Summary
- compute DIM/REDIM lengths as bound+1 and trap negative allocations before invoking the runtime helpers
- update the array out-of-bounds e2e to target the new inclusive upper bound semantics
- refresh BASIC→IL golden fixtures so DIM/REDIM and bounds-check traces reflect the inclusive length

## Testing
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68e2061c3e508324b15dffd4908de015