### PR TITLE
fix(fe_basic): coerce print expressions to scalar temps

### DIFF
--- a/src/frontends/basic/LowerExpr.cpp
+++ b/src/frontends/basic/LowerExpr.cpp
@@ -1321,5 +1321,27 @@ Lowerer::RVal Lowerer::lowerExpr(const Expr &expr)
     return visitor.result();
 }
 
+Lowerer::RVal Lowerer::lowerScalarExpr(const Expr &expr)
+{
+    return lowerScalarExpr(lowerExpr(expr), expr.loc);
+}
+
+Lowerer::RVal Lowerer::lowerScalarExpr(RVal value, il::support::SourceLoc loc)
+{
+    switch (value.type.kind)
+    {
+        case Type::Kind::I1:
+        case Type::Kind::I16:
+        case Type::Kind::I32:
+        case Type::Kind::I64:
+        case Type::Kind::F64:
+            value = coerceToI64(std::move(value), loc);
+            break;
+        default:
+            break;
+    }
+    return value;
+}
+
 } // namespace il::frontends::basic
 

--- a/src/frontends/basic/LowerStmt.cpp
+++ b/src/frontends/basic/LowerStmt.cpp
@@ -347,22 +347,20 @@ void Lowerer::lowerPrint(const PrintStmt &stmt)
         {
             case PrintItem::Kind::Expr:
             {
-                RVal v = lowerExpr(*it.expr);
-                if (v.type.kind == Type::Kind::I1)
-                {
-                    v = coerceToI64(std::move(v), stmt.loc);
-                }
-                else if (v.type.kind == Type::Kind::I16 || v.type.kind == Type::Kind::I32)
-                {
-                    v = ensureI64(std::move(v), stmt.loc);
-                }
+                RVal value = lowerExpr(*it.expr);
                 curLoc = stmt.loc;
-                if (v.type.kind == Type::Kind::Str)
-                    emitCall("rt_print_str", {v.value});
-                else if (v.type.kind == Type::Kind::F64)
-                    emitCall("rt_print_f64", {v.value});
-                else
-                    emitCall("rt_print_i64", {v.value});
+                if (value.type.kind == Type::Kind::Str)
+                {
+                    emitCall("rt_print_str", {value.value});
+                    break;
+                }
+                if (value.type.kind == Type::Kind::F64)
+                {
+                    emitCall("rt_print_f64", {value.value});
+                    break;
+                }
+                value = lowerScalarExpr(std::move(value), stmt.loc);
+                emitCall("rt_print_i64", {value.value});
                 break;
             }
             case PrintItem::Kind::Comma:

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -417,6 +417,8 @@ class Lowerer
     void lowerStmt(const Stmt &stmt);
 
     RVal lowerExpr(const Expr &expr);
+    RVal lowerScalarExpr(const Expr &expr);
+    RVal lowerScalarExpr(RVal value, il::support::SourceLoc loc);
 
     /// @brief Lower a variable reference expression.
     /// @param expr Variable expression node.


### PR DESCRIPTION
## Summary
- add a scalar-expression lowering helper that reuses the core expression lowering and coerces numeric results to i64 temporaries
- update PRINT lowering to route numeric items through the scalar helper before invoking the integer runtime printer

## Testing
- cmake -S . -B build
- cmake --build build --target fe_basic


------
https://chatgpt.com/codex/tasks/task_e_68e20c8c31008324bd1c9e1f066e0b5c