### PR TITLE
fix: support hash-prefixed IL comments

### DIFF
--- a/src/il/io/FunctionParser.cpp
+++ b/src/il/io/FunctionParser.cpp
@@ -329,7 +329,7 @@ Expected<void> parseFunction(std::istream &is, std::string &header, ParserState 
     {
         ++st.lineNo;
         line = trim(line);
-        if (line.empty() || line.rfind("//", 0) == 0)
+        if (line.empty() || line.rfind("//", 0) == 0 || (!line.empty() && line[0] == '#'))
             continue;
         if (line[0] == '}')
         {

--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -40,7 +40,7 @@ il::support::Expected<void> Parser::parse(std::istream &is, il::core::Module &m)
     {
         ++st.lineNo;
         line = trim(line);
-        if (line.empty() || line.rfind("//", 0) == 0)
+        if (line.empty() || line.rfind("//", 0) == 0 || (!line.empty() && line[0] == '#'))
             continue;
         if (auto result = detail::parseModuleHeader_E(is, line, st); !result)
             return result;

--- a/tests/unit/test_il_parse_comment.cpp
+++ b/tests/unit/test_il_parse_comment.cpp
@@ -12,9 +12,13 @@
 int main()
 {
     const char *src = R"(il 0.1.2
-// comment before function
+# hash comment before function
+   # hash comment with leading spaces
+// slash comment before function
 func @main() -> i64 {
 entry:
+  # hash comment inside block
+  // slash comment inside block
   ret 0
 }
 )";
@@ -29,5 +33,7 @@ entry:
     assert(pe);
     assert(diag.str().empty());
     assert(m.functions.size() == 1);
+    assert(m.functions.front().blocks.size() == 1);
+    assert(m.functions.front().blocks.front().instructions.size() == 1);
     return 0;
 }


### PR DESCRIPTION
## Summary
- teach the module and function parsers to treat trimmed lines beginning with `#` as comments alongside `//`
- extend the IL comment parsing unit test to cover hash-prefixed lines and ensure only the instruction remains

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e526e24f948324b05af3490cabaddd