### PR TITLE
fix(il/build): treat resume ops as terminators

### DIFF
--- a/src/il/build/IRBuilder.cpp
+++ b/src/il/build/IRBuilder.cpp
@@ -192,7 +192,8 @@ Instr &IRBuilder::append(Instr instr)
 bool IRBuilder::isTerminator(Opcode op) const
 {
     return op == Opcode::Br || op == Opcode::CBr || op == Opcode::SwitchI32 || op == Opcode::Ret ||
-           op == Opcode::Trap;
+           op == Opcode::Trap || op == Opcode::ResumeSame || op == Opcode::ResumeNext ||
+           op == Opcode::ResumeLabel;
 }
 
 /// @brief Materialize a string constant by referencing an existing global.
@@ -258,6 +259,37 @@ void IRBuilder::emitRet(const std::optional<Value> &v, il::support::SourceLoc lo
     instr.type = Type(Type::Kind::Void);
     if (v)
         instr.operands.push_back(*v);
+    instr.loc = loc;
+    append(std::move(instr));
+}
+
+void IRBuilder::emitResumeSame(Value token, il::support::SourceLoc loc)
+{
+    Instr instr;
+    instr.op = Opcode::ResumeSame;
+    instr.type = Type(Type::Kind::Void);
+    instr.operands.push_back(token);
+    instr.loc = loc;
+    append(std::move(instr));
+}
+
+void IRBuilder::emitResumeNext(Value token, il::support::SourceLoc loc)
+{
+    Instr instr;
+    instr.op = Opcode::ResumeNext;
+    instr.type = Type(Type::Kind::Void);
+    instr.operands.push_back(token);
+    instr.loc = loc;
+    append(std::move(instr));
+}
+
+void IRBuilder::emitResumeLabel(Value token, BasicBlock &target, il::support::SourceLoc loc)
+{
+    Instr instr;
+    instr.op = Opcode::ResumeLabel;
+    instr.type = Type(Type::Kind::Void);
+    instr.operands.push_back(token);
+    instr.labels.push_back(target.label);
     instr.loc = loc;
     append(std::move(instr));
 }

--- a/src/il/build/IRBuilder.hpp
+++ b/src/il/build/IRBuilder.hpp
@@ -95,6 +95,22 @@ class IRBuilder
     /// @param v Optional return value.
     void emitRet(const std::optional<Value> &v, il::support::SourceLoc loc);
 
+    /// @brief Emit resume that rethrows the current error within the same handler.
+    /// @param token Resume token supplied by the active handler.
+    /// @param loc Source location for diagnostics.
+    void emitResumeSame(Value token, il::support::SourceLoc loc);
+
+    /// @brief Emit resume that propagates to the next enclosing handler.
+    /// @param token Resume token supplied by the active handler.
+    /// @param loc Source location for diagnostics.
+    void emitResumeNext(Value token, il::support::SourceLoc loc);
+
+    /// @brief Emit resume to a specific handler block label.
+    /// @param token Resume token supplied by the active handler.
+    /// @param target Handler block receiving control.
+    /// @param loc Source location for diagnostics.
+    void emitResumeLabel(Value token, BasicBlock &target, il::support::SourceLoc loc);
+
     /// @brief Reserve the next SSA temporary identifier for the active function.
     /// @return Newly assigned temporary id.
     unsigned reserveTempId();

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -36,6 +36,13 @@ function(viper_add_il_core_tests)
   target_link_libraries(test_irbuilder_call_unknown PRIVATE il_build ${VIPER_IL_CORE_IO_LIBS})
   viper_add_ctest(test_irbuilder_call_unknown test_irbuilder_call_unknown)
 
+  viper_add_test(
+    test_irbuilder_resume_terminators
+    ${_VIPER_IL_UNIT_DIR}/test_irbuilder_resume_terminators.cpp)
+  target_link_libraries(test_irbuilder_resume_terminators PRIVATE il_build ${VIPER_IL_CORE_IO_LIBS})
+  viper_add_ctest(
+    test_irbuilder_resume_terminators test_irbuilder_resume_terminators)
+
   viper_add_test(test_il_roundtrip ${_VIPER_IL_UNIT_DIR}/test_il_roundtrip.cpp)
   target_link_libraries(test_il_roundtrip PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   target_compile_definitions(test_il_roundtrip PRIVATE EXAMPLES_DIR="${CMAKE_SOURCE_DIR}/examples" ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/roundtrip")

--- a/tests/unit/test_irbuilder_resume_terminators.cpp
+++ b/tests/unit/test_irbuilder_resume_terminators.cpp
@@ -1,0 +1,63 @@
+// File: tests/unit/test_irbuilder_resume_terminators.cpp
+// Purpose: Ensure IRBuilder marks blocks terminated after emitting resume instructions.
+// Key invariants: Resume opcodes behave as terminators when emitted via IRBuilder helpers.
+// Ownership: Test owns its module/function fixtures locally.
+// Links: docs/il-guide.md#reference
+
+#include "il/build/IRBuilder.hpp"
+
+#include "il/core/Instr.hpp"
+#include "il/core/Type.hpp"
+#include "il/core/Value.hpp"
+
+#include <cassert>
+
+int main()
+{
+    using namespace il::core;
+
+    Module module;
+    il::build::IRBuilder builder(module);
+
+    auto &function = builder.startFunction("resume_test", Type(Type::Kind::Void), {});
+    builder.addBlock(function, "resume_label_target");
+    builder.addBlock(function, "resume_same");
+    builder.addBlock(function, "resume_next");
+    builder.addBlock(function, "resume_label");
+
+    assert(function.blocks.size() == 4);
+    BasicBlock &labelTarget = function.blocks[0];
+    BasicBlock &sameBlock = function.blocks[1];
+    BasicBlock &nextBlock = function.blocks[2];
+    BasicBlock &labelBlock = function.blocks[3];
+
+    auto makeToken = [&]() {
+        unsigned id = builder.reserveTempId();
+        return Value::temp(id);
+    };
+
+    auto verifyTerminated = [&](BasicBlock &block, auto emit) {
+        builder.setInsertPoint(block);
+        Value token = makeToken();
+        emit(token);
+        assert(block.terminated);
+    };
+
+    verifyTerminated(sameBlock, [&](Value token) {
+        builder.emitResumeSame(token, {});
+    });
+
+    verifyTerminated(nextBlock, [&](Value token) {
+        builder.emitResumeNext(token, {});
+    });
+
+    verifyTerminated(labelBlock, [&](Value token) {
+        builder.emitResumeLabel(token, labelTarget, {});
+        assert(!labelBlock.instructions.empty());
+        const Instr &instr = labelBlock.instructions.back();
+        assert(instr.labels.size() == 1);
+        assert(instr.labels[0] == labelTarget.label);
+    });
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- mark resume opcodes as terminators in IRBuilder and add dedicated emit helpers
- add a builder unit test that verifies resume instructions terminate their blocks
- register the new test in the IL unit test suite

## Testing
- cmake --build build --target test_irbuilder_resume_terminators
- ctest --test-dir build --output-on-failure -R test_irbuilder_resume_terminators

------
https://chatgpt.com/codex/tasks/task_e_68e4452922c88324a74e02b04049a77f