### PR TITLE
Fix BASIC string locals initialization

### DIFF
--- a/src/frontends/basic/Lowerer.cpp
+++ b/src/frontends/basic/Lowerer.cpp
@@ -743,6 +743,11 @@ void Lowerer::allocateLocalSlots(const std::unordered_set<std::string> &paramNam
         info.slotId = slot.id;
         if (slotInfo.isBoolean)
             emitStore(ilBoolTy(), slot, emitBoolConst(false));
+        else if (slotInfo.type.kind == Type::Kind::Str)
+        {
+            Value empty = emitCallRet(slotInfo.type, "rt_str_empty", {});
+            emitStore(slotInfo.type, slot, empty);
+        }
     }
 
     if (!boundsChecks)

--- a/src/il/runtime/RuntimeSignatures.cpp
+++ b/src/il/runtime/RuntimeSignatures.cpp
@@ -763,6 +763,11 @@ std::vector<RuntimeDescriptor> buildRegistry()
         {Kind::I32, Kind::Ptr},
         &DirectHandler<&rt_line_input_ch_err, int32_t, int32_t, ViperString **>::invoke,
         manual());
+    add("rt_str_empty",
+        Kind::Str,
+        {},
+        &DirectHandler<&rt_str_empty, rt_string>::invoke,
+        always());
     add("rt_const_cstr",
         Kind::Str,
         {Kind::Ptr},

--- a/src/runtime/rt_string.c
+++ b/src/runtime/rt_string.c
@@ -169,6 +169,11 @@ void rt_str_retain_maybe(rt_string s)
     (void)rt_string_ref(s);
 }
 
