### PR TITLE
fix(frontends/basic): suppress caret snippets for unknown lines

### DIFF
--- a/src/frontends/basic/DiagnosticEmitter.cpp
+++ b/src/frontends/basic/DiagnosticEmitter.cpp
@@ -84,6 +84,9 @@ static const char *toString(il::support::Severity s)
 /// @return Line contents or empty string if unavailable.
 std::string DiagnosticEmitter::getLine(uint32_t fileId, uint32_t line) const
 {
+    if (line == 0)
+        return {};
+
     auto it = sources_.find(fileId);
     if (it == sources_.end())
         return {};

--- a/tests/unit/test_basic_diagnostic.cpp
+++ b/tests/unit/test_basic_diagnostic.cpp
@@ -30,15 +30,21 @@ int main()
     sema.analyze(*prog);
 
     em.emit(Severity::Error, "B9999", SourceLoc{fid, 2, 0}, 0, "zero column test");
+    em.emit(Severity::Error, "B0000", SourceLoc{fid, 0, 0}, 0, "unknown location test");
 
     std::ostringstream oss;
     em.printAll(oss);
     std::string out = oss.str();
-    assert(em.errorCount() == 2);
+    assert(em.errorCount() == 3);
     assert(out.find("error[B1001]") != std::string::npos);
     assert(out.find("unknown variable 'X'") != std::string::npos);
     assert(out.find("zero column test") != std::string::npos);
+    assert(out.find("unknown location test") != std::string::npos);
     assert(out.find("^") != std::string::npos);
     assert(out.find("\n^\n") != std::string::npos);
+    const std::string unknownLocationHeader = "test.bas:0:0: error[B0000]: unknown location test\n";
+    auto headerPos = out.rfind(unknownLocationHeader);
+    assert(headerPos != std::string::npos);
+    assert(headerPos + unknownLocationHeader.size() == out.size());
     return 0;
 }


### PR DESCRIPTION
## Summary
- prevent DiagnosticEmitter from returning source lines when the source location has line 0
- extend the basic diagnostic unit test to cover diagnostics with unknown line numbers and ensure no caret output is produced

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68e54fe9c8c08324a104e34fa1b5a63e