### PR TITLE
feat: retain string assignments

### DIFF
--- a/src/frontends/basic/LowerRuntime.cpp
+++ b/src/frontends/basic/LowerRuntime.cpp
@@ -175,6 +175,16 @@ void Lowerer::requireLineInputChErr()
     setManualHelperRequired(ManualRuntimeHelper::LineInputChErr);
 }
 
+void Lowerer::requireStrRetainMaybe()
+{
+    setManualHelperRequired(ManualRuntimeHelper::StrRetainMaybe);
+}
+
+void Lowerer::requireStrReleaseMaybe()
+{
+    setManualHelperRequired(ManualRuntimeHelper::StrReleaseMaybe);
+}
+
 void Lowerer::requestHelper(RuntimeFeature feature)
 {
     runtimeTracker.requestHelper(feature);
@@ -214,6 +224,8 @@ void Lowerer::declareRequiredRuntime(build::IRBuilder &b)
         {"rt_close_err", ManualRuntimeHelper::CloseErr, &Lowerer::requireCloseErr},
         {"rt_println_ch_err", ManualRuntimeHelper::PrintlnChErr, &Lowerer::requirePrintlnChErr},
         {"rt_line_input_ch_err", ManualRuntimeHelper::LineInputChErr, &Lowerer::requireLineInputChErr},
+        {"rt_str_retain_maybe", ManualRuntimeHelper::StrRetainMaybe, &Lowerer::requireStrRetainMaybe},
+        {"rt_str_release_maybe", ManualRuntimeHelper::StrReleaseMaybe, &Lowerer::requireStrReleaseMaybe},
     }};
 
     auto declareManual = [&](std::string_view name) {

--- a/src/frontends/basic/LowerScan.cpp
+++ b/src/frontends/basic/LowerScan.cpp
@@ -241,6 +241,16 @@ class ScanWalker final : public BasicAstWalker<ScanWalker>
                     lowerer_.requireArrayI32Retain();
                     lowerer_.requireArrayI32Release();
                 }
+                else
+                {
+                    const auto *symInfo = lowerer_.findSymbol(var->name);
+                    Type symType = symInfo ? symInfo->type : inferAstTypeFromName(var->name);
+                    if (symType == Type::Str)
+                    {
+                        lowerer_.requireStrRetainMaybe();
+                        lowerer_.requireStrReleaseMaybe();
+                    }
+                }
             }
         }
         else if (auto *arr = dynamic_cast<const ArrayExpr *>(stmt.target.get()))

--- a/src/frontends/basic/LowerStmt.cpp
+++ b/src/frontends/basic/LowerStmt.cpp
@@ -315,7 +315,19 @@ void Lowerer::lowerLet(const LetStmt &stmt)
             {
                 v = coerceToBool(std::move(v), stmt.loc);
             }
-            emitStore(targetTy, slot, v.value);
+            if (isStr)
+            {
+                requireStrReleaseMaybe();
+                Value oldValue = emitLoad(targetTy, slot);
+                emitCall("rt_str_release_maybe", {oldValue});
+                requireStrRetainMaybe();
+                emitCall("rt_str_retain_maybe", {v.value});
+                emitStore(targetTy, slot, v.value);
+            }
+            else
+            {
+                emitStore(targetTy, slot, v.value);
+            }
         }
     }
     else if (auto *arr = dynamic_cast<const ArrayExpr *>(stmt.target.get()))

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -715,6 +715,8 @@ class Lowerer
         CloseErr,
         PrintlnChErr,
         LineInputChErr,
+        StrRetainMaybe,
+        StrReleaseMaybe,
         Count
     };
 
@@ -744,6 +746,8 @@ class Lowerer
     void requireCloseErr();
     void requirePrintlnChErr();
     void requireLineInputChErr();
+    void requireStrRetainMaybe();
+    void requireStrReleaseMaybe();
     void requestHelper(RuntimeFeature feature);
 
     bool isHelperNeeded(RuntimeFeature feature) const;

--- a/src/il/runtime/RuntimeSignatures.cpp
+++ b/src/il/runtime/RuntimeSignatures.cpp
@@ -768,6 +768,16 @@ std::vector<RuntimeDescriptor> buildRegistry()
         {Kind::Ptr},
         &DirectHandler<&rt_const_cstr, rt_string, const char *>::invoke,
         manual());
