### PR TITLE
Refactor shared helpers for diagnostics, opcodes, and interning

### DIFF
--- a/src/il/build/IRBuilder.cpp
+++ b/src/il/build/IRBuilder.cpp
@@ -6,6 +6,7 @@
 // Links: docs/il-guide.md#reference
 
 #include "il/build/IRBuilder.hpp"
+#include "il/core/OpcodeInfo.hpp"
 #include <cassert>
 #include <stdexcept>
 
@@ -177,7 +178,7 @@ void IRBuilder::setInsertPoint(BasicBlock &bb)
 Instr &IRBuilder::append(Instr instr)
 {
     assert(curBlock && "insert point not set");
-    if (isTerminator(instr.op))
+    if (il::core::isTerminatorOpcode(instr.op))
     {
         assert(!curBlock->terminated && "block already terminated");
         curBlock->terminated = true;
@@ -191,8 +192,7 @@ Instr &IRBuilder::append(Instr instr)
 /// @return True when @p op ends the block (branch, conditional branch, return, trap).
 bool IRBuilder::isTerminator(Opcode op) const
 {
-    return op == Opcode::Br || op == Opcode::CBr || op == Opcode::SwitchI32 || op == Opcode::Ret ||
-           op == Opcode::Trap;
+    return il::core::isTerminatorOpcode(op);
 }
 
 /// @brief Materialize a string constant by referencing an existing global.

--- a/src/il/core/OpcodeInfo.cpp
+++ b/src/il/core/OpcodeInfo.cpp
@@ -92,4 +92,9 @@ std::string opcode_mnemonic(Opcode op)
     return toString(op);
 }
 
+bool isTerminatorOpcode(Opcode op)
+{
+    return getOpcodeInfo(op).isTerminator;
+}
+
 } // namespace il::core

--- a/src/il/core/OpcodeInfo.hpp
+++ b/src/il/core/OpcodeInfo.hpp
@@ -183,6 +183,11 @@ std::vector<Opcode> all_opcodes();
 /// @return Lowercase mnemonic defined by the IL spec, empty if invalid.
 std::string opcode_mnemonic(Opcode op);
 
+/// @brief Determine whether the opcode terminates a block.
+/// @param op Opcode to inspect.
+/// @return True if @p op is marked as a terminator in the opcode table.
+bool isTerminatorOpcode(Opcode op);
+
 /// @brief Determine whether @p value denotes a variadic operand upper bound.
 bool isVariadicOperandCount(uint8_t value);
 

--- a/src/il/utils/Utils.cpp
+++ b/src/il/utils/Utils.cpp
@@ -8,6 +8,7 @@
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Instr.hpp"
 #include "il/core/Opcode.hpp"
+#include "il/core/OpcodeInfo.hpp"
 
 namespace viper::il
 {
@@ -55,7 +56,7 @@ Instruction *terminator(Block &B)
         return nullptr;
     }
     Instruction &last = B.instructions.back();
-    return isTerminator(last) ? &last : nullptr;
+    return ::il::core::isTerminatorOpcode(last.op) ? &last : nullptr;
 }
 
 /// @brief Classify whether instruction @p I terminates control flow.
@@ -69,18 +70,7 @@ Instruction *terminator(Block &B)
 /// @invariant @p I.op must be a valid member of `il::core::Opcode`.
 bool isTerminator(const Instruction &I)
 {
-    using ::il::core::Opcode;
-    switch (I.op)
-    {
-        case Opcode::Br:
-        case Opcode::CBr:
-        case Opcode::SwitchI32:
-        case Opcode::Ret:
-        case Opcode::Trap:
-            return true;
-        default:
-            return false;
-    }
+    return ::il::core::isTerminatorOpcode(I.op);
 }
 
 } // namespace viper::il

--- a/src/il/verify/ControlFlowChecker.cpp
+++ b/src/il/verify/ControlFlowChecker.cpp
@@ -10,6 +10,7 @@
 #include "il/core/Extern.hpp"
 #include "il/core/Function.hpp"
 #include "il/core/Instr.hpp"
