### PR TITLE
Fix runtime array bounds checking for rt_arr_i32

### DIFF
--- a/src/runtime/rt_array.c
+++ b/src/runtime/rt_array.c
@@ -85,17 +85,31 @@ size_t rt_arr_i32_cap(int32_t *arr)
 
 int32_t rt_arr_i32_get(int32_t *arr, size_t idx)
 {
+    if (!arr)
+        rt_arr_oob_panic(idx, 0);
+
     rt_heap_hdr_t *hdr = rt_arr_i32_hdr(arr);
     rt_arr_i32_assert_header(hdr);
-    assert(idx < hdr->len);
+
+    size_t len = hdr->len;
+    if (idx >= len)
+        rt_arr_oob_panic(idx, len);
+
     return arr[idx];
 }
 
 void rt_arr_i32_set(int32_t *arr, size_t idx, int32_t value)
 {
+    if (!arr)
+        rt_arr_oob_panic(idx, 0);
+
     rt_heap_hdr_t *hdr = rt_arr_i32_hdr(arr);
     rt_arr_i32_assert_header(hdr);
-    assert(idx < hdr->len);
+
+    size_t len = hdr->len;
+    if (idx >= len)
+        rt_arr_oob_panic(idx, len);
+
     arr[idx] = value;
 }
 


### PR DESCRIPTION
## Summary
- ensure `rt_arr_i32_get`/`rt_arr_i32_set` trigger the runtime panic when the handle is null or the index exceeds the length
- extend the RTArrayI32 runtime test to cover out-of-bounds reads and assert the panic message

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e54b408b1c8324a085e01ad1d85fe4