### PR TITLE
fix(frontends/basic): treat colon separators like line breaks

### DIFF
--- a/src/frontends/basic/StatementSequencer.cpp
+++ b/src/frontends/basic/StatementSequencer.cpp
@@ -16,14 +16,29 @@ StatementSequencer::StatementSequencer(Parser &parser) : parser_(parser) {}
 
 void StatementSequencer::skipLeadingSeparator()
 {
-    if (parser_.at(TokenKind::EndOfLine))
+    bool consumedColon = false;
+    bool consumedLineBreak = false;
+
+    while (parser_.at(TokenKind::Colon) || parser_.at(TokenKind::EndOfLine))
     {
-        parser_.consume();
+        if (parser_.at(TokenKind::Colon))
+        {
+            parser_.consume();
+            consumedColon = true;
+        }
+        else
+        {
+            parser_.consume();
+            consumedLineBreak = true;
+        }
+    }
+
+    if (consumedLineBreak)
+    {
         lastSeparator_ = SeparatorKind::LineBreak;
     }
-    else if (parser_.at(TokenKind::Colon))
+    else if (consumedColon)
     {
-        parser_.consume();
         lastSeparator_ = SeparatorKind::Colon;
     }
     else
@@ -47,15 +62,30 @@ bool StatementSequencer::skipLineBreaks()
 
 void StatementSequencer::skipStatementSeparator()
 {
-    if (parser_.at(TokenKind::Colon))
+    bool consumedColon = false;
+    bool consumedLineBreak = false;
+
+    while (parser_.at(TokenKind::Colon) || parser_.at(TokenKind::EndOfLine))
     {
-        parser_.consume();
-        lastSeparator_ = SeparatorKind::Colon;
+        if (parser_.at(TokenKind::Colon))
+        {
+            parser_.consume();
+            consumedColon = true;
+        }
+        else
+        {
+            parser_.consume();
+            consumedLineBreak = true;
+        }
     }
-    else if (parser_.at(TokenKind::EndOfLine))
+
+    if (consumedLineBreak)
     {
-        parser_.consume();
         lastSeparator_ = SeparatorKind::LineBreak;
+    }
+    else if (consumedColon)
+    {
+        lastSeparator_ = SeparatorKind::Colon;
     }
     else
     {

--- a/tests/frontends/basic/ParserStatementContextTests.cpp
+++ b/tests/frontends/basic/ParserStatementContextTests.cpp
@@ -63,6 +63,22 @@ int main()
     }
 
     {
+        std::string src = "PRINT 1:: PRINT 2: END\n";
+        SourceManager sm;
+        uint32_t fid = sm.addFile("double_colon.bas");
+        Parser p(src, fid);
+        auto prog = p.parseProgram();
+        assert(prog);
+        assert(prog->main.size() == 1);
+        auto *list = dynamic_cast<StmtList *>(prog->main[0].get());
+        assert(list);
+        assert(list->stmts.size() == 3);
+        assert(dynamic_cast<PrintStmt *>(list->stmts[0].get()));
+        assert(dynamic_cast<PrintStmt *>(list->stmts[1].get()));
+        assert(dynamic_cast<EndStmt *>(list->stmts[2].get()));
+    }
+
+    {
         std::string src = "10 PRINT 1:20 LET X = 5\n30 END\n";
         SourceManager sm;
         uint32_t fid = sm.addFile("line-label.bas");


### PR DESCRIPTION
## Summary
- update the BASIC statement sequencer to consume runs of colon tokens just like line breaks so inline statements can be separated reliably
- add a parser regression test covering chained colon separators on a single BASIC line

## Testing
- cmake -S . -B build
- cmake --build build --target fe_basic
- cmake --build build --target test_frontends_basic_statement_context
- ctest --test-dir build --output-on-failure --tests-regex test_frontends_basic_statement_context

------
https://chatgpt.com/codex/tasks/task_e_68e213bb3aac8324aa3e8a879744e66d