### PR TITLE
Fix call parsing when extra tokens follow arguments

### DIFF
--- a/src/il/io/OperandParser.cpp
+++ b/src/il/io/OperandParser.cpp
@@ -132,6 +132,13 @@ Expected<void> OperandParser::parseCallOperands(const std::string &text)
             return Expected<void>{argVal.error()};
         instr_.operands.push_back(std::move(argVal.value()));
     }
+    std::string remainder = trim(text.substr(rp + 1));
+    if (!remainder.empty())
+    {
+        std::ostringstream oss;
+        oss << "line " << state_.lineNo << ": malformed call";
+        return Expected<void>{makeError(instr_.loc, oss.str())};
+    }
     if (!instr_.result)
         instr_.type = il::core::Type(il::core::Type::Kind::Void);
     return {};

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -101,6 +101,10 @@ function(viper_add_il_core_tests)
   target_link_libraries(test_il_parse_call_ret_type PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   viper_add_ctest(test_il_parse_call_ret_type test_il_parse_call_ret_type)
 
+  viper_add_test(test_il_parse_call_extra_token ${_VIPER_IL_UNIT_DIR}/test_il_parse_call_extra_token.cpp)
+  target_link_libraries(test_il_parse_call_extra_token PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  viper_add_ctest(test_il_parse_call_extra_token test_il_parse_call_extra_token)
+
   viper_add_test(test_il_parse_negative ${_VIPER_IL_UNIT_DIR}/test_il_parse_negative.cpp)
   target_link_libraries(test_il_parse_negative PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   target_compile_definitions(test_il_parse_negative PRIVATE BAD_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse")

--- a/tests/unit/test_il_parse_call_extra_token.cpp
+++ b/tests/unit/test_il_parse_call_extra_token.cpp
@@ -1,0 +1,38 @@
+// File: tests/unit/test_il_parse_call_extra_token.cpp
+// Purpose: Ensure call operands reject trailing tokens after the argument list.
+// Key invariants: Parser emits the malformed call diagnostic with the correct line number.
+// Ownership/Lifetime: Test owns the module and diagnostic buffers locally.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "support/diagnostics.hpp"
+
+#include <cassert>
+#include <sstream>
+
+int main()
+{
+    constexpr const char *kProgram = R"(il 0.1.2
+
+func @main() -> void {
+entry:
+  call @foo() extra
+  ret
+}
+)";
+
+    std::istringstream input(kProgram);
+    il::core::Module module;
+    auto parseResult = il::api::v2::parse_text_expected(input, module);
+    assert(!parseResult);
+
+    std::ostringstream diag;
+    il::support::printDiag(parseResult.error(), diag);
+    const std::string message = diag.str();
+
+    assert(message.find("line 5") != std::string::npos);
+    assert(message.find("malformed call") != std::string::npos);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ensure call operand parsing rejects extra tokens after the closing parenthesis
- add a unit test that covers a call with trailing text and expects the malformed call diagnostic
- wire the new test into the IL unit test CMake list

## Testing
- cmake --build build --target test_il_parse_call_extra_token
- ctest --test-dir build --output-on-failure -R test_il_parse_call_extra_token

------
https://chatgpt.com/codex/tasks/task_e_68e56889c4a08324b2d6b2fb7d3dc0fb