### PR TITLE
fix: align arena allocations using base pointer

### DIFF
--- a/tests/unit/test_support.cpp
+++ b/tests/unit/test_support.cpp
@@ -3,6 +3,7 @@
 #include "support/source_manager.hpp"
 #include "support/string_interner.hpp"
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <sstream>
@@ -32,6 +33,11 @@ int main()
     (void)p1;
     void *p2 = arena.allocate(sizeof(double), alignof(double));
     assert(reinterpret_cast<uintptr_t>(p2) % alignof(double) == 0);
+    const size_t large_align = alignof(std::max_align_t) << 1;
+    il::support::Arena large_arena(256);
+    void *p3 = large_arena.allocate(16, large_align);
+    assert(p3 != nullptr);
+    assert(reinterpret_cast<uintptr_t>(p3) % large_align == 0);
     assert(arena.allocate(1, 0) == nullptr);
     assert(arena.allocate(1, 3) == nullptr);
     arena.reset();


### PR DESCRIPTION
## Summary
- align Arena::allocate using the backing buffer base address to compute alignment and guard overflow
- add a unit test that requests an allocation with alignment larger than std::max_align_t and verifies the alignment

## Testing
- cmake -S . -B build && cmake --build build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e42a47a3d88324aec589a4294654fe