### PR TITLE
Fix BASIC division-by-zero diagnostic for literal RHS

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.Exprs.cpp
+++ b/src/frontends/basic/SemanticAnalyzer.Exprs.cpp
@@ -350,8 +350,19 @@ void SemanticAnalyzer::emitDivideByZero(const BinaryExpr &expr)
 
 bool SemanticAnalyzer::rhsIsLiteralZero(const BinaryExpr &expr) const
 {
-    const auto *ri = dynamic_cast<const IntExpr *>(expr.rhs.get());
-    return ri != nullptr && ri->value == 0;
+    if (const auto *ri = dynamic_cast<const IntExpr *>(expr.rhs.get());
+        ri != nullptr)
+    {
+        return ri->value == 0;
+    }
+
+    if (const auto *rf = dynamic_cast<const FloatExpr *>(expr.rhs.get());
+        rf != nullptr)
+    {
+        return rf->value == 0.0;
+    }
+
+    return false;
 }
 
 void SemanticAnalyzer::validateNumericOperands(const BinaryExpr &expr,
@@ -387,7 +398,7 @@ void SemanticAnalyzer::validateDivisionOperands(const BinaryExpr &expr,
                                                 std::string_view diagId)
 {
     validateNumericOperands(expr, lhs, rhs, diagId);
-    if (dynamic_cast<const IntExpr *>(expr.lhs.get()) && rhsIsLiteralZero(expr))
+    if (rhsIsLiteralZero(expr))
     {
         emitDivideByZero(expr);
     }
@@ -403,7 +414,7 @@ void SemanticAnalyzer::validateIntegerOperands(const BinaryExpr &expr,
     {
         emitOperandTypeMismatch(expr, diagId);
     }
-    if (dynamic_cast<const IntExpr *>(expr.lhs.get()) && rhsIsLiteralZero(expr))
+    if (rhsIsLiteralZero(expr))
     {
         emitDivideByZero(expr);
     }

--- a/tests/frontends/basic/SemanticAnalyzerBinaryExprTests.cpp
+++ b/tests/frontends/basic/SemanticAnalyzerBinaryExprTests.cpp
@@ -92,6 +92,12 @@ int main()
     }
 
     {
+        auto result = analyzeSnippet("10 LET A = 1\n20 LET X = A / 0\n30 END\n");
+        assert(result.errors == 1);
+        assert(result.output.find("error[B2002]") != std::string::npos);
+    }
+
+    {
         auto result = analyzeSnippet(makeSnippet("4 \\ 2.5"));
         assert(result.errors == 1);
         assert(result.output.find("error[B2001]") != std::string::npos);
@@ -113,6 +119,11 @@ int main()
         auto result = analyzeSnippet(makeSnippet("4 MOD 0"));
         assert(result.errors == 1);
         assert(result.output.find("error[B2002]") != std::string::npos);
+    }
+
+    {
+        auto result = analyzeSnippet("10 LET A = 0\n20 LET B = A\n30 LET X = 1 / B\n40 END\n");
+        assert(result.errors == 0);
     }
 
     {


### PR DESCRIPTION
## Summary
- flag division and integer division by zero when the right-hand operand is a literal zero, independent of the left operand
- recognize both integer and floating-point zeros when checking for compile-time division errors
- extend semantic analyzer tests to cover variable numerators and non-constant denominators

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68e5c9aed8bc8324a2523ad0dc657b99