### PR TITLE
fix(fe/basic): allow string addition

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.Exprs.cpp
+++ b/src/frontends/basic/SemanticAnalyzer.Exprs.cpp
@@ -97,7 +97,7 @@ const ExprRule &exprRule(BinaryExpr::Op op)
 {
     static const std::array<ExprRule, exprRuleCount()> rules = {
         {{BinaryExpr::Op::Add,
-          &SemanticAnalyzer::validateNumericOperands,
+          &SemanticAnalyzer::validateAddOperands,
           &addResult,
           "B2001"},
          {BinaryExpr::Op::Sub,
@@ -324,6 +324,21 @@ void SemanticAnalyzer::validateNumericOperands(const BinaryExpr &expr,
 {
     if (!semantic_analyzer_detail::isNumericType(lhs) ||
         !semantic_analyzer_detail::isNumericType(rhs))
+    {
+        emitOperandTypeMismatch(expr, diagId);
+    }
+}
+
+void SemanticAnalyzer::validateAddOperands(const BinaryExpr &expr,
+                                           Type lhs,
+                                           Type rhs,
+                                           std::string_view diagId)
+{
+    const bool numericOk = semantic_analyzer_detail::isNumericType(lhs) &&
+                           semantic_analyzer_detail::isNumericType(rhs);
+    const bool stringOk = semantic_analyzer_detail::isStringType(lhs) &&
+                          semantic_analyzer_detail::isStringType(rhs);
+    if (!numericOk && !stringOk)
     {
         emitOperandTypeMismatch(expr, diagId);
     }


### PR DESCRIPTION
## Summary
- allow the BASIC semantic analyzer to validate string + string additions
- ensure other addition combinations still trigger the existing mismatch diagnostic

## Testing
- cmake -S . -B build
- cmake --build build -j 8
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e3e30073988324ad3d753ed2bc1d77