### PR TITLE
fix(il/io): diagnose missing block labels

### DIFF
--- a/src/il/io/FunctionParser.cpp
+++ b/src/il/io/FunctionParser.cpp
@@ -239,6 +239,12 @@ Expected<void> parseBlockHeader(const std::string &header, ParserState &st)
     std::string label = lp != std::string::npos ? trim(work.substr(0, lp)) : trim(work);
     if (!label.empty() && label[0] == '^')
         label = label.substr(1);
+    if (label.empty())
+    {
+        std::ostringstream oss;
+        oss << "line " << st.lineNo << ": missing block label";
+        return Expected<void>{makeError({}, oss.str())};
+    }
     if (st.blockParamCount.find(label) != st.blockParamCount.end())
     {
         std::ostringstream oss;

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -77,6 +77,15 @@ function(viper_add_il_core_tests)
   viper_add_ctest(test_il_parse_missing_brace test_il_parse_missing_brace)
 
   viper_add_test(
+    test_il_parse_missing_block_label
+    ${_VIPER_IL_UNIT_DIR}/test_il_parse_missing_block_label.cpp)
+  target_link_libraries(test_il_parse_missing_block_label PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  target_compile_definitions(
+    test_il_parse_missing_block_label
+    PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
+  viper_add_ctest(test_il_parse_missing_block_label test_il_parse_missing_block_label)
+
+  viper_add_test(
     test_il_parse_function_name_trim
     ${_VIPER_IL_UNIT_DIR}/test_il_parse_function_name_trim.cpp)
   target_link_libraries(test_il_parse_function_name_trim PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)

--- a/tests/il/parse-roundtrip/missing_block_label.il
+++ b/tests/il/parse-roundtrip/missing_block_label.il
@@ -1,0 +1,6 @@
+il 0.1.2
+func @missing_block_label() -> void {
+entry:
+:
+  ret_void
+}

--- a/tests/unit/test_il_parse_missing_block_label.cpp
+++ b/tests/unit/test_il_parse_missing_block_label.cpp
@@ -1,0 +1,38 @@
+// File: tests/unit/test_il_parse_missing_block_label.cpp
+// Purpose: Validate that the IL parser diagnoses blocks without labels.
+// Key invariants: Parser identifies empty block headers and reports a line-aware diagnostic.
+// Ownership/Lifetime: Test owns parsing buffers and diagnostics output.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "support/diagnostics.hpp"
+
+#include <cassert>
+#include <fstream>
+#include <sstream>
+
+#ifndef PARSE_ROUNDTRIP_DIR
+#error "PARSE_ROUNDTRIP_DIR must be defined"
+#endif
+
+int main()
+{
+    const char *path = PARSE_ROUNDTRIP_DIR "/missing_block_label.il";
+    std::ifstream in(path);
+    std::stringstream buffer;
+    buffer << in.rdbuf();
+    buffer.seekg(0);
+
+    il::core::Module module;
+    auto parseResult = il::api::v2::parse_text_expected(buffer, module);
+    assert(!parseResult);
+
+    std::ostringstream diag;
+    il::support::printDiag(parseResult.error(), diag);
+    const std::string message = diag.str();
+    assert(message.find("line 4") != std::string::npos);
+    assert(message.find("missing block label") != std::string::npos);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- report a diagnostic when a block header loses its label before parsing parameters
- add a colon-only block fixture and regression test to cover the new failure mode
- register the test in the IL test suite with the parse-roundtrip directory definition

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e568a13b048324b620f0f5a66e598f