### PR TITLE
fix(frontends/basic): return from END and refresh goldens

### DIFF
--- a/src/frontends/basic/LowerStmt.cpp
+++ b/src/frontends/basic/LowerStmt.cpp
@@ -1135,15 +1135,13 @@ void Lowerer::lowerResume(const Resume &stmt)
 
 /// @brief Lower an END statement.
 /// @param stmt END statement closing the program.
-/// @details Emits a branch to the function exit block recorded in @ref fnExit.
-///          The branch uses @ref curLoc for diagnostics and leaves the current
-///          block terminated.
+/// @details Emits a return from the current block so execution does not fall
+///          through to subsequent statements. The return uses @ref curLoc for
+///          diagnostics and leaves the block terminated immediately.
 void Lowerer::lowerEnd(const EndStmt &stmt)
 {
     curLoc = stmt.loc;
-    Function *func = context().function();
-    assert(func && "lowerEnd requires an active function");
-    emitBr(&func->blocks[context().exitIndex()]);
+    emitRet(Value::constInt(0));
 }
 
 /// @brief Lower an INPUT statement.

--- a/tests/e2e/TraceSrcTests.bas.out
+++ b/tests/e2e/TraceSrcTests.bas.out
@@ -8,4 +8,3 @@
 [SRC] trace_src.bas:2:4  (fn=@main blk=L20 ip=#3)  PRINT A
 [SRC] trace_src.bas:2:4  (fn=@main blk=L20 ip=#4)  PRINT A
 [SRC] trace_src.bas:3:4  (fn=@main blk=L30 ip=#0)  END
-[SRC] <unknown>  (fn=@main blk=exit ip=#0)

--- a/tests/golden/basic_lowering/Instr.il
+++ b/tests/golden/basic_lowering/Instr.il
@@ -56,7 +56,7 @@ L30:
   br L40
 L40:
   .loc 1 4 4
-  br exit
+  ret 0
 exit:
   ret 0
 }

--- a/tests/golden/basic_lowering/LenMid.il
+++ b/tests/golden/basic_lowering/LenMid.il
@@ -65,7 +65,7 @@ L40:
   br L50
 L50:
   .loc 1 5 4
-  br exit
+  ret 0
 exit:
   ret 0
 }

--- a/tests/golden/basic_to_il/array_dim_redim.il
+++ b/tests/golden/basic_to_il/array_dim_redim.il
@@ -29,7 +29,7 @@ L20:
   cbr %t6, redim_len_fail, redim_len_cont
 L30:
   .loc 1 3 4
-  br exit
+  ret 0
 exit:
   %t10 = load ptr, %t0
   call @rt_arr_i32_release(%t10)

--- a/tests/golden/basic_to_il/array_dim_runtime.il
+++ b/tests/golden/basic_to_il/array_dim_runtime.il
@@ -116,7 +116,7 @@ L70:
   br L80
 L80:
   .loc 1 8 4
-  br exit
+  ret 0
 exit:
   %t40 = load ptr, %t2
   call @rt_arr_i32_release(%t40)

--- a/tests/golden/basic_to_il/calls_lowering.il
+++ b/tests/golden/basic_to_il/calls_lowering.il
@@ -167,7 +167,7 @@ L30:
   br L40
 L40:
   .loc 1 18 4
-  br exit
+  ret 0
 exit:
   ret 0
 }

--- a/tests/golden/basic_to_il/conversions.il
+++ b/tests/golden/basic_to_il/conversions.il
@@ -113,7 +113,7 @@ L80:
   br L90
 L90:
   .loc 1 9 4
-  br exit
+  ret 0
 exit:
   ret 0
 val_ok:

--- a/tests/golden/basic_to_il/ex1_hello_cond.il
+++ b/tests/golden/basic_to_il/ex1_hello_cond.il
@@ -65,7 +65,7 @@ L60:
   br if_test_0
 L70:
   .loc 1 7 4
-  br exit
+  ret 0
 exit:
   ret 0
 if_test_0:

--- a/tests/golden/basic_to_il/ex2_sum_1_to_10.il
+++ b/tests/golden/basic_to_il/ex2_sum_1_to_10.il
@@ -52,7 +52,7 @@ L40:
   br L50
 L50:
   .loc 1 5 4
-  br exit
+  ret 0
 exit:
   ret 0
 }

