### PR TITLE
fix(vm): trap on entry frame argument count mismatch

### DIFF
--- a/src/vm/VMInit.cpp
+++ b/src/vm/VMInit.cpp
@@ -6,6 +6,7 @@
 
 #include "vm/VM.hpp"
 #include "vm/Marshal.hpp"
+#include "vm/RuntimeBridge.hpp"
 #include "il/core/BasicBlock.hpp"
 #include "il/core/Function.hpp"
 #include "il/core/Global.hpp"
@@ -13,6 +14,7 @@
 
 #include <cassert>
 #include <clocale>
+#include <sstream>
 #include <utility>
 
 using namespace il::core;
@@ -103,6 +105,15 @@ Frame VM::setupFrame(const Function &fn,
     if (bb)
     {
         const auto &params = bb->params;
+        if (args.size() != params.size())
+        {
+            std::ostringstream os;
+            os << "argument count mismatch for function " << fn.name << ": expected "
+               << params.size() << " argument" << (params.size() == 1 ? "" : "s")
+               << ", received " << args.size();
+            RuntimeBridge::trap(
+                TrapKind::InvalidOperation, os.str(), {}, fn.name, bb->label);
+        }
         for (size_t i = 0; i < params.size() && i < args.size(); ++i)
         {
             const auto id = params[i].id;

--- a/tests/unit/test_vm_entry_arg_mismatch.cpp
+++ b/tests/unit/test_vm_entry_arg_mismatch.cpp
@@ -1,0 +1,88 @@
+// File: tests/unit/test_vm_entry_arg_mismatch.cpp
+// Purpose: Ensure VM traps when entry frame argument counts do not match block parameters.
+// Key invariants: Calling a function with mismatched argument count emits InvalidOperation trap.
+// Ownership: Builds synthetic module and executes VM in forked child to capture diagnostics.
+// Links: docs/codemap.md
+
+#include "VMTestHook.hpp"
+#include "il/build/IRBuilder.hpp"
+#include "vm/VM.hpp"
+
+#include <cassert>
+#include <optional>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
+
+using namespace il::core;
+
+namespace
+{
+std::string captureTrap(Module &module,
+                        const Function &fn,
+                        const std::vector<il::vm::Slot> &args)
+{
+    int fds[2];
+    assert(pipe(fds) == 0);
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0)
+    {
+        close(fds[0]);
+        dup2(fds[1], 2);
+        il::vm::VM vm(module);
+        il::vm::VMTestHook::run(vm, fn, args);
+        _exit(0);
+    }
+
+    close(fds[1]);
+    char buffer[512];
+    ssize_t n = read(fds[0], buffer, sizeof(buffer) - 1);
+    if (n < 0)
+        n = 0;
+    buffer[n] = '\0';
+    close(fds[0]);
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+    return std::string(buffer);
+}
+} // namespace
+
+int main()
+{
+    Module module;
+    il::build::IRBuilder builder(module);
+
+    builder.startFunction("too_many_args", Type(Type::Kind::Void), {});
+    auto &tooManyEntry = builder.createBlock(module.functions.back(), "entry");
+    builder.setInsertPoint(tooManyEntry);
+    builder.emitRet(std::optional<Value>{}, {1, 1, 1});
+
+    builder.startFunction("too_few_args", Type(Type::Kind::Void), {});
+    auto &tooFewEntry = builder.createBlock(
+        module.functions.back(),
+        "entry",
+        std::vector<Param>{{"p0", Type(Type::Kind::I64), 0}});
+    builder.setInsertPoint(tooFewEntry);
+    builder.emitRet(std::optional<Value>{}, {1, 1, 1});
+
+    auto &tooManyFn = module.functions.front();
+    auto &tooFewFn = module.functions.back();
+
+    il::vm::Slot slot{};
+    slot.i64 = 42;
+
+    const std::string extraDiag = captureTrap(module, tooManyFn, {slot});
+    assert(extraDiag.find("Trap @too_many_args#0 line -1: InvalidOperation (code=0)") !=
+           std::string::npos);
+    assert(extraDiag.find("argument count mismatch") != std::string::npos);
+
+    const std::string missingDiag = captureTrap(module, tooFewFn, {});
+    assert(missingDiag.find("Trap @too_few_args#0 line -1: InvalidOperation (code=0)") !=
+           std::string::npos);
+    assert(missingDiag.find("argument count mismatch") != std::string::npos);
+
+    return 0;
+}

--- a/tests/vm/CMakeLists.txt
+++ b/tests/vm/CMakeLists.txt
@@ -138,6 +138,10 @@ function(viper_add_vm_unit_tests)
   target_link_libraries(test_vm_rt_extra_arg PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   viper_add_ctest(test_vm_rt_extra_arg test_vm_rt_extra_arg)
 
+  viper_add_test(test_vm_entry_arg_mismatch ${VIPER_TESTS_DIR}/unit/test_vm_entry_arg_mismatch.cpp)
+  target_link_libraries(test_vm_entry_arg_mismatch PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
+  viper_add_ctest(test_vm_entry_arg_mismatch test_vm_entry_arg_mismatch)
+
   viper_add_test(test_vm_rt_concat_missing_args ${VIPER_TESTS_DIR}/unit/test_vm_rt_concat_missing_args.cpp)
   target_link_libraries(test_vm_rt_concat_missing_args PRIVATE il_build ${VIPER_VM_LIB} ${VIPER_VM_SUPPORT_LIB})
   viper_add_ctest(test_vm_rt_concat_missing_args test_vm_rt_concat_missing_args)


### PR DESCRIPTION
## Summary
- guard VM entry frame setup against argument count mismatches and raise InvalidOperation traps with context
- cover the mismatch scenarios with a new VM unit test capturing the trap diagnostic
- register the regression test with the VM unit-test suite

## Testing
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e54f12b4008324b0ab34ecd8cd3350