### PR TITLE
fix(il/io): enforce version directive before module body

### DIFF
--- a/src/il/io/ModuleParser.cpp
+++ b/src/il/io/ModuleParser.cpp
@@ -171,7 +171,14 @@ Expected<void> parseModuleHeader_E(std::istream &is, std::string &line, ParserSt
             st.m.version = ver;
         else
             st.m.version = "0.1.2";
+        st.sawVersion = true;
         return {};
+    }
+    if (!st.sawVersion)
+    {
+        std::ostringstream oss;
+        oss << "line " << st.lineNo << ": missing 'il' version directive";
+        return Expected<void>{il::support::makeError({}, oss.str())};
     }
     if (line.rfind("target", 0) == 0)
     {

--- a/src/il/io/Parser.cpp
+++ b/src/il/io/Parser.cpp
@@ -12,6 +12,7 @@
 #include "il/io/ParserUtil.hpp"
 #include "support/diag_expected.hpp"
 
+#include <sstream>
 #include <string>
 
 namespace il::io::detail
@@ -44,6 +45,12 @@ il::support::Expected<void> Parser::parse(std::istream &is, il::core::Module &m)
             continue;
         if (auto result = detail::parseModuleHeader_E(is, line, st); !result)
             return result;
+    }
+    if (!st.sawVersion)
+    {
+        std::ostringstream oss;
+        oss << "line " << st.lineNo << ": missing 'il' version directive";
+        return il::support::Expected<void>{il::support::makeError({}, oss.str())};
     }
     return {};
 }

--- a/src/il/io/ParserState.hpp
+++ b/src/il/io/ParserState.hpp
@@ -56,6 +56,9 @@ struct ParserState
     /// @brief Collection of outstanding branch targets to validate later.
     std::vector<PendingBr> pendingBrs;
 
+    /// @brief Tracks whether the module declared its IL version directive.
+    bool sawVersion = false;
+
     /// @brief Construct parser state for the provided module.
     explicit ParserState(il::core::Module &mod);
 };

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -114,6 +114,10 @@ function(viper_add_il_core_tests)
   target_link_libraries(test_il_parse_missing_eq PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   viper_add_ctest(test_il_parse_missing_eq test_il_parse_missing_eq)
 
+  viper_add_test(test_il_parse_missing_version ${_VIPER_IL_UNIT_DIR}/test_il_parse_missing_version.cpp)
+  target_link_libraries(test_il_parse_missing_version PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  viper_add_ctest(test_il_parse_missing_version test_il_parse_missing_version)
+
   viper_add_test(test_il_parse_first_error ${_VIPER_IL_UNIT_DIR}/test_il_parse_first_error.cpp)
   target_link_libraries(test_il_parse_first_error PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   viper_add_ctest(test_il_parse_first_error test_il_parse_first_error)

--- a/tests/unit/test_il_parse_missing_version.cpp
+++ b/tests/unit/test_il_parse_missing_version.cpp
@@ -1,0 +1,41 @@
+// File: tests/unit/test_il_parse_missing_version.cpp
+// Purpose: Validate parser errors when the module omits the leading version directive.
+// Key invariants: Parser should reject modules without an `il` directive before other content or EOF.
+// Ownership/Lifetime: Test owns the module and input streams.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "support/diag_expected.hpp"
+
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    {
+        const char *src = R"(target "x86_64-unknown-unknown")";
+        std::istringstream in(src);
+        il::core::Module m;
+        auto parse = il::api::v2::parse_text_expected(in, m);
+        assert(!parse);
+        std::ostringstream diag;
+        il::support::printDiag(parse.error(), diag);
+        std::string msg = diag.str();
+        assert(msg.find("missing 'il' version directive") != std::string::npos);
+    }
+
+    {
+        const char *src = "\n\n";
+        std::istringstream in(src);
+        il::core::Module m;
+        auto parse = il::api::v2::parse_text_expected(in, m);
+        assert(!parse);
+        std::ostringstream diag;
+        il::support::printDiag(parse.error(), diag);
+        std::string msg = diag.str();
+        assert(msg.find("missing 'il' version directive") != std::string::npos);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ensure Parser::parse and parseModuleHeader_E reject module content that appears before the required `il` version directive
- track version detection in ParserState and emit a diagnostic if EOF is reached before encountering it
- add a regression test covering modules with missing version directives and register it in the IL unit test suite

## Testing
- cmake -S . -B build
- cmake --build build --target test_il_parse_missing_version
- cmake --build build --target test_il_parse_missing_eq test_il_parse_first_error
- cmake --build build --target test_il_parse_missing_brace test_il_parse_missing_paren
- ctest --test-dir build --output-on-failure -R "test_il_parse_missing"


------
https://chatgpt.com/codex/tasks/task_e_68e531ce00388324a17bac45350d6e70