### PR TITLE
refactor(runtime): move rt_arr_i32_hdr out of header

### DIFF
--- a/src/runtime/rt_array.c
+++ b/src/runtime/rt_array.c
@@ -12,6 +12,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+/// @brief Helper returning the heap header associated with @p payload.
+/// @param payload Array payload pointer (may be NULL).
+/// @return Heap header describing the allocation, or NULL for NULL payloads.
+rt_heap_hdr_t *rt_arr_i32_hdr(const int32_t *payload)
+{
+    return payload ? rt_heap_hdr((void *)payload) : NULL;
+}
+
 void rt_arr_oob_panic(size_t idx, size_t len)
 {
     fprintf(stderr, "rt_arr_i32: index %zu out of bounds (len=%zu)\n", idx, len);

--- a/src/runtime/rt_array.h
+++ b/src/runtime/rt_array.h
@@ -17,10 +17,7 @@ extern "C" {
     /// @brief Helper returning the heap header associated with @p payload.
     /// @param payload Array payload pointer (may be NULL).
     /// @return Heap header describing the allocation, or NULL for NULL payloads.
-    static inline rt_heap_hdr_t *rt_arr_i32_hdr(const int32_t *payload)
-    {
-        return payload ? rt_heap_hdr((void *)payload) : NULL;
-    }
+    rt_heap_hdr_t *rt_arr_i32_hdr(const int32_t *payload);
 
 #if defined(__cplusplus)
 #    define RT_ARR_NORETURN [[noreturn]]


### PR DESCRIPTION
## Summary
- move the rt_arr_i32_hdr implementation from the header into the C source file to avoid duplicate definitions
- document the helper in the runtime source file while keeping the existing behavior intact

## Testing
- cmake -S . -B build
- cmake --build build -j4
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e3346658748324b9325770678cf788