### PR TITLE
fix(frontends/basic): lower FOR loops with runtime step sign

### DIFF
--- a/tests/golden/basic_lowering/labels_proc_loops.il
+++ b/tests/golden/basic_lowering/labels_proc_loops.il
@@ -15,7 +15,9 @@ L-999999999_F:
   .loc 1 4 1
   store i64, %t0, 1
   .loc 1 4 1
-  br for_head_1_F
+  %t2 = scmp_ge 1, 0
+  .loc 1 4 1
+  cbr %t2, for_head_pos_0_F, for_head_neg_0_F
 L-999999998_F:
   .loc 1 6 8
   ret 0
@@ -32,25 +34,32 @@ while_body_0_F:
 while_end_0_F:
   .loc 1 2 1
   br L-999999999_F
-for_head_1_F:
+for_head_pos_0_F:
   .loc 1 4 1
-  %t2 = load i64, %t0
+  %t3 = load i64, %t0
   .loc 1 4 1
-  %t3 = scmp_le %t2, 1
+  %t4 = scmp_le %t3, 1
   .loc 1 4 1
-  cbr %t3, for_body_1_F, for_end_1_F
+  cbr %t4, for_body_1_F, for_end_1_F
+for_head_neg_0_F:
+  .loc 1 4 1
+  %t5 = load i64, %t0
+  .loc 1 4 1
+  %t6 = scmp_ge %t5, 1
+  .loc 1 4 1
+  cbr %t6, for_body_1_F, for_end_1_F
 for_body_1_F:
   .loc 1 4 1
   br for_inc_1_F
 for_inc_1_F:
   .loc 1 4 1
-  %t4 = load i64, %t0
+  %t7 = load i64, %t0
   .loc 1 4 1
-  %t5 = iadd.ovf %t4, 1
+  %t8 = iadd.ovf %t7, 1
   .loc 1 4 1
-  store i64, %t0, %t5
+  store i64, %t0, %t8
   .loc 1 4 1
-  br for_head_1_F
+  cbr %t2, for_head_pos_0_F, for_head_neg_0_F
 for_end_1_F:
   .loc 1 4 1
   br L-999999998_F

--- a/tests/golden/basic_to_il/ex3_for_table.il
+++ b/tests/golden/basic_to_il/ex3_for_table.il
@@ -15,64 +15,82 @@ L10:
   .loc 1 1 4
   store i64, %t1, 1
   .loc 1 1 4
-  br for_head
+  %t2 = scmp_ge 1, 0
+  .loc 1 1 4
+  cbr %t2, for_head_pos, for_head_neg
 exit:
   ret 0
-for_head:
+for_head_pos:
   .loc 1 1 4
-  %t2 = load i64, %t1
+  %t3 = load i64, %t1
   .loc 1 1 4
-  %t3 = scmp_le %t2, 5
+  %t4 = scmp_le %t3, 5
   .loc 1 1 4
-  cbr %t3, for_body, for_done
+  cbr %t4, for_body, for_done
+for_head_neg:
+  .loc 1 1 4
+  %t5 = load i64, %t1
+  .loc 1 1 4
+  %t6 = scmp_ge %t5, 5
+  .loc 1 1 4
+  cbr %t6, for_body, for_done
 for_body:
   .loc 1 2 4
   store i64, %t0, 1
   .loc 1 2 4
-  br for_head1
+  %t7 = scmp_ge 1, 0
+  .loc 1 2 4
+  cbr %t7, for_head_pos1, for_head_neg1
 for_inc:
   .loc 1 1 4
-  %t12 = load i64, %t1
+  %t18 = load i64, %t1
   .loc 1 1 4
-  %t13 = iadd.ovf %t12, 1
+  %t19 = iadd.ovf %t18, 1
   .loc 1 1 4
-  store i64, %t1, %t13
+  store i64, %t1, %t19
   .loc 1 1 4
-  br for_head
+  cbr %t2, for_head_pos, for_head_neg
 for_done:
   .loc 1 1 4
   br exit
-for_head1:
+for_head_pos1:
   .loc 1 2 4
-  %t4 = load i64, %t0
+  %t8 = load i64, %t0
   .loc 1 2 4
-  %t5 = scmp_le %t4, 5
+  %t9 = scmp_le %t8, 5
   .loc 1 2 4
-  cbr %t5, for_body1, for_done1
+  cbr %t9, for_body1, for_done1
+for_head_neg1:
+  .loc 1 2 4
+  %t10 = load i64, %t0
+  .loc 1 2 4
+  %t11 = scmp_ge %t10, 5
+  .loc 1 2 4
+  cbr %t11, for_body1, for_done1
 for_body1:
   .loc 1 3 10
-  %t6 = load i64, %t1
+  %t12 = load i64, %t1
   .loc 1 3 14
-  %t7 = load i64, %t0
+  %t13 = load i64, %t0
   .loc 1 3 12
-  %t8 = imul.ovf %t6, %t7
+  %t14 = imul.ovf %t12, %t13
   .loc 1 3 4
-  call @rt_print_i64(%t8)
+  call @rt_print_i64(%t14)
   .loc 1 3 4
-  %t9 = const_str @.L0
+  %t15 = const_str @.L0
   .loc 1 3 4
-  call @rt_print_str(%t9)
+  call @rt_print_str(%t15)
   .loc 1 2 4
   br for_inc1
 for_inc1:
   .loc 1 2 4
-  %t10 = load i64, %t0
+  %t16 = load i64, %t0
   .loc 1 2 4
-  %t11 = iadd.ovf %t10, 1
+  %t17 = iadd.ovf %t16, 1
   .loc 1 2 4
-  store i64, %t0, %t11
+  store i64, %t0, %t17
   .loc 1 2 4
-  br for_head1
+  cbr %t7, for_head_pos1, for_head_neg1
 for_done1:
   .loc 1 1 4
   br for_inc


### PR DESCRIPTION
## Summary
- coerce FOR-loop bounds and step with `lowerScalarExpr` and always delegate to the sign-aware lowering path
- update BASIC→IL golden files to reflect the new positive/negative head branching

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e218c2b800832494bf6571e243ff38