### PR TITLE
fix(vm): preserve fp_to_ui round-trip bits

### DIFF
--- a/src/vm/fp_ops.cpp
+++ b/src/vm/fp_ops.cpp
@@ -14,6 +14,7 @@
 #include "vm/OpHandlerUtils.hpp"
 #include "vm/RuntimeBridge.hpp"
 
+#include <bit>
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -389,7 +390,7 @@ VM::ExecResult OpHandlers::handleCastFpToUiRteChk(VM &vm,
     const uint64_t rounded = castFpToUiRoundedOrTrap(value.f64, in, fr, bb);
 
     Slot out{};
-    out.i64 = static_cast<int64_t>(rounded);
+    out.i64 = std::bit_cast<int64_t>(rounded);
     ops::storeResult(fr, in, out);
     return {};
 }

--- a/tests/vm/CastOpsTests.cpp
+++ b/tests/vm/CastOpsTests.cpp
@@ -163,12 +163,13 @@ int main()
         assert(runZext1(input) == expected);
     }
 
-    const std::array<std::pair<double, uint64_t>, 5> fpCastCases = {
+    const std::array<std::pair<double, uint64_t>, 6> fpCastCases = {
         {{0.0, UINT64_C(0)},
          {0.5, UINT64_C(0)},
          {1.5, UINT64_C(2)},
          {2.5, UINT64_C(2)},
-         {4294967296.5, UINT64_C(4294967296)}}};
+         {4294967296.5, UINT64_C(4294967296)},
+         {std::ldexp(1.0, 63), UINT64_C(9223372036854775808)}}};
 
     for (const auto &[input, expected] : fpCastCases)
     {


### PR DESCRIPTION
## Summary
- include <bit> and bit-cast the rounded payload in cast.fp_to_ui.rte.chk so the raw uint64_t survives storage
- audited unsigned-int consumers to ensure they continue to interpret Slot::i64 through static_cast<uint64_t>
- extended the VM cast regression to cover a double that rounds just above INT64_MAX

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e54b223c248324acef1c392d2a81d8