--- a/tests/golden/basic_to_il/ex4_if_elseif.il
+++ b/tests/golden/basic_to_il/ex4_if_elseif.il
@@ -20,7 +20,7 @@ L20:
   br if_test_0
 L30:
   .loc 1 3 4
-  br exit
+  ret 0
 exit:
   ret 0
 if_test_0:

--- a/tests/golden/basic_to_il/ex6_array_sum.il
+++ b/tests/golden/basic_to_il/ex6_array_sum.il
@@ -67,7 +67,7 @@ L100:
   br L110
 L110:
   .loc 1 11 5
-  br exit
+  ret 0
 exit:
   %t45 = load ptr, %t2
   call @rt_arr_i32_release(%t45)

--- a/tests/golden/basic_to_il/instr.il
+++ b/tests/golden/basic_to_il/instr.il
@@ -56,7 +56,7 @@ L30:
   br L40
 L40:
   .loc 1 4 4
-  br exit
+  ret 0
 exit:
   ret 0
 }

--- a/tests/golden/basic_to_il/string_cmp.il
+++ b/tests/golden/basic_to_il/string_cmp.il
@@ -28,7 +28,7 @@ L30:
   br if_test_01
 L40:
   .loc 1 4 4
-  br exit
+  ret 0
 exit:
   ret 0
 if_test_0:

--- a/tests/golden/basic_to_il/strings.il
+++ b/tests/golden/basic_to_il/strings.il
@@ -93,7 +93,7 @@ L60:
   br L70
 L70:
   .loc 1 7 4
-  br exit
+  ret 0
 exit:
   ret 0
 }

--- a/tests/golden/eh_lowering/on_error_push_pop.il
+++ b/tests/golden/eh_lowering/on_error_push_pop.il
@@ -25,7 +25,9 @@ L20:
   br L30
 L30:
   .loc 1 3 4
-  br exit
+  eh.pop
+  .loc 1 3 4
+  ret 0
 L100:
   .loc 1 4 5
   call @rt_print_i64(2)
@@ -37,7 +39,9 @@ L100:
   br L110
 L110:
   .loc 1 5 5
-  br exit
+  eh.pop
+  .loc 1 5 5
+  ret 0
 exit:
   eh.pop
   ret 0

--- a/tests/golden/eh_lowering/resume_forms.il
+++ b/tests/golden/eh_lowering/resume_forms.il
@@ -28,28 +28,38 @@ L30:
   br L40
 L40:
   .loc 1 4 4
-  br exit
+  eh.pop
+  .loc 1 4 4
+  ret 0
 L100:
   .loc 1 5 5
   br L110
 L110:
   .loc 1 6 5
-  br exit
+  eh.pop
+  .loc 1 6 5
+  ret 0
 L200:
   .loc 1 7 5
   br L210
 L210:
   .loc 1 8 5
-  br exit
+  eh.pop
+  .loc 1 8 5
+  ret 0
 L300:
   .loc 1 9 5
   br L310
 L310:
   .loc 1 10 5
-  br exit
+  eh.pop
+  .loc 1 10 5
+  ret 0
 L400:
   .loc 1 11 5
-  br exit
+  eh.pop
+  .loc 1 11 5
+  ret 0
 exit:
   eh.pop
   ret 0


### PR DESCRIPTION
## Summary
- emit a direct return when lowering BASIC END to prevent fallthrough
- regenerate BASIC-to-IL and error-handling golden fixtures for the new return behavior
- update the source-trace golden to match the absence of exit-block execution

## Testing
- cmake -S . -B build
- cmake --build build -j4
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e213f22d048324a999dcaf231372d4