### PR TITLE
fix(il/analysis): handle resume.label in CFG

### DIFF
--- a/src/il/analysis/CFG.cpp
+++ b/src/il/analysis/CFG.cpp
@@ -53,8 +53,20 @@ CFGContext::CFGContext(il::core::Module &module) : module(&module)
                 continue;
 
             const il::core::Instr &term = blk.instructions.back();
-            if (term.op != il::core::Opcode::Br && term.op != il::core::Opcode::CBr &&
-                term.op != il::core::Opcode::SwitchI32)
+            bool isBranchTerminator = false;
+            switch (term.op)
+            {
+            case il::core::Opcode::Br:
+            case il::core::Opcode::CBr:
+            case il::core::Opcode::SwitchI32:
+            case il::core::Opcode::ResumeLabel:
+                isBranchTerminator = true;
+                break;
+            default:
+                break;
+            }
+
+            if (!isBranchTerminator)
                 continue;
 
             for (const auto &lbl : term.labels)


### PR DESCRIPTION
## Summary
- treat `resume.label` terminators as branching edges when building CFG successor and predecessor caches
- extend the CFG analysis test to cover blocks that end with `resume.label`

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e4487c59b083248f6ff2f8168bdad8