### PR TITLE
fix(support): make Expected<void> bool operator const

### DIFF
--- a/src/support/diag_expected.cpp
+++ b/src/support/diag_expected.cpp
@@ -21,7 +21,7 @@ bool Expected<void>::hasValue() const
 }
 
 /// @brief Allow Expected<void> to participate in boolean tests for success.
-Expected<void>::operator bool() const
+[[nodiscard]] Expected<void>::operator bool() const
 {
     return hasValue();
 }

--- a/src/support/diag_expected.hpp
+++ b/src/support/diag_expected.hpp
@@ -83,7 +83,7 @@ template <> class Expected<void>
     [[nodiscard]] bool hasValue() const;
 
     /// @brief Allow use in boolean contexts to test success.
-    explicit operator bool() const;
+    [[nodiscard]] explicit operator bool() const;
 
     /// @brief Access the diagnostic describing the failure.
     const Diag &error() const &;


### PR DESCRIPTION
## Summary
- ensure `Expected<void>::operator bool()` is defined as a `const` conversion and annotate it with `[[nodiscard]]`
- propagate the same attribute to the declaration so callers must inspect the conversion result

## Testing
- cmake -S . -B build
- cmake --build build --target viper_support


------
https://chatgpt.com/codex/tasks/task_e_68e56704218c8324954cd60bbaeddebc