### PR TITLE
fix(runtime): guard array setter bounds

### DIFF
--- a/src/runtime/rt_array.c
+++ b/src/runtime/rt_array.c
@@ -33,6 +33,19 @@ static void rt_arr_i32_assert_header(rt_heap_hdr_t *hdr)
     assert(hdr->elem_kind == RT_ELEM_I32);
 }
 
+static void rt_arr_i32_validate_bounds(int32_t *arr, size_t idx)
+{
+    if (!arr)
+        rt_arr_oob_panic(idx, 0);
+
+    rt_heap_hdr_t *hdr = rt_arr_i32_hdr(arr);
+    rt_arr_i32_assert_header(hdr);
+
+    size_t len = hdr->len;
+    if (idx >= len)
+        rt_arr_oob_panic(idx, len);
+}
+
 static size_t rt_arr_i32_payload_bytes(size_t cap)
 {
     if (cap == 0)
@@ -85,31 +98,13 @@ size_t rt_arr_i32_cap(int32_t *arr)
 
 int32_t rt_arr_i32_get(int32_t *arr, size_t idx)
 {
-    if (!arr)
-        rt_arr_oob_panic(idx, 0);
-
-    rt_heap_hdr_t *hdr = rt_arr_i32_hdr(arr);
-    rt_arr_i32_assert_header(hdr);
-
-    size_t len = hdr->len;
-    if (idx >= len)
-        rt_arr_oob_panic(idx, len);
-
+    rt_arr_i32_validate_bounds(arr, idx);
     return arr[idx];
 }
 
 void rt_arr_i32_set(int32_t *arr, size_t idx, int32_t value)
 {
-    if (!arr)
-        rt_arr_oob_panic(idx, 0);
-
-    rt_heap_hdr_t *hdr = rt_arr_i32_hdr(arr);
-    rt_arr_i32_assert_header(hdr);
-
-    size_t len = hdr->len;
-    if (idx >= len)
-        rt_arr_oob_panic(idx, len);
-
+    rt_arr_i32_validate_bounds(arr, idx);
     arr[idx] = value;
 }
 

--- a/tests/runtime/RTArrayI32Tests.cpp
+++ b/tests/runtime/RTArrayI32Tests.cpp
@@ -96,19 +96,28 @@ int main()
         return std::string(buf);
     };
 
+    auto expect_oob_message = [](const std::string &stderr_output) {
+        bool saw_panic = stderr_output.find("rt_arr_i32: index 1 out of bounds") != std::string::npos;
+        if (!saw_panic)
+        {
+            std::fprintf(stderr, "expected panic message, got: %s\n", stderr_output.c_str());
+            std::abort();
+        }
+    };
+
     auto invoke_oob_get = []() {
         int32_t *panic_arr = rt_arr_i32_new(1);
         assert(panic_arr != nullptr);
         rt_arr_i32_get(panic_arr, 1);
     };
+    expect_oob_message(capture_stderr(invoke_oob_get));
 
-    std::string stderr_output = capture_stderr(invoke_oob_get);
-    bool saw_panic = stderr_output.find("rt_arr_i32: index 1 out of bounds") != std::string::npos;
-    if (!saw_panic)
-    {
-        std::fprintf(stderr, "expected panic message, got: %s\n", stderr_output.c_str());
-        std::abort();
-    }
+    auto invoke_oob_set = []() {
+        int32_t *panic_arr = rt_arr_i32_new(1);
+        assert(panic_arr != nullptr);
+        rt_arr_i32_set(panic_arr, 1, 42);
+    };
+    expect_oob_message(capture_stderr(invoke_oob_set));
 #endif
 
     return 0;


### PR DESCRIPTION
## Summary
- add a shared bounds validation helper so both rt_arr_i32_get and rt_arr_i32_set abort with the same panic
- extend the runtime array test to cover out-of-bounds writes and confirm the reported error message

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e54fdabec08324a158799c2a673de2