+rt_string rt_str_empty(void)
+{
+    return rt_empty_string();
+}
+
 rt_string rt_const_cstr(const char *c)
 {
     if (!c)

--- a/src/runtime/rt_string.h
+++ b/src/runtime/rt_string.h
@@ -35,6 +35,8 @@ extern "C" {
     /// @param s String handle that may be NULL.
     void rt_str_retain_maybe(rt_string s);
 
+    rt_string rt_str_empty(void);
+
     /// @brief Return the number of bytes stored in @p s (excluding the terminator).
     /// @param s String to measure; NULL returns 0.
     /// @return Length in bytes.

--- a/tests/golden/basic_lowering/Instr.il
+++ b/tests/golden/basic_lowering/Instr.il
@@ -6,6 +6,7 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_instr2(str, str) -> i64
 extern @rt_instr3(i64, str, str) -> i64
+extern @rt_str_empty() -> str
 extern @rt_str_retain_maybe(str) -> void
 extern @rt_str_release_maybe(str) -> void
 global const str @.L0 = "HELLO"
@@ -16,50 +17,52 @@ global const str @.L3 = "L"
 func @main() -> i64 {
 entry:
   %t0 = alloca 8
+  %t1 = call @rt_str_empty()
+  store str, %t0, %t1
   br L10
 L10:
   .loc 1 1 13
-  %t1 = const_str @.L0
+  %t2 = const_str @.L0
   .loc 1 1 4
-  %t2 = load str, %t0
+  %t3 = load str, %t0
   .loc 1 1 4
-  call @rt_str_release_maybe(%t2)
+  call @rt_str_release_maybe(%t3)
   .loc 1 1 4
-  call @rt_str_retain_maybe(%t1)
+  call @rt_str_retain_maybe(%t2)
   .loc 1 1 4
-  store str, %t0, %t1
+  store str, %t0, %t2
   .loc 1 1 4
   br L20
 L20:
   .loc 1 2 16
-  %t3 = load str, %t0
+  %t4 = load str, %t0
   .loc 1 2 20
-  %t4 = const_str @.L1
+  %t5 = const_str @.L1
   .loc 1 2 20
-  %t5 = call @rt_instr2(%t3, %t4)
+  %t6 = call @rt_instr2(%t4, %t5)
   .loc 1 2 4
-  call @rt_print_i64(%t5)
+  call @rt_print_i64(%t6)
   .loc 1 2 4
-  %t6 = const_str @.L2
+  %t7 = const_str @.L2
   .loc 1 2 4
-  call @rt_print_str(%t6)
+  call @rt_print_str(%t7)
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 16
-  %t7 = iadd.ovf 3, -1
+  %t8 = iadd.ovf 3, -1
   .loc 1 3 19
-  %t8 = load str, %t0
+  %t9 = load str, %t0
   .loc 1 3 23
-  %t9 = const_str @.L3
+  %t10 = const_str @.L3
   .loc 1 3 23
-  %t10 = call @rt_instr3(%t7, %t8, %t9)
+  %t11 = call @rt_instr3(%t8, %t9, %t10)
   .loc 1 3 4
-  call @rt_print_i64(%t10)
+  call @rt_print_i64(%t11)
   .loc 1 3 4
-  %t11 = const_str @.L2
+  %t12 = const_str @.L2
   .loc 1 3 4
-  call @rt_print_str(%t11)
+  call @rt_print_str(%t12)
   .loc 1 3 4
   br L40
 L40:

--- a/tests/golden/basic_lowering/LenMid.il
+++ b/tests/golden/basic_lowering/LenMid.il
@@ -6,6 +6,7 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_mid2(str, i64) -> str
 extern @rt_mid3(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 extern @rt_str_retain_maybe(str) -> void
 extern @rt_str_release_maybe(str) -> void
 global const str @.L0 = "HELLO"
@@ -14,61 +15,63 @@ global const str @.L1 = "
 func @main() -> i64 {
 entry:
   %t0 = alloca 8
+  %t1 = call @rt_str_empty()
+  store str, %t0, %t1
   br L10
 L10:
   .loc 1 1 13
-  %t1 = const_str @.L0
+  %t2 = const_str @.L0
   .loc 1 1 4
-  %t2 = load str, %t0
+  %t3 = load str, %t0
   .loc 1 1 4
-  call @rt_str_release_maybe(%t2)
+  call @rt_str_release_maybe(%t3)
   .loc 1 1 4
-  call @rt_str_retain_maybe(%t1)
+  call @rt_str_retain_maybe(%t2)
   .loc 1 1 4
-  store str, %t0, %t1
+  store str, %t0, %t2
   .loc 1 1 4
   br L20
 L20:
   .loc 1 2 14
-  %t3 = load str, %t0
+  %t4 = load str, %t0
   .loc 1 2 10
-  %t4 = call @rt_len(%t3)
+  %t5 = call @rt_len(%t4)
   .loc 1 2 4
-  call @rt_print_i64(%t4)
+  call @rt_print_i64(%t5)
   .loc 1 2 4
-  %t5 = const_str @.L1
+  %t6 = const_str @.L1
   .loc 1 2 4
-  call @rt_print_str(%t5)
+  call @rt_print_str(%t6)
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 15
-  %t6 = load str, %t0
+  %t7 = load str, %t0
   .loc 1 3 19
-  %t7 = iadd.ovf 2, -1
+  %t8 = iadd.ovf 2, -1
   .loc 1 3 22
-  %t8 = call @rt_mid3(%t6, %t7, 3)
-  .loc 1 3 4
-  call @rt_print_str(%t8)
-  .loc 1 3 4
-  %t9 = const_str @.L1
+  %t9 = call @rt_mid3(%t7, %t8, 3)
   .loc 1 3 4
   call @rt_print_str(%t9)
+  .loc 1 3 4
+  %t10 = const_str @.L1
+  .loc 1 3 4
+  call @rt_print_str(%t10)
   .loc 1 3 4
   br L40
 L40:
   .loc 1 4 15
-  %t10 = load str, %t0
+  %t11 = load str, %t0
   .loc 1 4 19
-  %t11 = iadd.ovf 3, -1
+  %t12 = iadd.ovf 3, -1
   .loc 1 4 10
-  %t12 = call @rt_mid2(%t10, %t11)
-  .loc 1 4 4
-  call @rt_print_str(%t12)
-  .loc 1 4 4
-  %t13 = const_str @.L1
+  %t13 = call @rt_mid2(%t11, %t12)
   .loc 1 4 4
   call @rt_print_str(%t13)
+  .loc 1 4 4
+  %t14 = const_str @.L1
+  .loc 1 4 4
+  call @rt_print_str(%t14)
   .loc 1 4 4
   br L50
 L50:

--- a/tests/golden/basic_lowering/LowerProgramWithProc.il
+++ b/tests/golden/basic_lowering/LowerProgramWithProc.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @F() -> i64 {

--- a/tests/golden/basic_lowering/ReturnNest.il
+++ b/tests/golden/basic_lowering/ReturnNest.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @F() -> i64 {

--- a/tests/golden/basic_lowering/SuffixFreeVars.il
+++ b/tests/golden/basic_lowering/SuffixFreeVars.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 extern @rt_arr_i32_new(i64) -> ptr
 extern @rt_arr_i32_len(ptr) -> i64
 extern @rt_arr_i32_get(ptr, i64) -> i64
@@ -22,6 +23,8 @@ entry:
   store ptr, %t0, null
   %t1 = alloca 8
   %t2 = alloca 8
+  %t3 = call @rt_str_empty()
+  store str, %t2, %t3
   br L-1000000000
 L-1000000000:
   .loc 1 1 1
@@ -31,22 +34,22 @@ L-999999999:
   br L-999999998
 L-999999998:
   .loc 1 3 1
-  %t3 = iadd.ovf 2, 1
+  %t4 = iadd.ovf 2, 1
   .loc 1 3 1
-  %t4 = scmp_lt %t3, 0
+  %t5 = scmp_lt %t4, 0
   .loc 1 3 1
-  cbr %t4, dim_len_fail, dim_len_cont
+  cbr %t5, dim_len_fail, dim_len_cont
 L-999999997:
   .loc 1 4 15
-  %t7 = const_str @.L0
+  %t8 = const_str @.L0
   .loc 1 4 1
-  %t8 = load str, %t2
+  %t9 = load str, %t2
   .loc 1 4 1
-  call @rt_str_release_maybe(%t8)
+  call @rt_str_release_maybe(%t9)
   .loc 1 4 1
-  call @rt_str_retain_maybe(%t7)
+  call @rt_str_retain_maybe(%t8)
   .loc 1 4 1
-  store str, %t2, %t7
+  store str, %t2, %t8
   .loc 1 4 1
   br L-999999996
 L-999999996:
@@ -56,69 +59,69 @@ L-999999996:
   br L-999999995
 L-999999995:
   .loc 1 6 17
-  %t9 = load i64, %t1
+  %t10 = load i64, %t1
   .loc 1 6 17
-  %t10 = load ptr, %t0
+  %t11 = load ptr, %t0
   .loc 1 6 5
-  %t11 = call @rt_arr_i32_len(%t10)
+  %t12 = call @rt_arr_i32_len(%t11)
   .loc 1 6 5
-  %t12 = scmp_lt 0, 0
+  %t13 = scmp_lt 0, 0
   .loc 1 6 5
-  %t13 = scmp_ge 0, %t11
-  .loc 1 6 5
-  %t14 = zext1 %t12
+  %t14 = scmp_ge 0, %t12
   .loc 1 6 5
   %t15 = zext1 %t13
   .loc 1 6 5
-  %t16 = or %t14, %t15
+  %t16 = zext1 %t14
   .loc 1 6 5
-  %t17 = icmp_ne %t16, 0
+  %t17 = or %t15, %t16
   .loc 1 6 5
-  cbr %t17, bc_oob0, bc_ok0
+  %t18 = icmp_ne %t17, 0
+  .loc 1 6 5
+  cbr %t18, bc_oob0, bc_ok0
 L-999999994:
   .loc 1 7 7
-  %t18 = load str, %t2
-  .loc 1 7 1
-  call @rt_print_str(%t18)
-  .loc 1 7 1
-  %t19 = const_str @.L1
+  %t19 = load str, %t2
   .loc 1 7 1
   call @rt_print_str(%t19)
+  .loc 1 7 1
+  %t20 = const_str @.L1
+  .loc 1 7 1
+  call @rt_print_str(%t20)
   .loc 1 7 1
   br L-999999993
 L-999999993:
   .loc 1 8 7
-  %t20 = load i64, %t1
+  %t21 = load i64, %t1
   .loc 1 8 1
-  call @rt_print_i64(%t20)
+  call @rt_print_i64(%t21)
   .loc 1 8 1
-  %t21 = const_str @.L1
+  %t22 = const_str @.L1
   .loc 1 8 1
-  call @rt_print_str(%t21)
+  call @rt_print_str(%t22)
   .loc 1 8 1
   br L-999999992
 L-999999992:
   .loc 1 9 7
-  %t22 = load ptr, %t0
+  %t23 = load ptr, %t0
   .loc 1 9 7
-  %t23 = call @rt_arr_i32_len(%t22)
+  %t24 = call @rt_arr_i32_len(%t23)
   .loc 1 9 7
-  %t24 = scmp_lt 0, 0
+  %t25 = scmp_lt 0, 0
   .loc 1 9 7
-  %t25 = scmp_ge 0, %t23
-  .loc 1 9 7
-  %t26 = zext1 %t24
+  %t26 = scmp_ge 0, %t24
   .loc 1 9 7
   %t27 = zext1 %t25
   .loc 1 9 7
-  %t28 = or %t26, %t27
+  %t28 = zext1 %t26
   .loc 1 9 7
-  %t29 = icmp_ne %t28, 0
+  %t29 = or %t27, %t28
   .loc 1 9 7
-  cbr %t29, bc_oob1, bc_ok1
+  %t30 = icmp_ne %t29, 0
+  .loc 1 9 7
+  cbr %t30, bc_oob1, bc_ok1
 exit:
-  %t32 = load ptr, %t0
-  call @rt_arr_i32_release(%t32)
+  %t33 = load ptr, %t0
+  call @rt_arr_i32_release(%t33)
   store ptr, %t0, null
   ret 0
 dim_len_fail:
@@ -126,41 +129,41 @@ dim_len_fail:
   trap
 dim_len_cont:
   .loc 1 3 1
-  %t5 = call @rt_arr_i32_new(%t3)
+  %t6 = call @rt_arr_i32_new(%t4)
   .loc 1 3 1
-  call @rt_arr_i32_retain(%t5)
+  call @rt_arr_i32_retain(%t6)
   .loc 1 3 1
-  %t6 = load ptr, %t0
+  %t7 = load ptr, %t0
   .loc 1 3 1
-  call @rt_arr_i32_release(%t6)
+  call @rt_arr_i32_release(%t7)
   .loc 1 3 1
-  store ptr, %t0, %t5
+  store ptr, %t0, %t6
   .loc 1 3 1
   br L-999999997
 bc_ok0:
   .loc 1 6 1
-  call @rt_arr_i32_set(%t10, 0, %t9)
+  call @rt_arr_i32_set(%t11, 0, %t10)
   .loc 1 6 1
   br L-999999994
 bc_oob0:
   .loc 1 6 5
-  call @rt_arr_oob_panic(0, %t11)
+  call @rt_arr_oob_panic(0, %t12)
   .loc 1 6 5
   trap
 bc_ok1:
   .loc 1 9 7
-  %t30 = call @rt_arr_i32_get(%t22, 0)
+  %t31 = call @rt_arr_i32_get(%t23, 0)
   .loc 1 9 1
-  call @rt_print_i64(%t30)
+  call @rt_print_i64(%t31)
   .loc 1 9 1
-  %t31 = const_str @.L1
+  %t32 = const_str @.L1
   .loc 1 9 1
-  call @rt_print_str(%t31)
+  call @rt_print_str(%t32)
   .loc 1 9 1
   br exit
 bc_oob1:
   .loc 1 9 7
-  call @rt_arr_oob_panic(0, %t23)
+  call @rt_arr_oob_panic(0, %t24)
   .loc 1 9 7
   trap
 }

--- a/tests/golden/basic_lowering/do_exit.il
+++ b/tests/golden/basic_lowering/do_exit.il
@@ -4,11 +4,12 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 func @F() -> i64 {
 entry_F:
-  br L0_F
-L0_F:
-L0_F:
+  br L-1000000000_F
+L-1000000000_F:
+L-999999999_F:
   .loc 1 5 8
   ret 0
 ret_F:
@@ -21,7 +22,7 @@ do_body_0_F:
   br do_end_0_F
 do_end_0_F:
   .loc 1 3 1
-  br L0_F
+  br L-999999999_F
 }
 func @main() -> i64 {
 entry:

--- a/tests/golden/basic_lowering/do_loops.il
+++ b/tests/golden/basic_lowering/do_loops.il
@@ -4,14 +4,15 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 func @F() -> i64 {
 entry_F:
-  br L0_F
-L0_F:
-L0_F:
-L0_F:
+  br L-1000000000_F
+L-1000000000_F:
   .loc 1 2 1
   br do_head_0_F
+L-999999999_F:
+L-999999998_F:
   .loc 1 6 8
   ret 0
 ret_F:
@@ -26,7 +27,7 @@ do_body_0_F:
   br do_head_0_F
 do_end_0_F:
   .loc 1 2 1
-  br L0_F
+  br L-999999999_F
 do_head_1_F:
   .loc 1 4 1
   %t1 = trunc1 0
@@ -37,7 +38,7 @@ do_body_1_F:
   br do_head_1_F
 do_end_1_F:
   .loc 1 4 1
-  br L0_F
+  br L-999999998_F
 }
 func @main() -> i64 {
 entry:

--- a/tests/golden/basic_lowering/labels_proc_loops.il
+++ b/tests/golden/basic_lowering/labels_proc_loops.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 func @F() -> i64 {
 entry_F:
   %t0 = alloca 8

--- a/tests/golden/basic_to_il/abs_mixed.il
+++ b/tests/golden/basic_to_il/abs_mixed.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 extern @rt_abs_i64(i64) -> i64
 extern @rt_abs_f64(f64) -> f64
 global const str @.L0 = "

--- a/tests/golden/basic_to_il/array_dim_redim.il
+++ b/tests/golden/basic_to_il/array_dim_redim.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 extern @rt_arr_i32_new(i64) -> ptr
 extern @rt_arr_i32_resize(ptr, i64) -> ptr
 extern @rt_arr_i32_retain(ptr) -> void

--- a/tests/golden/basic_to_il/array_dim_runtime.il
+++ b/tests/golden/basic_to_il/array_dim_runtime.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 extern @rt_arr_i32_new(i64) -> ptr
 extern @rt_arr_i32_resize(ptr, i64) -> ptr
 extern @rt_arr_i32_len(ptr) -> i64

--- a/tests/golden/basic_to_il/bounds_check.il
+++ b/tests/golden/basic_to_il/bounds_check.il
@@ -5,6 +5,7 @@ extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_trap(str) -> void
+extern @rt_str_empty() -> str
 extern @rt_arr_i32_new(i64) -> ptr
 extern @rt_arr_i32_len(ptr) -> i64
 extern @rt_arr_i32_get(ptr, i64) -> i64

--- a/tests/golden/basic_to_il/calls_lowering.il
+++ b/tests/golden/basic_to_il/calls_lowering.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = ""
 global const str @.L1 = "
 "

--- a/tests/golden/basic_to_il/conversions.il
+++ b/tests/golden/basic_to_il/conversions.il
@@ -10,6 +10,7 @@ extern @rt_int_floor(f64) -> f64
 extern @rt_val(str) -> f64
 extern @rt_val_to_double(ptr, ptr) -> f64
 extern @rt_string_cstr(str) -> ptr
+extern @rt_str_empty() -> str
 extern @rt_int_floor(f64) -> f64
 extern @rt_str_retain_maybe(str) -> void
 extern @rt_str_release_maybe(str) -> void
@@ -22,70 +23,72 @@ entry:
   %t0 = alloca 8
   %t1 = alloca 8
   %t2 = alloca 8
-  %t3 = alloca 8
+  %t3 = call @rt_str_empty()
+  store str, %t2, %t3
   %t4 = alloca 8
+  %t5 = alloca 8
   br L10
 L10:
   .loc 1 1 4
-  store i64, %t4, 1
+  store i64, %t5, 1
   .loc 1 1 4
   br L20
 L20:
   .loc 1 2 4
-  store f64, %t3, 2.5
+  store f64, %t4, 2.5
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 15
-  %t5 = load i64, %t4
+  %t6 = load i64, %t5
   .loc 1 3 15
-  %t6:i32 = cast.si_narrow.chk %t5
+  %t7:i32 = cast.si_narrow.chk %t6
   .loc 1 3 10
-  %t7 = call @rt_str_i32_alloc(%t6)
-  .loc 1 3 4
-  call @rt_print_str(%t7)
-  .loc 1 3 4
-  %t8 = const_str @.L0
+  %t8 = call @rt_str_i32_alloc(%t7)
   .loc 1 3 4
   call @rt_print_str(%t8)
+  .loc 1 3 4
+  %t9 = const_str @.L0
+  .loc 1 3 4
+  call @rt_print_str(%t9)
   .loc 1 3 24
-  %t9 = load f64, %t3
+  %t10 = load f64, %t4
   .loc 1 3 19
-  %t10 = call @rt_str_d_alloc(%t9)
-  .loc 1 3 4
-  call @rt_print_str(%t10)
-  .loc 1 3 4
-  %t11 = const_str @.L1
+  %t11 = call @rt_str_d_alloc(%t10)
   .loc 1 3 4
   call @rt_print_str(%t11)
+  .loc 1 3 4
+  %t12 = const_str @.L1
+  .loc 1 3 4
+  call @rt_print_str(%t12)
   .loc 1 3 4
   br L40
 L40:
   .loc 1 4 13
-  %t12 = const_str @.L2
+  %t13 = const_str @.L2
   .loc 1 4 4
-  %t13 = load str, %t2
+  %t14 = load str, %t2
   .loc 1 4 4
-  call @rt_str_release_maybe(%t13)
+  call @rt_str_release_maybe(%t14)
   .loc 1 4 4
-  call @rt_str_retain_maybe(%t12)
+  call @rt_str_retain_maybe(%t13)
   .loc 1 4 4
-  store str, %t2, %t12
+  store str, %t2, %t13
   .loc 1 4 4
   br L50
 L50:
   .loc 1 5 14
-  %t14 = load str, %t2
+  %t15 = load str, %t2
   .loc 1 5 14
-  %t15 = call @rt_string_cstr(%t14)
+  %t16 = call @rt_string_cstr(%t15)
   .loc 1 5 14
-  %t16 = alloca 1
+  %t17 = alloca 1
   .loc 1 5 14
-  %t17 = call @rt_val_to_double(%t15, %t16)
+  %t18 = call @rt_val_to_double(%t16, %t17)
   .loc 1 5 14
-  %t18 = load i1, %t16
+  %t19 = load i1, %t17
   .loc 1 5 14
-  cbr %t18, val_ok, val_fail
+  cbr %t19, val_ok, val_fail
 L60:
   .loc 1 6 4
   store f64, %t1, 1.8999999999999999
@@ -98,25 +101,25 @@ L70:
   br L80
 L80:
   .loc 1 8 14
-  %t23 = load f64, %t1
+  %t24 = load f64, %t1
   .loc 1 8 10
-  %t24 = call @rt_int_floor(%t23)
+  %t25 = call @rt_int_floor(%t24)
   .loc 1 8 4
-  call @rt_print_f64(%t24)
+  call @rt_print_f64(%t25)
   .loc 1 8 4
-  %t25 = const_str @.L0
+  %t26 = const_str @.L0
   .loc 1 8 4
-  call @rt_print_str(%t25)
+  call @rt_print_str(%t26)
   .loc 1 8 23
-  %t26 = load f64, %t0
+  %t27 = load f64, %t0
   .loc 1 8 19
-  %t27 = call @rt_int_floor(%t26)
+  %t28 = call @rt_int_floor(%t27)
   .loc 1 8 4
-  call @rt_print_f64(%t27)
+  call @rt_print_f64(%t28)
   .loc 1 8 4
-  %t28 = const_str @.L1
+  %t29 = const_str @.L1
   .loc 1 8 4
-  call @rt_print_str(%t28)
+  call @rt_print_str(%t29)
   .loc 1 8 4
   br L90
 L90:
@@ -126,26 +129,26 @@ exit:
   ret 0
 val_ok:
   .loc 1 5 4
-  call @rt_print_f64(%t17)
+  call @rt_print_f64(%t18)
   .loc 1 5 4
-  %t22 = const_str @.L1
+  %t23 = const_str @.L1
   .loc 1 5 4
-  call @rt_print_str(%t22)
+  call @rt_print_str(%t23)
   .loc 1 5 4
   br L60
 val_fail:
   .loc 1 5 14
-  %t19 = fcmp_ne %t17, %t17
+  %t20 = fcmp_ne %t18, %t18
   .loc 1 5 14
-  cbr %t19, val_nan, val_over
+  cbr %t20, val_nan, val_over
 val_nan:
   .loc 1 5 14
-  %t20 = cast.fp_to_si.rte.chk nan
+  %t21 = cast.fp_to_si.rte.chk nan
   .loc 1 5 14
   trap
 val_over:
   .loc 1 5 14
-  %t21 = cast.fp_to_si.rte.chk 1.7976931348623157e+308
+  %t22 = cast.fp_to_si.rte.chk 1.7976931348623157e+308
   .loc 1 5 14
   trap
 }

--- a/tests/golden/basic_to_il/ex1_hello_cond.il
+++ b/tests/golden/basic_to_il/ex1_hello_cond.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "HELLO"
 global const str @.L1 = "
 "

--- a/tests/golden/basic_to_il/ex2_sum_1_to_10.il
+++ b/tests/golden/basic_to_il/ex2_sum_1_to_10.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "SUM"
 global const str @.L1 = "
 "

--- a/tests/golden/basic_to_il/ex3_for_table.il
+++ b/tests/golden/basic_to_il/ex3_for_table.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/basic_to_il/ex4_if_elseif.il
+++ b/tests/golden/basic_to_il/ex4_if_elseif.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/basic_to_il/ex6_array_sum.il
+++ b/tests/golden/basic_to_il/ex6_array_sum.il
@@ -6,6 +6,7 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_input_line() -> str
 extern @rt_to_int(str) -> i64
+extern @rt_str_empty() -> str
 extern @rt_arr_i32_new(i64) -> ptr
 extern @rt_arr_i32_len(ptr) -> i64
 extern @rt_arr_i32_get(ptr, i64) -> i64

--- a/tests/golden/basic_to_il/ex_colon.il
+++ b/tests/golden/basic_to_il/ex_colon.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/basic_to_il/ex_elseif.il
+++ b/tests/golden/basic_to_il/ex_elseif.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "ONE"
 global const str @.L1 = "
 "

--- a/tests/golden/basic_to_il/float_ops.il
+++ b/tests/golden/basic_to_il/float_ops.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/basic_to_il/instr.il
+++ b/tests/golden/basic_to_il/instr.il
@@ -6,6 +6,7 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_instr2(str, str) -> i64
 extern @rt_instr3(i64, str, str) -> i64
+extern @rt_str_empty() -> str
 extern @rt_str_retain_maybe(str) -> void
 extern @rt_str_release_maybe(str) -> void
 global const str @.L0 = "HELLO"
@@ -16,50 +17,52 @@ global const str @.L3 = "L"
 func @main() -> i64 {
 entry:
   %t0 = alloca 8
+  %t1 = call @rt_str_empty()
+  store str, %t0, %t1
   br L10
 L10:
   .loc 1 1 13
-  %t1 = const_str @.L0
+  %t2 = const_str @.L0
   .loc 1 1 4
-  %t2 = load str, %t0
+  %t3 = load str, %t0
   .loc 1 1 4
-  call @rt_str_release_maybe(%t2)
+  call @rt_str_release_maybe(%t3)
   .loc 1 1 4
-  call @rt_str_retain_maybe(%t1)
+  call @rt_str_retain_maybe(%t2)
   .loc 1 1 4
-  store str, %t0, %t1
+  store str, %t0, %t2
   .loc 1 1 4
   br L20
 L20:
   .loc 1 2 16
-  %t3 = load str, %t0
+  %t4 = load str, %t0
   .loc 1 2 20
-  %t4 = const_str @.L1
+  %t5 = const_str @.L1
   .loc 1 2 20
-  %t5 = call @rt_instr2(%t3, %t4)
+  %t6 = call @rt_instr2(%t4, %t5)
   .loc 1 2 4
-  call @rt_print_i64(%t5)
+  call @rt_print_i64(%t6)
   .loc 1 2 4
-  %t6 = const_str @.L2
+  %t7 = const_str @.L2
   .loc 1 2 4
-  call @rt_print_str(%t6)
+  call @rt_print_str(%t7)
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 16
-  %t7 = iadd.ovf 3, -1
+  %t8 = iadd.ovf 3, -1
   .loc 1 3 19
-  %t8 = load str, %t0
+  %t9 = load str, %t0
   .loc 1 3 23
-  %t9 = const_str @.L3
+  %t10 = const_str @.L3
   .loc 1 3 23
-  %t10 = call @rt_instr3(%t7, %t8, %t9)
+  %t11 = call @rt_instr3(%t8, %t9, %t10)
   .loc 1 3 4
-  call @rt_print_i64(%t10)
+  call @rt_print_i64(%t11)
   .loc 1 3 4
-  %t11 = const_str @.L2
+  %t12 = const_str @.L2
   .loc 1 3 4
-  call @rt_print_str(%t11)
+  call @rt_print_str(%t12)
   .loc 1 3 4
   br L40
 L40:

--- a/tests/golden/basic_to_il/loc_add.il
+++ b/tests/golden/basic_to_il/loc_add.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/basic_to_il/lower_funcdef_only.il
+++ b/tests/golden/basic_to_il/lower_funcdef_only.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @F() -> i64 {

--- a/tests/golden/basic_to_il/math_phase1.il
+++ b/tests/golden/basic_to_il/math_phase1.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 extern @rt_abs_i64(i64) -> i64
 extern @rt_abs_f64(f64) -> f64
 extern @rt_floor(f64) -> f64

--- a/tests/golden/basic_to_il/math_phase2.il
+++ b/tests/golden/basic_to_il/math_phase2.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 extern @rt_sin(f64) -> f64
 extern @rt_cos(f64) -> f64
 extern @rt_pow_f64_chkdom(f64, f64) -> f64

--- a/tests/golden/basic_to_il/not.il
+++ b/tests/golden/basic_to_il/not.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/basic_to_il/print_commas.il
+++ b/tests/golden/basic_to_il/print_commas.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "A"
 global const str @.L1 = " "
 global const str @.L2 = "B"

--- a/tests/golden/basic_to_il/print_newline_control.il
+++ b/tests/golden/basic_to_il/print_newline_control.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "A"
 global const str @.L1 = "B"
 global const str @.L2 = "

--- a/tests/golden/basic_to_il/print_semicolons.il
+++ b/tests/golden/basic_to_il/print_semicolons.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "A"
 global const str @.L1 = "B"
 global const str @.L2 = "

--- a/tests/golden/basic_to_il/randomize.il
+++ b/tests/golden/basic_to_il/randomize.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 extern @rt_randomize_i64(i64) -> void
 func @main() -> i64 {
 entry:

--- a/tests/golden/basic_to_il/rnd.il
+++ b/tests/golden/basic_to_il/rnd.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 extern @rt_rnd() -> f64
 global const str @.L0 = "
 "

--- a/tests/golden/basic_to_il/string_cmp.il
+++ b/tests/golden/basic_to_il/string_cmp.il
@@ -5,6 +5,7 @@ extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_str_eq(str, str) -> i1
+extern @rt_str_empty() -> str
 extern @rt_str_retain_maybe(str) -> void
 extern @rt_str_release_maybe(str) -> void
 global const str @.L0 = "HELLO"
@@ -14,18 +15,20 @@ global const str @.L2 = "X"
 func @main() -> i64 {
 entry:
   %t0 = alloca 8
+  %t1 = call @rt_str_empty()
+  store str, %t0, %t1
   br L10
 L10:
   .loc 1 1 13
-  %t1 = const_str @.L0
+  %t2 = const_str @.L0
   .loc 1 1 4
-  %t2 = load str, %t0
+  %t3 = load str, %t0
   .loc 1 1 4
-  call @rt_str_release_maybe(%t2)
+  call @rt_str_release_maybe(%t3)
   .loc 1 1 4
-  call @rt_str_retain_maybe(%t1)
+  call @rt_str_retain_maybe(%t2)
   .loc 1 1 4
-  store str, %t0, %t1
+  store str, %t0, %t2
   .loc 1 1 4
   br L20
 L20:
@@ -41,26 +44,26 @@ exit:
   ret 0
 if_test_0:
   .loc 1 2 7
-  %t3 = load str, %t0
+  %t4 = load str, %t0
   .loc 1 2 12
-  %t4 = const_str @.L0
+  %t5 = const_str @.L0
   .loc 1 2 10
-  %t5 = call @rt_str_eq(%t3, %t4)
+  %t6 = call @rt_str_eq(%t4, %t5)
   .loc 1 2 10
-  %t6 = zext1 %t5
+  %t7 = zext1 %t6
   .loc 1 2 10
-  %t7 = isub.ovf 0, %t6
+  %t8 = isub.ovf 0, %t7
   .loc 1 2 4
-  %t8 = trunc1 %t7
+  %t9 = trunc1 %t8
   .loc 1 2 4
-  cbr %t8, if_then_0, if_else
+  cbr %t9, if_then_0, if_else
 if_then_0:
   .loc 1 2 25
   call @rt_print_i64(1)
   .loc 1 2 25
-  %t9 = const_str @.L1
+  %t10 = const_str @.L1
   .loc 1 2 25
-  call @rt_print_str(%t9)
+  call @rt_print_str(%t10)
   .loc 1 2 4
   br if_exit
 if_else:
@@ -71,28 +74,28 @@ if_exit:
   br L30
 if_test_01:
   .loc 1 3 7
-  %t10 = load str, %t0
+  %t11 = load str, %t0
   .loc 1 3 13
-  %t11 = const_str @.L2
+  %t12 = const_str @.L2
   .loc 1 3 10
-  %t12 = call @rt_str_eq(%t10, %t11)
+  %t13 = call @rt_str_eq(%t11, %t12)
   .loc 1 3 10
-  %t13 = zext1 %t12
+  %t14 = zext1 %t13
   .loc 1 3 10
-  %t14 = isub.ovf 0, %t13
+  %t15 = isub.ovf 0, %t14
   .loc 1 3 10
-  %t15 = xor %t14, -1
+  %t16 = xor %t15, -1
   .loc 1 3 4
-  %t16 = trunc1 %t15
+  %t17 = trunc1 %t16
   .loc 1 3 4
-  cbr %t16, if_then_01, if_else1
+  cbr %t17, if_then_01, if_else1
 if_then_01:
   .loc 1 3 22
   call @rt_print_i64(2)
   .loc 1 3 22
-  %t17 = const_str @.L1
+  %t18 = const_str @.L1
   .loc 1 3 22
-  call @rt_print_str(%t17)
+  call @rt_print_str(%t18)
   .loc 1 3 4
   br if_exit1
 if_else1:

--- a/tests/golden/basic_to_il/strings.il
+++ b/tests/golden/basic_to_il/strings.il
@@ -8,6 +8,7 @@ extern @rt_left(str, i64) -> str
 extern @rt_right(str, i64) -> str
 extern @rt_mid2(str, i64) -> str
 extern @rt_mid3(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 extern @rt_str_retain_maybe(str) -> void
 extern @rt_str_release_maybe(str) -> void
 global const str @.L0 = "HELLO"
@@ -16,87 +17,89 @@ global const str @.L1 = "
 func @main() -> i64 {
 entry:
   %t0 = alloca 8
+  %t1 = call @rt_str_empty()
+  store str, %t0, %t1
   br L10
 L10:
   .loc 1 1 13
-  %t1 = const_str @.L0
+  %t2 = const_str @.L0
   .loc 1 1 4
-  %t2 = load str, %t0
+  %t3 = load str, %t0
   .loc 1 1 4
-  call @rt_str_release_maybe(%t2)
+  call @rt_str_release_maybe(%t3)
   .loc 1 1 4
-  call @rt_str_retain_maybe(%t1)
+  call @rt_str_retain_maybe(%t2)
   .loc 1 1 4
-  store str, %t0, %t1
+  store str, %t0, %t2
   .loc 1 1 4
   br L20
 L20:
   .loc 1 2 14
-  %t3 = load str, %t0
+  %t4 = load str, %t0
   .loc 1 2 10
-  %t4 = call @rt_len(%t3)
+  %t5 = call @rt_len(%t4)
   .loc 1 2 4
-  call @rt_print_i64(%t4)
+  call @rt_print_i64(%t5)
   .loc 1 2 4
-  %t5 = const_str @.L1
+  %t6 = const_str @.L1
   .loc 1 2 4
-  call @rt_print_str(%t5)
+  call @rt_print_str(%t6)
   .loc 1 2 4
   br L30
 L30:
   .loc 1 3 15
-  %t6 = load str, %t0
+  %t7 = load str, %t0
   .loc 1 3 19
-  %t7 = iadd.ovf 2, -1
+  %t8 = iadd.ovf 2, -1
   .loc 1 3 22
-  %t8 = call @rt_mid3(%t6, %t7, 3)
-  .loc 1 3 4
-  call @rt_print_str(%t8)
-  .loc 1 3 4
-  %t9 = const_str @.L1
+  %t9 = call @rt_mid3(%t7, %t8, 3)
   .loc 1 3 4
   call @rt_print_str(%t9)
+  .loc 1 3 4
+  %t10 = const_str @.L1
+  .loc 1 3 4
+  call @rt_print_str(%t10)
   .loc 1 3 4
   br L40
 L40:
   .loc 1 4 15
-  %t10 = load str, %t0
+  %t11 = load str, %t0
   .loc 1 4 19
-  %t11 = iadd.ovf 3, -1
+  %t12 = iadd.ovf 3, -1
   .loc 1 4 10
-  %t12 = call @rt_mid2(%t10, %t11)
-  .loc 1 4 4
-  call @rt_print_str(%t12)
-  .loc 1 4 4
-  %t13 = const_str @.L1
+  %t13 = call @rt_mid2(%t11, %t12)
   .loc 1 4 4
   call @rt_print_str(%t13)
+  .loc 1 4 4
+  %t14 = const_str @.L1
+  .loc 1 4 4
+  call @rt_print_str(%t14)
   .loc 1 4 4
   br L50
 L50:
   .loc 1 5 16
-  %t14 = load str, %t0
+  %t15 = load str, %t0
   .loc 1 5 10
-  %t15 = call @rt_left(%t14, 2)
-  .loc 1 5 4
-  call @rt_print_str(%t15)
-  .loc 1 5 4
-  %t16 = const_str @.L1
+  %t16 = call @rt_left(%t15, 2)
   .loc 1 5 4
   call @rt_print_str(%t16)
+  .loc 1 5 4
+  %t17 = const_str @.L1
+  .loc 1 5 4
+  call @rt_print_str(%t17)
   .loc 1 5 4
   br L60
 L60:
   .loc 1 6 17
-  %t17 = load str, %t0
+  %t18 = load str, %t0
   .loc 1 6 10
-  %t18 = call @rt_right(%t17, 2)
-  .loc 1 6 4
-  call @rt_print_str(%t18)
-  .loc 1 6 4
-  %t19 = const_str @.L1
+  %t19 = call @rt_right(%t18, 2)
   .loc 1 6 4
   call @rt_print_str(%t19)
+  .loc 1 6 4
+  %t20 = const_str @.L1
+  .loc 1 6 4
+  call @rt_print_str(%t20)
   .loc 1 6 4
   br L70
 L70:

--- a/tests/golden/basic_to_il/ubound.il
+++ b/tests/golden/basic_to_il/ubound.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 extern @rt_arr_i32_new(i64) -> ptr
 extern @rt_arr_i32_len(ptr) -> i64
 extern @rt_arr_i32_retain(ptr) -> void

--- a/tests/golden/eh_lowering/on_error_push_pop.il
+++ b/tests/golden/eh_lowering/on_error_push_pop.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/eh_lowering/resume_forms.il
+++ b/tests/golden/eh_lowering/resume_forms.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 func @main() -> i64 {
 entry:
   br L10

--- a/tests/golden/fileio/lowering_open_close.il
+++ b/tests/golden/fileio/lowering_open_close.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 extern @rt_open_err_vstr(str, i32, i32) -> i32
 extern @rt_close_err(i32) -> i32
 global const str @.L0 = "foo.txt"

--- a/tests/golden/il/boolean_and.il
+++ b/tests/golden/il/boolean_and.il
@@ -6,6 +6,7 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_input_line() -> str
 extern @rt_to_int(str) -> i64
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/il/boolean_andalso.il
+++ b/tests/golden/il/boolean_andalso.il
@@ -6,6 +6,7 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_input_line() -> str
 extern @rt_to_int(str) -> i64
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/il/boolean_branch_join_skeleton.il
+++ b/tests/golden/il/boolean_branch_join_skeleton.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/il/boolean_dim_and_assign.il
+++ b/tests/golden/il/boolean_dim_and_assign.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/il/boolean_literals.il
+++ b/tests/golden/il/boolean_literals.il
@@ -6,6 +6,7 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_input_line() -> str
 extern @rt_to_int(str) -> i64
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/il/boolean_not.il
+++ b/tests/golden/il/boolean_not.il
@@ -4,6 +4,7 @@ extern @rt_print_i64(i64) -> void
 extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/il/boolean_or.il
+++ b/tests/golden/il/boolean_or.il
@@ -6,6 +6,7 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_input_line() -> str
 extern @rt_to_int(str) -> i64
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @main() -> i64 {

--- a/tests/golden/il/boolean_orelse.il
+++ b/tests/golden/il/boolean_orelse.il
@@ -6,6 +6,7 @@ extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_input_line() -> str
 extern @rt_to_int(str) -> i64
+extern @rt_str_empty() -> str
 global const str @.L0 = "
 "
 func @main() -> i64 {


### PR DESCRIPTION
## Summary
- add a runtime `rt_str_empty` helper that returns the immortal empty string handle
- initialize BASIC string stack slots with `rt_str_empty` and make the helper always available to the front end
- regenerate BASIC IL golden files and string output goldens to reflect the new safe initialization

## Testing
- cmake -S . -B build
- cmake --build build -j4
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e41acc4e988324abe933a2f05e329a