### PR TITLE
Fix function header parsing to trim names

### DIFF
--- a/src/il/io/FunctionParser.cpp
+++ b/src/il/io/FunctionParser.cpp
@@ -102,6 +102,7 @@ Expected<void> parseFunctionHeader(const std::string &header, ParserState &st)
         return Expected<void>{makeError({}, oss.str())};
     }
     std::string name = header.substr(at + 1, lp - at - 1);
+    name = trim(name);
     std::string paramsStr = header.substr(lp + 1, rp - lp - 1);
     std::vector<Param> params;
     std::stringstream pss(paramsStr);

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -61,6 +61,12 @@ function(viper_add_il_core_tests)
   target_compile_definitions(test_il_parse_missing_brace PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
   viper_add_ctest(test_il_parse_missing_brace test_il_parse_missing_brace)
 
+  viper_add_test(
+    test_il_parse_function_name_trim
+    ${_VIPER_IL_UNIT_DIR}/test_il_parse_function_name_trim.cpp)
+  target_link_libraries(test_il_parse_function_name_trim PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  viper_add_ctest(test_il_parse_function_name_trim test_il_parse_function_name_trim)
+
   viper_add_test(test_il_parse_duplicate_block ${_VIPER_IL_UNIT_DIR}/test_il_parse_duplicate_block.cpp)
   target_link_libraries(test_il_parse_duplicate_block PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   target_compile_definitions(test_il_parse_duplicate_block PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")

--- a/tests/unit/test_il_parse_function_name_trim.cpp
+++ b/tests/unit/test_il_parse_function_name_trim.cpp
@@ -1,0 +1,42 @@
+// File: tests/unit/test_il_parse_function_name_trim.cpp
+// Purpose: Ensure function headers trim trailing whitespace from symbol names.
+// Key invariants: Parser normalises function identifiers; verifier resolves calls.
+// Ownership/Lifetime: Test owns module buffers parsed from string literals.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "il/verify/Verifier.hpp"
+
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    static constexpr const char *kSource = R"(il 0.1.2
+func @caller() -> void {
+entry:
+  call @callee()
+  ret
+}
+
+func @callee   () -> void {
+entry:
+  ret
+}
+)";
+
+    std::istringstream input(kSource);
+    il::core::Module module;
+    auto parseResult = il::api::v2::parse_text_expected(input, module);
+    assert(parseResult && "parser should accept headers with trailing spaces");
+    assert(module.functions.size() == 2);
+
+    const auto &callee = module.functions.back();
+    assert(callee.name == "callee" && "function name should be trimmed");
+
+    auto verifyResult = il::verify::Verifier::verify(module);
+    assert(verifyResult && "verifier should resolve calls to trimmed names");
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- trim whitespace from parsed function names to avoid trailing-space symbols
- add a parser regression test to ensure trimmed names verify successfully
- register the new test in the IL test suite build

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e42a8b87d88324960f27ddb5fdfec7