### PR TITLE
fix(il/io): correctly handle escaped string literals

### DIFF
--- a/src/il/io/OperandParser.cpp
+++ b/src/il/io/OperandParser.cpp
@@ -10,12 +10,14 @@
 #include "il/core/OpcodeInfo.hpp"
 #include "il/core/Value.hpp"
 #include "il/io/ParserUtil.hpp"
+#include "il/io/StringEscape.hpp"
 
 #include "support/diag_expected.hpp"
 
 #include <cctype>
 #include <exception>
 #include <sstream>
+#include <string_view>
 #include <utility>
 
 namespace il::io::detail
@@ -72,7 +74,21 @@ Expected<Value> OperandParser::parseValueToken(const std::string &tok) const
     if (tok == "null")
         return Value::null();
     if (tok.size() >= 2 && tok.front() == '"' && tok.back() == '"')
-        return Value::constStr(tok.substr(1, tok.size() - 2));
+    {
+        std::string decoded;
+        std::string errMsg;
+        if (!il::io::decodeEscapedString(std::string_view(tok).substr(1, tok.size() - 2),
+                                         decoded,
+                                         &errMsg))
+        {
+            std::ostringstream oss;
+            oss << "Line " << state_.lineNo << ": invalid string literal '" << tok << "'";
+            if (!errMsg.empty())
+                oss << ": " << errMsg;
+            return Expected<Value>{makeError(state_.curLoc, oss.str())};
+        }
+        return Value::constStr(std::move(decoded));
+    }
     if (tok.find('.') != std::string::npos || tok.find('e') != std::string::npos ||
         tok.find('E') != std::string::npos)
     {

--- a/src/il/io/Serializer.cpp
+++ b/src/il/io/Serializer.cpp
@@ -22,6 +22,7 @@
 #include <functional>
 #include <optional>
 #include <sstream>
+#include <string>
 
 namespace il::io
 {
@@ -38,13 +39,20 @@ constexpr size_t toIndex(Opcode op)
     return static_cast<size_t>(op);
 }
 
+std::string formatValue(const Value &value)
+{
+    if (value.kind == Value::Kind::ConstStr)
+        return std::string("\"") + encodeEscapedString(value.str) + "\"";
+    return il::core::toString(value);
+}
+
 void printValueList(std::ostream &os, const std::vector<Value> &values)
 {
     for (size_t i = 0; i < values.size(); ++i)
     {
         if (i)
             os << ", ";
-        os << il::core::toString(values[i]);
+        os << formatValue(values[i]);
     }
 }
 
@@ -69,14 +77,14 @@ void printTrapKindOperand(const Instr &instr, std::ostream &os)
             return;
         }
     }
-    os << ' ' << il::core::toString(operand);
+    os << ' ' << formatValue(operand);
 }
 
 void printTrapFromErrOperands(const Instr &instr, std::ostream &os)
 {
     os << ' ' << instr.type.toString();
     if (!instr.operands.empty())
-        os << ' ' << il::core::toString(instr.operands.front());
+        os << ' ' << formatValue(instr.operands.front());
 }
 
 void printCallOperands(const Instr &instr, std::ostream &os)
@@ -90,14 +98,14 @@ void printRetOperand(const Instr &instr, std::ostream &os)
 {
     if (instr.operands.empty())
         return;
-    os << ' ' << il::core::toString(instr.operands[0]);
+    os << ' ' << formatValue(instr.operands[0]);
 }
 
 void printLoadOperands(const Instr &instr, std::ostream &os)
 {
     os << ' ' << instr.type.toString();
     if (!instr.operands.empty())
-        os << ", " << il::core::toString(instr.operands[0]);
+        os << ", " << formatValue(instr.operands[0]);
 }
 
 void printStoreOperands(const Instr &instr, std::ostream &os)
@@ -105,9 +113,9 @@ void printStoreOperands(const Instr &instr, std::ostream &os)
     os << ' ' << instr.type.toString();
     if (!instr.operands.empty())
     {
-        os << ", " << il::core::toString(instr.operands[0]);
+        os << ", " << formatValue(instr.operands[0]);
         if (instr.operands.size() > 1)
-            os << ", " << il::core::toString(instr.operands[1]);
+            os << ", " << formatValue(instr.operands[1]);
     }
 }
 
@@ -153,7 +161,7 @@ void printCBrOperands(const Instr &instr, std::ostream &os)
         return;
     }
 
-    os << ' ' << il::core::toString(instr.operands[0]);
+    os << ' ' << formatValue(instr.operands[0]);
 
     if (instr.labels.empty())
     {
@@ -180,14 +188,14 @@ void printSwitchI32Operands(const Instr &instr, std::ostream &os)
     if (instr.operands.empty() || instr.labels.empty())
         return;
 
-    os << ' ' << il::core::toString(switchScrutinee(instr));
+    os << ' ' << formatValue(switchScrutinee(instr));
     os << ", ";
     printCaretBranchTarget(instr, 0, os);
 
     const size_t caseCount = switchCaseCount(instr);
     for (size_t idx = 0; idx < caseCount; ++idx)
     {
-        os << ", " << il::core::toString(switchCaseValue(instr, idx)) << " -> ";
+        os << ", " << formatValue(switchCaseValue(instr, idx)) << " -> ";
         printCaretBranchTarget(instr, idx + 1, os);
     }
 }
@@ -230,7 +238,7 @@ const Formatter &formatterFor(Opcode op)
         table[toIndex(Opcode::ResumeLabel)] = [](const Instr &instr, std::ostream &os)
         {
             if (!instr.operands.empty())
-                os << ' ' << il::core::toString(instr.operands[0]);
+                os << ' ' << formatValue(instr.operands[0]);
             if (!instr.labels.empty())
             {
                 os << ", ";

--- a/tests/il/parse-roundtrip/trap_newline.il
+++ b/tests/il/parse-roundtrip/trap_newline.il
@@ -1,0 +1,8 @@
+il 0.1.2
+
+func @trap_newline() -> void {
+entry:
+  %msg = const_str "\n"
+  %err = trap.err 42, %msg
+  trap
+}


### PR DESCRIPTION
## Summary
- decode string literal tokens with il::io::decodeEscapedString and surface diagnostics on failure
- re-escape string constants during serialization so control characters remain escaped
- add a trap.err newline round-trip case and assertions that the escaped newline survives serialization

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e561f304d88324a732c5e0688ad895