### PR TITLE
feat(il/io): parse special float literals

### DIFF
--- a/src/il/io/OperandParser.cpp
+++ b/src/il/io/OperandParser.cpp
@@ -16,6 +16,7 @@
 
 #include <cctype>
 #include <exception>
+#include <limits>
 #include <sstream>
 #include <string_view>
 #include <utility>
@@ -99,6 +100,16 @@ Expected<Value> OperandParser::parseValueToken(const std::string &tok) const
         oss << "Line " << state_.lineNo << ": invalid floating literal '" << tok << "'";
         return Expected<Value>{makeError(state_.curLoc, oss.str())};
     }
+    std::string lower;
+    lower.reserve(tok.size());
+    for (unsigned char ch : tok)
+        lower.push_back(static_cast<char>(std::tolower(ch)));
+    if (lower == "nan")
+        return Value::constFloat(std::numeric_limits<double>::quiet_NaN());
+    if (lower == "inf" || lower == "+inf")
+        return Value::constFloat(std::numeric_limits<double>::infinity());
+    if (lower == "-inf")
+        return Value::constFloat(-std::numeric_limits<double>::infinity());
     long long intValue = 0;
     if (parseIntegerLiteral(tok, intValue))
         return Value::constInt(intValue);

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -142,6 +142,10 @@ function(viper_add_il_core_tests)
   target_link_libraries(test_il_parse_misc_instructions PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   viper_add_ctest(test_il_parse_misc_instructions test_il_parse_misc_instructions)
 
+  viper_add_test(test_il_parse_float_specials ${_VIPER_IL_UNIT_DIR}/test_il_parse_float_specials.cpp)
+  target_link_libraries(test_il_parse_float_specials PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  viper_add_ctest(test_il_parse_float_specials test_il_parse_float_specials)
+
   viper_add_test(test_il_function_parser_errors ${_VIPER_IL_UNIT_DIR}/test_il_function_parser_errors.cpp)
   target_link_libraries(test_il_function_parser_errors PRIVATE ${VIPER_IL_CORE_IO_LIBS})
   viper_add_ctest(test_il_function_parser_errors test_il_function_parser_errors)

--- a/tests/unit/test_il_parse_float_specials.cpp
+++ b/tests/unit/test_il_parse_float_specials.cpp
@@ -1,0 +1,64 @@
+// File: tests/unit/test_il_parse_float_specials.cpp
+// Purpose: Verify the IL parser accepts special floating-point literals.
+// Key invariants: NaN and infinity tokens parse case-insensitively and map to IEEE values.
+// Ownership/Lifetime: Test owns parsed module memory during execution.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "il/core/Value.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <sstream>
+
+int main()
+{
+    const char *src = R"(il 0.1.2
+extern @rt_print_f64(f64) -> void
+func @main() -> void {
+entry:
+  call @rt_print_f64(NaN)
+  call @rt_print_f64(Inf)
+  call @rt_print_f64(+Inf)
+  call @rt_print_f64(-Inf)
+  ret
+}
+)";
+
+    std::istringstream in(src);
+    il::core::Module module;
+    auto parse = il::api::v2::parse_text_expected(in, module);
+    assert(parse);
+
+    assert(module.functions.size() == 1);
+    const auto &fn = module.functions[0];
+    assert(fn.blocks.size() == 1);
+    const auto &entry = fn.blocks[0];
+    assert(entry.instructions.size() == 5);
+
+    const auto &nanCall = entry.instructions[0];
+    assert(nanCall.operands.size() == 1);
+    assert(nanCall.operands[0].kind == il::core::Value::Kind::ConstFloat);
+    assert(std::isnan(nanCall.operands[0].f64));
+
+    const auto &infCall = entry.instructions[1];
+    assert(infCall.operands.size() == 1);
+    assert(infCall.operands[0].kind == il::core::Value::Kind::ConstFloat);
+    assert(std::isinf(infCall.operands[0].f64));
+    assert(!std::signbit(infCall.operands[0].f64));
+
+    const auto &posInfCall = entry.instructions[2];
+    assert(posInfCall.operands.size() == 1);
+    assert(posInfCall.operands[0].kind == il::core::Value::Kind::ConstFloat);
+    assert(std::isinf(posInfCall.operands[0].f64));
+    assert(!std::signbit(posInfCall.operands[0].f64));
+
+    const auto &negInfCall = entry.instructions[3];
+    assert(negInfCall.operands.size() == 1);
+    assert(negInfCall.operands[0].kind == il::core::Value::Kind::ConstFloat);
+    assert(std::isinf(negInfCall.operands[0].f64));
+    assert(std::signbit(negInfCall.operands[0].f64));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- recognize case-insensitive NaN and Inf value tokens and map them to IEEE constants during parsing
- add a parser unit test that exercises NaN, Inf, +Inf, and -Inf literals and register it with the IL test suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e56b427ba4832492ea499dec0efd67