### PR TITLE
fix: trim extern name whitespace and add regression test

### DIFF
--- a/src/il/io/ModuleParser.cpp
+++ b/src/il/io/ModuleParser.cpp
@@ -68,7 +68,7 @@ Expected<void> parseExtern_E(const std::string &line, ParserState &st)
         oss << "line " << st.lineNo << ": missing '->'";
         return Expected<void>{makeError({}, oss.str())};
     }
-    std::string name = line.substr(at + 1, lp - at - 1);
+    std::string name = trim(line.substr(at + 1, lp - at - 1));
     std::string paramsStr = line.substr(lp + 1, rp - lp - 1);
     std::vector<Type> params;
     std::stringstream pss(paramsStr);

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -71,6 +71,11 @@ function(viper_add_il_core_tests)
   target_compile_definitions(test_il_parse_missing_paren PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
   viper_add_ctest(test_il_parse_missing_paren test_il_parse_missing_paren)
 
+  viper_add_test(test_il_parse_extern_whitespace ${_VIPER_IL_UNIT_DIR}/test_il_parse_extern_whitespace.cpp)
+  target_link_libraries(test_il_parse_extern_whitespace PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  target_compile_definitions(test_il_parse_extern_whitespace PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
+  viper_add_ctest(test_il_parse_extern_whitespace test_il_parse_extern_whitespace)
+
   viper_add_test(test_il_parse_negative ${_VIPER_IL_UNIT_DIR}/test_il_parse_negative.cpp)
   target_link_libraries(test_il_parse_negative PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   target_compile_definitions(test_il_parse_negative PRIVATE BAD_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse")

--- a/tests/il/parse-roundtrip/extern_whitespace.il
+++ b/tests/il/parse-roundtrip/extern_whitespace.il
@@ -1,0 +1,9 @@
+il 0.1.2
+
+extern     @foo   (   i64 ,   i64   ) -> void
+
+func @main() -> void {
+entry:
+  call    @foo(   42 ,   13 )
+  ret
+}

--- a/tests/unit/test_il_parse_extern_whitespace.cpp
+++ b/tests/unit/test_il_parse_extern_whitespace.cpp
@@ -1,0 +1,67 @@
+// File: tests/unit/test_il_parse_extern_whitespace.cpp
+// Purpose: Ensure extern declarations tolerate incidental whitespace around names.
+// Key invariants: Parser trims extern identifiers so verification resolves calls.
+// Ownership/Lifetime: Test owns IL module and buffers.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Module.hpp"
+#include "il/core/Opcode.hpp"
+#include "il/core/Type.hpp"
+#include "il/core/Value.hpp"
+
+#include <cassert>
+#include <fstream>
+#include <sstream>
+
+#ifndef PARSE_ROUNDTRIP_DIR
+#error "PARSE_ROUNDTRIP_DIR must be defined"
+#endif
+
+int main()
+{
+    const char *path = PARSE_ROUNDTRIP_DIR "/extern_whitespace.il";
+    std::ifstream input(path);
+    assert(input && "failed to open extern_whitespace.il");
+
+    std::stringstream buffer;
+    buffer << input.rdbuf();
+    buffer.seekg(0);
+
+    il::core::Module module;
+    auto parseResult = il::api::v2::parse_text_expected(buffer, module);
+    assert(parseResult);
+
+    assert(module.externs.size() == 1);
+    const auto &ext = module.externs.front();
+    assert(ext.name == "foo");
+    assert(ext.params.size() == 2);
+    assert(ext.params[0].kind == il::core::Type::Kind::I64);
+    assert(ext.params[1].kind == il::core::Type::Kind::I64);
+    assert(ext.retType.kind == il::core::Type::Kind::Void);
+
+    assert(module.functions.size() == 1);
+    const auto &fn = module.functions.front();
+    assert(fn.blocks.size() == 1);
+    const auto &entry = fn.blocks.front();
+    assert(entry.instructions.size() == 2);
+
+    const auto &callInstr = entry.instructions[0];
+    assert(callInstr.op == il::core::Opcode::Call);
+    assert(callInstr.callee == "foo");
+    assert(callInstr.operands.size() == 2);
+    assert(callInstr.operands[0].kind == il::core::Value::Kind::ConstInt);
+    assert(callInstr.operands[1].kind == il::core::Value::Kind::ConstInt);
+    assert(callInstr.type.kind == il::core::Type::Kind::Void);
+
+    const auto &retInstr = entry.instructions[1];
+    assert(retInstr.op == il::core::Opcode::Ret);
+    assert(retInstr.operands.empty());
+    assert(retInstr.type.kind == il::core::Type::Kind::Void);
+
+    auto verifyResult = il::api::v2::verify_module_expected(module);
+    assert(verifyResult);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- trim extern identifiers in the module parser so whitespace is dropped before storage
- add an IL fixture and unit test that parse and verify an extern declared with padded whitespace

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68e42a70e60883249ffc95c4d2bc636a