### PR TITLE
docs: expand IL source documentation

### DIFF
--- a/src/il/api/expected_api.cpp
+++ b/src/il/api/expected_api.cpp
@@ -1,4 +1,5 @@
 // File: src/il/api/expected_api.cpp
+// License: MIT (see LICENSE for details).
 // Purpose: Provide Expected-based implementations for IL parsing and verification wrappers.
 // Key invariants: Mirrors legacy bool-returning APIs while emitting diagnostics through Expected.
 // Ownership/Lifetime: Callers retain ownership of modules and streams passed by reference.
@@ -13,11 +14,27 @@
 namespace il::api::v2
 {
 
+/// @brief Parse IL text into a module using the modern Expected-oriented API.
+/// @details Forwards to @ref il::io::Parser::parse so textual IL is decoded
+/// into the provided module. The wrapper exists to keep the public C++ API
+/// symmetrical with the legacy bool-returning helpers while surfacing
+/// diagnostics via @ref il::support::Expected.
+/// @param is Stream supplying UTF-8 IL source text.
+/// @param m Module that receives the parsed representation.
+/// @returns Empty Expected on success; otherwise the parse diagnostics.
 il::support::Expected<void> parse_text_expected(std::istream &is, il::core::Module &m)
 {
     return il::io::Parser::parse(is, m);
 }
 
+/// @brief Verify a module using the Expected-returning API surface.
+/// @details Delegates to @ref il::verify::Verifier::verify so the full suite
+/// of structural and semantic checks run on the caller-supplied module. The
+/// result mirrors @ref parse_text_expected by forwarding diagnostics through an
+/// Expected payload.
+/// @param m Module to validate.
+/// @returns Empty Expected when verification succeeds; otherwise a populated
+/// diagnostic collection.
 il::support::Expected<void> verify_module_expected(const il::core::Module &m)
 {
     return il::verify::Verifier::verify(m);

--- a/src/il/build/IRBuilder.cpp
+++ b/src/il/build/IRBuilder.cpp
@@ -263,6 +263,13 @@ void IRBuilder::emitRet(const std::optional<Value> &v, il::support::SourceLoc lo
     append(std::move(instr));
 }
 
+/// @brief Emit a resume-same instruction for structured exception handlers.
+/// @details Creates an @ref Opcode::ResumeSame terminator that rethrows the
+/// current exception token to the innermost handler. The builder appends the
+/// instruction to the current block, marks it terminated, and records the
+/// source location for diagnostics.
+/// @param token SSA value representing the exception token to resume.
+/// @param loc Source location used when formatting verifier diagnostics.
 void IRBuilder::emitResumeSame(Value token, il::support::SourceLoc loc)
 {
     Instr instr;
@@ -273,6 +280,13 @@ void IRBuilder::emitResumeSame(Value token, il::support::SourceLoc loc)
     append(std::move(instr));
 }
 
+/// @brief Emit a resume-next instruction for structured exception handlers.
+/// @details Generates an @ref Opcode::ResumeNext terminator that forwards the
+/// active exception token to the next handler in the stack. Like
+/// @ref emitResumeSame, the helper appends the instruction, marks termination,
+/// and records the provided source location.
+/// @param token SSA value representing the exception token to resume.
+/// @param loc Source location used when formatting verifier diagnostics.
 void IRBuilder::emitResumeNext(Value token, il::support::SourceLoc loc)
 {
     Instr instr;
@@ -283,6 +297,14 @@ void IRBuilder::emitResumeNext(Value token, il::support::SourceLoc loc)
     append(std::move(instr));
 }
 
+/// @brief Emit a resume-label instruction transferring control to @p target.
+/// @details Appends an @ref Opcode::ResumeLabel terminator that jumps to a
+/// specific handler block. The token operand is preserved and the destination
+/// label is recorded to maintain block parameter arity.
+/// @param token SSA value representing the exception token to resume with.
+/// @param target Handler block that receives control once the token is
+/// resumed.
+/// @param loc Source location used when formatting verifier diagnostics.
 void IRBuilder::emitResumeLabel(Value token, BasicBlock &target, il::support::SourceLoc loc)
 {
     Instr instr;

--- a/src/il/core/Extern.cpp
+++ b/src/il/core/Extern.cpp
@@ -1,4 +1,5 @@
 // File: src/il/core/Extern.cpp
+// License: MIT (see LICENSE for details).
 // Purpose: Provides out-of-line helpers for Extern.
 // Key invariants: None.
 // Ownership/Lifetime: Module owns extern declarations.

--- a/src/il/core/Global.cpp
+++ b/src/il/core/Global.cpp
@@ -1,4 +1,5 @@
 // File: src/il/core/Global.cpp
+// License: MIT (see LICENSE for details).
 // Purpose: Provides helpers for global variables.
 // Key invariants: None.
 // Ownership/Lifetime: Module owns global declarations.

--- a/src/il/transform/ConstFold.cpp
+++ b/src/il/transform/ConstFold.cpp
@@ -1,9 +1,9 @@
 // File: src/il/transform/ConstFold.cpp
+// License: MIT (see LICENSE for details).
 // Purpose: Implements constant folding for integer ops and math intrinsics.
 // Key invariants: Mirrors checked integer semantics and C math for f64.
 // Ownership/Lifetime: Operates in place on the module.
 // Links: docs/codemap.md
-// License: MIT (see LICENSE)
 
 #include "il/transform/ConstFold.hpp"
 #include "il/core/Function.hpp"

--- a/src/il/transform/Mem2Reg.cpp
+++ b/src/il/transform/Mem2Reg.cpp
@@ -1,4 +1,5 @@
 // File: src/il/transform/Mem2Reg.cpp
+// License: MIT (see LICENSE for details).
 // Purpose: Implement alloca promotion to SSA using block parameters with the
 // seal-and-rename algorithm (mem2reg v3).
 // Key invariants: Handles i64/f64/i1 allocas whose addresses do not escape,


### PR DESCRIPTION
## Summary
- add MIT license headers and detailed file descriptions to frequently used IL sources
- document IRBuilder resume helpers, DCE flow, and constant folding utilities with thorough inline comments
- elaborate pass manager, EH verifier, and function verifier helpers with analysis explanations

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e670b398648324b8ca96615a70354f