+    add("rt_str_retain_maybe",
+        Kind::Void,
+        {Kind::Str},
+        &DirectHandler<&rt_str_retain_maybe, void, rt_string>::invoke,
+        manual());
+    add("rt_str_release_maybe",
+        Kind::Void,
+        {Kind::Str},
+        &DirectHandler<&rt_str_release_maybe, void, rt_string>::invoke,
+        manual());
 
     return entries;
 }

--- a/src/runtime/rt_string.c
+++ b/src/runtime/rt_string.c
@@ -159,6 +159,16 @@ void rt_string_unref(rt_string s)
         free(s);
 }
 
+void rt_str_release_maybe(rt_string s)
+{
+    rt_string_unref(s);
+}
+
+void rt_str_retain_maybe(rt_string s)
+{
+    (void)rt_string_ref(s);
+}
+
 rt_string rt_const_cstr(const char *c)
 {
     if (!c)

--- a/src/runtime/rt_string.h
+++ b/src/runtime/rt_string.h
@@ -27,6 +27,14 @@ extern "C" {
     /// @param s String to release; may be NULL.
     void rt_string_unref(rt_string s);
 
+    /// @brief Release @p s when non-null.
+    /// @param s String handle that may be NULL.
+    void rt_str_release_maybe(rt_string s);
+
+    /// @brief Retain @p s when non-null.
+    /// @param s String handle that may be NULL.
+    void rt_str_retain_maybe(rt_string s);
+
     /// @brief Return the number of bytes stored in @p s (excluding the terminator).
     /// @param s String to measure; NULL returns 0.
     /// @return Length in bytes.

--- a/tests/basic/CMakeLists.txt
+++ b/tests/basic/CMakeLists.txt
@@ -50,6 +50,10 @@ function(viper_add_basic_main_tests)
   target_link_libraries(test_basic_lowerer_runtime_helpers PRIVATE ${VIPER_BASIC_LIBS})
   viper_add_ctest(test_basic_lowerer_runtime_helpers test_basic_lowerer_runtime_helpers)
 
+  viper_add_test(test_basic_lowerer_string_assignment ${_VIPER_BASIC_UNIT_DIR}/test_basic_lowerer_string_assignment.cpp)
+  target_link_libraries(test_basic_lowerer_string_assignment PRIVATE ${VIPER_BASIC_LIBS})
+  viper_add_ctest(test_basic_lowerer_string_assignment test_basic_lowerer_string_assignment)
+
   viper_add_test(test_basic_semantic_components ${_VIPER_BASIC_UNIT_DIR}/test_basic_semantic_components.cpp)
   target_link_libraries(test_basic_semantic_components PRIVATE ${VIPER_BASIC_LIBS})
   viper_add_ctest(test_basic_semantic_components test_basic_semantic_components)

--- a/tests/golden/basic_lowering/Instr.il
+++ b/tests/golden/basic_lowering/Instr.il
@@ -6,6 +6,8 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_instr2(str, str) -> i64
 extern @rt_instr3(i64, str, str) -> i64
+extern @rt_str_retain_maybe(str) -> void
+extern @rt_str_release_maybe(str) -> void
 global const str @.L0 = "HELLO"
 global const str @.L1 = "LL"
 global const str @.L2 = "
@@ -19,39 +21,45 @@ L10:
   .loc 1 1 13
   %t1 = const_str @.L0
   .loc 1 1 4
+  %t2 = load str, %t0
+  .loc 1 1 4
+  call @rt_str_release_maybe(%t2)
+  .loc 1 1 4
+  call @rt_str_retain_maybe(%t1)
+  .loc 1 1 4
   store str, %t0, %t1
   .loc 1 1 4
   br L20
 L20:
   .loc 1 2 16
-  %t2 = load str, %t0
+  %t3 = load str, %t0
   .loc 1 2 20
-  %t3 = const_str @.L1
+  %t4 = const_str @.L1
   .loc 1 2 20
-  %t4 = call @rt_instr2(%t2, %t3)
+  %t5 = call @rt_instr2(%t3, %t4)
   .loc 1 2 4
-  call @rt_print_i64(%t4)
+  call @rt_print_i64(%t5)
   .loc 1 2 4
-  %t5 = const_str @.L2
+  %t6 = const_str @.L2
   .loc 1 2 4
-  call @rt_print_str(%t5)
+  call @rt_print_str(%t6)
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 16
-  %t6 = iadd.ovf 3, -1
+  %t7 = iadd.ovf 3, -1
   .loc 1 3 19
-  %t7 = load str, %t0
+  %t8 = load str, %t0
   .loc 1 3 23
-  %t8 = const_str @.L3
+  %t9 = const_str @.L3
   .loc 1 3 23
-  %t9 = call @rt_instr3(%t6, %t7, %t8)
+  %t10 = call @rt_instr3(%t7, %t8, %t9)
   .loc 1 3 4
-  call @rt_print_i64(%t9)
+  call @rt_print_i64(%t10)
   .loc 1 3 4
-  %t10 = const_str @.L2
+  %t11 = const_str @.L2
   .loc 1 3 4
-  call @rt_print_str(%t10)
+  call @rt_print_str(%t11)
   .loc 1 3 4
   br L40
 L40:

--- a/tests/golden/basic_lowering/LenMid.il
+++ b/tests/golden/basic_lowering/LenMid.il
@@ -6,6 +6,8 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_mid2(str, i64) -> str
 extern @rt_mid3(str, i64, i64) -> str
+extern @rt_str_retain_maybe(str) -> void
+extern @rt_str_release_maybe(str) -> void
 global const str @.L0 = "HELLO"
 global const str @.L1 = "
 "
@@ -17,50 +19,56 @@ L10:
   .loc 1 1 13
   %t1 = const_str @.L0
   .loc 1 1 4
+  %t2 = load str, %t0
+  .loc 1 1 4
+  call @rt_str_release_maybe(%t2)
+  .loc 1 1 4
+  call @rt_str_retain_maybe(%t1)
+  .loc 1 1 4
   store str, %t0, %t1
   .loc 1 1 4
   br L20
 L20:
   .loc 1 2 14
-  %t2 = load str, %t0
+  %t3 = load str, %t0
   .loc 1 2 10
-  %t3 = call @rt_len(%t2)
+  %t4 = call @rt_len(%t3)
   .loc 1 2 4
-  call @rt_print_i64(%t3)
+  call @rt_print_i64(%t4)
   .loc 1 2 4
-  %t4 = const_str @.L1
+  %t5 = const_str @.L1
   .loc 1 2 4
-  call @rt_print_str(%t4)
+  call @rt_print_str(%t5)
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 15
-  %t5 = load str, %t0
+  %t6 = load str, %t0
   .loc 1 3 19
-  %t6 = iadd.ovf 2, -1
+  %t7 = iadd.ovf 2, -1
   .loc 1 3 22
-  %t7 = call @rt_mid3(%t5, %t6, 3)
-  .loc 1 3 4
-  call @rt_print_str(%t7)
-  .loc 1 3 4
-  %t8 = const_str @.L1
+  %t8 = call @rt_mid3(%t6, %t7, 3)
   .loc 1 3 4
   call @rt_print_str(%t8)
+  .loc 1 3 4
+  %t9 = const_str @.L1
+  .loc 1 3 4
+  call @rt_print_str(%t9)
   .loc 1 3 4
   br L40
 L40:
   .loc 1 4 15
-  %t9 = load str, %t0
+  %t10 = load str, %t0
   .loc 1 4 19
-  %t10 = iadd.ovf 3, -1
+  %t11 = iadd.ovf 3, -1
   .loc 1 4 10
-  %t11 = call @rt_mid2(%t9, %t10)
-  .loc 1 4 4
-  call @rt_print_str(%t11)
-  .loc 1 4 4
-  %t12 = const_str @.L1
+  %t12 = call @rt_mid2(%t10, %t11)
   .loc 1 4 4
   call @rt_print_str(%t12)
+  .loc 1 4 4
+  %t13 = const_str @.L1
+  .loc 1 4 4
+  call @rt_print_str(%t13)
   .loc 1 4 4
   br L50
 L50:

--- a/tests/golden/basic_lowering/SuffixFreeVars.il
+++ b/tests/golden/basic_lowering/SuffixFreeVars.il
@@ -11,6 +11,8 @@ extern @rt_arr_i32_set(ptr, i64, i64) -> void
 extern @rt_arr_i32_retain(ptr) -> void
 extern @rt_arr_i32_release(ptr) -> void
 extern @rt_arr_oob_panic(i64, i64) -> void
+extern @rt_str_retain_maybe(str) -> void
+extern @rt_str_release_maybe(str) -> void
 global const str @.L0 = "ok"
 global const str @.L1 = "
 "
@@ -38,6 +40,12 @@ L-999999997:
   .loc 1 4 15
   %t7 = const_str @.L0
   .loc 1 4 1
+  %t8 = load str, %t2
+  .loc 1 4 1
+  call @rt_str_release_maybe(%t8)
+  .loc 1 4 1
+  call @rt_str_retain_maybe(%t7)
+  .loc 1 4 1
   store str, %t2, %t7
   .loc 1 4 1
   br L-999999996
@@ -48,69 +56,69 @@ L-999999996:
   br L-999999995
 L-999999995:
   .loc 1 6 17
-  %t8 = load i64, %t1
+  %t9 = load i64, %t1
   .loc 1 6 17
-  %t9 = load ptr, %t0
+  %t10 = load ptr, %t0
   .loc 1 6 5
-  %t10 = call @rt_arr_i32_len(%t9)
+  %t11 = call @rt_arr_i32_len(%t10)
   .loc 1 6 5
-  %t11 = scmp_lt 0, 0
+  %t12 = scmp_lt 0, 0
   .loc 1 6 5
-  %t12 = scmp_ge 0, %t10
-  .loc 1 6 5
-  %t13 = zext1 %t11
+  %t13 = scmp_ge 0, %t11
   .loc 1 6 5
   %t14 = zext1 %t12
   .loc 1 6 5
-  %t15 = or %t13, %t14
+  %t15 = zext1 %t13
   .loc 1 6 5
-  %t16 = icmp_ne %t15, 0
+  %t16 = or %t14, %t15
   .loc 1 6 5
-  cbr %t16, bc_oob0, bc_ok0
+  %t17 = icmp_ne %t16, 0
+  .loc 1 6 5
+  cbr %t17, bc_oob0, bc_ok0
 L-999999994:
   .loc 1 7 7
-  %t17 = load str, %t2
-  .loc 1 7 1
-  call @rt_print_str(%t17)
-  .loc 1 7 1
-  %t18 = const_str @.L1
+  %t18 = load str, %t2
   .loc 1 7 1
   call @rt_print_str(%t18)
+  .loc 1 7 1
+  %t19 = const_str @.L1
+  .loc 1 7 1
+  call @rt_print_str(%t19)
   .loc 1 7 1
   br L-999999993
 L-999999993:
   .loc 1 8 7
-  %t19 = load i64, %t1
+  %t20 = load i64, %t1
   .loc 1 8 1
-  call @rt_print_i64(%t19)
+  call @rt_print_i64(%t20)
   .loc 1 8 1
-  %t20 = const_str @.L1
+  %t21 = const_str @.L1
   .loc 1 8 1
-  call @rt_print_str(%t20)
+  call @rt_print_str(%t21)
   .loc 1 8 1
   br L-999999992
 L-999999992:
   .loc 1 9 7
-  %t21 = load ptr, %t0
+  %t22 = load ptr, %t0
   .loc 1 9 7
-  %t22 = call @rt_arr_i32_len(%t21)
+  %t23 = call @rt_arr_i32_len(%t22)
   .loc 1 9 7
-  %t23 = scmp_lt 0, 0
+  %t24 = scmp_lt 0, 0
   .loc 1 9 7
-  %t24 = scmp_ge 0, %t22
-  .loc 1 9 7
-  %t25 = zext1 %t23
+  %t25 = scmp_ge 0, %t23
   .loc 1 9 7
   %t26 = zext1 %t24
   .loc 1 9 7
-  %t27 = or %t25, %t26
+  %t27 = zext1 %t25
   .loc 1 9 7
-  %t28 = icmp_ne %t27, 0
+  %t28 = or %t26, %t27
   .loc 1 9 7
-  cbr %t28, bc_oob1, bc_ok1
+  %t29 = icmp_ne %t28, 0
+  .loc 1 9 7
+  cbr %t29, bc_oob1, bc_ok1
 exit:
-  %t31 = load ptr, %t0
-  call @rt_arr_i32_release(%t31)
+  %t32 = load ptr, %t0
+  call @rt_arr_i32_release(%t32)
   store ptr, %t0, null
   ret 0
 dim_len_fail:
@@ -131,28 +139,28 @@ dim_len_cont:
   br L-999999997
 bc_ok0:
   .loc 1 6 1
-  call @rt_arr_i32_set(%t9, 0, %t8)
+  call @rt_arr_i32_set(%t10, 0, %t9)
   .loc 1 6 1
   br L-999999994
 bc_oob0:
   .loc 1 6 5
-  call @rt_arr_oob_panic(0, %t10)
+  call @rt_arr_oob_panic(0, %t11)
   .loc 1 6 5
   trap
 bc_ok1:
   .loc 1 9 7
-  %t29 = call @rt_arr_i32_get(%t21, 0)
+  %t30 = call @rt_arr_i32_get(%t22, 0)
   .loc 1 9 1
-  call @rt_print_i64(%t29)
+  call @rt_print_i64(%t30)
   .loc 1 9 1
-  %t30 = const_str @.L1
+  %t31 = const_str @.L1
   .loc 1 9 1
-  call @rt_print_str(%t30)
+  call @rt_print_str(%t31)
   .loc 1 9 1
   br exit
 bc_oob1:
   .loc 1 9 7
-  call @rt_arr_oob_panic(0, %t22)
+  call @rt_arr_oob_panic(0, %t23)
   .loc 1 9 7
   trap
 }

--- a/tests/golden/basic_to_il/conversions.il
+++ b/tests/golden/basic_to_il/conversions.il
@@ -11,6 +11,8 @@ extern @rt_val(str) -> f64
 extern @rt_val_to_double(ptr, ptr) -> f64
 extern @rt_string_cstr(str) -> ptr
 extern @rt_int_floor(f64) -> f64
+extern @rt_str_retain_maybe(str) -> void
+extern @rt_str_release_maybe(str) -> void
 global const str @.L0 = " "
 global const str @.L1 = "
 "
@@ -62,22 +64,28 @@ L40:
   .loc 1 4 13
   %t12 = const_str @.L2
   .loc 1 4 4
+  %t13 = load str, %t2
+  .loc 1 4 4
+  call @rt_str_release_maybe(%t13)
+  .loc 1 4 4
+  call @rt_str_retain_maybe(%t12)
+  .loc 1 4 4
   store str, %t2, %t12
   .loc 1 4 4
   br L50
 L50:
   .loc 1 5 14
-  %t13 = load str, %t2
+  %t14 = load str, %t2
   .loc 1 5 14
-  %t14 = call @rt_string_cstr(%t13)
+  %t15 = call @rt_string_cstr(%t14)
   .loc 1 5 14
-  %t15 = alloca 1
+  %t16 = alloca 1
   .loc 1 5 14
-  %t16 = call @rt_val_to_double(%t14, %t15)
+  %t17 = call @rt_val_to_double(%t15, %t16)
   .loc 1 5 14
-  %t17 = load i1, %t15
+  %t18 = load i1, %t16
   .loc 1 5 14
-  cbr %t17, val_ok, val_fail
+  cbr %t18, val_ok, val_fail
 L60:
   .loc 1 6 4
   store f64, %t1, 1.8999999999999999
@@ -90,25 +98,25 @@ L70:
   br L80
 L80:
   .loc 1 8 14
-  %t22 = load f64, %t1
+  %t23 = load f64, %t1
   .loc 1 8 10
-  %t23 = call @rt_int_floor(%t22)
+  %t24 = call @rt_int_floor(%t23)
   .loc 1 8 4
-  call @rt_print_f64(%t23)
+  call @rt_print_f64(%t24)
   .loc 1 8 4
-  %t24 = const_str @.L0
+  %t25 = const_str @.L0
   .loc 1 8 4
-  call @rt_print_str(%t24)
+  call @rt_print_str(%t25)
   .loc 1 8 23
-  %t25 = load f64, %t0
+  %t26 = load f64, %t0
   .loc 1 8 19
-  %t26 = call @rt_int_floor(%t25)
+  %t27 = call @rt_int_floor(%t26)
   .loc 1 8 4
-  call @rt_print_f64(%t26)
+  call @rt_print_f64(%t27)
   .loc 1 8 4
-  %t27 = const_str @.L1
+  %t28 = const_str @.L1
   .loc 1 8 4
-  call @rt_print_str(%t27)
+  call @rt_print_str(%t28)
   .loc 1 8 4
   br L90
 L90:
@@ -118,26 +126,26 @@ exit:
   ret 0
 val_ok:
   .loc 1 5 4
-  call @rt_print_f64(%t16)
+  call @rt_print_f64(%t17)
   .loc 1 5 4
-  %t21 = const_str @.L1
+  %t22 = const_str @.L1
   .loc 1 5 4
-  call @rt_print_str(%t21)
+  call @rt_print_str(%t22)
   .loc 1 5 4
   br L60
 val_fail:
   .loc 1 5 14
-  %t18 = fcmp_ne %t16, %t16
+  %t19 = fcmp_ne %t17, %t17
   .loc 1 5 14
-  cbr %t18, val_nan, val_over
+  cbr %t19, val_nan, val_over
 val_nan:
   .loc 1 5 14
-  %t19 = cast.fp_to_si.rte.chk nan
+  %t20 = cast.fp_to_si.rte.chk nan
   .loc 1 5 14
   trap
 val_over:
   .loc 1 5 14
-  %t20 = cast.fp_to_si.rte.chk 1.7976931348623157e+308
+  %t21 = cast.fp_to_si.rte.chk 1.7976931348623157e+308
   .loc 1 5 14
   trap
 }

