### PR TITLE
fix(runtime): guard maybe string retain/release wrappers

### DIFF
--- a/src/runtime/rt_string.c
+++ b/src/runtime/rt_string.c
@@ -161,11 +161,15 @@ void rt_string_unref(rt_string s)
 
 void rt_str_release_maybe(rt_string s)
 {
+    if (!s || !s->data)
+        return;
     rt_string_unref(s);
 }
 
 void rt_str_retain_maybe(rt_string s)
 {
+    if (!s || !s->data)
+        return;
     (void)rt_string_ref(s);
 }
 


### PR DESCRIPTION
## Summary
- guard `rt_str_retain_maybe` and `rt_str_release_maybe` from handling null handles before touching underlying storage

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e4165f7cc4832491529f090c816ebf