### PR TITLE
refactor(basic): move LowerCtx accessors out of header

### DIFF
--- a/src/frontends/basic/builtins/StringBuiltins.cpp
+++ b/src/frontends/basic/builtins/StringBuiltins.cpp
@@ -270,6 +270,27 @@ LowerCtx::LowerCtx(Lowerer &lowerer, const BuiltinCallExpr &call)
     }
 }
 
+/// @brief Retrieve the lowering driver powering this context.
+/// @return Reference to the owning lowering driver.
+Lowerer &LowerCtx::lowerer() const noexcept
+{
+    return lowerer_;
+}
+
+/// @brief Access the builtin call node being processed.
+/// @return Immutable reference to the builtin call expression.
+const BuiltinCallExpr &LowerCtx::call() const noexcept
+{
+    return call_;
+}
+
+/// @brief Compute the total number of argument slots available.
+/// @return Number of argument positions recorded on the call.
+std::size_t LowerCtx::argCount() const noexcept
+{
+    return call_.args.size();
+}
+
 bool LowerCtx::hasArg(std::size_t idx) const noexcept
 {
     return idx < hasArg_.size() && hasArg_[idx];
@@ -297,6 +318,20 @@ Value &LowerCtx::argValue(std::size_t idx)
 ArrayRef<Value> LowerCtx::values() noexcept
 {
     return ArrayRef<Value>(argValues_.data(), argValues_.size());
+}
+
+/// @brief Record the result type that the handler will synthesize.
+/// @param ty Result type chosen by the lowering routine.
+void LowerCtx::setResultType(Type ty) noexcept
+{
+    resultType_ = ty;
+}
+
+/// @brief Query the result type previously recorded by the handler.
+/// @return Type reported by the lowering routine.
+Type LowerCtx::resultType() const noexcept
+{
+    return resultType_;
 }
 
 Lowerer::RVal &LowerCtx::ensureI64(std::size_t idx, il::support::SourceLoc loc)

--- a/src/frontends/basic/builtins/StringBuiltins.hpp
+++ b/src/frontends/basic/builtins/StringBuiltins.hpp
@@ -61,13 +61,13 @@ class LowerCtx
     LowerCtx(Lowerer &lowerer, const BuiltinCallExpr &call);
 
     /// @brief Retrieve the lowering driver.
-    Lowerer &lowerer() const noexcept { return lowerer_; }
+    Lowerer &lowerer() const noexcept;
 
     /// @brief Access the builtin call AST node.
-    const BuiltinCallExpr &call() const noexcept { return call_; }
+    const BuiltinCallExpr &call() const noexcept;
 
     /// @brief Total number of argument slots recorded on the call.
-    std::size_t argCount() const noexcept { return call_.args.size(); }
+    std::size_t argCount() const noexcept;
 
     /// @brief Check whether argument @p idx is present.
     bool hasArg(std::size_t idx) const noexcept;
@@ -85,10 +85,10 @@ class LowerCtx
     ArrayRef<Value> values() noexcept;
 
     /// @brief Update the result type that the handler will produce.
-    void setResultType(Type ty) noexcept { resultType_ = ty; }
+    void setResultType(Type ty) noexcept;
 
     /// @brief Final result type populated by the handler.
-    Type resultType() const noexcept { return resultType_; }
+    Type resultType() const noexcept;
 
     /// @brief Ensure argument @p idx is materialized as a 64-bit integer.
     Lowerer::RVal &ensureI64(std::size_t idx, il::support::SourceLoc loc);


### PR DESCRIPTION
## Summary
- convert LowerCtx inline accessors in StringBuiltins.hpp into declarations
- add documented out-of-line definitions in StringBuiltins.cpp for the moved helpers

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e334a941a48324b992ff3d94dceb2c