### PR TITLE
fix(frontends/basic): trap gosub stack errors

### DIFF
--- a/src/frontends/basic/LowerRuntime.cpp
+++ b/src/frontends/basic/LowerRuntime.cpp
@@ -185,6 +185,11 @@ void Lowerer::requireStrReleaseMaybe()
     setManualHelperRequired(ManualRuntimeHelper::StrReleaseMaybe);
 }
 
+void Lowerer::requireRuntimeTrap()
+{
+    setManualHelperRequired(ManualRuntimeHelper::Trap);
+}
+
 void Lowerer::requestHelper(RuntimeFeature feature)
 {
     runtimeTracker.requestHelper(feature);
@@ -226,6 +231,7 @@ void Lowerer::declareRequiredRuntime(build::IRBuilder &b)
         {"rt_line_input_ch_err", ManualRuntimeHelper::LineInputChErr, &Lowerer::requireLineInputChErr},
         {"rt_str_retain_maybe", ManualRuntimeHelper::StrRetainMaybe, &Lowerer::requireStrRetainMaybe},
         {"rt_str_release_maybe", ManualRuntimeHelper::StrReleaseMaybe, &Lowerer::requireStrReleaseMaybe},
+        {"rt_trap", ManualRuntimeHelper::Trap, &Lowerer::requireRuntimeTrap},
     }};
 
     auto declareManual = [&](std::string_view name) {

--- a/src/frontends/basic/LowerStmt.cpp
+++ b/src/frontends/basic/LowerStmt.cpp
@@ -1074,6 +1074,10 @@ void Lowerer::lowerGosub(const GosubStmt &stmt)
 
     ctx.setCurrent(overflowBlk);
     curLoc = stmt.loc;
+    requireRuntimeTrap();
+    std::string overflowMsgLbl = getStringLabel("gosub: stack overflow");
+    Value overflowMsg = emitConstStr(overflowMsgLbl);
+    emitCall("rt_trap", {overflowMsg});
     emitTrap();
 
     ctx.setCurrent(pushBlk);
@@ -1149,6 +1153,10 @@ void Lowerer::lowerGosubReturn(const ReturnStmt &stmt)
 
     ctx.setCurrent(emptyBlk);
     curLoc = stmt.loc;
+    requireRuntimeTrap();
+    std::string emptyMsgLbl = getStringLabel("gosub: empty return stack");
+    Value emptyMsg = emitConstStr(emptyMsgLbl);
+    emitCall("rt_trap", {emptyMsg});
     emitTrap();
 
     ctx.setCurrent(contBlk);

--- a/src/frontends/basic/Lowerer.hpp
+++ b/src/frontends/basic/Lowerer.hpp
@@ -759,6 +759,7 @@ class Lowerer
         LineInputChErr,
         StrRetainMaybe,
         StrReleaseMaybe,
+        Trap,
         Count
     };
 
@@ -790,6 +791,7 @@ class Lowerer
     void requireLineInputChErr();
     void requireStrRetainMaybe();
     void requireStrReleaseMaybe();
+    void requireRuntimeTrap();
     void requestHelper(RuntimeFeature feature);
 
     bool isHelperNeeded(RuntimeFeature feature) const;

--- a/src/frontends/basic/LoweringPipeline.cpp
+++ b/src/frontends/basic/LoweringPipeline.cpp
@@ -286,7 +286,10 @@ void StatementLowering::lowerSequence(
     }
 
     if (hasGosub)
+    {
+        lowerer.requireRuntimeTrap();
         lowerer.ensureGosubStack();
+    }
     int firstLine = lowerer.virtualLine(*stmts.front());
     lowerer.emitBr(&func->blocks[lineBlocks[firstLine]]);
 

--- a/tests/golden/basic_to_il/gosub.il
+++ b/tests/golden/basic_to_il/gosub.il
@@ -5,13 +5,15 @@ extern @rt_print_f64(f64) -> void
 extern @rt_len(str) -> i64
 extern @rt_substr(str, i64, i64) -> str
 extern @rt_str_empty() -> str
