### PR TITLE
fix(il/io): reject duplicate function parameter names

### DIFF
--- a/src/il/io/FunctionParser.cpp
+++ b/src/il/io/FunctionParser.cpp
@@ -174,6 +174,12 @@ Expected<void> parseFunctionHeader(const std::string &header, ParserState &st)
     unsigned idx = 0;
     for (auto &param : params)
     {
+        if (st.tempIds.find(param.name) != st.tempIds.end())
+        {
+            std::ostringstream oss;
+            oss << "line " << st.lineNo << ": duplicate parameter name '%" << param.name << "'";
+            return Expected<void>{makeError({}, oss.str())};
+        }
         param.id = idx;
         st.tempIds[param.name] = idx;
         ++idx;

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -63,6 +63,10 @@ function(viper_add_il_core_tests)
   target_compile_definitions(test_il_parse_param_prefix PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
   viper_add_ctest(test_il_parse_param_prefix test_il_parse_param_prefix)
 
+  viper_add_test(test_il_parse_duplicate_param ${_VIPER_IL_UNIT_DIR}/test_il_parse_duplicate_param.cpp)
+  target_link_libraries(test_il_parse_duplicate_param PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  viper_add_ctest(test_il_parse_duplicate_param test_il_parse_duplicate_param)
+
   viper_add_test(test_il_parse_missing_brace ${_VIPER_IL_UNIT_DIR}/test_il_parse_missing_brace.cpp)
   target_link_libraries(test_il_parse_missing_brace PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   target_compile_definitions(test_il_parse_missing_brace PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")

--- a/tests/unit/test_il_parse_duplicate_param.cpp
+++ b/tests/unit/test_il_parse_duplicate_param.cpp
@@ -1,0 +1,36 @@
+// File: tests/unit/test_il_parse_duplicate_param.cpp
+// Purpose: Ensure the IL parser rejects duplicate parameter names in function headers.
+// Key invariants: Parser reports diagnostics without clobbering existing temporaries.
+// Ownership/Lifetime: Test owns module and diagnostic buffers constructed from string literals.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "support/diagnostics.hpp"
+
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    static constexpr const char *kSource = R"(il 0.1.2
+func @dup(i32 %x, i32 %x) -> void {
+entry:
+  ret
+}
+)";
+
+    std::istringstream input(kSource);
+    il::core::Module module;
+    auto parseResult = il::api::v2::parse_text_expected(input, module);
+    assert(!parseResult && "parser should reject duplicate parameter names");
+
+    std::ostringstream diag;
+    il::support::printDiag(parseResult.error(), diag);
+    const std::string message = diag.str();
+    assert(message.find("duplicate parameter name '%x'") != std::string::npos);
+    assert(message.find("line 2") != std::string::npos);
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- prevent parseFunctionHeader from reusing an existing SSA name by emitting a duplicate-parameter diagnostic
- add a unit test that exercises duplicate header parameters and register it with the IL parser test suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure -R test_il_parse_duplicate_param
- ctest --test-dir build --output-on-failure -R test_il_parse_function_name_trim

------
https://chatgpt.com/codex/tasks/task_e_68e4998a36fc8324a903240ec668963b