### PR TITLE
Refactor runtime helpers and diagnostics utilities

### DIFF
--- a/src/frontends/basic/DiagnosticEmitter.cpp
+++ b/src/frontends/basic/DiagnosticEmitter.cpp
@@ -60,24 +60,6 @@ void DiagnosticEmitter::emitExpected(TokenKind got, TokenKind expect, il::suppor
     emit(il::support::Severity::Error, "B0001", loc, 0, std::move(msg));
 }
 
-/// @brief Convert severity enum to human-readable string.
-/// @param s Severity to convert.
-/// @return Null-terminated severity name.
-static const char *toString(il::support::Severity s)
-{
-    using il::support::Severity;
-    switch (s)
-    {
-        case Severity::Note:
-            return "note";
-        case Severity::Warning:
-            return "warning";
-        case Severity::Error:
-            return "error";
-    }
-    return "";
-}
-
 /// @brief Retrieve a specific line from stored source text.
 /// @param fileId Source file identifier.
 /// @param line 1-based line number to fetch.
@@ -110,7 +92,8 @@ void DiagnosticEmitter::printAll(std::ostream &os) const
     for (const auto &e : entries_)
     {
         auto path = sm_.getPath(e.loc.file_id);
-        os << path << ':' << e.loc.line << ':' << e.loc.column << ": " << toString(e.severity)
+        os << path << ':' << e.loc.line << ':' << e.loc.column << ": "
+           << il::support::toString(e.severity)
            << '[' << e.code << "]: " << e.message << '\n';
         std::string line = getLine(e.loc.file_id, e.loc.line);
         if (!line.empty())

--- a/src/support/diag_expected.cpp
+++ b/src/support/diag_expected.cpp
@@ -32,23 +32,6 @@ const Diag &Expected<void>::error() const &
     return *error_;
 }
 
-namespace detail
-{
-const char *diagSeverityToString(Severity severity)
-{
-    switch (severity)
-    {
-        case Severity::Note:
-            return "note";
-        case Severity::Warning:
-            return "warning";
-        case Severity::Error:
-            return "error";
-    }
-    return "";
-}
-} // namespace detail
-
 Diag makeError(SourceLoc loc, std::string msg)
 {
     return Diag{Severity::Error, std::move(msg), loc};
@@ -61,7 +44,7 @@ void printDiag(const Diag &diag, std::ostream &os, const SourceManager *sm)
         auto path = sm->getPath(diag.loc.file_id);
         os << path << ":" << diag.loc.line << ":" << diag.loc.column << ": ";
     }
-    os << detail::diagSeverityToString(diag.severity) << ": " << diag.message
+    os << toString(diag.severity) << ": " << diag.message
        << '\n';
 }
 } // namespace il::support

--- a/src/support/diag_expected.hpp
+++ b/src/support/diag_expected.hpp
@@ -92,12 +92,6 @@ template <> class Expected<void>
     std::optional<Diag> error_;
 };
 
-namespace detail
-{
-/// @brief Convert diagnostic severity to lowercase string.
-const char *diagSeverityToString(Severity severity);
-} // namespace detail
-
 /// @brief Create an error diagnostic with location and message.
 /// @param loc Optional source location associated with the diagnostic.
 /// @param msg Human-readable diagnostic message.

--- a/src/support/diagnostics.cpp
+++ b/src/support/diagnostics.cpp
@@ -24,7 +24,7 @@ void DiagnosticEngine::report(Diagnostic d)
 /// @brief Convert a severity enum to a string.
 /// @param s Severity value to convert.
 /// @return Lowercase string representation of @p s.
-static const char *toString(Severity s)
+const char *toString(Severity s)
 {
     switch (s)
     {

--- a/src/support/diagnostics.hpp
+++ b/src/support/diagnostics.hpp
@@ -26,6 +26,9 @@ enum class Severity
     Error
 };
 
+/// @brief Convert a diagnostic severity to its lowercase string form.
+[[nodiscard]] const char *toString(Severity severity);
+
 /// @brief Single diagnostic message with location.
 struct Diagnostic
 {

--- a/src/support/string_interner.cpp
+++ b/src/support/string_interner.cpp
@@ -18,9 +18,9 @@ namespace il::support
 // previous symbol is reused.  Symbol id 0 is reserved and never produced.
 Symbol StringInterner::intern(std::string_view str)
 {
-    auto it = map_.find(std::string(str));
-    if (it != map_.end())
+    if (auto it = map_.find(str); it != map_.end())
         return it->second;
+
     storage_.emplace_back(str);
     Symbol sym{static_cast<uint32_t>(storage_.size())};
     map_.emplace(storage_.back(), sym);


### PR DESCRIPTION
## Summary
- centralize runtime bridge argument access and result writing helpers in RuntimeSignatures
- add transparent hashing for StringInterner to avoid redundant string copies and reuse severity formatting helpers across support and frontend diagnostics

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e33e3d372c8324b260784cf6f78fc4