### PR TITLE
feat(il/io): allow literal global initializers

### DIFF
--- a/src/il/build/IRBuilder.cpp
+++ b/src/il/build/IRBuilder.cpp
@@ -43,7 +43,7 @@ Extern &IRBuilder::addExtern(const std::string &name, Type ret, const std::vecto
 /// @note The global is always recorded with Type::Kind::Str.
 Global &IRBuilder::addGlobalStr(const std::string &name, const std::string &value)
 {
-    mod.globals.push_back({name, Type(Type::Kind::Str), value});
+    mod.globals.push_back({name, Type(Type::Kind::Str), Value::constStr(value)});
     return mod.globals.back();
 }
 

--- a/src/il/core/Global.hpp
+++ b/src/il/core/Global.hpp
@@ -6,6 +6,9 @@
 #pragma once
 
 #include "il/core/Type.hpp"
+#include "il/core/Value.hpp"
+
+#include <optional>
 #include <string>
 
 namespace il::core
@@ -26,10 +29,9 @@ struct Global
     /// @invariant Must match the type of any provided initializer.
     Type type;
 
-    /// @brief Serialized initializer data, if any.
-    /// @invariant Non-empty only for globals with constant values (e.g. UTF-8
-    /// string literals).
-    std::string init;
+    /// @brief Optional constant initializer attached to the global.
+    /// @invariant When engaged, the value's kind matches the declared type.
+    std::optional<Value> init;
 };
 
 } // namespace il::core

--- a/src/il/io/Serializer.cpp
+++ b/src/il/io/Serializer.cpp
@@ -367,7 +367,10 @@ void Serializer::write(const Module &m, std::ostream &os, Mode mode)
 
     for (const auto &g : m.globals)
     {
-        os << "global const " << g.type.toString() << " @" << g.name << " = \"" << g.init << "\"\n";
+        os << "global const " << g.type.toString() << " @" << g.name;
+        if (g.init)
+            os << " = " << il::core::toString(*g.init);
+        os << "\n";
     }
 
     for (const auto &f : m.functions)

--- a/src/vm/VMInit.cpp
+++ b/src/vm/VMInit.cpp
@@ -59,7 +59,10 @@ VM::VM(const Module &m, TraceConfig tc, uint64_t ms, DebugCtrl dbg, DebugScript 
     for (const auto &f : m.functions)
         fnMap[f.name] = &f;
     for (const auto &g : m.globals)
-        strMap[g.name] = toViperString(g.init);
+    {
+        if (g.init && g.init->kind == Value::Kind::ConstStr)
+            strMap[g.name] = toViperString(g.init->str);
+    }
 }
 
 /// Initialise a fresh @c Frame for executing function @p fn.

--- a/tests/il/parse-roundtrip/globals_literals.il
+++ b/tests/il/parse-roundtrip/globals_literals.il
@@ -1,0 +1,12 @@
+il 0.1.2
+
+global const str @.msg = "hello"
+global const i32 @.int = 123
+global const f64 @.flt = 3.5
+global const ptr @.null = null
+global const ptr @.sym = @.msg
+
+func @main() -> i32 {
+entry:
+  ret 0
+}

--- a/tests/unit/test_il_parse_roundtrip.cpp
+++ b/tests/unit/test_il_parse_roundtrip.cpp
@@ -19,13 +19,14 @@
 
 int main()
 {
-    constexpr std::array<const char *, 8> files = {PARSE_ROUNDTRIP_DIR "/checked-arith.il",
+    constexpr std::array<const char *, 9> files = {PARSE_ROUNDTRIP_DIR "/checked-arith.il",
                                                    PARSE_ROUNDTRIP_DIR "/checked-divrem.il",
                                                    PARSE_ROUNDTRIP_DIR "/cast-checks.il",
                                                    PARSE_ROUNDTRIP_DIR "/errors_eh.il",
                                                    PARSE_ROUNDTRIP_DIR "/idx_chk.il",
                                                    PARSE_ROUNDTRIP_DIR "/err_access.il",
                                                    PARSE_ROUNDTRIP_DIR "/target_directive.il",
+                                                   PARSE_ROUNDTRIP_DIR "/globals_literals.il",
                                                    SWITCH_GOLDEN};
 
     for (const char *path : files)

--- a/tests/unit/test_il_serialize_opcodes.cpp
+++ b/tests/unit/test_il_serialize_opcodes.cpp
@@ -31,7 +31,7 @@ int main()
     Global g;
     g.name = ".Lstr";
     g.type = Type(Type::Kind::Str);
-    g.init = "ops";
+    g.init = Value::constStr("ops");
     m.globals.push_back(g);
 
     Function f;

--- a/tests/unit/test_vm_addr_of.cpp
+++ b/tests/unit/test_vm_addr_of.cpp
@@ -33,6 +33,8 @@ int main()
     il::vm::VM vm(m);
     int64_t rv = vm.run();
     rt_string s = reinterpret_cast<rt_string>(static_cast<uintptr_t>(rv));
-    assert(s->data == m.globals.front().init.c_str());
+    assert(m.globals.front().init);
+    assert(m.globals.front().init->kind == il::core::Value::Kind::ConstStr);
+    assert(s->data == m.globals.front().init->str.c_str());
     return 0;
 }


### PR DESCRIPTION
## Summary
- parse global declarations that initialize integers, floats, null pointers, and symbol addresses while retaining typed metadata
- update serializer, IR builder, and VM bootstrap code to honor the richer global initializer representation
- add a parse round-trip golden covering each supported initializer form

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e47ee0f14c832480fd05e87474624e