### PR TITLE
Fix VM null pointer load/store handling

### DIFF
--- a/tests/unit/test_vm_null_mem_ops.cpp
+++ b/tests/unit/test_vm_null_mem_ops.cpp
@@ -1,0 +1,116 @@
+// File: tests/unit/test_vm_null_mem_ops.cpp
+// Purpose: Verify VM traps when load/store operate on null pointers.
+// Key invariants: Null pointer operands surface InvalidOperation traps with detail messages.
+// Ownership: Standalone unit test executable.
+// Links: docs/codemap.md
+
+#include "il/core/BasicBlock.hpp"
+#include "il/core/Function.hpp"
+#include "il/core/Instr.hpp"
+#include "il/core/Module.hpp"
+#include "il/core/Opcode.hpp"
+#include "il/core/Type.hpp"
+#include "il/core/Value.hpp"
+#include "vm/VM.hpp"
+
+#include <cassert>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace
+{
+
+il::core::Module makeLoadModule()
+{
+    using namespace il::core;
+
+    Module m;
+    Function fn;
+    fn.name = "main";
+    fn.retType = Type(Type::Kind::I64);
+
+    BasicBlock bb;
+    bb.label = "entry";
+
+    Instr load;
+    load.result = 0U;
+    load.op = Opcode::Load;
+    load.type = Type(Type::Kind::I64);
+    load.operands.push_back(Value::null());
+    load.loc = {1, 1, 1};
+    bb.instructions.push_back(load);
+
+    fn.blocks.push_back(std::move(bb));
+    m.functions.push_back(std::move(fn));
+    return m;
+}
+
+il::core::Module makeStoreModule()
+{
+    using namespace il::core;
+
+    Module m;
+    Function fn;
+    fn.name = "main";
+    fn.retType = Type(Type::Kind::I64);
+
+    BasicBlock bb;
+    bb.label = "entry";
+
+    Instr store;
+    store.op = Opcode::Store;
+    store.type = Type(Type::Kind::I64);
+    store.operands.push_back(Value::null());
+    store.operands.push_back(Value::constInt(42));
+    store.loc = {1, 2, 1};
+    bb.instructions.push_back(store);
+
+    fn.blocks.push_back(std::move(bb));
+    m.functions.push_back(std::move(fn));
+    return m;
+}
+
+std::string runModuleAndCapture(il::core::Module module)
+{
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        il::vm::VM vm(module);
+        vm.run();
+        _exit(0);
+    }
+
+    close(fds[1]);
+    char buf[512];
+    ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
+    if (n > 0)
+        buf[n] = '\0';
+    else
+        buf[0] = '\0';
+    close(fds[0]);
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+    return std::string(buf);
+}
+
+} // namespace
+
+int main()
+{
+    std::string loadTrap = runModuleAndCapture(makeLoadModule());
+    bool loadOk = loadTrap.find("Trap @main#0 line 1: InvalidOperation (code=0): null load") != std::string::npos;
+    assert(loadOk);
+
+    std::string storeTrap = runModuleAndCapture(makeStoreModule());
+    bool storeOk = storeTrap.find("Trap @main#0 line 2: InvalidOperation (code=0): null store") != std::string::npos;
+    assert(storeOk);
+
+    return 0;
+}

--- a/tests/vm/CMakeLists.txt
+++ b/tests/vm/CMakeLists.txt
@@ -170,6 +170,10 @@ function(viper_add_vm_unit_tests)
   target_link_libraries(test_vm_unknown_global PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   viper_add_ctest(test_vm_unknown_global test_vm_unknown_global)
 
+  viper_add_test(test_vm_null_mem_ops ${VIPER_TESTS_DIR}/unit/test_vm_null_mem_ops.cpp)
+  target_link_libraries(test_vm_null_mem_ops PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
+  viper_add_ctest(test_vm_null_mem_ops test_vm_null_mem_ops)
+
   viper_add_test(test_vm_many_temps ${VIPER_TESTS_DIR}/unit/test_vm_many_temps.cpp)
   target_link_libraries(test_vm_many_temps PRIVATE ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   viper_add_ctest(test_vm_many_temps test_vm_many_temps)


### PR DESCRIPTION
## Summary
- replace the VM load/store null-pointer assertions with RuntimeBridge traps that report instruction context
- add a regression test exercising null pointer load/store traps and register it with the VM unit tests

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e54ebe75b883248ccabf81ff6ffafc