### PR TITLE
Fix boolean array parameter rejection

### DIFF
--- a/src/frontends/basic/ProcRegistry.cpp
+++ b/src/frontends/basic/ProcRegistry.cpp
@@ -37,7 +37,7 @@ ProcSignature ProcRegistry::buildSignature(const ProcDescriptor &descriptor)
                     static_cast<uint32_t>(p.name.size()),
                     std::move(msg));
         }
-        if (p.is_array && p.type != Type::I64 && p.type != Type::Str && p.type != Type::Bool)
+        if (p.is_array && p.type != Type::I64 && p.type != Type::Str)
         {
             std::string msg = "array parameter must be i64 or str";
             de.emit(il::support::Severity::Error,

--- a/tests/basic/CMakeLists.txt
+++ b/tests/basic/CMakeLists.txt
@@ -62,6 +62,13 @@ function(viper_add_basic_main_tests)
   target_link_libraries(test_basic_semantic_arrays PRIVATE ${VIPER_BASIC_LIBS})
   viper_add_ctest(test_basic_semantic_arrays test_basic_semantic_arrays)
 
+  viper_add_test(
+    test_basic_semantic_proc_bool_array
+    ${_VIPER_BASIC_UNIT_DIR}/test_basic_semantic_proc_bool_array.cpp)
+  target_link_libraries(test_basic_semantic_proc_bool_array PRIVATE ${VIPER_BASIC_LIBS})
+  viper_add_ctest(
+    test_basic_semantic_proc_bool_array test_basic_semantic_proc_bool_array)
+
   viper_add_test(test_basic_intrinsic_semantics ${_VIPER_BASIC_UNIT_DIR}/test_basic_intrinsic_semantics.cpp)
   target_link_libraries(test_basic_intrinsic_semantics PRIVATE ${VIPER_BASIC_LIBS})
   viper_add_ctest(test_basic_intrinsic_semantics test_basic_intrinsic_semantics)

--- a/tests/unit/test_basic_semantic_proc_bool_array.cpp
+++ b/tests/unit/test_basic_semantic_proc_bool_array.cpp
@@ -1,0 +1,51 @@
+// File: tests/unit/test_basic_semantic_proc_bool_array.cpp
+// Purpose: Ensure semantic analyzer rejects boolean array parameters in procedures.
+// Key invariants: Procedure registration forbids array parameters unless i64 or str.
+// Ownership/Lifetime: Test owns constructed AST and diagnostic infrastructure.
+// Links: docs/codemap.md
+
+#include "frontends/basic/DiagnosticEmitter.hpp"
+#include "frontends/basic/SemanticAnalyzer.hpp"
+#include "support/source_manager.hpp"
+
+#include <cassert>
+#include <memory>
+#include <string>
+
+using namespace il::frontends::basic;
+using namespace il::support;
+
+int main()
+{
+    const std::string src = "10 SUB CHECK(B() AS BOOLEAN)\n20 END SUB\n";
+
+    SourceManager sm;
+    uint32_t fid = sm.addFile("bool_array_param.bas");
+
+    DiagnosticEngine engine;
+    DiagnosticEmitter emitter(engine, sm);
+    emitter.addSource(fid, src);
+
+    Program prog;
+
+    auto sub = std::make_unique<SubDecl>();
+    sub->line = 10;
+    sub->loc = {fid, 1, 4};
+    sub->name = "CHECK";
+
+    Param param;
+    param.name = "FLAGS";
+    param.type = Type::Bool;
+    param.is_array = true;
+    param.loc = {fid, 1, 14};
+    sub->params.push_back(param);
+
+    prog.procs.push_back(std::move(sub));
+
+    SemanticAnalyzer sema(emitter);
+    sema.analyze(prog);
+
+    assert(emitter.errorCount() == 1);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- restrict ProcRegistry array parameter validation to I64 or Str
- add a semantic analyzer unit test that covers boolean array parameters
- register the new test with the BASIC unit test suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e4488818c08324a1a2f79dbfd5e180