--- a/tests/golden/basic_to_il/instr.il
+++ b/tests/golden/basic_to_il/instr.il
@@ -6,6 +6,8 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_instr2(str, str) -> i64
 extern @rt_instr3(i64, str, str) -> i64
+extern @rt_str_retain_maybe(str) -> void
+extern @rt_str_release_maybe(str) -> void
 global const str @.L0 = "HELLO"
 global const str @.L1 = "LL"
 global const str @.L2 = "
@@ -19,39 +21,45 @@ L10:
   .loc 1 1 13
   %t1 = const_str @.L0
   .loc 1 1 4
+  %t2 = load str, %t0
+  .loc 1 1 4
+  call @rt_str_release_maybe(%t2)
+  .loc 1 1 4
+  call @rt_str_retain_maybe(%t1)
+  .loc 1 1 4
   store str, %t0, %t1
   .loc 1 1 4
   br L20
 L20:
   .loc 1 2 16
-  %t2 = load str, %t0
+  %t3 = load str, %t0
   .loc 1 2 20
-  %t3 = const_str @.L1
+  %t4 = const_str @.L1
   .loc 1 2 20
-  %t4 = call @rt_instr2(%t2, %t3)
+  %t5 = call @rt_instr2(%t3, %t4)
   .loc 1 2 4
