### PR TITLE
Fix parser duplicate SSA result handling

### DIFF
--- a/src/il/io/InstrParser.cpp
+++ b/src/il/io/InstrParser.cpp
@@ -395,14 +395,18 @@ Expected<void> parseInstruction_E(const std::string &line, ParserState &st)
             annotatedType = ty.value();
         }
         auto [it, inserted] = st.tempIds.emplace(res, st.nextTemp);
-        if (inserted)
+        if (!inserted)
         {
-            if (st.curFn->valueNames.size() <= st.nextTemp)
-                st.curFn->valueNames.resize(st.nextTemp + 1);
-            st.curFn->valueNames[st.nextTemp] = res;
-            st.nextTemp++;
+            std::ostringstream oss;
+            oss << "line " << st.lineNo << ": duplicate result name '%" << res << "'";
+            return Expected<void>{makeError(in.loc, oss.str())};
         }
-        in.result = it->second;
+
+        if (st.curFn->valueNames.size() <= st.nextTemp)
+            st.curFn->valueNames.resize(st.nextTemp + 1);
+        st.curFn->valueNames[st.nextTemp] = res;
+        in.result = st.nextTemp;
+        st.nextTemp++;
         work = trim(work.substr(eq + 1));
     }
     std::istringstream ss(work);

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -67,6 +67,10 @@ function(viper_add_il_core_tests)
   target_link_libraries(test_il_parse_duplicate_param PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   viper_add_ctest(test_il_parse_duplicate_param test_il_parse_duplicate_param)
 
+  viper_add_test(test_il_parse_duplicate_result ${_VIPER_IL_UNIT_DIR}/test_il_parse_duplicate_result.cpp)
+  target_link_libraries(test_il_parse_duplicate_result PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  viper_add_ctest(test_il_parse_duplicate_result test_il_parse_duplicate_result)
+
   viper_add_test(test_il_parse_missing_brace ${_VIPER_IL_UNIT_DIR}/test_il_parse_missing_brace.cpp)
   target_link_libraries(test_il_parse_missing_brace PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   target_compile_definitions(test_il_parse_missing_brace PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")

--- a/tests/unit/test_il_parse_duplicate_result.cpp
+++ b/tests/unit/test_il_parse_duplicate_result.cpp
@@ -1,0 +1,38 @@
+// File: tests/unit/test_il_parse_duplicate_result.cpp
+// Purpose: Ensure the IL parser rejects duplicate SSA result names within a block.
+// Key invariants: Parser reports diagnostics when a result name is redefined.
+// Ownership/Lifetime: Test owns module and diagnostic buffers constructed from string literals.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "support/diagnostics.hpp"
+
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    static constexpr const char *kSource = R"(il 0.1.2
+func @dup_result() -> void {
+entry:
+  %x = const_null
+  %x = const_null
+  ret
+}
+)";
+
+    std::istringstream input(kSource);
+    il::core::Module module;
+    auto parseResult = il::api::v2::parse_text_expected(input, module);
+    assert(!parseResult && "parser should reject duplicate result names");
+
+    std::ostringstream diag;
+    il::support::printDiag(parseResult.error(), diag);
+    const std::string message = diag.str();
+    assert(message.find("duplicate result name '%x'") != std::string::npos);
+    assert(message.find("line 5") != std::string::npos);
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- emit a diagnostic when parseInstruction_E sees a duplicate SSA result name
- add a regression test to cover duplicate instruction results

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e5615e9e3c8324ae137569284fac02