### PR TITLE
fix(il/io): reject duplicate block parameter names

### DIFF
--- a/src/il/io/FunctionParser.cpp
+++ b/src/il/io/FunctionParser.cpp
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <sstream>
 #include <string_view>
+#include <unordered_set>
 #include <utility>
 
 namespace il::io::detail
@@ -251,6 +252,7 @@ Expected<void> parseBlockHeader(const std::string &header, ParserState &st)
         oss << "line " << st.lineNo << ": duplicate block '" << label << "'";
         return Expected<void>{makeError({}, oss.str())};
     }
+    std::unordered_set<std::string> localNames;
     if (lp != std::string::npos)
     {
         size_t rp = work.find(')', lp);
@@ -291,6 +293,13 @@ Expected<void> parseBlockHeader(const std::string &header, ParserState &st)
             {
                 std::ostringstream oss;
                 oss << "line " << st.lineNo << ": unknown param type";
+                return Expected<void>{makeError({}, oss.str())};
+            }
+            if (!localNames.insert(nm).second)
+            {
+                std::ostringstream oss;
+                oss << "line " << st.lineNo
+                    << ": duplicate parameter name '%" << nm << "'";
                 return Expected<void>{makeError({}, oss.str())};
             }
             bparams.push_back({nm, ty, st.nextTemp});

--- a/tests/il/CMakeLists.txt
+++ b/tests/il/CMakeLists.txt
@@ -71,6 +71,15 @@ function(viper_add_il_core_tests)
   target_link_libraries(test_il_parse_duplicate_result PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   viper_add_ctest(test_il_parse_duplicate_result test_il_parse_duplicate_result)
 
+  viper_add_test(
+    test_il_parse_duplicate_block_param
+    ${_VIPER_IL_UNIT_DIR}/test_il_parse_duplicate_block_param.cpp)
+  target_link_libraries(test_il_parse_duplicate_block_param PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
+  target_compile_definitions(
+    test_il_parse_duplicate_block_param
+    PRIVATE PARSE_ERROR_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse")
+  viper_add_ctest(test_il_parse_duplicate_block_param test_il_parse_duplicate_block_param)
+
   viper_add_test(test_il_parse_missing_brace ${_VIPER_IL_UNIT_DIR}/test_il_parse_missing_brace.cpp)
   target_link_libraries(test_il_parse_missing_brace PRIVATE ${VIPER_IL_CORE_IO_LIBS} il_api)
   target_compile_definitions(test_il_parse_missing_brace PRIVATE PARSE_ROUNDTRIP_DIR="${CMAKE_SOURCE_DIR}/tests/il/parse-roundtrip")

--- a/tests/il/parse/duplicate_block_param.il
+++ b/tests/il/parse/duplicate_block_param.il
@@ -1,0 +1,5 @@
+il 0.1.2
+func @duplicate_block_param() -> void {
+bb0(%x: i32, %x: i32):
+  ret
+}

--- a/tests/unit/test_il_parse_duplicate_block_param.cpp
+++ b/tests/unit/test_il_parse_duplicate_block_param.cpp
@@ -1,0 +1,38 @@
+// File: tests/unit/test_il_parse_duplicate_block_param.cpp
+// Purpose: Ensure the IL parser rejects duplicate parameter names within a block header.
+// Key invariants: Parser emits a diagnostic mentioning the duplicate name and source line.
+// Ownership/Lifetime: Test constructs module and diagnostic buffers locally.
+// Links: docs/il-guide.md#reference
+
+#include "il/api/expected_api.hpp"
+#include "il/core/Module.hpp"
+#include "support/diagnostics.hpp"
+
+#include <cassert>
+#include <fstream>
+#include <sstream>
+
+#ifndef PARSE_ERROR_DIR
+#error "PARSE_ERROR_DIR must be defined"
+#endif
+
+int main()
+{
+    const char *path = PARSE_ERROR_DIR "/duplicate_block_param.il";
+    std::ifstream in(path);
+    std::stringstream buf;
+    buf << in.rdbuf();
+    buf.seekg(0);
+
+    il::core::Module module;
+    auto parseResult = il::api::v2::parse_text_expected(buf, module);
+    assert(!parseResult && "parser should reject duplicate block parameters");
+
+    std::ostringstream diag;
+    il::support::printDiag(parseResult.error(), diag);
+    const std::string message = diag.str();
+    assert(message.find("duplicate parameter name '%x'") != std::string::npos);
+    assert(message.find("line 3") != std::string::npos);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- track basic-block parameter names while parsing and reject duplicates within the same header
- add a duplicate block-parameter parse-error sample and unit test to check for the diagnostic
- hook the new test into the IL test suite via CMake

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e57046aa348324b83104d1bdf1113a