### PR TITLE
Fix missing diagnostic for unnamed block parameters

### DIFF
--- a/src/il/io/FunctionParser.cpp
+++ b/src/il/io/FunctionParser.cpp
@@ -272,6 +272,12 @@ Expected<void> parseBlockHeader(const std::string &header, ParserState &st)
             std::string nm = trim(q.substr(0, col));
             if (!nm.empty() && nm[0] == '%')
                 nm = nm.substr(1);
+            if (nm.empty())
+            {
+                std::ostringstream oss;
+                oss << "line " << st.lineNo << ": missing parameter name";
+                return Expected<void>{makeError({}, oss.str())};
+            }
             std::string tyStr = trim(q.substr(col + 1));
             bool ok = true;
             Type ty = parseType(tyStr, &ok);

--- a/tests/il/parse/block_param_missing_name.il
+++ b/tests/il/parse/block_param_missing_name.il
@@ -1,0 +1,5 @@
+il 0.1.2
+func @missing_name() -> i32 {
+entry(%: i32):
+  ret 0
+}

--- a/tests/unit/test_il_function_parser_errors.cpp
+++ b/tests/unit/test_il_function_parser_errors.cpp
@@ -57,6 +57,20 @@ int main()
         assert(msg.find("bad param") != std::string::npos);
     }
 
+    // Block parameter missing an identifier should report the dedicated diagnostic.
+    {
+        il::core::Module m;
+        ParserState st{m};
+        st.lineNo = 7;
+        auto headerOk = parseFunctionHeader("func @block_missing() -> i32 {", st);
+        assert(headerOk);
+        st.lineNo = 8;
+        auto blockErr = parseBlockHeader("entry(%: i32)", st);
+        assert(!blockErr);
+        const std::string &msg = blockErr.error().message;
+        assert(msg.find("missing parameter name") != std::string::npos);
+    }
+
     // Body without an opening block should surface an instruction-placement error.
     {
         il::core::Module m;

--- a/tests/unit/test_il_parse_negative.cpp
+++ b/tests/unit/test_il_parse_negative.cpp
@@ -18,7 +18,8 @@ int main()
                            BAD_DIR "/bad_int_literal.il",
                            BAD_DIR "/bad_float_literal.il",
                            BAD_DIR "/alloca_missing_size.il",
-                           BAD_DIR "/target_missing_quotes.il"};
+                           BAD_DIR "/target_missing_quotes.il",
+                           BAD_DIR "/block_param_missing_name.il"};
     for (const char *path : files)
     {
         std::ifstream in(path);


### PR DESCRIPTION
## Summary
- ensure block header parsing reports an explicit error when a parameter loses its `%` name
- add a negative IL fixture and parser unit coverage for unnamed block parameters

## Testing
- cmake --build build --target test_il_function_parser_errors test_il_parse_negative -- -j
- ctest --test-dir build --output-on-failure -R test_il_function_parser_errors|test_il_parse_negative

------
https://chatgpt.com/codex/tasks/task_e_68e561e2129c8324b5a30772921f6130