### PR TITLE
fix(frontends/basic): add string-aware add result helper

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.Exprs.cpp
+++ b/src/frontends/basic/SemanticAnalyzer.Exprs.cpp
@@ -59,6 +59,14 @@ SemanticAnalyzer::Type numericResult(SemanticAnalyzer::Type lhs,
     return (lhs == Type::Float || rhs == Type::Float) ? Type::Float : Type::Int;
 }
 
+static SemanticAnalyzer::Type addResult(SemanticAnalyzer::Type lhs,
+                                        SemanticAnalyzer::Type rhs) noexcept
+{
+    using T = SemanticAnalyzer::Type;
+    if (lhs == T::String && rhs == T::String) return T::String;
+    return (lhs == T::Float || rhs == T::Float) ? T::Float : T::Int;
+}
+
 SemanticAnalyzer::Type powResult(SemanticAnalyzer::Type,
                                  SemanticAnalyzer::Type) noexcept
 {
@@ -90,7 +98,7 @@ const ExprRule &exprRule(BinaryExpr::Op op)
     static const std::array<ExprRule, exprRuleCount()> rules = {
         {{BinaryExpr::Op::Add,
           &SemanticAnalyzer::validateNumericOperands,
-          &numericResult,
+          &addResult,
           "B2001"},
          {BinaryExpr::Op::Sub,
           &SemanticAnalyzer::validateNumericOperands,


### PR DESCRIPTION
## Summary
- add an addition result helper that returns string when both operands are string literals
- route the addition expression rule through the helper to preserve numeric promotion otherwise

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3e1873b2c8324ba9b067bd43af0d8