### PR TITLE
feat: support IL target directive round-trip

### DIFF
--- a/src/il/core/Module.hpp
+++ b/src/il/core/Module.hpp
@@ -8,6 +8,7 @@
 #include "il/core/Extern.hpp"
 #include "il/core/Function.hpp"
 #include "il/core/Global.hpp"
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -22,6 +23,12 @@ struct Module
     /// Defaults to "0.1.2" for newly constructed modules and may be
     /// overwritten by parsers when reading serialized IL.
     std::string version = "0.1.2";
+
+    /// @brief Optional target triple directive associated with the module.
+    ///
+    /// Absent by default; populated when a `target "triple"` directive is
+    /// encountered during parsing or assigned programmatically.
+    std::optional<std::string> target;
 
     /// @brief Declared external functions available to the module.
     ///

--- a/src/il/io/ModuleParser.cpp
+++ b/src/il/io/ModuleParser.cpp
@@ -16,6 +16,7 @@
 
 #include "support/diag_expected.hpp"
 
+#include <iomanip>
 #include <sstream>
 #include <utility>
 #include <vector>
@@ -161,6 +162,18 @@ Expected<void> parseModuleHeader_E(std::istream &is, std::string &line, ParserSt
             st.m.version = ver;
         else
             st.m.version = "0.1.2";
+        return {};
+    }
+    if (line.rfind("target", 0) == 0)
+    {
+        std::istringstream ls(line);
+        std::string kw;
+        ls >> kw;
+        std::string triple;
+        if (ls >> std::quoted(triple))
+            st.m.target = triple;
+        else
+            st.m.target.reset();
         return {};
     }
     if (line.rfind("extern", 0) == 0)

--- a/src/il/io/Serializer.cpp
+++ b/src/il/io/Serializer.cpp
@@ -349,6 +349,8 @@ void printInstr(const Instr &in, std::ostream &os)
 void Serializer::write(const Module &m, std::ostream &os, Mode mode)
 {
     os << "il " << m.version << "\n";
+    if (m.target)
+        os << "target \"" << *m.target << "\"\n";
     if (mode == Mode::Canonical)
     {
         std::vector<Extern> ex(m.externs.begin(), m.externs.end());

--- a/tests/golden/hello_expected.il
+++ b/tests/golden/hello_expected.il
@@ -1,4 +1,5 @@
 il 0.1.2
+target "x86_64-unknown-linux-gnu"
 extern @rt_print_str(str) -> void
 global const str @.L0 = "HELLO"
 func @main() -> i64 {

--- a/tests/il/parse-roundtrip/target_directive.il
+++ b/tests/il/parse-roundtrip/target_directive.il
@@ -1,0 +1,7 @@
+il 0.1.2
+target "wasm32-unknown-unknown"
+extern @host_print(str) -> void
+func @main() -> void {
+entry:
+  ret
+}

--- a/tests/unit/test_il_parse_roundtrip.cpp
+++ b/tests/unit/test_il_parse_roundtrip.cpp
@@ -19,12 +19,13 @@
 
 int main()
 {
-    constexpr std::array<const char *, 7> files = {PARSE_ROUNDTRIP_DIR "/checked-arith.il",
+    constexpr std::array<const char *, 8> files = {PARSE_ROUNDTRIP_DIR "/checked-arith.il",
                                                    PARSE_ROUNDTRIP_DIR "/checked-divrem.il",
                                                    PARSE_ROUNDTRIP_DIR "/cast-checks.il",
                                                    PARSE_ROUNDTRIP_DIR "/errors_eh.il",
                                                    PARSE_ROUNDTRIP_DIR "/idx_chk.il",
                                                    PARSE_ROUNDTRIP_DIR "/err_access.il",
+                                                   PARSE_ROUNDTRIP_DIR "/target_directive.il",
                                                    SWITCH_GOLDEN};
 
     for (const char *path : files)

--- a/tests/unit/test_il_serialize.cpp
+++ b/tests/unit/test_il_serialize.cpp
@@ -7,6 +7,7 @@
 int main()
 {
     il::core::Module m;
+    m.target = std::string("x86_64-unknown-linux-gnu");
     il::build::IRBuilder builder(m);
     builder.addExtern("rt_print_str",
                       il::core::Type(il::core::Type::Kind::Void),


### PR DESCRIPTION
## Summary
- add a target triple field to `il::core::Module` and serialize it when present
- teach the module parser to accept `target` directives without producing diagnostics
- extend serializer/round-trip tests with IL modules that include the target directive

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e479a53728832482613fe17d26733b