### PR TITLE
fix: validate block parameter prefix

### DIFF
--- a/src/il/io/FunctionParser.cpp
+++ b/src/il/io/FunctionParser.cpp
@@ -269,7 +269,14 @@ Expected<void> parseBlockHeader(const std::string &header, ParserState &st)
                 oss << "line " << st.lineNo << ": bad param";
                 return Expected<void>{makeError({}, oss.str())};
             }
-            std::string nm = trim(q.substr(0, col));
+            std::string rawName = trim(q.substr(0, col));
+            if (!rawName.empty() && rawName[0] != '%')
+            {
+                std::ostringstream oss;
+                oss << "line " << st.lineNo << ": parameter name must start with '%'";
+                return Expected<void>{makeError({}, oss.str())};
+            }
+            std::string nm = rawName;
             if (!nm.empty() && nm[0] == '%')
                 nm = nm.substr(1);
             if (nm.empty())

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -63,6 +63,11 @@ function(viper_add_il_core_tests)
   target_compile_definitions(test_il_parse_param_prefix PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
   viper_add_ctest(test_il_parse_param_prefix test_il_parse_param_prefix)
 
+  viper_add_test(test_il_parse_block_param_prefix ${_VIPER_IL_UNIT_DIR}/test_il_parse_block_param_prefix.cpp)
+  target_link_libraries(test_il_parse_block_param_prefix PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  target_compile_definitions(test_il_parse_block_param_prefix PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")
+  viper_add_ctest(test_il_parse_block_param_prefix test_il_parse_block_param_prefix)
+
   viper_add_test(test_il_parse_duplicate_param ${_VIPER_IL_UNIT_DIR}/test_il_parse_duplicate_param.cpp)
   target_link_libraries(test_il_parse_duplicate_param PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   viper_add_ctest(test_il_parse_duplicate_param test_il_parse_duplicate_param)

--- a/tests/il/parse-roundtrip/block_param_missing_percent.il
+++ b/tests/il/parse-roundtrip/block_param_missing_percent.il
@@ -1,0 +1,7 @@
+il 0.1.2
+func @block_param_missing_percent() -> i32 {
+entry:
+  br bb0()
+bb0(x: i32):
+  ret 0
+}

--- a/tests/unit/test_il_parse_block_param_prefix.cpp
+++ b/tests/unit/test_il_parse_block_param_prefix.cpp
@@ -1,0 +1,38 @@
+// File: tests/unit/test_il_parse_block_param_prefix.cpp
+// Purpose: Ensure block headers reject parameters missing the '%' prefix.
+// Key invariants: Parser reports descriptive diagnostics for malformed block parameter names.
+// Ownership/Lifetime: Test constructs modules and diagnostic buffers locally.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "support/diagnostics.hpp"
+
+#include <cassert>
+#include <fstream>
+#include <sstream>
+
+#ifndef PARSE_ROUNDTRIP_DIR
+#error "PARSE_ROUNDTRIP_DIR must be defined"
+#endif
+
+int main()
+{
+    const char *path = PARSE_ROUNDTRIP_DIR "/block_param_missing_percent.il";
+    std::ifstream in(path);
+    std::stringstream buffer;
+    buffer << in.rdbuf();
+    buffer.seekg(0);
+
+    il::core::Module m;
+    auto parse = il::api::v2::parse_text_expected(buffer, m);
+    assert(!parse);
+
+    std::ostringstream diag;
+    il::support::printDiag(parse.error(), diag);
+    const std::string message = diag.str();
+    assert(message.find("parameter name must start with '%'") != std::string::npos);
+    assert(message.find("line 5") != std::string::npos);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- require block header parameters to start with a '%' and produce a clear diagnostic when missing
- add a parse-roundtrip fixture plus a unit test covering the block-parameter diagnostic
- register the new unit test in the IL test CMake configuration

## Testing
- cmake -S . -B build
- cmake --build build -j2
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e56ae645c0832492817f760000e743