### PR TITLE
fix(il/io): diagnose missing target triple quotes

### DIFF
--- a/src/il/io/ModuleParser.cpp
+++ b/src/il/io/ModuleParser.cpp
@@ -178,12 +178,24 @@ Expected<void> parseModuleHeader_E(std::istream &is, std::string &line, ParserSt
         std::istringstream ls(line);
         std::string kw;
         ls >> kw;
+        ls >> std::ws;
+        if (ls.peek() != '"')
+        {
+            std::ostringstream oss;
+            oss << "line " << st.lineNo << ": missing quoted target triple";
+            return Expected<void>{makeError({}, oss.str())};
+        }
+
         std::string triple;
         if (ls >> std::quoted(triple))
+        {
             st.m.target = triple;
-        else
-            st.m.target.reset();
-        return {};
+            return {};
+        }
+
+        std::ostringstream oss;
+        oss << "line " << st.lineNo << ": missing quoted target triple";
+        return Expected<void>{makeError({}, oss.str())};
     }
     if (line.rfind("extern", 0) == 0)
         return parseExtern_E(line, st);

--- a/tests/il/parse/target_missing_quotes.il
+++ b/tests/il/parse/target_missing_quotes.il
@@ -1,0 +1,2 @@
+il 0.1.2
+target wasm32-unknown-unknown

--- a/tests/unit/test_il_parse_negative.cpp
+++ b/tests/unit/test_il_parse_negative.cpp
@@ -17,7 +17,8 @@ int main()
                            BAD_DIR "/bad_i128.il",
                            BAD_DIR "/bad_int_literal.il",
                            BAD_DIR "/bad_float_literal.il",
-                           BAD_DIR "/alloca_missing_size.il"};
+                           BAD_DIR "/alloca_missing_size.il",
+                           BAD_DIR "/target_missing_quotes.il"};
     for (const char *path : files)
     {
         std::ifstream in(path);


### PR DESCRIPTION
## Summary
- surface a diagnostic when the module target directive is missing a quoted triple
- add a negative fixture covering an unquoted target triple and include it in parser regression tests

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure -R il_parse`


------
https://chatgpt.com/codex/tasks/task_e_68e527035ee48324b8d3429369aebfcb