-  call @rt_print_i64(%t4)
+  call @rt_print_i64(%t5)
   .loc 1 2 4
-  %t5 = const_str @.L2
+  %t6 = const_str @.L2
   .loc 1 2 4
-  call @rt_print_str(%t5)
+  call @rt_print_str(%t6)
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 16
-  %t6 = iadd.ovf 3, -1
+  %t7 = iadd.ovf 3, -1
   .loc 1 3 19
-  %t7 = load str, %t0
+  %t8 = load str, %t0
   .loc 1 3 23
-  %t8 = const_str @.L3
+  %t9 = const_str @.L3
   .loc 1 3 23
-  %t9 = call @rt_instr3(%t6, %t7, %t8)
+  %t10 = call @rt_instr3(%t7, %t8, %t9)
   .loc 1 3 4
-  call @rt_print_i64(%t9)
+  call @rt_print_i64(%t10)
   .loc 1 3 4
-  %t10 = const_str @.L2
+  %t11 = const_str @.L2
   .loc 1 3 4
-  call @rt_print_str(%t10)
+  call @rt_print_str(%t11)
   .loc 1 3 4
   br L40
 L40:

--- a/tests/golden/basic_to_il/string_cmp.il
+++ b/tests/golden/basic_to_il/string_cmp.il
@@ -5,6 +5,8 @@ extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_str_eq(str, str) -> i1
+extern @rt_str_retain_maybe(str) -> void
+extern @rt_str_release_maybe(str) -> void
 global const str @.L0 = "HELLO"
 global const str @.L1 = "
 "
