### PR TITLE
Fix duplicate block parameter detection in parser

### DIFF
--- a/src/il/io/FunctionParser.cpp
+++ b/src/il/io/FunctionParser.cpp
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <sstream>
 #include <string_view>
+#include <unordered_set>
 #include <utility>
 
 namespace il::io::detail
@@ -251,6 +252,7 @@ Expected<void> parseBlockHeader(const std::string &header, ParserState &st)
         oss << "line " << st.lineNo << ": duplicate block '" << label << "'";
         return Expected<void>{makeError({}, oss.str())};
     }
+    std::unordered_set<std::string> blockParamNames;
     if (lp != std::string::npos)
     {
         size_t rp = work.find(')', lp);
@@ -300,6 +302,13 @@ Expected<void> parseBlockHeader(const std::string &header, ParserState &st)
                 oss << "line " << st.lineNo << ": unknown param type";
                 return Expected<void>{makeError({}, oss.str())};
             }
+            if (st.tempIds.find(nm) != st.tempIds.end() && blockParamNames.find(nm) != blockParamNames.end())
+            {
+                std::ostringstream oss;
+                oss << "line " << st.lineNo << ": duplicate parameter name '%" << nm << "'";
+                return Expected<void>{makeError({}, oss.str())};
+            }
+            blockParamNames.insert(nm);
             bparams.push_back({nm, ty, st.nextTemp});
             st.tempIds[nm] = st.nextTemp;
             if (st.curFn->valueNames.size() <= st.nextTemp)

--- a/tests/il/parse/block_param_duplicate_name.il
+++ b/tests/il/parse/block_param_duplicate_name.il
@@ -1,0 +1,5 @@
+il 0.1.2
+func @dup_block_param() -> void {
+entry(%x: i32, %x: i32):
+  ret
+}

--- a/tests/unit/test_il_parse_negative.cpp
+++ b/tests/unit/test_il_parse_negative.cpp
@@ -5,6 +5,7 @@
 
 #include "il/api/expected_api.hpp"
 #include "il/core/Module.hpp"
+#include "support/diagnostics.hpp"
 #include <cassert>
 #include <fstream>
 #include <sstream>
@@ -19,7 +20,8 @@ int main()
                            BAD_DIR "/bad_float_literal.il",
                            BAD_DIR "/alloca_missing_size.il",
                            BAD_DIR "/target_missing_quotes.il",
-                           BAD_DIR "/block_param_missing_name.il"};
+                           BAD_DIR "/block_param_missing_name.il",
+                           BAD_DIR "/block_param_duplicate_name.il"};
     for (const char *path : files)
     {
         std::ifstream in(path);
@@ -29,6 +31,22 @@ int main()
         il::core::Module m;
         auto parse = il::api::v2::parse_text_expected(buf, m);
         assert(!parse);
+    }
+
+    {
+        std::ifstream in(BAD_DIR "/block_param_duplicate_name.il");
+        std::stringstream buf;
+        buf << in.rdbuf();
+        buf.seekg(0);
+        il::core::Module m;
+        auto parse = il::api::v2::parse_text_expected(buf, m);
+        assert(!parse);
+
+        std::ostringstream diag;
+        il::support::printDiag(parse.error(), diag);
+        const std::string message = diag.str();
+        assert(message.find("duplicate parameter name '%x'") != std::string::npos);
+        assert(message.find("line 3") != std::string::npos);
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- flag duplicate block parameter names when parsing basic block headers
- add a regression test covering duplicate block parameter diagnostics

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e57844c39c8324a393183f03b697fa