### PR TITLE
feat(frontends/basic): allow top-level RETURN for GOSUB

### DIFF
--- a/src/frontends/basic/AST.hpp
+++ b/src/frontends/basic/AST.hpp
@@ -769,6 +769,9 @@ struct ReturnStmt : Stmt
 {
     /// Expression whose value is returned; null when no expression is provided.
     ExprPtr value;
+
+    /// True when this RETURN exits a GOSUB (top-level RETURN without a value).
+    bool isGosubReturn = false;
     void accept(StmtVisitor &visitor) const override;
     void accept(MutStmtVisitor &visitor) override;
 };

--- a/src/frontends/basic/AstPrint_Stmt.cpp
+++ b/src/frontends/basic/AstPrint_Stmt.cpp
@@ -424,6 +424,8 @@ struct AstPrinter::StmtPrinter final : StmtVisitor
     void visit(const ReturnStmt &stmt) override
     {
         printer.os << "(RETURN";
+        if (stmt.isGosubReturn)
+            printer.os << " GOSUB";
         if (stmt.value)
         {
             printer.os << ' ';

--- a/src/frontends/basic/SemanticAnalyzer.Stmts.cpp
+++ b/src/frontends/basic/SemanticAnalyzer.Stmts.cpp
@@ -651,7 +651,22 @@ void SemanticAnalyzer::analyzeResume(const Resume &stmt)
 
 void SemanticAnalyzer::analyzeReturn(ReturnStmt &stmt)
 {
-    (void)stmt;
+    if (!activeProcScope_)
+    {
+        if (stmt.value)
+        {
+            std::string msg = "RETURN with value not allowed at top level";
+            de.emit(il::support::Severity::Error,
+                    "B1008",
+                    stmt.loc,
+                    6,
+                    std::move(msg));
+        }
+        else
+        {
+            stmt.isGosubReturn = true;
+        }
+    }
     if (hasActiveErrorHandler())
         clearErrorHandler();
 }

--- a/tests/frontends/basic/SemanticAnalyzerGosubTests.cpp
+++ b/tests/frontends/basic/SemanticAnalyzerGosubTests.cpp
@@ -59,5 +59,11 @@ int main()
         assert(result.errors == 0);
     }
 
+    {
+        auto result = analyzeSnippet("10 RETURN 42\n20 END\n");
+        assert(result.errors == 1);
+        assert(result.output.find("error[B1008]") != std::string::npos);
+    }
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- mark top-level RETURN without a value as a GOSUB return and flag valued top-level returns
- propagate the new GOSUB return bit into the AST printer output
- expand the BASIC GOSUB semantic test to cover the new diagnostic

## Testing
- build/tests/test_frontends_basic_semantic_gosub

------
https://chatgpt.com/codex/tasks/task_e_68e5e2080b98832488299fbf061dbe15