### PR TITLE
Support boolean literal operands in IL parser

### DIFF
--- a/src/il/core/Value.cpp
+++ b/src/il/core/Value.cpp
@@ -24,6 +24,11 @@ Value Value::constInt(long long v)
     return Value{Kind::ConstInt, v, 0.0, 0, ""};
 }
 
+Value Value::constBool(bool v)
+{
+    return Value{Kind::ConstInt, v ? 1 : 0, 0.0, 0, "", true};
+}
+
 Value Value::constFloat(double v)
 {
     return Value{Kind::ConstFloat, 0, v, 0, ""};
@@ -51,6 +56,8 @@ std::string toString(const Value &v)
         case Value::Kind::Temp:
             return "%t" + std::to_string(v.id);
         case Value::Kind::ConstInt:
+            if (v.isBool)
+                return v.i64 != 0 ? "true" : "false";
             return std::to_string(v.i64);
         case Value::Kind::ConstFloat:
         {

--- a/src/il/core/Value.hpp
+++ b/src/il/core/Value.hpp
@@ -34,6 +34,10 @@ struct Value
     /// String payload for string constants and global names.
     std::string str;
 
+    /// @brief Flag set when the integer literal represents an i1 boolean.
+    /// @invariant Only meaningful when kind == Kind::ConstInt.
+    bool isBool{false};
+
     /// @brief Construct a temporary value.
     /// @param t Identifier of the temporary.
     /// @return Value with kind Kind::Temp and id set to t.
@@ -45,6 +49,12 @@ struct Value
     /// @return Value with kind Kind::ConstInt and i64 set to v.
     /// @invariant result.kind == Kind::ConstInt.
     static Value constInt(long long v);
+
+    /// @brief Construct a boolean constant value.
+    /// @param v Boolean literal to encode as an i1 constant.
+    /// @return Value with kind Kind::ConstInt and boolean flag set.
+    /// @invariant result.kind == Kind::ConstInt and result.isBool == true.
+    static Value constBool(bool v);
 
     /// @brief Construct a floating-point constant value.
     /// @param v IEEE-754 double literal.

--- a/src/il/io/OperandParser.cpp
+++ b/src/il/io/OperandParser.cpp
@@ -15,6 +15,7 @@
 
 #include <cctype>
 #include <exception>
+#include <cstring>
 #include <sstream>
 #include <utility>
 
@@ -32,6 +33,25 @@ Expected<Value> OperandParser::parseValueToken(const std::string &tok) const
 {
     if (tok.empty())
         return Value::constInt(0);
+
+    const auto equalsIgnoreCase = [](const std::string &value, const char *literal) {
+        const size_t len = std::strlen(literal);
+        if (value.size() != len)
+            return false;
+        for (size_t i = 0; i < len; ++i)
+        {
+            const unsigned char lhs = static_cast<unsigned char>(value[i]);
+            const unsigned char rhs = static_cast<unsigned char>(literal[i]);
+            if (std::tolower(lhs) != std::tolower(rhs))
+                return false;
+        }
+        return true;
+    };
+
+    if (equalsIgnoreCase(tok, "true"))
+        return Value::constBool(true);
+    if (equalsIgnoreCase(tok, "false"))
+        return Value::constBool(false);
     if (tok[0] == '%')
     {
         std::string name = tok.substr(1);

--- a/src/il/verify/TypeInference.cpp
+++ b/src/il/verify/TypeInference.cpp
@@ -84,7 +84,7 @@ Type TypeInference::valueType(const Value &value, bool *missing) const
             return Type(Type::Kind::Void);
         }
         case Value::Kind::ConstInt:
-            return Type(Type::Kind::I64);
+            return Type(value.isBool ? Type::Kind::I1 : Type::Kind::I64);
         case Value::Kind::ConstFloat:
             return Type(Type::Kind::F64);
         case Value::Kind::ConstStr:

--- a/tests/unit/test_il_parse_misc_instructions.cpp
+++ b/tests/unit/test_il_parse_misc_instructions.cpp
@@ -29,6 +29,9 @@ entry(%flag:i1):
   store i64, %t3, 0b101010
   %t4 = load i64, %t3
   %t5 = zext1 %flag
+  %t6 = alloca 1
+  store i1, %t6, true
+  store i1, %t6, FALSE
   cbr %flag, true_bb(%t4), false_bb
 true_bb(%x:i64):
   br exit(%x)
@@ -55,7 +58,7 @@ exit(%v:i64):
     assert(fn.blocks.size() == 4);
 
     const auto &entry = fn.blocks[0];
-    assert(entry.instructions.size() == 10);
+    assert(entry.instructions.size() == 13);
 
     const auto &constNull = entry.instructions[0];
     assert(constNull.op == il::core::Opcode::ConstNull);
@@ -117,7 +120,29 @@ exit(%v:i64):
     assert(zextInstr.operands[0].kind == il::core::Value::Kind::Temp);
     assert(zextInstr.type.kind == il::core::Type::Kind::I64);
 
-    const auto &cbrInstr = entry.instructions[9];
+    const auto &boolAlloca = entry.instructions[9];
+    assert(boolAlloca.op == il::core::Opcode::Alloca);
+    assert(boolAlloca.operands.size() == 1);
+    assert(boolAlloca.operands[0].kind == il::core::Value::Kind::ConstInt);
+    assert(boolAlloca.operands[0].i64 == 1);
+
+    const auto &storeBoolTrue = entry.instructions[10];
+    assert(storeBoolTrue.op == il::core::Opcode::Store);
+    assert(storeBoolTrue.type.kind == il::core::Type::Kind::I1);
+    assert(storeBoolTrue.operands.size() == 2);
+    assert(storeBoolTrue.operands[1].kind == il::core::Value::Kind::ConstInt);
+    assert(storeBoolTrue.operands[1].i64 == 1);
+    assert(storeBoolTrue.operands[1].isBool);
+
+    const auto &storeBoolFalse = entry.instructions[11];
+    assert(storeBoolFalse.op == il::core::Opcode::Store);
+    assert(storeBoolFalse.type.kind == il::core::Type::Kind::I1);
+    assert(storeBoolFalse.operands.size() == 2);
+    assert(storeBoolFalse.operands[1].kind == il::core::Value::Kind::ConstInt);
+    assert(storeBoolFalse.operands[1].i64 == 0);
+    assert(storeBoolFalse.operands[1].isBool);
+
+    const auto &cbrInstr = entry.instructions[12];
     assert(cbrInstr.op == il::core::Opcode::CBr);
     assert(cbrInstr.operands.size() == 1);
     assert(cbrInstr.operands[0].kind == il::core::Value::Kind::Temp);

--- a/tests/unit/test_il_type_inference.cpp
+++ b/tests/unit/test_il_type_inference.cpp
@@ -30,6 +30,12 @@ int main()
     Value c = Value::constInt(42);
     assert(types.valueType(c).kind == Type::Kind::I64);
 
+    Value bTrue = Value::constBool(true);
+    assert(types.valueType(bTrue).kind == Type::Kind::I1);
+
+    Value bFalse = Value::constBool(false);
+    assert(types.valueType(bFalse).kind == Type::Kind::I1);
+
     Value missingVal = Value::temp(2);
     bool missing = false;
     Type missingType = types.valueType(missingVal, &missing);


### PR DESCRIPTION
## Summary
- allow the operand parser to accept case-insensitive `true`/`false` tokens and materialize boolean constants
- tag `Value` integers that represent booleans so type inference reports them as `i1`
- extend IL parsing and type inference unit tests to cover boolean operands

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e5671117c48324996aec5b53f9f4ab