### PR TITLE
fix: harden incremental utf-8 decoder validation

### DIFF
--- a/tui/include/tui/term/Utf8Decoder.hpp
+++ b/tui/include/tui/term/Utf8Decoder.hpp
@@ -37,6 +37,7 @@ class Utf8Decoder
   private:
     uint32_t cp_{0};
     unsigned expected_{0};
+    unsigned length_{0};
 };
 
 } // namespace viper::tui::term

--- a/tui/src/term/Utf8Decoder.cpp
+++ b/tui/src/term/Utf8Decoder.cpp
@@ -13,6 +13,7 @@ Utf8Result Utf8Decoder::feed(unsigned char byte) noexcept
     Utf8Result result{};
     if (expected_ == 0)
     {
+        length_ = 0;
         if (byte < 0x80)
         {
             result.has_codepoint = true;
@@ -22,16 +23,19 @@ Utf8Result Utf8Decoder::feed(unsigned char byte) noexcept
         {
             cp_ = byte & 0x1F;
             expected_ = 1;
+            length_ = 2;
         }
         else if ((byte & 0xF0) == 0xE0)
         {
             cp_ = byte & 0x0F;
             expected_ = 2;
+            length_ = 3;
         }
         else if ((byte & 0xF8) == 0xF0)
         {
             cp_ = byte & 0x07;
             expected_ = 3;
+            length_ = 4;
         }
         else
         {
@@ -44,9 +48,38 @@ Utf8Result Utf8Decoder::feed(unsigned char byte) noexcept
         cp_ = (cp_ << 6) | (byte & 0x3F);
         if (--expected_ == 0)
         {
-            result.has_codepoint = true;
-            result.codepoint = cp_;
-            cp_ = 0;
+            const uint32_t codepoint = cp_;
+            const unsigned length = length_;
+            length_ = 0;
+
+            bool overlong = false;
+            switch (length)
+            {
+                case 2:
+                    overlong = codepoint < 0x80;
+                    break;
+                case 3:
+                    overlong = codepoint < 0x800;
+                    break;
+                case 4:
+                    overlong = codepoint < 0x10000;
+                    break;
+                default:
+                    break;
+            }
+
+            if (overlong || codepoint > 0x10FFFF ||
+                (codepoint >= 0xD800 && codepoint <= 0xDFFF))
+            {
+                result.error = true;
+                reset();
+            }
+            else
+            {
+                result.has_codepoint = true;
+                result.codepoint = codepoint;
+                cp_ = 0;
+            }
         }
     }
     else
@@ -67,6 +100,7 @@ void Utf8Decoder::reset() noexcept
 {
     cp_ = 0;
     expected_ = 0;
+    length_ = 0;
 }
 
 } // namespace viper::tui::term

--- a/tui/tests/test_input_utf8.cpp
+++ b/tui/tests/test_input_utf8.cpp
@@ -42,5 +42,28 @@ int main()
     assert(ev[3].code == KeyEvent::Code::Backspace);
     assert(ev[4].code == KeyEvent::Code::Enter);
 
+    d.feed("\xC0\xAF");
+    ev = d.drain();
+    assert(ev.size() == 1);
+    assert(ev[0].code == KeyEvent::Code::Unknown);
+    assert(ev[0].codepoint == 0);
+
+    d.feed("\xED\xA0\x80");
+    ev = d.drain();
+    assert(ev.size() == 1);
+    assert(ev[0].code == KeyEvent::Code::Unknown);
+    assert(ev[0].codepoint == 0);
+
+    d.feed("\xF4\x90\x80\x80");
+    ev = d.drain();
+    assert(ev.size() == 1);
+    assert(ev[0].code == KeyEvent::Code::Unknown);
+    assert(ev[0].codepoint == 0);
+
+    d.feed("C");
+    ev = d.drain();
+    assert(ev.size() == 1);
+    assert(ev[0].codepoint == 'C');
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- track the incremental UTF-8 decoder's sequence length so it can reject overlong, surrogate, and >U+10FFFF code points while resetting state on errors
- extend the UTF-8 input decoder test to cover malformed sequences and recovery

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e5319a240c8324bfb77fab12f354f3