+#include "il/core/OpcodeInfo.hpp"
 #include "il/core/Param.hpp"
 #include "il/verify/BranchVerifier.hpp"
 #include "il/verify/DiagFormat.hpp"
@@ -217,21 +218,7 @@ Expected<void> checkBlockTerminators_E(const Function &fn, const BasicBlock &bb)
 
 bool isTerminator(Opcode op)
 {
-    switch (op)
-    {
-        case Opcode::Br:
-        case Opcode::CBr:
-        case Opcode::SwitchI32:
-        case Opcode::Ret:
-        case Opcode::Trap:
-        case Opcode::TrapFromErr:
-        case Opcode::ResumeSame:
-        case Opcode::ResumeNext:
-        case Opcode::ResumeLabel:
-            return true;
-        default:
-            return false;
-    }
+    return il::core::isTerminatorOpcode(op);
 }
 
 bool validateBlockParams(const Function &fn,

--- a/src/support/diag_expected.cpp
+++ b/src/support/diag_expected.cpp
@@ -36,16 +36,7 @@ namespace detail
 {
 const char *diagSeverityToString(Severity severity)
 {
-    switch (severity)
-    {
-        case Severity::Note:
-            return "note";
-        case Severity::Warning:
-            return "warning";
-        case Severity::Error:
-            return "error";
-    }
-    return "";
+    return severityToString(severity);
 }
 } // namespace detail
 

--- a/src/support/diagnostics.cpp
+++ b/src/support/diagnostics.cpp
@@ -21,23 +21,6 @@ void DiagnosticEngine::report(Diagnostic d)
     diags_.push_back(std::move(d));
 }
 
-/// @brief Convert a severity enum to a string.
-/// @param s Severity value to convert.
-/// @return Lowercase string representation of @p s.
-static const char *toString(Severity s)
-{
-    switch (s)
-    {
-        case Severity::Note:
-            return "note";
-        case Severity::Warning:
-            return "warning";
-        case Severity::Error:
-            return "error";
-    }
-    return "";
-}
-
 /// @brief Print all recorded diagnostics.
 /// @param os Output stream receiving diagnostic text.
 /// @param sm Optional source manager for resolving locations.
@@ -51,7 +34,7 @@ void DiagnosticEngine::printAll(std::ostream &os, const SourceManager *sm) const
             auto path = sm->getPath(d.loc.file_id);
             os << path << ":" << d.loc.line << ":" << d.loc.column << ": ";
         }
-        os << toString(d.severity) << ": " << d.message << '\n';
+        os << severityToString(d.severity) << ": " << d.message << '\n';
     }
 }
 

--- a/src/support/diagnostics.hpp
+++ b/src/support/diagnostics.hpp
@@ -26,6 +26,21 @@ enum class Severity
     Error
 };
 
+/// @brief Convert severity enum to lowercase string literal.
+constexpr const char *severityToString(Severity severity) noexcept
+{
+    switch (severity)
+    {
+        case Severity::Note:
+            return "note";
+        case Severity::Warning:
+            return "warning";
+        case Severity::Error:
+            return "error";
+    }
+    return "";
+}
+
 /// @brief Single diagnostic message with location.
 struct Diagnostic
 {

--- a/src/support/string_interner.cpp
+++ b/src/support/string_interner.cpp
@@ -18,7 +18,7 @@ namespace il::support
 // previous symbol is reused.  Symbol id 0 is reserved and never produced.
 Symbol StringInterner::intern(std::string_view str)
 {
-    auto it = map_.find(std::string(str));
+    auto it = map_.find(str);
     if (it != map_.end())
         return it->second;
     storage_.emplace_back(str);


### PR DESCRIPTION
## Summary
- centralize `severityToString` and reuse it across diagnostic formatting helpers
- add an `isTerminatorOpcode` query so builders and verifiers share the opcode metadata
- enable heterogeneous lookups in the string interner to avoid temporary allocations

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e33e3d372c8324b260784cf6f78fc4