### PR TITLE
Refactor diagnostics, interner lookup, and debug path helpers

### DIFF
--- a/src/support/diagnostics.cpp
+++ b/src/support/diagnostics.cpp
@@ -5,6 +5,7 @@
 // Links: docs/codemap.md
 
 #include "diagnostics.hpp"
+#include "diag_expected.hpp"
 #include "source_manager.hpp"
 
 namespace il::support
@@ -21,23 +22,6 @@ void DiagnosticEngine::report(Diagnostic d)
     diags_.push_back(std::move(d));
 }
 
-/// @brief Convert a severity enum to a string.
-/// @param s Severity value to convert.
-/// @return Lowercase string representation of @p s.
-static const char *toString(Severity s)
-{
-    switch (s)
-    {
-        case Severity::Note:
-            return "note";
-        case Severity::Warning:
-            return "warning";
-        case Severity::Error:
-            return "error";
-    }
-    return "";
-}
-
 /// @brief Print all recorded diagnostics.
 /// @param os Output stream receiving diagnostic text.
 /// @param sm Optional source manager for resolving locations.
@@ -46,12 +30,7 @@ void DiagnosticEngine::printAll(std::ostream &os, const SourceManager *sm) const
 {
     for (const auto &d : diags_)
     {
-        if (d.loc.isValid() && sm)
-        {
-            auto path = sm->getPath(d.loc.file_id);
-            os << path << ":" << d.loc.line << ":" << d.loc.column << ": ";
-        }
-        os << toString(d.severity) << ": " << d.message << '\n';
+        printDiag(d, os, sm);
     }
 }
 

--- a/src/support/string_interner.cpp
+++ b/src/support/string_interner.cpp
@@ -18,7 +18,7 @@ namespace il::support
 // previous symbol is reused.  Symbol id 0 is reserved and never produced.
 Symbol StringInterner::intern(std::string_view str)
 {
-    auto it = map_.find(std::string(str));
+    auto it = map_.find(str);
     if (it != map_.end())
         return it->second;
     storage_.emplace_back(str);

--- a/src/support/string_interner.hpp
+++ b/src/support/string_interner.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "symbol.hpp"
+#include <functional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -40,8 +41,48 @@ class StringInterner
     std::string_view lookup(Symbol sym) const;
 
   private:
+    struct TransparentHash
+    {
+        using is_transparent = void;
+
+        size_t operator()(std::string_view sv) const noexcept
+        {
+            return std::hash<std::string_view>{}(sv);
+        }
+
+        size_t operator()(const std::string &s) const noexcept
+        {
+            return (*this)(std::string_view{s});
+        }
+    };
+
+    struct TransparentEqual
+    {
+        using is_transparent = void;
+
+        bool operator()(std::string_view lhs, std::string_view rhs) const noexcept
+        {
+            return lhs == rhs;
+        }
+
+        bool operator()(const std::string &lhs, const std::string &rhs) const noexcept
+        {
+            return lhs == rhs;
+        }
+
+        bool operator()(const std::string &lhs, std::string_view rhs) const noexcept
+        {
+            return lhs == rhs;
+        }
+
+        bool operator()(std::string_view lhs, const std::string &rhs) const noexcept
+        {
+            return lhs == rhs;
+        }
+    };
+
     /// Maps string content to assigned symbols for O(1) lookup during interning.
-    std::unordered_map<std::string, Symbol> map_;
+    std::unordered_map<std::string, Symbol, TransparentHash, TransparentEqual> map_;
     /// Retains copies of interned strings so lookups return stable views.
     std::vector<std::string> storage_;
 };

--- a/src/vm/Debug.hpp
+++ b/src/vm/Debug.hpp
@@ -16,6 +16,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace il::core
@@ -89,6 +90,8 @@ class DebugCtrl
     void resetLastHit();
 
   private:
+    static std::pair<std::string, std::string> normalizePathWithBase(std::string path);
+
     mutable il::support::StringInterner interner_;   ///< Label interner
     std::unordered_set<il::support::Symbol> breaks_; ///< Registered breakpoints
 


### PR DESCRIPTION
## Summary
- reuse the shared diagnostic printer from `diag_expected` in `DiagnosticEngine::printAll`
- allow `StringInterner` to look up keys without allocating temporaries by using transparent hashing and equality
- centralize `DebugCtrl` path and basename normalization so source breakpoint handling shares one helper

## Testing
- cmake --build build -j --target viper_support
- cmake --build build -j --target il_vm
- cmake --build build -j --target test_support test_vm_normalize_path
- ctest --test-dir build --output-on-failure -R "test_support|test_vm_normalize_path"


------
https://chatgpt.com/codex/tasks/task_e_68e33e3d372c8324b260784cf6f78fc4