### PR TITLE
Add BASIC string smoke tests

### DIFF
--- a/scripts/smoke_basic.sh
+++ b/scripts/smoke_basic.sh
@@ -76,3 +76,9 @@ echo "tests/smoke/basic/concat_input.bas passed"
 echo
 
 echo "All smoke tests passed."
+
+# String concat test
+timeout 2 "$BUILD_ROOT/src/tools/ilc/ilc" front basic -run tests/smoke/basic/strings_concat.bas | grep -F "Hello, World"
+
+# String aliasing test
+printf "Stephen\n" | timeout 2 "$BUILD_ROOT/src/tools/ilc/ilc" front basic -run tests/smoke/basic/strings_alias.bas | grep -F "StephenStephen"

--- a/tests/smoke/basic/strings_alias.bas
+++ b/tests/smoke/basic/strings_alias.bas
@@ -1,0 +1,5 @@
+10 INPUT a$
+20 b$ = a$
+30 c$ = b$ + a$
+40 PRINT c$
+50 END

--- a/tests/smoke/basic/strings_concat.bas
+++ b/tests/smoke/basic/strings_concat.bas
@@ -1,0 +1,5 @@
+10 a$ = "Hello, "
+20 b$ = "World"
+30 c$ = a$ + b$
+40 PRINT c$
+50 END


### PR DESCRIPTION
## Summary
- add smoke tests covering BASIC string concatenation and aliasing
- invoke the new programs from the smoke_basic.sh script

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e422a553ac83248a17e7f2c193d8e8