### PR TITLE
fix(il/io): preserve commas inside string operands

### DIFF
--- a/src/il/io/OperandParser.cpp
+++ b/src/il/io/OperandParser.cpp
@@ -107,6 +107,58 @@ Expected<Value> OperandParser::parseValueToken(const std::string &tok) const
     return Expected<Value>{makeError(state_.curLoc, oss.str())};
 }
 
+Expected<std::vector<std::string>>
+OperandParser::splitCommaSeparated(const std::string &text, const char *context) const
+{
+    std::vector<std::string> tokens;
+    std::string current;
+    bool inString = false;
+    bool escape = false;
+
+    auto error = [&]() -> Expected<std::vector<std::string>> {
+        std::ostringstream oss;
+        oss << "line " << state_.lineNo << ": malformed " << context;
+        return Expected<std::vector<std::string>>{makeError(instr_.loc, oss.str())};
+    };
+
+    for (char c : text)
+    {
+        if (!inString && c == ',')
+        {
+            std::string trimmed = trim(current);
+            if (!trimmed.empty())
+                tokens.push_back(std::move(trimmed));
+            current.clear();
+            continue;
+        }
+
+        current.push_back(c);
+
+        if (inString)
+        {
+            if (escape)
+                escape = false;
+            else if (c == '\\')
+                escape = true;
+            else if (c == '"')
+                inString = false;
+        }
+        else if (c == '"')
+        {
+            inString = true;
+        }
+    }
+
+    if (escape || inString)
+        return error();
+
+    std::string trimmed = trim(current);
+    if (!trimmed.empty())
+        tokens.push_back(std::move(trimmed));
+
+    return Expected<std::vector<std::string>>{std::move(tokens)};
+}
+
 Expected<void> OperandParser::parseCallOperands(const std::string &text)
 {
     const size_t at = text.find('@');
@@ -120,14 +172,12 @@ Expected<void> OperandParser::parseCallOperands(const std::string &text)
     }
     instr_.callee = trim(text.substr(at + 1, lp - at - 1));
     std::string args = text.substr(lp + 1, rp - lp - 1);
-    std::stringstream as(args);
-    std::string a;
-    while (std::getline(as, a, ','))
+    auto tokens = splitCommaSeparated(args, "call");
+    if (!tokens)
+        return Expected<void>{tokens.error()};
+    for (const auto &token : tokens.value())
     {
-        a = trim(a);
-        if (a.empty())
-            continue;
-        auto argVal = parseValueToken(a);
+        auto argVal = parseValueToken(token);
         if (!argVal)
             return Expected<void>{argVal.error()};
         instr_.operands.push_back(std::move(argVal.value()));
@@ -142,6 +192,7 @@ Expected<void> OperandParser::parseBranchTarget(const std::string &segment,
                                                 std::vector<Value> &args) const
 {
     std::string text = trim(segment);
+    const char *mnemonic = il::core::getOpcodeInfo(instr_.op).name;
     if (text.rfind("label ", 0) == 0)
         text = trim(text.substr(6));
     if (!text.empty() && text[0] == '^')
@@ -161,13 +212,11 @@ Expected<void> OperandParser::parseBranchTarget(const std::string &segment,
     }
     label = trim(text.substr(0, lp));
     std::string argsStr = text.substr(lp + 1, rp - lp - 1);
-    std::stringstream as(argsStr);
-    std::string token;
-    while (std::getline(as, token, ','))
+    auto tokens = splitCommaSeparated(argsStr, mnemonic);
+    if (!tokens)
+        return Expected<void>{tokens.error()};
+    for (const auto &token : tokens.value())
     {
-        token = trim(token);
-        if (token.empty())
-            continue;
         auto val = parseValueToken(token);
         if (!val)
             return Expected<void>{val.error()};

--- a/src/il/io/OperandParser.hpp
+++ b/src/il/io/OperandParser.hpp
@@ -46,6 +46,9 @@ class OperandParser
     il::support::Expected<void> parseSwitchTargets(const std::string &text);
 
   private:
+    il::support::Expected<std::vector<std::string>>
+    splitCommaSeparated(const std::string &text, const char *context) const;
+
     il::support::Expected<void> parseBranchTarget(const std::string &segment,
                                                   std::string &label,
                                                   std::vector<il::core::Value> &args) const;

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -142,6 +142,12 @@ function(viper_add_il_core_tests)
   target_link_libraries(test_il_parse_misc_instructions PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   viper_add_ctest(test_il_parse_misc_instructions test_il_parse_misc_instructions)
 
+  viper_add_test(
+    test_il_parse_call_string_comma
+    ${_VIPER_IL_UNIT_DIR}/test_il_parse_call_string_comma.cpp)
+  target_link_libraries(test_il_parse_call_string_comma PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  viper_add_ctest(test_il_parse_call_string_comma test_il_parse_call_string_comma)
+
   viper_add_test(test_il_function_parser_errors ${_VIPER_IL_UNIT_DIR}/test_il_function_parser_errors.cpp)
   target_link_libraries(test_il_function_parser_errors PRIVATE ${VIPER_IL_CORE_IO_LIBS})
   viper_add_ctest(test_il_function_parser_errors test_il_function_parser_errors)


### PR DESCRIPTION
## Summary
- replace the call operand splitter with a quote-aware parser and reuse it for branch targets
- add a regression test ensuring calls keep string arguments that contain commas intact

## Testing
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e5687cc3ec8324af4e8f2d27bd81be