### PR TITLE
refactor(vm): move map_err_to_trap implementation

### DIFF
--- a/src/vm/err_bridge.cpp
+++ b/src/vm/err_bridge.cpp
@@ -6,6 +6,44 @@
 
 #include "vm/err_bridge.hpp"
 
+#ifdef EOF
+#pragma push_macro("EOF")
+#undef EOF
+#define IL_VM_ERR_BRIDGE_CPP_RESTORE_EOF 1
+#endif
+
 namespace il::vm
 {
+/// @copydoc map_err_to_trap
+TrapKind map_err_to_trap(int err_code)
+{
+    switch (err_code)
+    {
+        case 1:
+            return TrapKind::FileNotFound;
+        case 2:
+            return TrapKind::EOF;
+        case 3:
+            return TrapKind::IOError;
+        case 4:
+            return TrapKind::Overflow;
+        case 5:
+            return TrapKind::InvalidCast;
+        case 6:
+            return TrapKind::DomainError;
+        case 7:
+            return TrapKind::Bounds;
+        case 8:
+            return TrapKind::InvalidOperation;
+        case 9:
+            return TrapKind::RuntimeError;
+        default:
+            return TrapKind::RuntimeError;
+    }
+}
 } // namespace il::vm
+
+#ifdef IL_VM_ERR_BRIDGE_CPP_RESTORE_EOF
+#pragma pop_macro("EOF")
+#undef IL_VM_ERR_BRIDGE_CPP_RESTORE_EOF
+#endif

--- a/src/vm/err_bridge.hpp
+++ b/src/vm/err_bridge.hpp
@@ -36,32 +36,7 @@ enum class ErrCode : int32_t
 /// @brief Map a legacy runtime error code to the corresponding trap kind.
 /// @param err_code Numeric code reported by the runtime.
 /// @return TrapKind describing the semantic category of the error.
-inline TrapKind map_err_to_trap(int err_code)
-{
-    switch (err_code)
-    {
-        case 1:
-            return TrapKind::FileNotFound;
-        case 2:
-            return TrapKind::EOF;
-        case 3:
-            return TrapKind::IOError;
-        case 4:
-            return TrapKind::Overflow;
-        case 5:
-            return TrapKind::InvalidCast;
-        case 6:
-            return TrapKind::DomainError;
-        case 7:
-            return TrapKind::Bounds;
-        case 8:
-            return TrapKind::InvalidOperation;
-        case 9:
-            return TrapKind::RuntimeError;
-        default:
-            return TrapKind::RuntimeError;
-    }
-}
+TrapKind map_err_to_trap(int err_code);
 
 #ifdef IL_VM_ERR_BRIDGE_RESTORE_EOF
 #pragma pop_macro("EOF")


### PR DESCRIPTION
## Summary
- move the map_err_to_trap implementation out of the header into err_bridge.cpp while retaining its Doxygen documentation
- add an EOF macro guard in the translation unit to keep the switch-based mapping intact after relocation

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e33478e22c8324bf693ccb6883001b