### PR TITLE
fix(vm): copy zero-length non-literal views

### DIFF
--- a/src/vm/Marshal.cpp
+++ b/src/vm/Marshal.cpp
@@ -17,7 +17,11 @@ namespace il::vm
 ViperString toViperString(StringRef text)
 {
     if (text.empty())
-        return rt_const_cstr("");
+    {
+        if (text.data() == nullptr)
+            return rt_const_cstr("");
+        return rt_string_from_bytes(text.data(), 0);
+    }
     if (text.data() == nullptr)
         return nullptr;
     if (text.find('\0') != StringRef::npos)

--- a/tests/unit/test_vm_runtime_bridge_marshalling.cpp
+++ b/tests/unit/test_vm_runtime_bridge_marshalling.cpp
@@ -24,6 +24,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <string>
+#include <string_view>
 #include <vector>
 
 int main()
@@ -196,6 +197,18 @@ int main()
 
     if (roundTripEmpty != emptyString)
         rt_string_unref(roundTripEmpty);
+
+    {
+        std::string backing = "backing";
+        std::string_view nonLiteralEmpty{backing.data(), static_cast<size_t>(0)};
+        assert(nonLiteralEmpty.data() != nullptr);
+        il::vm::ViperString nonLiteralHandle = il::vm::toViperString(nonLiteralEmpty);
+        assert(nonLiteralHandle != nullptr);
+        assert(rt_len(nonLiteralHandle) == 0);
+        assert(nonLiteralHandle != emptyString);
+        rt_string_unref(nonLiteralHandle);
+    }
+
     rt_string_unref(emptyString);
 
     {


### PR DESCRIPTION
## Summary
- ensure `toViperString` copies zero-length views with non-null data via `rt_string_from_bytes`
- extend runtime bridge marshalling coverage to verify zero-length `std::string_view` inputs stay distinct from the canonical literal handle

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e53e245d1483249355c8662a108d5b