### PR TITLE
fix: decode escaped const_str operands in parser

### DIFF
--- a/src/il/io/OperandParser.cpp
+++ b/src/il/io/OperandParser.cpp
@@ -77,14 +77,11 @@ Expected<Value> OperandParser::parseValueToken(const std::string &tok) const
     {
         std::string decoded;
         std::string errMsg;
-        if (!il::io::decodeEscapedString(std::string_view(tok).substr(1, tok.size() - 2),
-                                         decoded,
-                                         &errMsg))
+        std::string literal = tok.substr(1, tok.size() - 2);
+        if (!il::io::decodeEscapedString(literal, decoded, &errMsg))
         {
             std::ostringstream oss;
-            oss << "Line " << state_.lineNo << ": invalid string literal '" << tok << "'";
-            if (!errMsg.empty())
-                oss << ": " << errMsg;
+            oss << "Line " << state_.lineNo << ": " << errMsg;
             return Expected<Value>{makeError(state_.curLoc, oss.str())};
         }
         return Value::constStr(std::move(decoded));

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -134,6 +134,10 @@ function(viper_add_il_core_tests)
   target_link_libraries(test_il_parse_string_escapes PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   viper_add_ctest(test_il_parse_string_escapes test_il_parse_string_escapes)
 
+  viper_add_test(test_il_parse_conststr_escapes ${_VIPER_IL_UNIT_DIR}/test_il_parse_conststr_escapes.cpp)
+  target_link_libraries(test_il_parse_conststr_escapes PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  viper_add_ctest(test_il_parse_conststr_escapes test_il_parse_conststr_escapes)
+
   viper_add_test(test_il_parse_invalid_type ${_VIPER_IL_UNIT_DIR}/test_il_parse_invalid_type.cpp)
   target_link_libraries(test_il_parse_invalid_type PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   viper_add_ctest(test_il_parse_invalid_type test_il_parse_invalid_type)

--- a/tests/unit/test_il_parse_conststr_escapes.cpp
+++ b/tests/unit/test_il_parse_conststr_escapes.cpp
@@ -1,0 +1,53 @@
+// File: tests/unit/test_il_parse_conststr_escapes.cpp
+// Purpose: Ensure const_str operands decode escape sequences when parsed.
+// Key invariants: Operand parser stores decoded bytes for Value::ConstStr operands.
+// Ownership/Lifetime: Test owns the module produced by the parser.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "il/core/Opcode.hpp"
+#include "il/core/Value.hpp"
+#include "support/diag_expected.hpp"
+
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+int main()
+{
+    const char *source = R"(il 0.1.2
+func @main() -> void {
+entry:
+  %s0 = const_str "line\n_tab\t_quote:\"_hex:\x21"
+  ret
+}
+)";
+
+    std::istringstream in(source);
+    il::core::Module module;
+    auto parsed = il::api::v2::parse_text_expected(in, module);
+    if (!parsed)
+    {
+        il::support::printDiag(parsed.error(), std::cerr);
+        return 1;
+    }
+
+    assert(module.functions.size() == 1);
+    const auto &fn = module.functions[0];
+    assert(fn.blocks.size() == 1);
+
+    const auto &block = fn.blocks[0];
+    assert(block.instructions.size() == 2);
+
+    const auto &constStr = block.instructions[0];
+    assert(constStr.op == il::core::Opcode::ConstStr);
+    assert(constStr.operands.size() == 1);
+    assert(constStr.operands[0].kind == il::core::Value::Kind::ConstStr);
+
+    const std::string expected = std::string("line\n_tab\t_quote:\"_hex:!");
+    assert(constStr.operands[0].str == expected);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- forward string literal substrings to `decodeEscapedString` in `OperandParser` and bubble up its diagnostic message when decoding fails
- add a unit test covering `const_str` operands with escapes and register it with the IL parser suite

## Testing
- cmake --build build --target viper_il_io
- cmake --build build --target test_il_parse_conststr_escapes
- ctest --test-dir build --output-on-failure -R test_il_parse_conststr_escapes


------
https://chatgpt.com/codex/tasks/task_e_68e56b5238788324912d71ebcf362e81