### PR TITLE
fix(vm): preserve empty string view when marshalling

### DIFF
--- a/src/vm/Marshal.cpp
+++ b/src/vm/Marshal.cpp
@@ -32,7 +32,7 @@ StringRef fromViperString(const ViperString &str)
     if (!data)
         return {};
     const int64_t length = rt_len(str);
-    if (length <= 0)
+    if (length < 0)
         return {};
     return StringRef{data, static_cast<size_t>(length)};
 }

--- a/tests/unit/test_vm_runtime_bridge_marshalling.cpp
+++ b/tests/unit/test_vm_runtime_bridge_marshalling.cpp
@@ -173,6 +173,19 @@ int main()
     const char *emptyData = rt_string_cstr(emptyString);
     assert(emptyData != nullptr);
     assert(emptyData[0] == '\0');
+    il::vm::StringRef emptyView = il::vm::fromViperString(emptyString);
+    assert(emptyView.data() == emptyData);
+    assert(emptyView.size() == 0);
+
+    il::vm::ViperString roundTripEmpty = il::vm::toViperString(emptyView);
+    assert(roundTripEmpty != nullptr);
+    assert(rt_len(roundTripEmpty) == 0);
+    const char *roundTripData = rt_string_cstr(roundTripEmpty);
+    assert(roundTripData != nullptr);
+    assert(roundTripData[0] == '\0');
+
+    if (roundTripEmpty != emptyString)
+        rt_string_unref(roundTripEmpty);
     rt_string_unref(emptyString);
 
     for (bool covered : coveredKinds)


### PR DESCRIPTION
## Summary
- ensure `fromViperString` retains runtime data pointers for zero-length strings instead of returning a default-initialized view
- extend VM marshalling coverage so empty runtime strings round-trip through `fromViperString`/`toViperString` without null handles

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e531a98698832485626fba4e3b054a