@@ -16,6 +18,12 @@ entry:
 L10:
   .loc 1 1 13
   %t1 = const_str @.L0
+  .loc 1 1 4
+  %t2 = load str, %t0
+  .loc 1 1 4
+  call @rt_str_release_maybe(%t2)
+  .loc 1 1 4
+  call @rt_str_retain_maybe(%t1)
   .loc 1 1 4
   store str, %t0, %t1
   .loc 1 1 4
@@ -33,26 +41,26 @@ exit:
   ret 0
 if_test_0:
   .loc 1 2 7
-  %t2 = load str, %t0
+  %t3 = load str, %t0
   .loc 1 2 12
-  %t3 = const_str @.L0
+  %t4 = const_str @.L0
   .loc 1 2 10
-  %t4 = call @rt_str_eq(%t2, %t3)
+  %t5 = call @rt_str_eq(%t3, %t4)
   .loc 1 2 10
-  %t5 = zext1 %t4
+  %t6 = zext1 %t5
   .loc 1 2 10
-  %t6 = isub.ovf 0, %t5
+  %t7 = isub.ovf 0, %t6
   .loc 1 2 4
-  %t7 = trunc1 %t6
+  %t8 = trunc1 %t7
   .loc 1 2 4
-  cbr %t7, if_then_0, if_else
+  cbr %t8, if_then_0, if_else
 if_then_0:
   .loc 1 2 25
   call @rt_print_i64(1)
   .loc 1 2 25
