### PR TITLE
fix(frontends): short-circuit branch condition lowering

### DIFF
--- a/src/frontends/basic/LowerEmit.hpp
+++ b/src/frontends/basic/LowerEmit.hpp
@@ -111,6 +111,11 @@ void lowerIfCondition(const Expr &cond,
                       BasicBlock *thenBlk,
                       BasicBlock *falseBlk,
                       il::support::SourceLoc loc);
+/// @brief Lower a boolean expression directly into a conditional branch.
+void lowerCondBranch(const Expr &expr,
+                     BasicBlock *trueBlk,
+                     BasicBlock *falseBlk,
+                     il::support::SourceLoc loc);
 /// @brief Lower a THEN/ELSE branch and link to exit.
 /// @return True if branch falls through to @p exitBlk.
 bool lowerIfBranch(const Stmt *stmt,

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -141,8 +141,8 @@ class Lowerer
     {
         std::vector<size_t> tests; ///< indexes of test blocks
         std::vector<size_t> thens; ///< indexes of THEN blocks
-        BasicBlock *elseBlk;       ///< pointer to ELSE block
-        BasicBlock *exitBlk;       ///< pointer to common exit
+        size_t elseIdx;            ///< index of ELSE block
+        size_t exitIdx;            ///< index of common exit block
     };
 
     /// @brief Deterministic per-procedure block name generator.
@@ -552,6 +552,10 @@ class Lowerer
                           BasicBlock *thenBlk,
                           BasicBlock *falseBlk,
                           il::support::SourceLoc loc);
+    void lowerCondBranch(const Expr &expr,
+                         BasicBlock *trueBlk,
+                         BasicBlock *falseBlk,
+                         il::support::SourceLoc loc);
 
     /// @brief Lower a THEN/ELSE branch and link to exit.
     /// @return True if branch falls through to @p exitBlk.


### PR DESCRIPTION
## Summary
- add a dedicated lowerCondBranch helper that emits short-circuit CFGs for logical AND/OR when branching
- switch IF/WHILE/DO lowering to use the helper and keep block indices stable when new blocks are added

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e211cf755083248132bd16b2251d08