### PR TITLE
fix(frontends/basic): declare add operand validator

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.hpp
+++ b/src/frontends/basic/SemanticAnalyzer.hpp
@@ -269,6 +269,11 @@ class SemanticAnalyzer
                                  Type lhs,
                                  Type rhs,
                                  std::string_view diagId);
+    /// @brief Allows + for numeric+numeric and string+string.
+    void validateAddOperands(const BinaryExpr &expr,
+                             Type lhs,
+                             Type rhs,
+                             std::string_view diagId);
     /// @brief Validate division operands and detect divide-by-zero.
     void validateDivisionOperands(const BinaryExpr &expr,
                                   Type lhs,


### PR DESCRIPTION
## Summary
- declare `validateAddOperands` to cover numeric and string addition validation cases alongside existing helpers

## Testing
- not run (header-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e3e09453e4832486439ea8022c56a1