-  %t8 = const_str @.L1
+  %t9 = const_str @.L1
   .loc 1 2 25
-  call @rt_print_str(%t8)
+  call @rt_print_str(%t9)
   .loc 1 2 4
   br if_exit
 if_else:
@@ -63,28 +71,28 @@ if_exit:
   br L30
 if_test_01:
   .loc 1 3 7
-  %t9 = load str, %t0
+  %t10 = load str, %t0
   .loc 1 3 13
-  %t10 = const_str @.L2
+  %t11 = const_str @.L2
   .loc 1 3 10
-  %t11 = call @rt_str_eq(%t9, %t10)
+  %t12 = call @rt_str_eq(%t10, %t11)
   .loc 1 3 10
-  %t12 = zext1 %t11
+  %t13 = zext1 %t12
   .loc 1 3 10
-  %t13 = isub.ovf 0, %t12
+  %t14 = isub.ovf 0, %t13
   .loc 1 3 10
-  %t14 = xor %t13, -1
+  %t15 = xor %t14, -1
   .loc 1 3 4
-  %t15 = trunc1 %t14
+  %t16 = trunc1 %t15
   .loc 1 3 4
-  cbr %t15, if_then_01, if_else1
+  cbr %t16, if_then_01, if_else1
 if_then_01:
   .loc 1 3 22
   call @rt_print_i64(2)
   .loc 1 3 22
