### PR TITLE
Fix VM string marshalling to copy byte spans

### DIFF
--- a/src/runtime/rt_string.c
+++ b/src/runtime/rt_string.c
@@ -186,6 +186,13 @@ rt_string rt_const_cstr(const char *c)
     return s;
 }
 
+rt_string rt_str_from_bytes(const char *bytes, size_t len)
+{
+    if (!bytes && len > 0)
+        return NULL;
+    return rt_string_from_bytes(bytes, len);
+}
+
 int64_t rt_len(rt_string s)
 {
     return (int64_t)rt_string_len_bytes(s);

--- a/src/runtime/rt_string.h
+++ b/src/runtime/rt_string.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -188,6 +189,12 @@ extern "C" {
     /// @param str Null-terminated literal pointer.
     /// @return Non-owning runtime string view.
     rt_string rt_const_cstr(const char *str);
+
+    /// @brief Allocate a runtime string by copying @p len bytes from @p bytes.
+    /// @param bytes Pointer to the source byte span; may be NULL when @p len is 0.
+    /// @param len Number of bytes to copy into the runtime string.
+    /// @return Newly allocated runtime string containing the copied bytes.
+    rt_string rt_str_from_bytes(const char *bytes, size_t len);
 
 #ifdef __cplusplus
 }

--- a/src/vm/Marshal.cpp
+++ b/src/vm/Marshal.cpp
@@ -19,7 +19,7 @@ ViperString toViperString(StringRef text)
         return nullptr;
     if (text.empty())
         return rt_const_cstr("");
-    return rt_const_cstr(text.data());
+    return rt_str_from_bytes(text.data(), text.size());
 }
 
 StringRef fromViperString(const ViperString &str)

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -133,7 +133,7 @@ Slot VM::eval(Frame &fr, const Value &v)
             if (it == strMap.end())
                 RuntimeBridge::trap(TrapKind::DomainError, "unknown global", {}, fr.func->name, "");
             else
-                s.str = it->second;
+                s.str = rt_string_ref(it->second);
             return s;
         }
         case Value::Kind::NullPtr:

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -144,6 +144,9 @@ class VM
        DebugCtrl dbg = {},
        DebugScript *script = nullptr);
 
+    /// @brief Release runtime resources held by the VM.
+    ~VM();
+
     /// @brief Execute the module's entry function.
     /// @return Exit code from @c main or `1` when the entry point is missing.
     int64_t run();

--- a/src/vm/VMInit.cpp
+++ b/src/vm/VMInit.cpp
@@ -62,6 +62,15 @@ VM::VM(const Module &m, TraceConfig tc, uint64_t ms, DebugCtrl dbg, DebugScript 
         strMap[g.name] = toViperString(g.init);
 }
 
+VM::~VM()
+{
+    for (auto &[name, handle] : strMap)
+    {
+        (void)name;
+        rt_string_unref(handle);
+    }
+}
+
 /// Initialise a fresh @c Frame for executing function @p fn.
 ///
 /// Populates a basic-block lookup table, selects the entry block and seeds the

--- a/tests/unit/test_vm_addr_of.cpp
+++ b/tests/unit/test_vm_addr_of.cpp
@@ -33,6 +33,11 @@ int main()
     il::vm::VM vm(m);
     int64_t rv = vm.run();
     rt_string s = reinterpret_cast<rt_string>(static_cast<uintptr_t>(rv));
-    assert(s->data == m.globals.front().init.c_str());
+    const std::string &init = m.globals.front().init;
+    assert(rt_len(s) == static_cast<int64_t>(init.size()));
+    std::string payload(s->data, static_cast<size_t>(rt_len(s)));
+    assert(payload == init);
+    assert(s->data[rt_len(s)] == '\0');
+    rt_string_unref(s);
     return 0;
 }

--- a/tests/unit/test_vm_const_string_bytes.cpp
+++ b/tests/unit/test_vm_const_string_bytes.cpp
@@ -1,0 +1,51 @@
+// File: tests/unit/test_vm_const_string_bytes.cpp
+// Purpose: Ensure VM marshals constant strings with embedded null bytes without truncation.
+// Key invariants: Runtime receives the full byte payload and reports the correct length.
+// Ownership: Test builds a throwaway module and relies on VM teardown to release globals.
+// Links: docs/codemap.md
+
+#include "il/build/IRBuilder.hpp"
+#include "support/source_location.hpp"
+#include "vm/VM.hpp"
+
+#include <cassert>
+#include <optional>
+#include <string>
+
+int main()
+{
+    using il::build::IRBuilder;
+    using il::core::Module;
+    using il::core::Type;
+    using il::core::Value;
+    using il::support::SourceLoc;
+
+    Module module;
+    IRBuilder builder(module);
+
+    builder.addExtern("rt_len", Type(Type::Kind::I64), {Type(Type::Kind::Str)});
+    builder.addExtern("rt_str_release_maybe", Type(Type::Kind::Void), {Type(Type::Kind::Str)});
+
+    const std::string globalName = "g_payload";
+    const std::string payload{"A\0B", 3};
+    builder.addGlobalStr(globalName, payload);
+
+    auto &fn = builder.startFunction("main", Type(Type::Kind::I64), {});
+    auto &bb = builder.addBlock(fn, "entry");
+    builder.setInsertPoint(bb);
+
+    const SourceLoc loc{1, 1, 1};
+
+    Value strVal = builder.emitConstStr(globalName, loc);
+    unsigned lenId = builder.reserveTempId();
+    Value lenVal = Value::temp(lenId);
+    std::optional<Value> lenDst = lenVal;
+    builder.emitCall("rt_len", {strVal}, lenDst, loc);
+    builder.emitCall("rt_str_release_maybe", {strVal}, std::nullopt, loc);
+    builder.emitRet(lenVal, loc);
+
+    il::vm::VM vm(module);
+    const int64_t exitCode = vm.run();
+    assert(exitCode == static_cast<int64_t>(payload.size()));
+    return 0;
+}

--- a/tests/vm/CMakeLists.txt
+++ b/tests/vm/CMakeLists.txt
@@ -154,6 +154,10 @@ function(viper_add_vm_unit_tests)
   target_link_libraries(test_vm_runtime_bridge_marshalling PRIVATE ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   viper_add_ctest(test_vm_runtime_bridge_marshalling test_vm_runtime_bridge_marshalling)
 
+  viper_add_test(test_vm_const_string_bytes ${VIPER_TESTS_DIR}/unit/test_vm_const_string_bytes.cpp)
+  target_link_libraries(test_vm_const_string_bytes PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
+  viper_add_ctest(test_vm_const_string_bytes test_vm_const_string_bytes)
+
   viper_add_test(test_vm_alloca_negative ${VIPER_TESTS_DIR}/unit/test_vm_alloca_negative.cpp)
   target_link_libraries(test_vm_alloca_negative PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   viper_add_ctest(test_vm_alloca_negative test_vm_alloca_negative)


### PR DESCRIPTION
## Summary
- add a runtime helper to copy byte spans into owned strings and use it in `toViperString`
- retain and release VM-managed global strings to respect runtime ownership
- extend tests with embedded-null coverage and update addr_of expectations

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e448b71fec8324bc2ddda3c9b6d856