### PR TITLE
fix(vm): move trap dispatch signal definitions to source

### DIFF
--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -59,6 +59,18 @@ std::string opcodeMnemonic(Opcode op)
 } // namespace
 
 
+/// Construct a trap dispatch signal targeting a specific execution state.
+VM::TrapDispatchSignal::TrapDispatchSignal(ExecState *targetState) : target(targetState)
+{
+}
+
+/// Retrieve the diagnostic message associated with trap dispatch signals.
+const char *VM::TrapDispatchSignal::what() const noexcept
+{
+    return "trap dispatch";
+}
+
+
 /// Locate and execute the module's @c main function.
 ///
 /// The entry point is looked up by name in the cached function map and then

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -317,11 +317,11 @@ class VM
 
     struct TrapDispatchSignal : std::exception
     {
-        explicit TrapDispatchSignal(ExecState *targetState) : target(targetState) {}
+        explicit TrapDispatchSignal(ExecState *targetState);
 
         ExecState *target;
 
-        const char *what() const noexcept override { return "trap dispatch"; }
+        const char *what() const noexcept override;
     };
 
     /// @brief Active execution stack for trap unwinding.


### PR DESCRIPTION
## Summary
- move the TrapDispatchSignal constructor and what implementation out of VM.hpp into VM.cpp to keep the header declarative
- document the out-of-line definitions using the existing Doxygen comment style

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e33926fe888324b4e2a2e723aae0b2