### PR TITLE
fix(vm): move trap helper definitions out of header

### DIFF
--- a/src/vm/Trap.cpp
+++ b/src/vm/Trap.cpp
@@ -12,8 +12,81 @@
 #include <sstream>
 #include <string_view>
 
+#ifdef EOF
+#pragma push_macro("EOF")
+#undef EOF
+#define IL_VM_TRAP_CPP_RESTORE_EOF 1
+#endif
+
 namespace il::vm
 {
+
+std::string_view toString(TrapKind kind)
+{
+    switch (kind)
+    {
+        case TrapKind::DivideByZero:
+            return "DivideByZero";
+        case TrapKind::Overflow:
+            return "Overflow";
+        case TrapKind::InvalidCast:
+            return "InvalidCast";
+        case TrapKind::DomainError:
+            return "DomainError";
+        case TrapKind::Bounds:
+            return "Bounds";
+        case TrapKind::FileNotFound:
+            return "FileNotFound";
+        case TrapKind::EOF:
+            return "EOF";
+        case TrapKind::IOError:
+            return "IOError";
+        case TrapKind::InvalidOperation:
+            return "InvalidOperation";
+        case TrapKind::RuntimeError:
+            return "RuntimeError";
+    }
+
+    // NOTE: Maintain graceful degradation when encountering unexpected enumerators.
+    return "RuntimeError";
+}
+
+TrapKind trapKindFromValue(int32_t value)
+{
+    switch (value)
+    {
+        case static_cast<int32_t>(TrapKind::DivideByZero):
+            return TrapKind::DivideByZero;
+        case static_cast<int32_t>(TrapKind::Overflow):
+            return TrapKind::Overflow;
+        case static_cast<int32_t>(TrapKind::InvalidCast):
+            return TrapKind::InvalidCast;
+        case static_cast<int32_t>(TrapKind::DomainError):
+            return TrapKind::DomainError;
+        case static_cast<int32_t>(TrapKind::Bounds):
+            return TrapKind::Bounds;
+        case static_cast<int32_t>(TrapKind::FileNotFound):
+            return TrapKind::FileNotFound;
+        case static_cast<int32_t>(TrapKind::EOF):
+            return TrapKind::EOF;
+        case static_cast<int32_t>(TrapKind::IOError):
+            return TrapKind::IOError;
+        case static_cast<int32_t>(TrapKind::InvalidOperation):
+            return TrapKind::InvalidOperation;
+        case static_cast<int32_t>(TrapKind::RuntimeError):
+            return TrapKind::RuntimeError;
+        default:
+            break;
+    }
+
+    // NOTE: Legacy IL payloads may encode unexpected values; fall back to RuntimeError.
+    return TrapKind::RuntimeError;
+}
+
+#ifdef IL_VM_TRAP_CPP_RESTORE_EOF
+#pragma pop_macro("EOF")
+#undef IL_VM_TRAP_CPP_RESTORE_EOF
+#endif
 
 namespace
 {

--- a/src/vm/Trap.hpp
+++ b/src/vm/Trap.hpp
@@ -53,65 +53,12 @@ struct FrameInfo
 /// @brief Convert trap kind to canonical diagnostic string.
 /// @param kind Enumerated trap kind.
 /// @return Stable string view naming the trap category.
-constexpr std::string_view toString(TrapKind kind)
-{
-    switch (kind)
-    {
-        case TrapKind::DivideByZero:
-            return "DivideByZero";
-        case TrapKind::Overflow:
-            return "Overflow";
-        case TrapKind::InvalidCast:
-            return "InvalidCast";
-        case TrapKind::DomainError:
-            return "DomainError";
-        case TrapKind::Bounds:
-            return "Bounds";
-        case TrapKind::FileNotFound:
-            return "FileNotFound";
-        case TrapKind::EOF:
-            return "EOF";
-        case TrapKind::IOError:
-            return "IOError";
-        case TrapKind::InvalidOperation:
-            return "InvalidOperation";
-        case TrapKind::RuntimeError:
-            return "RuntimeError";
-    }
-    return "RuntimeError";
-}
+std::string_view toString(TrapKind kind);
 
 /// @brief Translate an integer payload into a TrapKind value.
 /// @param value Integer supplied by IL operands.
 /// @return Enumerated trap kind, defaulting to RuntimeError for unknown values.
-constexpr TrapKind trapKindFromValue(int32_t value)
-{
-    switch (value)
-    {
-        case static_cast<int32_t>(TrapKind::DivideByZero):
-            return TrapKind::DivideByZero;
-        case static_cast<int32_t>(TrapKind::Overflow):
-            return TrapKind::Overflow;
-        case static_cast<int32_t>(TrapKind::InvalidCast):
-            return TrapKind::InvalidCast;
-        case static_cast<int32_t>(TrapKind::DomainError):
-            return TrapKind::DomainError;
-        case static_cast<int32_t>(TrapKind::Bounds):
-            return TrapKind::Bounds;
-        case static_cast<int32_t>(TrapKind::FileNotFound):
-            return TrapKind::FileNotFound;
-        case static_cast<int32_t>(TrapKind::EOF):
-            return TrapKind::EOF;
-        case static_cast<int32_t>(TrapKind::IOError):
-            return TrapKind::IOError;
-        case static_cast<int32_t>(TrapKind::InvalidOperation):
-            return TrapKind::InvalidOperation;
-        case static_cast<int32_t>(TrapKind::RuntimeError):
-            return TrapKind::RuntimeError;
-        default:
-            return TrapKind::RuntimeError;
-    }
-}
+TrapKind trapKindFromValue(int32_t value);
 
 /// @brief Obtain writable storage for constructing a trap token in the active VM.
 /// @return Pointer to a VmError slot owned by the VM or thread-local fallback when no VM is active.

--- a/tests/unit/test_vm_trap_kind.cpp
+++ b/tests/unit/test_vm_trap_kind.cpp
@@ -1,0 +1,57 @@
+// File: tests/unit/test_vm_trap_kind.cpp
+// Purpose: Validate TrapKind helpers provide stable string names and decoding.
+// Key invariants: Bidirectional mapping covers every TrapKind enumerator and fallback path.
+// Ownership: Standalone unit test executable.
+// Links: docs/codemap.md
+
+#include "vm/Trap.hpp"
+
+#include <array>
+#include <cassert>
+#include <string_view>
+
+#ifdef EOF
+#pragma push_macro("EOF")
+#undef EOF
+#define IL_VM_TRAP_KIND_TEST_RESTORE_EOF 1
+#endif
+
+using il::vm::TrapKind;
+
+int main()
+{
+    constexpr std::array<std::pair<TrapKind, std::string_view>, 10> cases{{
+        {TrapKind::DivideByZero, "DivideByZero"},
+        {TrapKind::Overflow, "Overflow"},
+        {TrapKind::InvalidCast, "InvalidCast"},
+        {TrapKind::DomainError, "DomainError"},
+        {TrapKind::Bounds, "Bounds"},
+        {TrapKind::FileNotFound, "FileNotFound"},
+        {TrapKind::EOF, "EOF"},
+        {TrapKind::IOError, "IOError"},
+        {TrapKind::InvalidOperation, "InvalidOperation"},
+        {TrapKind::RuntimeError, "RuntimeError"},
+    }};
+
+    for (const auto &[kind, name] : cases)
+    {
+        const auto stringified = il::vm::toString(kind);
+        assert(stringified == name);
+
+        const auto decoded = il::vm::trapKindFromValue(static_cast<int32_t>(kind));
+        assert(decoded == kind);
+    }
+
+    const auto fallbackKind = il::vm::trapKindFromValue(127);
+    assert(fallbackKind == TrapKind::RuntimeError);
+
+    const auto fallbackName = il::vm::toString(static_cast<TrapKind>(-42));
+    assert(fallbackName == std::string_view("RuntimeError"));
+
+    return 0;
+}
+
+#ifdef IL_VM_TRAP_KIND_TEST_RESTORE_EOF
+#pragma pop_macro("EOF")
+#undef IL_VM_TRAP_KIND_TEST_RESTORE_EOF
+#endif

--- a/tests/vm/CMakeLists.txt
+++ b/tests/vm/CMakeLists.txt
@@ -73,6 +73,10 @@ function(viper_add_vm_unit_tests)
   target_link_libraries(test_vm_trap_overflow PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   viper_add_ctest(test_vm_trap_overflow test_vm_trap_overflow)
 
+  viper_add_test(test_vm_trap_kind ${VIPER_TESTS_DIR}/unit/test_vm_trap_kind.cpp)
+  target_link_libraries(test_vm_trap_kind PRIVATE ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
+  viper_add_ctest(test_vm_trap_kind test_vm_trap_kind)
+
   viper_add_test(test_vm_errors_core ${_VIPER_VM_DIR}/ErrorsCoreTests.cpp)
   target_link_libraries(test_vm_errors_core PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   viper_add_ctest(test_vm_errors_core test_vm_errors_core)


### PR DESCRIPTION
## Summary
- move the TrapKind helper declarations out of the header and implement them in Trap.cpp with local EOF macro handling
- add a unit test covering TrapKind stringification/decoding and wire it into the VM unit suite

## Testing
- cmake -S . -B build
- cmake --build build -j4
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e3348422248324a908e4ab95e9c3a3