### PR TITLE
fix: handle invalid function key tokens in TUI config loader

### DIFF
--- a/tui/src/config/config.cpp
+++ b/tui/src/config/config.cpp
@@ -9,6 +9,7 @@
 #include <cctype>
 #include <fstream>
 #include <sstream>
+#include <stdexcept>
 #include <string_view>
 
 namespace viper::tui::config
@@ -87,35 +88,52 @@ term::KeyEvent::Code parse_code(const std::string &name)
         return Code::Delete;
     if (name.size() > 1 && name[0] == 'f')
     {
-        int num = std::stoi(name.substr(1));
-        switch (num)
+        const std::string suffix = name.substr(1);
+        try
         {
-            case 1:
-                return Code::F1;
-            case 2:
-                return Code::F2;
-            case 3:
-                return Code::F3;
-            case 4:
-                return Code::F4;
-            case 5:
-                return Code::F5;
-            case 6:
-                return Code::F6;
-            case 7:
-                return Code::F7;
-            case 8:
-                return Code::F8;
-            case 9:
-                return Code::F9;
-            case 10:
-                return Code::F10;
-            case 11:
-                return Code::F11;
-            case 12:
-                return Code::F12;
-            default:
-                break;
+            size_t parsed = 0;
+            const int num = std::stoi(suffix, &parsed);
+            if (parsed != suffix.size())
+            {
+                return Code::Unknown;
+            }
+            switch (num)
+            {
+                case 1:
+                    return Code::F1;
+                case 2:
+                    return Code::F2;
+                case 3:
+                    return Code::F3;
+                case 4:
+                    return Code::F4;
+                case 5:
+                    return Code::F5;
+                case 6:
+                    return Code::F6;
+                case 7:
+                    return Code::F7;
+                case 8:
+                    return Code::F8;
+                case 9:
+                    return Code::F9;
+                case 10:
+                    return Code::F10;
+                case 11:
+                    return Code::F11;
+                case 12:
+                    return Code::F12;
+                default:
+                    return Code::Unknown;
+            }
+        }
+        catch (const std::invalid_argument &)
+        {
+            return Code::Unknown;
+        }
+        catch (const std::out_of_range &)
+        {
+            return Code::Unknown;
         }
     }
     return Code::Unknown;

--- a/tui/tests/CMakeLists.txt
+++ b/tui/tests/CMakeLists.txt
@@ -97,7 +97,11 @@ add_test(NAME tui_test_list_tree COMMAND tui_test_list_tree)
 
 add_executable(tui_test_config test_config.cpp)
 target_link_libraries(tui_test_config PRIVATE tui)
-target_compile_definitions(tui_test_config PRIVATE CONFIG_INI="${CMAKE_CURRENT_SOURCE_DIR}/data/config.ini")
+target_compile_definitions(
+    tui_test_config
+    PRIVATE
+        CONFIG_INI="${CMAKE_CURRENT_SOURCE_DIR}/data/config.ini"
+        CONFIG_INVALID_INI="${CMAKE_CURRENT_SOURCE_DIR}/data/config_invalid_function_key.ini")
 add_test(NAME tui_test_config COMMAND tui_test_config)
 
 add_executable(tui_test_demo_headless test_demo_headless.cpp)

--- a/tui/tests/data/config_invalid_function_key.ini
+++ b/tui/tests/data/config_invalid_function_key.ini
@@ -1,0 +1,2 @@
+[keymap.global]
+ctrl + fbogus = save

--- a/tui/tests/test_config.cpp
+++ b/tui/tests/test_config.cpp
@@ -37,5 +37,14 @@ int main()
         }
     }
     assert(found_save);
+
+    Config invalid_cfg;
+    ok = loadFromFile(CONFIG_INVALID_INI, invalid_cfg);
+    assert(ok);
+    assert(!invalid_cfg.keymap_global.empty());
+    const auto &invalid_binding = invalid_cfg.keymap_global.front();
+    assert(invalid_binding.chord.code == KeyEvent::Code::Unknown);
+    assert(invalid_binding.chord.codepoint == 0);
+    assert(invalid_binding.command == "save");
     return 0;
 }


### PR DESCRIPTION
## Summary
- guard the TUI configuration loader against invalid function-key tokens by returning KeyEvent::Unknown instead of throwing
- add a regression config fixture and extend tui_test_config to cover invalid function-key bindings
- teach the test build to locate the new fixture path

## Testing
- cmake -S . -B build
- cmake --build build --target tui_test_config
- ctest --test-dir build --output-on-failure -R tui_test_config

------
https://chatgpt.com/codex/tasks/task_e_68e449ede2148324b8022d80a76f7d96