### PR TITLE
fix: validate .loc directive parsing

### DIFF
--- a/src/il/io/FunctionParser.cpp
+++ b/src/il/io/FunctionParser.cpp
@@ -338,6 +338,19 @@ Expected<void> parseFunction(std::istream &is, std::string &header, ParserState 
             std::istringstream ls(line.substr(4));
             uint32_t fid = 0, ln = 0, col = 0;
             ls >> fid >> ln >> col;
+            if (!ls)
+            {
+                std::ostringstream oss;
+                oss << "line " << st.lineNo << ": malformed .loc directive";
+                return Expected<void>{makeError({}, oss.str())};
+            }
+            ls >> std::ws;
+            if (ls.peek() != std::char_traits<char>::eof())
+            {
+                std::ostringstream oss;
+                oss << "line " << st.lineNo << ": malformed .loc directive";
+                return Expected<void>{makeError({}, oss.str())};
+            }
             st.curLoc = {fid, ln, col};
             continue;
         }

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -130,6 +130,10 @@ function(viper_add_il_core_tests)
   target_link_libraries(test_il_function_parser_errors PRIVATE ${VIPER_IL_CORE_IO_LIBS})
   viper_add_ctest(test_il_function_parser_errors test_il_function_parser_errors)
 
+  viper_add_test(test_il_parse_loc_errors ${_VIPER_IL_UNIT_DIR}/test_il_parse_loc_errors.cpp)
+  target_link_libraries(test_il_parse_loc_errors PRIVATE ${VIPER_IL_CORE_IO_LIBS})
+  viper_add_ctest(test_il_parse_loc_errors test_il_parse_loc_errors)
+
   viper_add_test(test_expected_api_build ${_VIPER_IL_UNIT_DIR}/test_expected_api_build.cpp)
   target_link_libraries(test_expected_api_build PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   viper_add_ctest(test_expected_api_build test_expected_api_build)

--- a/tests/unit/test_il_parse_loc_errors.cpp
+++ b/tests/unit/test_il_parse_loc_errors.cpp
@@ -1,0 +1,38 @@
+// File: tests/unit/test_il_parse_loc_errors.cpp
+// Purpose: Ensure the IL function parser reports malformed .loc directives.
+// Key invariants: ParserState diagnostics identify incorrect location triplets.
+// Ownership/Lifetime: Constructs parser state locally for each scenario.
+// Links: docs/il-guide.md#reference
+
+#include "il/io/FunctionParser.hpp"
+#include "il/io/ParserState.hpp"
+#include "il/core/Module.hpp"
+
+#include <cassert>
+#include <sstream>
+#include <string>
+
+int main()
+{
+    using il::io::detail::parseFunction;
+    using il::io::detail::ParserState;
+
+    il::core::Module m;
+    ParserState st{m};
+    st.lineNo = 1;
+
+    std::string header = "func @loc() -> i64 {";
+    std::istringstream body(R"(entry:
+  .loc 1 2
+  ret 0
+}
+)");
+
+    auto result = parseFunction(body, header, st);
+    assert(!result);
+    const std::string &msg = result.error().message;
+    assert(msg.find("malformed .loc directive") != std::string::npos);
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- ensure the function parser verifies `.loc` directives read a complete triplet and fail when extra tokens remain
- add a regression test covering an incomplete `.loc` directive and register it with the IL test suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e499ab0e5083248a99fdb08afa2821