### PR TITLE
Fix --max-steps parsing and add CLI regression test

### DIFF
--- a/src/tools/ilc/cli.cpp
+++ b/src/tools/ilc/cli.cpp
@@ -7,6 +7,10 @@
 
 #include "cli.hpp"
 
+#include <charconv>
+#include <string_view>
+#include <system_error>
+
 namespace ilc
 {
 
@@ -41,7 +45,17 @@ SharedOptionParseResult parseSharedOption(int &index,
         {
             return SharedOptionParseResult::Error;
         }
-        opts.maxSteps = std::stoull(argv[++index]);
+        std::string_view value(argv[index + 1]);
+        std::uint64_t parsed = 0;
+        const char *const begin = value.data();
+        const char *const end = begin + value.size();
+        const auto fc = std::from_chars(begin, end, parsed);
+        if (fc.ec != std::errc() || fc.ptr != end)
+        {
+            return SharedOptionParseResult::Error;
+        }
+        ++index;
+        opts.maxSteps = parsed;
         return SharedOptionParseResult::Parsed;
     }
     if (arg == "--bounds-checks")

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -41,4 +41,13 @@ function(viper_add_tools_tests)
   target_include_directories(test_cli_run_invalid_break_line PRIVATE ${CMAKE_SOURCE_DIR}/src)
   target_link_libraries(test_cli_run_invalid_break_line PRIVATE ${VIPER_TOOLS_LIBS})
   viper_add_ctest(test_cli_run_invalid_break_line test_cli_run_invalid_break_line)
+
+  viper_add_test(test_cli_run_invalid_max_steps
+    ${VIPER_TESTS_DIR}/unit/test_cli_run_invalid_max_steps.cpp
+    ${CMAKE_SOURCE_DIR}/src/tools/ilc/cli.cpp
+    ${CMAKE_SOURCE_DIR}/src/tools/ilc/cmd_run_il.cpp
+    ${CMAKE_SOURCE_DIR}/src/tools/ilc/break_spec.cpp)
+  target_include_directories(test_cli_run_invalid_max_steps PRIVATE ${CMAKE_SOURCE_DIR}/src)
+  target_link_libraries(test_cli_run_invalid_max_steps PRIVATE ${VIPER_TOOLS_LIBS})
+  viper_add_ctest(test_cli_run_invalid_max_steps test_cli_run_invalid_max_steps)
 endfunction()

--- a/tests/unit/test_cli_run_invalid_max_steps.cpp
+++ b/tests/unit/test_cli_run_invalid_max_steps.cpp
@@ -1,0 +1,73 @@
+// File: tests/unit/test_cli_run_invalid_max_steps.cpp
+// Purpose: Verify --max-steps parsing rejects malformed values without throwing.
+// Key invariants: Invalid max step specifications must trigger usage() and non-zero exit.
+// Ownership/Lifetime: N/A.
+// Links: src/tools/ilc/cli.cpp, src/tools/ilc/cmd_run_il.cpp
+
+#include "tools/ilc/cli.hpp"
+
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+int invokeRunIL(const std::vector<std::string> &extraArgs, std::string &stderrText)
+{
+    std::vector<std::string> storage;
+    storage.emplace_back("placeholder.il");
+    storage.insert(storage.end(), extraArgs.begin(), extraArgs.end());
+
+    std::vector<char *> argv;
+    argv.reserve(storage.size());
+    for (auto &arg : storage)
+    {
+        argv.push_back(arg.data());
+    }
+
+    std::ostringstream errStream;
+    auto *oldBuf = std::cerr.rdbuf(errStream.rdbuf());
+    const int rc = cmdRunIL(static_cast<int>(argv.size()), argv.data());
+    std::cerr.flush();
+    std::cerr.rdbuf(oldBuf);
+
+    stderrText = errStream.str();
+    return rc;
+}
+
+} // namespace
+
+static bool gUsageCalled = false;
+
+void usage()
+{
+    gUsageCalled = true;
+}
+
+int main()
+{
+    std::string err;
+
+    gUsageCalled = false;
+    int rc = invokeRunIL({ "--max-steps", "not-a-number" }, err);
+    assert(rc != 0);
+    assert(gUsageCalled);
+
+    gUsageCalled = false;
+    err.clear();
+    rc = invokeRunIL({ "--max-steps", "18446744073709551616" }, err);
+    assert(rc != 0);
+    assert(gUsageCalled);
+
+    gUsageCalled = false;
+    err.clear();
+    rc = invokeRunIL({ "--max-steps", "-1" }, err);
+    assert(rc != 0);
+    assert(gUsageCalled);
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- parse `--max-steps` with `std::from_chars` so malformed input surfaces a parse error instead of throwing
- add a CLI regression test that exercises invalid `--max-steps` values and verifies usage() is called
- register the new CLI test with the tools test suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e4451bcf38832484cad824ad7b59de