### PR TITLE
fix: adjust runtime string concat ownership

### DIFF
--- a/src/runtime/rt_string.c
+++ b/src/runtime/rt_string.c
@@ -190,20 +190,21 @@ int64_t rt_len(rt_string s)
  */
 rt_string rt_concat(rt_string a, rt_string b)
 {
-    size_t asz = rt_string_len_bytes(a);
-    size_t bsz = rt_string_len_bytes(b);
-    size_t total = asz + bsz;
-    rt_string s = rt_string_alloc(total, total + 1);
-    if (a && a->data && asz > 0)
-        memcpy(s->data, a->data, asz);
-    if (b && b->data && bsz > 0)
-        memcpy(s->data + asz, b->data, bsz);
-    s->data[total] = '\0';
-    if (a)
-        rt_string_unref(a);
-    if (b)
-        rt_string_unref(b);
-    return s;
+    size_t len_a = rt_string_len_bytes(a);
+    size_t len_b = rt_string_len_bytes(b);
+    size_t total = len_a + len_b;
+
+    rt_string out = rt_string_alloc(total, total + 1);
+    if (!out)
+        return NULL;
+
+    if (a && a->data && len_a > 0)
+        memcpy(out->data, a->data, len_a);
+    if (b && b->data && len_b > 0)
+        memcpy(out->data + len_a, b->data, len_b);
+
+    out->data[total] = '\0';
+    return out;
 }
 
 /**

--- a/tests/unit/test_rt_string.cpp
+++ b/tests/unit/test_rt_string.cpp
@@ -84,9 +84,11 @@ int main()
         auto *right_impl = (rt_string_impl *)right_owned;
         assert(left_impl->heap == nullptr);
         assert(right_impl->heap == nullptr);
-        assert(left_impl->literal_refs == 1);
-        assert(right_impl->literal_refs == 1);
+        assert(left_impl->literal_refs == 2);
+        assert(right_impl->literal_refs == 2);
         rt_string_unref(joined);
+        rt_string_unref(left_ref);
+        rt_string_unref(right_ref);
         rt_string_unref(left_owned);
         rt_string_unref(right_owned);
     }
@@ -98,8 +100,10 @@ int main()
         rt_string doubled = rt_concat(first, second);
         auto *base_impl = (rt_string_impl *)base;
         assert(base_impl->heap == nullptr);
-        assert(base_impl->literal_refs == 1);
+        assert(base_impl->literal_refs == 3);
         rt_string_unref(doubled);
+        rt_string_unref(first);
+        rt_string_unref(second);
         rt_string_unref(base);
     }
 


### PR DESCRIPTION
## Summary
- stop `rt_concat` from releasing its input strings and ensure the newly allocated buffer is null-terminated
- update runtime string tests to expect retained literal references and explicitly release temporary retains

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e40940add483248769eb724600f55c