### PR TITLE
fix(runtime): correct bright background sgr

### DIFF
--- a/src/runtime/rt_term.c
+++ b/src/runtime/rt_term.c
@@ -81,7 +81,7 @@ static void sgr_color(int fg, int bg) {
     if (bg <= 7) {
       n += snprintf(buf + n, sizeof(buf)-n, "%d", 40 + bg);
     } else if (bg <= 15) {
-      n += snprintf(buf + n, sizeof(buf)-n, "48;5;%d", 100 + (bg - 8));
+      n += snprintf(buf + n, sizeof(buf)-n, "%d", 100 + (bg - 8));
     } else {
       n += snprintf(buf + n, sizeof(buf)-n, "48;5;%d", bg);
     }

--- a/tests/runtime/RTTermColorTests.cpp
+++ b/tests/runtime/RTTermColorTests.cpp
@@ -1,0 +1,83 @@
+// File: tests/runtime/RTTermColorTests.cpp
+// Purpose: Verify rt_term_color_i32 emits correct SGR codes for bright backgrounds.
+// Key invariants: Background values 8-15 map to ANSI 100-107 without using 48;5.
+// Ownership: Runtime library tests.
+// Links: docs/runtime-vm.md#runtime-abi
+
+#include "rt.hpp"
+
+#include <cassert>
+#include <string>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#if defined(__linux__)
+#  include <pty.h>
+#elif defined(__APPLE__)
+#  include <util.h>
+#else
+#  error "openpty is required for RTTermColorTests"
+#endif
+
+namespace {
+
+std::string capture_sgr(int fg, int bg)
+{
+    int master = -1;
+    int slave = -1;
+    int rc = openpty(&master, &slave, nullptr, nullptr, nullptr);
+    assert(rc == 0);
+
+    pid_t pid = fork();
+    assert(pid >= 0);
+
+    if (pid == 0)
+    {
+        close(master);
+        dup2(slave, STDOUT_FILENO);
+        close(slave);
+        rt_term_color_i32(fg, bg);
+        _exit(0);
+    }
+
+    close(slave);
+
+    std::string result;
+    char buf[64];
+    ssize_t n = 0;
+    while ((n = read(master, buf, sizeof(buf))) > 0)
+    {
+        result.append(buf, static_cast<size_t>(n));
+        if (n < static_cast<ssize_t>(sizeof(buf)))
+        {
+            break;
+        }
+    }
+
+    close(master);
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+
+    return result;
+}
+
+} // namespace
+
+int main()
+{
+    for (int bg = 8; bg <= 15; ++bg)
+    {
+        std::string sgr = capture_sgr(-1, bg);
+        std::string expected = "\x1b[" + std::to_string(100 + (bg - 8)) + "m";
+        assert(sgr == expected);
+        assert(sgr.find("48;5") == std::string::npos);
+    }
+
+    std::string combined = capture_sgr(8, 8);
+    assert(combined == "\x1b[1;30;100m");
+
+    return 0;
+}
+

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -95,6 +95,10 @@ function(viper_add_runtime_tests)
   target_link_libraries(test_rt_instr PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_instr test_rt_instr)
 
+  viper_add_test(test_rt_term_color ${VIPER_TESTS_DIR}/runtime/RTTermColorTests.cpp)
+  target_link_libraries(test_rt_term_color PRIVATE ${VIPER_RUNTIME_TEST_LIBS} util)
+  viper_add_ctest(test_rt_term_color test_rt_term_color)
+
   viper_add_test(test_rt_trim_case ${VIPER_TESTS_DIR}/runtime/RTTrimCaseTests.cpp)
   target_link_libraries(test_rt_trim_case PRIVATE ${VIPER_RUNTIME_TEST_LIBS})
   viper_add_ctest(test_rt_trim_case test_rt_trim_case)


### PR DESCRIPTION
## Summary
- ensure bright background codes map to ANSI 100-107 instead of 48;5 escapes
- add a runtime terminal test that captures bright background SGR output via a pseudo-terminal

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e448adf0d8832499e9f17fbc311a4c