-  %t16 = const_str @.L1
+  %t17 = const_str @.L1
   .loc 1 3 22
-  call @rt_print_str(%t16)
+  call @rt_print_str(%t17)
   .loc 1 3 4
   br if_exit1
 if_else1:

--- a/tests/golden/basic_to_il/strings.il
+++ b/tests/golden/basic_to_il/strings.il
@@ -8,6 +8,8 @@ extern @rt_left(str, i64) -> str
 extern @rt_right(str, i64) -> str
 extern @rt_mid2(str, i64) -> str
 extern @rt_mid3(str, i64, i64) -> str
+extern @rt_str_retain_maybe(str) -> void
+extern @rt_str_release_maybe(str) -> void
 global const str @.L0 = "HELLO"
 global const str @.L1 = "
 "
@@ -19,76 +21,82 @@ L10:
   .loc 1 1 13
   %t1 = const_str @.L0
   .loc 1 1 4
+  %t2 = load str, %t0
+  .loc 1 1 4
+  call @rt_str_release_maybe(%t2)
+  .loc 1 1 4
+  call @rt_str_retain_maybe(%t1)
+  .loc 1 1 4
   store str, %t0, %t1
   .loc 1 1 4
   br L20
 L20:
   .loc 1 2 14
-  %t2 = load str, %t0
+  %t3 = load str, %t0
   .loc 1 2 10
-  %t3 = call @rt_len(%t2)
+  %t4 = call @rt_len(%t3)
   .loc 1 2 4
-  call @rt_print_i64(%t3)
+  call @rt_print_i64(%t4)
   .loc 1 2 4
-  %t4 = const_str @.L1
+  %t5 = const_str @.L1
   .loc 1 2 4
-  call @rt_print_str(%t4)
+  call @rt_print_str(%t5)
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 15
-  %t5 = load str, %t0
+  %t6 = load str, %t0
   .loc 1 3 19
-  %t6 = iadd.ovf 2, -1
+  %t7 = iadd.ovf 2, -1
   .loc 1 3 22
-  %t7 = call @rt_mid3(%t5, %t6, 3)
-  .loc 1 3 4
-  call @rt_print_str(%t7)
-  .loc 1 3 4
-  %t8 = const_str @.L1
+  %t8 = call @rt_mid3(%t6, %t7, 3)
   .loc 1 3 4
   call @rt_print_str(%t8)
+  .loc 1 3 4
+  %t9 = const_str @.L1
+  .loc 1 3 4
+  call @rt_print_str(%t9)
   .loc 1 3 4
   br L40
 L40:
   .loc 1 4 15
-  %t9 = load str, %t0
+  %t10 = load str, %t0
   .loc 1 4 19
-  %t10 = iadd.ovf 3, -1
+  %t11 = iadd.ovf 3, -1
   .loc 1 4 10
-  %t11 = call @rt_mid2(%t9, %t10)
-  .loc 1 4 4
-  call @rt_print_str(%t11)
-  .loc 1 4 4
-  %t12 = const_str @.L1
+  %t12 = call @rt_mid2(%t10, %t11)
   .loc 1 4 4
   call @rt_print_str(%t12)
