### PR TITLE
Fix resume opcodes terminator classification

### DIFF
--- a/src/il/utils/Utils.cpp
+++ b/src/il/utils/Utils.cpp
@@ -77,6 +77,9 @@ bool isTerminator(const Instruction &I)
         case Opcode::SwitchI32:
         case Opcode::Ret:
         case Opcode::Trap:
+        case Opcode::ResumeSame:
+        case Opcode::ResumeNext:
+        case Opcode::ResumeLabel:
             return true;
         default:
             return false;

--- a/tests/il/UtilsTests.cpp
+++ b/tests/il/UtilsTests.cpp
@@ -48,6 +48,9 @@ int main()
     checkTerm(Opcode::CBr);
     checkTerm(Opcode::Ret);
     checkTerm(Opcode::Trap);
+    checkTerm(Opcode::ResumeSame);
+    checkTerm(Opcode::ResumeNext);
+    checkTerm(Opcode::ResumeLabel);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- treat ResumeSame, ResumeNext, and ResumeLabel as terminators in the IL utilities helper
- extend the IL utilities tests to cover the resume opcodes

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e4453bf798832481a2b87d569bb3fa