### PR TITLE
fix(frontends/basic): warn on extra INPUT variables

### DIFF
--- a/tests/basic/CMakeLists.txt
+++ b/tests/basic/CMakeLists.txt
@@ -122,6 +122,14 @@ function(viper_add_basic_main_tests)
   viper_add_ctest(test_frontends_basic_parse_gosub test_frontends_basic_parse_gosub)
 
   viper_add_test(
+    test_frontends_basic_parse_input_extra_args
+    ${VIPER_TESTS_DIR}/frontends/basic/ParserInputExtraArgsTests.cpp)
+  target_link_libraries(test_frontends_basic_parse_input_extra_args PRIVATE ${VIPER_BASIC_LIBS})
+  viper_add_ctest(
+    test_frontends_basic_parse_input_extra_args
+    test_frontends_basic_parse_input_extra_args)
+
+  viper_add_test(
     test_frontends_basic_parse_unknown_stmt
     ${VIPER_TESTS_DIR}/frontends/basic/ParserUnknownStatementTests.cpp)
   target_link_libraries(test_frontends_basic_parse_unknown_stmt PRIVATE ${VIPER_BASIC_LIBS})

--- a/tests/frontends/basic/ParserInputExtraArgsTests.cpp
+++ b/tests/frontends/basic/ParserInputExtraArgsTests.cpp
@@ -1,0 +1,48 @@
+// File: tests/frontends/basic/ParserInputExtraArgsTests.cpp
+// Purpose: Verify INPUT parser emits diagnostics for unsupported extra variables.
+// Key invariants: Parser should report B0101 once and continue parsing subsequent statements.
+// Ownership/Lifetime: Test owns parser/emitter instances and inspects AST and diagnostics.
+// Links: docs/codemap.md
+
+#include "frontends/basic/DiagnosticEmitter.hpp"
+#include "frontends/basic/Parser.hpp"
+#include "support/diagnostics.hpp"
+#include "support/source_manager.hpp"
+
+#include <cassert>
+#include <sstream>
+#include <string>
+
+using namespace il::frontends::basic;
+using namespace il::support;
+
+int main()
+{
+    const std::string src = "10 INPUT A, B\n20 PRINT A\n30 END\n";
+
+    SourceManager sm;
+    uint32_t fid = sm.addFile("input.bas");
+
+    DiagnosticEngine de;
+    DiagnosticEmitter emitter(de, sm);
+    emitter.addSource(fid, src);
+
+    Parser parser(src, fid, &emitter);
+    auto program = parser.parseProgram();
+    assert(program);
+    assert(program->main.size() == 3);
+    assert(dynamic_cast<InputStmt *>(program->main[0].get()));
+    assert(dynamic_cast<PrintStmt *>(program->main[1].get()));
+    assert(dynamic_cast<EndStmt *>(program->main[2].get()));
+
+    assert(emitter.errorCount() == 1);
+
+    std::ostringstream oss;
+    emitter.printAll(oss);
+    std::string output = oss.str();
+    assert(output.find("error[B0101]") != std::string::npos);
+    assert(output.find(
+               "INPUT currently supports a single variable; extra items will be ignored") != std::string::npos);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- emit B0101 when the BASIC parser encounters multiple variables in an INPUT statement and discard the extra tokens on that line
- add a regression test to cover INPUT with extra variables and register it with the BASIC frontend test suite

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e5ff622edc832488ff1a4036526182