+  .loc 1 4 4
+  %t13 = const_str @.L1
+  .loc 1 4 4
+  call @rt_print_str(%t13)
   .loc 1 4 4
   br L50
 L50:
   .loc 1 5 16
-  %t13 = load str, %t0
+  %t14 = load str, %t0
   .loc 1 5 10
-  %t14 = call @rt_left(%t13, 2)
-  .loc 1 5 4
-  call @rt_print_str(%t14)
-  .loc 1 5 4
-  %t15 = const_str @.L1
+  %t15 = call @rt_left(%t14, 2)
   .loc 1 5 4
   call @rt_print_str(%t15)
+  .loc 1 5 4
+  %t16 = const_str @.L1
+  .loc 1 5 4
+  call @rt_print_str(%t16)
   .loc 1 5 4
   br L60
 L60:
   .loc 1 6 17
-  %t16 = load str, %t0
+  %t17 = load str, %t0
   .loc 1 6 10
-  %t17 = call @rt_right(%t16, 2)
-  .loc 1 6 4
-  call @rt_print_str(%t17)
-  .loc 1 6 4
-  %t18 = const_str @.L1
+  %t18 = call @rt_right(%t17, 2)
   .loc 1 6 4
   call @rt_print_str(%t18)
+  .loc 1 6 4
+  %t19 = const_str @.L1
+  .loc 1 6 4
+  call @rt_print_str(%t19)
   .loc 1 6 4
   br L70
 L70:

--- a/tests/unit/test_basic_lowerer_string_assignment.cpp
+++ b/tests/unit/test_basic_lowerer_string_assignment.cpp
@@ -1,0 +1,94 @@
+// File: tests/unit/test_basic_lowerer_string_assignment.cpp
+// Purpose: Verify BASIC lowerer retains and releases strings on assignment.
+// Key invariants: String variables release old values before retaining new ones.
+// Ownership: Test owns parser, lowerer, and resulting module.
+// Links: docs/codemap.md
+
+#include "frontends/basic/Lowerer.hpp"
+#include "frontends/basic/Parser.hpp"
+#include "support/source_manager.hpp"
+#include <cassert>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+using namespace il::frontends::basic;
+using namespace il::support;
+
+namespace
+{
+
+std::unordered_set<std::string> collectExternNames(const il::core::Module &module)
+{
+    std::unordered_set<std::string> names;
+    for (const auto &ext : module.externs)
+        names.insert(ext.name);
+    return names;
+}
+
+} // namespace
+
+int main()
+{
+    const std::string src =
+        "10 LET S$ = \"HELLO\"\n"
+        "20 LET S$ = \"WORLD\"\n";
+
+    SourceManager sm;
+    uint32_t fid = sm.addFile("string_assign.bas");
+    Parser parser(src, fid);
+    auto program = parser.parseProgram();
+    assert(program);
+
+    Lowerer lowerer;
+    il::core::Module module = lowerer.lowerProgram(*program);
+
+    auto externs = collectExternNames(module);
+    assert(externs.count("rt_str_release_maybe") == 1);
+    assert(externs.count("rt_str_retain_maybe") == 1);
+
+    const il::core::Function *mainFn = nullptr;
+    for (const auto &fn : module.functions)
+    {
+        if (fn.name == "main")
+        {
+            mainFn = &fn;
+            break;
+        }
+    }
+    assert(mainFn);
+
+    std::unordered_map<int, int> releaseCounts;
+    std::unordered_map<int, int> retainCounts;
+    std::unordered_set<int> assignmentLines;
+
+    for (const auto &block : mainFn->blocks)
+    {
+        for (const auto &instr : block.instructions)
+        {
+            if (instr.op != il::core::Opcode::Call)
+                continue;
+            const int line = instr.loc.line;
+            if (instr.callee == "rt_str_release_maybe")
+            {
+                ++releaseCounts[line];
+                assignmentLines.insert(line);
+            }
+            else if (instr.callee == "rt_str_retain_maybe")
+            {
+                assert(releaseCounts[line] > 0);
+                ++retainCounts[line];
+                assignmentLines.insert(line);
+            }
+        }
+    }
+
+    assert(assignmentLines.size() == 2);
+    for (int line : assignmentLines)
+    {
+        assert(releaseCounts[line] == 1);
+        assert(retainCounts[line] == 1);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- release old string values and retain new ones when lowering LET assignments
- declare and expose runtime helpers for conditional string retain/release and request them during scans
- update goldens and add a unit test covering helper emission and call ordering

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68e40d51dd44832482d62db7a7b98730