### PR TITLE
fix(il/io): preserve call result type in parser

### DIFF
--- a/src/il/io/OperandParser.cpp
+++ b/src/il/io/OperandParser.cpp
@@ -116,7 +116,8 @@ Expected<void> OperandParser::parseCallOperands(const std::string &text)
             return Expected<void>{argVal.error()};
         instr_.operands.push_back(std::move(argVal.value()));
     }
-    instr_.type = il::core::Type(il::core::Type::Kind::Void);
+    if (!instr_.result)
+        instr_.type = il::core::Type(il::core::Type::Kind::Void);
     return {};
 }
 

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -93,6 +93,10 @@ function(viper_add_il_core_tests)
   target_compile_definitions(test_il_parse_extern_whitespace PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
   viper_add_ctest(test_il_parse_extern_whitespace test_il_parse_extern_whitespace)
 
+  viper_add_test(test_il_parse_call_ret_type ${_VIPER_IL_UNIT_DIR}/test_il_parse_call_ret_type.cpp)
+  target_link_libraries(test_il_parse_call_ret_type PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  viper_add_ctest(test_il_parse_call_ret_type test_il_parse_call_ret_type)
+
   viper_add_test(test_il_parse_negative ${_VIPER_IL_UNIT_DIR}/test_il_parse_negative.cpp)
   target_link_libraries(test_il_parse_negative PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   target_compile_definitions(test_il_parse_negative PRIVATE BAD_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse")

--- a/tests/unit/test_il_parse_call_ret_type.cpp
+++ b/tests/unit/test_il_parse_call_ret_type.cpp
@@ -1,0 +1,53 @@
+// File: tests/unit/test_il_parse_call_ret_type.cpp
+// Purpose: Ensure parsing a call with a non-void return preserves the instruction type.
+// Key invariants: Call instruction retains deduced result type from annotation/signature.
+// Ownership/Lifetime: Test owns module and input stream locally.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Module.hpp"
+#include "il/core/Opcode.hpp"
+#include "il/core/Type.hpp"
+
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    constexpr const char *kProgram = R"(il 0.1.2
+
+extern @foo() -> str
+
+func @main() -> void {
+entry:
+  %s: str = call @foo()
+  ret
+}
+)";
+
+    std::istringstream input(kProgram);
+    il::core::Module module;
+    auto parse = il::api::v2::parse_text_expected(input, module);
+    assert(parse);
+
+    assert(module.functions.size() == 1);
+    const auto &fn = module.functions.front();
+    assert(fn.blocks.size() == 1);
+    const auto &entry = fn.blocks.front();
+    assert(entry.instructions.size() == 2);
+
+    const auto &callInstr = entry.instructions[0];
+    assert(callInstr.op == il::core::Opcode::Call);
+    assert(callInstr.result.has_value());
+    assert(callInstr.type.kind == il::core::Type::Kind::Str);
+
+    const auto &retInstr = entry.instructions[1];
+    assert(retInstr.op == il::core::Opcode::Ret);
+    assert(retInstr.type.kind == il::core::Type::Kind::Void);
+
+    auto verify = il::api::v2::verify_module_expected(module);
+    assert(verify);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- avoid overriding call instruction result types when parsing operands
- add a parser regression test to ensure string-returning calls keep their type metadata

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e4a0f1eb8c8324a77e3523420e7db9