### PR TITLE
Refactor TextBuffer iteration to use FunctionRef callbacks

### DIFF
--- a/tui/include/tui/support/function_ref.hpp
+++ b/tui/include/tui/support/function_ref.hpp
@@ -1,0 +1,65 @@
+// tui/include/tui/support/function_ref.hpp
+// @brief Lightweight non-owning callable reference for performance-critical callbacks.
+// @invariant Referenced callable must outlive the FunctionRef instance.
+// @ownership FunctionRef stores raw pointer to caller-owned callable without lifetime extension.
+#pragma once
+
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+namespace viper::tui
+{
+/// @brief Non-owning reference to a callable with the specified signature.
+///
+/// FunctionRef allows passing inline lambdas or function objects without incurring
+/// heap allocations. The referenced callable must remain alive for the duration of
+/// the FunctionRef use.
+template <typename Signature>
+class FunctionRef;
+
+/// @brief Specialization handling invocation of callables matching the signature.
+template <typename Ret, typename... Args>
+class FunctionRef<Ret(Args...)>
+{
+  public:
+    /// @brief Construct from a function pointer.
+    FunctionRef(Ret (*fn)(Args...)) noexcept
+        : obj_(reinterpret_cast<void *>(fn)), callback_(&invokeFunctionPtr)
+    {
+    }
+
+    /// @brief Construct from any callable matching the signature.
+    template <typename Callable,
+              typename = std::enable_if_t<
+                  !std::is_same_v<std::remove_cvref_t<Callable>, FunctionRef>>>
+    FunctionRef(Callable &&callable) noexcept
+        : obj_(const_cast<void *>(static_cast<const void *>(std::addressof(callable)))),
+          callback_(&invoke<Callable>)
+    {
+    }
+
+    /// @brief Invoke the referenced callable.
+    Ret operator()(Args... args) const
+    {
+        return callback_(obj_, std::forward<Args>(args)...);
+    }
+
+  private:
+    template <typename Callable>
+    static Ret invoke(void *obj, Args... args)
+    {
+        return std::invoke(*static_cast<std::remove_reference_t<Callable> *>(obj),
+                           std::forward<Args>(args)...);
+    }
+
+    static Ret invokeFunctionPtr(void *obj, Args... args)
+    {
+        auto *fn = reinterpret_cast<Ret (*)(Args...)>(obj);
+        return std::invoke(fn, std::forward<Args>(args)...);
+    }
+
+    void *obj_{};
+    Ret (*callback_)(void *, Args...){};
+};
+} // namespace viper::tui

--- a/tui/src/text/text_buffer.cpp
+++ b/tui/src/text/text_buffer.cpp
@@ -24,6 +24,12 @@ std::size_t TextBuffer::LineView::length() const
     return length_;
 }
 
+/// @copydoc viper::tui::text::TextBuffer::LineView::forEachSegment
+void TextBuffer::LineView::forEachSegment(SegmentVisitor fn) const
+{
+    table_.forEachSegment(offset_, length_, fn);
+}
+
 void TextBuffer::load(std::string text)
 {
     auto change = table_.load(std::move(text));
@@ -184,5 +190,19 @@ std::string TextBuffer::getLine(std::size_t lineNo) const
         end = start;
     }
     return table_.getText(start, end - start);
+}
+
+/// @copydoc viper::tui::text::TextBuffer::forEachLine
+void TextBuffer::forEachLine(LineVisitor fn) const
+{
+    const std::size_t lines = line_index_.count();
+    for (std::size_t line = 0; line < lines; ++line)
+    {
+        LineView view(table_, lineOffset(line), lineLength(line));
+        if (!fn(line, view))
+        {
+            break;
+        }
+    }
 }
 } // namespace viper::tui::text

--- a/tui/tests/test_text_buffer.cpp
+++ b/tui/tests/test_text_buffer.cpp
@@ -7,6 +7,7 @@
 
 #include <cassert>
 #include <string>
+#include <string_view>
 
 using viper::tui::text::TextBuffer;
 
@@ -48,6 +49,49 @@ int main()
     ok = buf.redo();
     assert(ok);
     assert(buf.getLine(0) == "bye, there");
+
+    std::size_t visited = 0;
+    buf.forEachLine([&](std::size_t lineNo, const TextBuffer::LineView &view) {
+        std::string reconstructed;
+        std::size_t segments = 0;
+        view.forEachSegment([&](std::string_view segment) {
+            reconstructed.append(segment);
+            ++segments;
+            return true;
+        });
+
+        if (lineNo == 0)
+        {
+            assert(reconstructed == "bye, there");
+            assert(segments >= 2);
+        }
+        else if (lineNo == 1)
+        {
+            assert(reconstructed == "beautiful");
+        }
+        else if (lineNo == 2)
+        {
+            assert(reconstructed == "world");
+        }
+
+        ++visited;
+        return true;
+    });
+    assert(visited == buf.lineCount());
+
+    visited = 0;
+    buf.forEachLine([&](std::size_t lineNo, const TextBuffer::LineView &) {
+        ++visited;
+        return lineNo < 1;
+    });
+    assert(visited == 2);
+
+    std::size_t segmentVisits = 0;
+    buf.lineView(0).forEachSegment([&](std::string_view) {
+        ++segmentVisits;
+        return false;
+    });
+    assert(segmentVisits == 1);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a lightweight tui::FunctionRef utility for non-owning callbacks
- update TextBuffer to expose concrete visitor types and define the iteration logic in the cpp file
- extend the text buffer test to exercise the new visitors and early-exit behaviour

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e33958f2388324aea995edbe25f4ec