### PR TITLE
Refactor PieceTable segment iteration callback

### DIFF
--- a/tui/include/tui/text/text_buffer.hpp
+++ b/tui/include/tui/text/text_buffer.hpp
@@ -36,7 +36,7 @@ class TextBuffer
         template <typename Fn>
         void forEachSegment(Fn &&fn) const
         {
-            table_.forEachSegment(offset_, length_, std::forward<Fn>(fn));
+            table_.forEachSegment(offset_, length_, PieceTable::SegmentCallback(std::forward<Fn>(fn)));
         }
 
       private:

--- a/tui/tests/test_text_buffer.cpp
+++ b/tui/tests/test_text_buffer.cpp
@@ -7,6 +7,7 @@
 
 #include <cassert>
 #include <string>
+#include <vector>
 
 using viper::tui::text::TextBuffer;
 
@@ -24,6 +25,24 @@ int main()
     assert(buf.lineStart(5) == buf.size());
     assert(buf.lineEnd(5) == buf.size());
 
+    {
+        auto view = buf.lineView(0);
+        std::vector<std::string> segments;
+        view.forEachSegment([&](std::string_view segment) {
+            segments.emplace_back(segment);
+            return true;
+        });
+        assert(segments.size() == 1);
+        assert(segments.front() == "hello");
+
+        std::size_t calls = 0;
+        view.forEachSegment([&](std::string_view) {
+            ++calls;
+            return false;
+        });
+        assert(calls == 1);
+    }
+
     buf.insert(5, ", there\nbeautiful");
     assert(buf.getLine(0) == "hello, there");
     assert(buf.getLine(1) == "beautiful");
@@ -34,6 +53,18 @@ int main()
     assert(buf.lineEnd(2) == buf.lineStart(2) + buf.getLine(2).size());
     assert(buf.lineStart(99) == buf.size());
     assert(buf.lineEnd(99) == buf.size());
+
+    {
+        auto view = buf.lineView(0);
+        std::vector<std::string> segments;
+        view.forEachSegment([&](std::string_view segment) {
+            segments.emplace_back(segment);
+            return true;
+        });
+        assert(segments.size() == 2);
+        assert(segments[0] == "hello");
+        assert(segments[1] == ", there");
+    }
 
     buf.beginTxn();
     buf.erase(0, 5); // remove 'hello'


### PR DESCRIPTION
## Summary
- replace `PieceTable::forEachSegment`'s template with a lightweight `SegmentCallback` function-ref and move the iteration loop into the implementation file
- adjust `TextBuffer::LineView::forEachSegment` to wrap visitors with the new callback type
- extend the text buffer test to cover multi-piece iteration and early termination

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e3397ed2b483249ffd1d7911cc6ec4