### PR TITLE
Fix BASIC diagnostic caret indentation when column is zero

### DIFF
--- a/src/frontends/basic/DiagnosticEmitter.cpp
+++ b/src/frontends/basic/DiagnosticEmitter.cpp
@@ -117,7 +117,8 @@ void DiagnosticEmitter::printAll(std::ostream &os) const
         {
             os << line << '\n';
             uint32_t caretLen = e.length == 0 ? 1 : e.length;
-            os << std::string(e.loc.column - 1, ' ') << std::string(caretLen, '^') << '\n';
+            uint32_t indent = e.loc.column > 0 ? e.loc.column - 1 : 0;
+            os << std::string(indent, ' ') << std::string(caretLen, '^') << '\n';
         }
     }
 }

--- a/tests/unit/test_basic_diagnostic.cpp
+++ b/tests/unit/test_basic_diagnostic.cpp
@@ -29,12 +29,16 @@ int main()
     SemanticAnalyzer sema(em);
     sema.analyze(*prog);
 
+    em.emit(Severity::Error, "B9999", SourceLoc{fid, 2, 0}, 0, "zero column test");
+
     std::ostringstream oss;
     em.printAll(oss);
     std::string out = oss.str();
-    assert(em.errorCount() == 1);
+    assert(em.errorCount() == 2);
     assert(out.find("error[B1001]") != std::string::npos);
     assert(out.find("unknown variable 'X'") != std::string::npos);
+    assert(out.find("zero column test") != std::string::npos);
     assert(out.find("^") != std::string::npos);
+    assert(out.find("\n^\n") != std::string::npos);
     return 0;
 }


### PR DESCRIPTION
## Summary
- clamp the BASIC diagnostic emitter's caret indentation so column 0 no longer underflows the padding logic
- extend the BASIC diagnostic unit test to cover a column-0 diagnostic and assert the caret begins at column 1

## Testing
- cmake -S . -B build
- cmake --build build -j2
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e54b332d7c8324abe4d2b6469c3148