### PR TITLE
Fix VM string marshalling for embedded NUL bytes

### DIFF
--- a/src/runtime/rt_string.c
+++ b/src/runtime/rt_string.c
@@ -72,12 +72,22 @@ static rt_string rt_string_alloc(size_t len, size_t cap)
     return rt_string_wrap(payload);
 }
 
-static rt_string rt_string_from_bytes(const char *bytes, size_t len)
+/**
+ * Purpose: Allocate a runtime string from arbitrary bytes and explicit length.
+ *
+ * Parameters:
+ *   bytes - Pointer to the UTF-8 byte sequence to copy; may be NULL when
+ *           @p len is zero.
+ *   len   - Number of bytes to copy from @p bytes.
+ *
+ * Returns: Newly allocated runtime string containing the copied bytes.
+ */
+rt_string rt_string_from_bytes(const char *bytes, size_t len)
 {
     rt_string s = rt_string_alloc(len, len + 1);
     if (!s)
         return NULL;
-    if (len > 0)
+    if (len > 0 && bytes)
         memcpy(s->data, bytes, len);
     s->data[len] = '\0';
     return s;

--- a/src/runtime/rt_string.h
+++ b/src/runtime/rt_string.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,6 +37,12 @@ extern "C" {
     void rt_str_retain_maybe(rt_string s);
 
     rt_string rt_str_empty(void);
+
+    /// @brief Allocate a runtime string by copying @p len bytes from @p bytes.
+    /// @param bytes Source buffer; may be NULL when @p len is zero.
+    /// @param len Number of bytes to copy into the new runtime string.
+    /// @return Newly allocated runtime string containing the copied bytes.
+    rt_string rt_string_from_bytes(const char *bytes, size_t len);
 
     /// @brief Return the number of bytes stored in @p s (excluding the terminator).
     /// @param s String to measure; NULL returns 0.

--- a/src/vm/Marshal.cpp
+++ b/src/vm/Marshal.cpp
@@ -19,6 +19,8 @@ ViperString toViperString(StringRef text)
         return nullptr;
     if (text.empty())
         return rt_const_cstr("");
+    if (text.find('\0') != StringRef::npos)
+        return rt_string_from_bytes(text.data(), text.size());
     return rt_const_cstr(text.data());
 }
 


### PR DESCRIPTION
## Summary
- expose a runtime helper that copies byte buffers into `rt_string` instances
- update `toViperString` to allocate strings when embedded NULs are present
- extend the runtime bridge marshalling test to cover strings containing `\0`

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e4a0d21790832482a85514761f601e