### PR TITLE
fix(vm): ensure marshalled strings are runtime-owned

### DIFF
--- a/src/vm/Marshal.cpp
+++ b/src/vm/Marshal.cpp
@@ -19,9 +19,7 @@ ViperString toViperString(StringRef text)
         return nullptr;
     if (text.empty())
         return rt_const_cstr("");
-    if (text.find('\0') != StringRef::npos)
-        return rt_string_from_bytes(text.data(), text.size());
-    return rt_const_cstr(text.data());
+    return rt_string_from_bytes(text.data(), text.size());
 }
 
 StringRef fromViperString(const ViperString &str)

--- a/tests/unit/test_vm_addr_of.cpp
+++ b/tests/unit/test_vm_addr_of.cpp
@@ -33,6 +33,12 @@ int main()
     il::vm::VM vm(m);
     int64_t rv = vm.run();
     rt_string s = reinterpret_cast<rt_string>(static_cast<uintptr_t>(rv));
-    assert(s->data == m.globals.front().init.c_str());
+    assert(s != nullptr);
+    const std::string &globalInit = m.globals.front().init;
+    const int64_t runtimeLen = rt_len(s);
+    assert(runtimeLen == static_cast<int64_t>(globalInit.size()));
+    std::string runtimeText(s->data, static_cast<size_t>(runtimeLen));
+    assert(runtimeText == globalInit);
+    assert(s->data != globalInit.c_str());
     return 0;
 }


### PR DESCRIPTION
## Summary
- update `toViperString` to copy all non-empty views into runtime-owned storage
- add regression coverage for marshalling temporary-backed views and addr_of results to ensure copies remain valid

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e5293a8e9c832485476e219b18b6d8