### PR TITLE
fix(il/parser): reject instructions after terminators

### DIFF
--- a/tests/il/parse-roundtrip/err_access.il
+++ b/tests/il/parse-roundtrip/err_access.il
@@ -3,11 +3,12 @@ func @f() -> void {
 entry:
   eh.push ^H
   trap.from_err i32 7
+exit:
   ret
 handler ^H(%e:Error, %t:ResumeTok):
   eh.entry
   %kind = trap.kind
   %k = err.get_kind %e
   %ln = err.get_line %e
-  resume.next %t
+  resume.label %t, ^exit
 }

--- a/tests/il/parse-roundtrip/errors_eh.il
+++ b/tests/il/parse-roundtrip/errors_eh.il
@@ -6,26 +6,28 @@ func @errors_demo() -> void {
 entry:
   eh.push ^handle_same
   trap.from_err i32 6
+after_same:
   eh.push ^handle_next
   trap.from_err i32 4
+after_next:
   eh.push ^handle_label
   trap.from_err i32 5
+after_label:
   trap
-  eh.pop
-  ret
 handler ^handle_same(%err:Error, %tok:ResumeTok):
   eh.entry
   %k0 = trap.kind
-  resume.same %tok
+  resume.label %tok, ^after_same
 handler ^handle_next(%err:Error, %tok:ResumeTok):
   eh.entry
   %msg0 = const_str @.msg0
   %err0 = trap.err 7, %msg0
-  resume.next %tok
+  resume.label %tok, ^after_next
 handler ^handle_label(%err:Error, %tok:ResumeTok):
   eh.entry
   resume.label %tok, ^after(%err)
 after(%incoming:Error):
+  eh.pop
   %msg1 = const_str @.msg1
   %err1 = trap.err 9, %msg1
   ret

--- a/tests/il/parse-roundtrip/expected/errors_eh.il
+++ b/tests/il/parse-roundtrip/expected/errors_eh.il
@@ -6,26 +6,28 @@ func @errors_demo() -> void {
 entry:
   eh.push ^handle_same
   trap.from_err i32 6
+after_same:
   eh.push ^handle_next
   trap.from_err i32 4
+after_next:
   eh.push ^handle_label
   trap.from_err i32 5
+after_label:
   trap
-  eh.pop
-  ret
 handler ^handle_same(%err:Error, %tok:ResumeTok):
   eh.entry
   %k0 = trap.kind
-  resume.same %tok
+  resume.label %tok, ^after_same
 handler ^handle_next(%err:Error, %tok:ResumeTok):
   eh.entry
   %msg0 = const_str @.msg0
   %err0 = trap.err 7, %msg0
-  resume.next %tok
+  resume.label %tok, ^after_next
 handler ^handle_label(%err:Error, %tok:ResumeTok):
   eh.entry
   resume.label %tok, ^after(%err)
 after(%incoming:Error):
+  eh.pop
   %msg1 = const_str @.msg1
   %err1 = trap.err 9, %msg1
   ret


### PR DESCRIPTION
## Summary
- enforce terminator detection inside the instruction parser and mark basic blocks accordingly
- update error-handling round-trip IL fixtures so terminators close their blocks
- extend the miscellaneous parser unit test to assert termination flags and the new diagnostic

## Testing
- ctest --test-dir build --output-on-failure -R "test_il_parse|test_il_control_flow_checker"

------
https://chatgpt.com/codex/tasks/task_e_68e4a0bd5a0483249b04ee787a364640