-global const str @.L0 = "Back"
-global const str @.L1 = "\n"
-global const str @.L2 = "Done"
-global const str @.L3 = "First"
-global const str @.L4 = "After Inner"
-global const str @.L5 = "Second"
-global const str @.L6 = "Inner"
+global const str @.L0 = "gosub: stack overflow"
+global const str @.L1 = "Back"
+global const str @.L2 = "\n"
+global const str @.L3 = "Done"
+global const str @.L4 = "First"
+global const str @.L5 = "After Inner"
+global const str @.L6 = "gosub: empty return stack"
+global const str @.L7 = "Second"
+global const str @.L8 = "Inner"
 func @main() -> i64 {
 entry:
   %t0 = alloca 8
@@ -39,31 +41,31 @@ L30:
   cbr %t5, gosub_overflow, gosub_push
 L40:
   .loc 1 4 10
-  %t9 = const_str @.L0
-  .loc 1 4 4
-  call @rt_print_str(%t9)
-  .loc 1 4 4
   %t10 = const_str @.L1
   .loc 1 4 4
   call @rt_print_str(%t10)
   .loc 1 4 4
+  %t11 = const_str @.L2
+  .loc 1 4 4
+  call @rt_print_str(%t11)
+  .loc 1 4 4
   br L50
 L50:
   .loc 1 5 4
-  %t11 = load i64, %t2
+  %t12 = load i64, %t2
   .loc 1 5 4
-  %t12 = scmp_ge %t11, 128
+  %t13 = scmp_ge %t12, 128
   .loc 1 5 4
-  cbr %t12, gosub_overflow1, gosub_push1
+  cbr %t13, gosub_overflow1, gosub_push1
 L60:
   .loc 1 6 10
-  %t16 = const_str @.L2
+  %t18 = const_str @.L3
   .loc 1 6 4
-  call @rt_print_str(%t16)
+  call @rt_print_str(%t18)
   .loc 1 6 4
-  %t17 = const_str @.L1
+  %t19 = const_str @.L2
   .loc 1 6 4
-  call @rt_print_str(%t17)
+  call @rt_print_str(%t19)
   .loc 1 6 4
   br L70
 L70:
@@ -71,180 +73,204 @@ L70:
   ret 0
 L200:
   .loc 1 8 11
-  %t18 = const_str @.L3
+  %t20 = const_str @.L4
   .loc 1 8 5
-  call @rt_print_str(%t18)
+  call @rt_print_str(%t20)
   .loc 1 8 5
-  %t19 = const_str @.L1
+  %t21 = const_str @.L2
   .loc 1 8 5
-  call @rt_print_str(%t19)
+  call @rt_print_str(%t21)
   .loc 1 8 5
   br L210
 L210:
   .loc 1 9 5
-  %t20 = load i64, %t2
+  %t22 = load i64, %t2
   .loc 1 9 5
-  %t21 = scmp_ge %t20, 128
+  %t23 = scmp_ge %t22, 128
   .loc 1 9 5
-  cbr %t21, gosub_overflow2, gosub_push2
+  cbr %t23, gosub_overflow2, gosub_push2
 L220:
   .loc 1 10 11
-  %t25 = const_str @.L4
+  %t28 = const_str @.L5
   .loc 1 10 5
-  call @rt_print_str(%t25)
+  call @rt_print_str(%t28)
   .loc 1 10 5
-  %t26 = const_str @.L1
+  %t29 = const_str @.L2
   .loc 1 10 5
-  call @rt_print_str(%t26)
+  call @rt_print_str(%t29)
   .loc 1 10 5
   br L230
 L230:
   .loc 1 11 5
-  %t27 = load i64, %t2
+  %t30 = load i64, %t2
   .loc 1 11 5
-  %t28 = icmp_eq %t27, 0
+  %t31 = icmp_eq %t30, 0
   .loc 1 11 5
-  cbr %t28, gosub_ret_empty, gosub_ret_cont
+  cbr %t31, gosub_ret_empty, gosub_ret_cont
 L300:
   .loc 1 12 11
-  %t33 = const_str @.L5
+  %t37 = const_str @.L7
   .loc 1 12 5
-  call @rt_print_str(%t33)
+  call @rt_print_str(%t37)
   .loc 1 12 5
-  %t34 = const_str @.L1
+  %t38 = const_str @.L2
   .loc 1 12 5
-  call @rt_print_str(%t34)
+  call @rt_print_str(%t38)
   .loc 1 12 5
   br L310
 L310:
   .loc 1 13 5
-  %t35 = load i64, %t2
+  %t39 = load i64, %t2
   .loc 1 13 5
-  %t36 = icmp_eq %t35, 0
+  %t40 = icmp_eq %t39, 0
   .loc 1 13 5
-  cbr %t36, gosub_ret_empty1, gosub_ret_cont1
+  cbr %t40, gosub_ret_empty1, gosub_ret_cont1
 L400:
   .loc 1 14 11
-  %t41 = const_str @.L6
+  %t46 = const_str @.L8
   .loc 1 14 5
-  call @rt_print_str(%t41)
+  call @rt_print_str(%t46)
   .loc 1 14 5
-  %t42 = const_str @.L1
+  %t47 = const_str @.L2
   .loc 1 14 5
-  call @rt_print_str(%t42)
+  call @rt_print_str(%t47)
   .loc 1 14 5
   br L410
 L410:
   .loc 1 15 5
-  %t43 = load i64, %t2
+  %t48 = load i64, %t2
   .loc 1 15 5
-  %t44 = icmp_eq %t43, 0
+  %t49 = icmp_eq %t48, 0
   .loc 1 15 5
-  cbr %t44, gosub_ret_empty2, gosub_ret_cont2
+  cbr %t49, gosub_ret_empty2, gosub_ret_cont2
 exit:
   ret 0
 gosub_overflow:
   .loc 1 3 4
+  %t6 = const_str @.L0
+  .loc 1 3 4
+  call @rt_trap(%t6)
+  .loc 1 3 4
   trap
 gosub_push:
   .loc 1 3 4
-  %t6 = imul.ovf %t4, 4
+  %t7 = imul.ovf %t4, 4
   .loc 1 3 4
-  %t7 = gep %t3, %t6
+  %t8 = gep %t3, %t7
   .loc 1 3 4
-  store i32, %t7, 0
+  store i32, %t8, 0
   .loc 1 3 4
-  %t8 = iadd.ovf %t4, 1
+  %t9 = iadd.ovf %t4, 1
   .loc 1 3 4
-  store i64, %t2, %t8
+  store i64, %t2, %t9
   .loc 1 3 4
   br L200
 gosub_overflow1:
   .loc 1 5 4
+  %t14 = const_str @.L0
+  .loc 1 5 4
+  call @rt_trap(%t14)
+  .loc 1 5 4
   trap
 gosub_push1:
   .loc 1 5 4
-  %t13 = imul.ovf %t11, 4
+  %t15 = imul.ovf %t12, 4
   .loc 1 5 4
-  %t14 = gep %t3, %t13
+  %t16 = gep %t3, %t15
   .loc 1 5 4
-  store i32, %t14, 1
+  store i32, %t16, 1
   .loc 1 5 4
-  %t15 = iadd.ovf %t11, 1
+  %t17 = iadd.ovf %t12, 1
   .loc 1 5 4
-  store i64, %t2, %t15
+  store i64, %t2, %t17
   .loc 1 5 4
   br L300
 gosub_overflow2:
   .loc 1 9 5
+  %t24 = const_str @.L0
+  .loc 1 9 5
+  call @rt_trap(%t24)
+  .loc 1 9 5
   trap
 gosub_push2:
   .loc 1 9 5
-  %t22 = imul.ovf %t20, 4
+  %t25 = imul.ovf %t22, 4
   .loc 1 9 5
-  %t23 = gep %t3, %t22
+  %t26 = gep %t3, %t25
   .loc 1 9 5
-  store i32, %t23, 2
+  store i32, %t26, 2
   .loc 1 9 5
-  %t24 = iadd.ovf %t20, 1
+  %t27 = iadd.ovf %t22, 1
   .loc 1 9 5
-  store i64, %t2, %t24
+  store i64, %t2, %t27
   .loc 1 9 5
   br L400
 gosub_ret_empty:
   .loc 1 11 5
+  %t32 = const_str @.L6
+  .loc 1 11 5
+  call @rt_trap(%t32)
+  .loc 1 11 5
   trap
 gosub_ret_cont:
   .loc 1 11 5
-  %t29 = isub.ovf %t27, 1
+  %t33 = isub.ovf %t30, 1
   .loc 1 11 5
-  store i64, %t2, %t29
+  store i64, %t2, %t33
   .loc 1 11 5
-  %t30 = imul.ovf %t29, 4
+  %t34 = imul.ovf %t33, 4
   .loc 1 11 5
-  %t31 = gep %t3, %t30
+  %t35 = gep %t3, %t34
   .loc 1 11 5
-  %t32 = load i32, %t31
+  %t36 = load i32, %t35
   .loc 1 11 5
-  switch.i32 %t32, ^gosub_ret_invalid, 0 -> ^L40, 1 -> ^L60, 2 -> ^L220
+  switch.i32 %t36, ^gosub_ret_invalid, 0 -> ^L40, 1 -> ^L60, 2 -> ^L220
 gosub_ret_invalid:
   .loc 1 11 5
   trap
 gosub_ret_empty1:
   .loc 1 13 5
+  %t41 = const_str @.L6
+  .loc 1 13 5
+  call @rt_trap(%t41)
+  .loc 1 13 5
   trap
 gosub_ret_cont1:
   .loc 1 13 5
-  %t37 = isub.ovf %t35, 1
+  %t42 = isub.ovf %t39, 1
   .loc 1 13 5
-  store i64, %t2, %t37
+  store i64, %t2, %t42
   .loc 1 13 5
-  %t38 = imul.ovf %t37, 4
+  %t43 = imul.ovf %t42, 4
   .loc 1 13 5
-  %t39 = gep %t3, %t38
+  %t44 = gep %t3, %t43
   .loc 1 13 5
-  %t40 = load i32, %t39
+  %t45 = load i32, %t44
   .loc 1 13 5
-  switch.i32 %t40, ^gosub_ret_invalid1, 0 -> ^L40, 1 -> ^L60, 2 -> ^L220
+  switch.i32 %t45, ^gosub_ret_invalid1, 0 -> ^L40, 1 -> ^L60, 2 -> ^L220
 gosub_ret_invalid1:
   .loc 1 13 5
   trap
 gosub_ret_empty2:
   .loc 1 15 5
+  %t50 = const_str @.L6
+  .loc 1 15 5
+  call @rt_trap(%t50)
+  .loc 1 15 5
   trap
 gosub_ret_cont2:
   .loc 1 15 5
-  %t45 = isub.ovf %t43, 1
+  %t51 = isub.ovf %t48, 1
   .loc 1 15 5
-  store i64, %t2, %t45
+  store i64, %t2, %t51
   .loc 1 15 5
-  %t46 = imul.ovf %t45, 4
+  %t52 = imul.ovf %t51, 4
   .loc 1 15 5
-  %t47 = gep %t3, %t46
+  %t53 = gep %t3, %t52
   .loc 1 15 5
-  %t48 = load i32, %t47
+  %t54 = load i32, %t53
   .loc 1 15 5
-  switch.i32 %t48, ^gosub_ret_invalid2, 0 -> ^L40, 1 -> ^L60, 2 -> ^L220
+  switch.i32 %t54, ^gosub_ret_invalid2, 0 -> ^L40, 1 -> ^L60, 2 -> ^L220
 gosub_ret_invalid2:
   .loc 1 15 5
   trap


### PR DESCRIPTION
## Summary
- add rt_trap calls when the BASIC gosub stack overflows or underflows
- request the runtime trap helper during lowering and refresh the gosub IL golden

## Testing
- cmake --build build --target fe_basic -j
- cmake --build build --target ilc -j
- ctest --test-dir build --output-on-failure --tests-regex basic_to_il_gosub

------
https://chatgpt.com/codex/tasks/task_e_68e5f71e2fc48324911785ab8700eda9