### PR TITLE
fix(vm): ensure empty string views produce runtime empty string

### DIFF
--- a/src/vm/Marshal.cpp
+++ b/src/vm/Marshal.cpp
@@ -15,10 +15,10 @@ namespace il::vm
 
 ViperString toViperString(StringRef text)
 {
-    if (text.data() == nullptr)
-        return nullptr;
     if (text.empty())
         return rt_const_cstr("");
+    if (text.data() == nullptr)
+        return nullptr;
     if (text.find('\0') != StringRef::npos)
         return rt_string_from_bytes(text.data(), text.size());
     return rt_const_cstr(text.data());

--- a/tests/unit/test_vm_runtime_bridge_marshalling.cpp
+++ b/tests/unit/test_vm_runtime_bridge_marshalling.cpp
@@ -166,6 +166,15 @@ int main()
     assert(roundTrip == embeddedLiteral);
     rt_string_unref(embedded);
 
+    il::vm::StringRef emptyRef{};
+    il::vm::ViperString emptyString = il::vm::toViperString(emptyRef);
+    assert(emptyString != nullptr);
+    assert(rt_len(emptyString) == 0);
+    const char *emptyData = rt_string_cstr(emptyString);
+    assert(emptyData != nullptr);
+    assert(emptyData[0] == '\0');
+    rt_string_unref(emptyString);
+
     for (bool covered : coveredKinds)
         assert(covered);
 


### PR DESCRIPTION
## Summary
- ensure `toViperString` converts empty string views to the runtime empty string instead of nullptr
- extend the VM runtime bridge marshalling test to cover empty `std::string_view` round-tripping

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e5291b972c8324bb6a06f78a1b4129