### PR TITLE
fix(vm): release runtime string handles

### DIFF
--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -144,6 +144,14 @@ class VM
        DebugCtrl dbg = {},
        DebugScript *script = nullptr);
 
+    /// @brief Release runtime string handles retained by the VM.
+    ~VM();
+
+    VM(const VM &) = delete;
+    VM &operator=(const VM &) = delete;
+    VM(VM &&) noexcept = default;
+    VM &operator=(VM &&) = delete;
+
     /// @brief Execute the module's entry function.
     /// @return Exit code from @c main or `1` when the entry point is missing.
     int64_t run();

--- a/src/vm/VMInit.cpp
+++ b/src/vm/VMInit.cpp
@@ -62,6 +62,14 @@ VM::VM(const Module &m, TraceConfig tc, uint64_t ms, DebugCtrl dbg, DebugScript 
         strMap[g.name] = toViperString(g.init);
 }
 
+/// Release runtime string handles owned by the VM instance.
+VM::~VM()
+{
+    for (auto &entry : strMap)
+        rt_str_release_maybe(entry.second);
+    strMap.clear();
+}
+
 /// Initialise a fresh @c Frame for executing function @p fn.
 ///
 /// Populates a basic-block lookup table, selects the entry block and seeds the


### PR DESCRIPTION
## Summary
- add a VM destructor that drops cached `rt_string` handles before clearing the cache
- disable copy semantics and default the move constructor now that destruction performs handle release

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e47f1d5270832484a4c4f1225390a5