### PR TITLE
docs: document C++ source files

### DIFF
--- a/src/il/core/OpcodeNames.cpp
+++ b/src/il/core/OpcodeNames.cpp
@@ -1,8 +1,12 @@
-// File: src/il/core/OpcodeNames.cpp
-// Purpose: Provide lightweight mnemonic lookups for IL opcodes.
-// Key invariants: Table entries align exactly with the order of il::core::Opcode.
-// Ownership/Lifetime: Static storage duration for shared string literals.
-// Links: docs/il-guide.md#reference
+/**
+ * @file OpcodeNames.cpp
+ * @brief Provides lightweight mnemonic lookups for IL opcodes.
+ * @copyright
+ *     MIT License. See the LICENSE file in the project root for full terms.
+ * @details
+ *     The file defines a constexpr lookup table generated from `Opcode.def` and
+ *     exposes `toString` for translating opcodes into mnemonic strings.
+ */
 
 #include "il/core/Opcode.hpp"
 
@@ -12,6 +16,13 @@ namespace il::core
 {
 namespace
 {
+/**
+ * @brief Compile-time array of opcode mnemonics generated from `Opcode.def`.
+ *
+ * The array order mirrors the `Opcode` enumeration to allow O(1) translation
+ * from enumeration value to mnemonic.  A static assertion verifies the sizes
+ * remain in sync.
+ */
 constexpr std::array<const char *, kNumOpcodes> kOpcodeNames = {
 #define IL_OPCODE(NAME, MNEMONIC, ...) MNEMONIC,
 #include "il/core/Opcode.def"
@@ -21,6 +32,15 @@ constexpr std::array<const char *, kNumOpcodes> kOpcodeNames = {
 static_assert(kOpcodeNames.size() == kNumOpcodes, "Opcode name table must match enum count");
 } // namespace
 
+/**
+ * @brief Converts an opcode into its mnemonic string representation.
+ *
+ * The function performs a bounds check to guard against invalid enumeration
+ * values.  Out-of-range inputs yield an empty string literal.
+ *
+ * @param op Opcode to translate.
+ * @return Pointer to a null-terminated mnemonic string; empty string when invalid.
+ */
 const char *toString(Opcode op)
 {
     const size_t index = static_cast<size_t>(op);

--- a/src/support/diag_capture.cpp
+++ b/src/support/diag_capture.cpp
@@ -1,32 +1,57 @@
-// File: src/support/diag_capture.cpp
-// Purpose: Provide out-of-line definitions for DiagCapture helper methods.
-// Key invariants: The stored string stream contents are preserved when converting
-//                 to a Diagnostic; print operations delegate to printDiag.
-// Ownership/Lifetime: DiagCapture owns its string buffer; diagnostics copy the text.
-// License: MIT License (see LICENSE).
-// Links: docs/codemap.md
+/**
+ * @file diag_capture.cpp
+ * @brief Implements helpers for capturing formatted diagnostics in memory.
+ * @copyright
+ *     MIT License. See the LICENSE file in the project root for full terms.
+ * @details
+ *     `DiagCapture` accumulates message text in a string stream so that callers
+ *     can convert legacy interfaces into structured diagnostics without losing
+ *     the formatted output.
+ */
 
 #include "support/diag_capture.hpp"
 
 namespace il::support
 {
-/// @brief Write the given diagnostic to the supplied stream.
-/// @param out Destination stream that receives the formatted diagnostic text.
-/// @param diag Diagnostic instance to serialize.
-/// @note Writes to @p out but does not mutate the capture state.
+/**
+ * @brief Writes a diagnostic to the caller-supplied output stream.
+ *
+ * The helper forwards to the shared `printDiag` routine to ensure consistent
+ * formatting.  Because no internal state changes, captures can be reprinted
+ * multiple times.
+ *
+ * @param out Destination stream for the diagnostic text.
+ * @param diag Diagnostic value to serialize.
+ */
 void DiagCapture::printTo(std::ostream &out, const Diag &diag)
 {
     printDiag(diag, out);
 }
 
-/// @brief Convert the captured message into a Diagnostic value.
-/// @return Diagnostic containing a copy of the captured text.
+/**
+ * @brief Converts the captured buffer into an error diagnostic.
+ *
+ * The method constructs a `Diag` with severity `Error` and no source location,
+ * copying the accumulated string stream contents into the diagnostic message.
+ *
+ * @return Newly created diagnostic containing the captured text.
+ */
 Diag DiagCapture::toDiag() const
 {
     return makeError({}, ss.str());
 }
 
-/// @brief Convert the legacy call result into an Expected<void> diagnostic outcome.
+/**
+ * @brief Bridges legacy boolean success codes to `Expected<void>` diagnostics.
+ *
+ * When `ok` is `true`, the function returns a default-constructed successful
+ * `Expected<void>`.  Otherwise it materializes the captured diagnostic to
+ * describe the failure and returns it as an error payload.
+ *
+ * @param ok Legacy success flag.
+ * @param capture Diagnostic capture holding the formatted message.
+ * @return Success or failure expressed as `Expected<void>`.
+ */
 Expected<void> capture_to_expected_impl(bool ok, DiagCapture &capture)
 {
     if (ok)

--- a/src/support/diag_expected.cpp
+++ b/src/support/diag_expected.cpp
@@ -1,32 +1,63 @@
-// File: src/support/diag_expected.cpp
-// Purpose: Implements diagnostic helper functions shared across Expected utilities.
-// License: MIT License. See LICENSE in the project root for details.
-// Key invariants: Diagnostics consistently report severity and optional source locations.
-// Ownership/Lifetime: Diagnostics own their message strings; no additional ownership here.
-// Links: docs/codemap.md
+/**
+ * @file diag_expected.cpp
+ * @brief Provides diagnostic-aware Expected helpers used throughout the codebase.
+ * @copyright
+ *     MIT License. See the LICENSE file in the project root for full terms.
+ * @details
+ *     These utilities adapt diagnostics to the `Expected` error-handling pattern
+ *     and expose shared formatting helpers used by diagnostic printing.
+ */
 
 #include "diag_expected.hpp"
 
 namespace il::support
 {
-/// @brief Construct an error Expected<void> carrying the provided diagnostic.
+/**
+ * @brief Constructs an `Expected<void>` holding an error diagnostic.
+ *
+ * The constructor stores the diagnostic in the optional error payload, leaving
+ * the object in a failure state.
+ *
+ * @param diag Diagnostic describing the failure.
+ */
 Expected<void>::Expected(Diag diag) : error_(std::move(diag))
 {
 }
 
-/// @brief Report whether the Expected<void> represents a successful outcome.
+/**
+ * @brief Indicates whether the Expected contains a success value.
+ *
+ * Because the success variant carries no payload for `void`, the method simply
+ * checks whether an error diagnostic is present.
+ *
+ * @return `true` when no error is stored.
+ */
 bool Expected<void>::hasValue() const
 {
     return !error_.has_value();
 }
 
-/// @brief Allow Expected<void> to participate in boolean tests for success.
+/**
+ * @brief Enables implicit boolean tests to check for success.
+ *
+ * Delegates to `hasValue()` so that idioms like `if (expected)` reflect whether
+ * an error diagnostic was recorded.
+ *
+ * @return `true` when the Expected represents success.
+ */
 Expected<void>::operator bool() const
 {
     return hasValue();
 }
 
-/// @brief Access the diagnostic describing the recorded failure.
+/**
+ * @brief Retrieves the diagnostic describing the failure.
+ *
+ * Callers must ensure the Expected holds an error before invoking this method.
+ * The diagnostic is returned by reference to avoid unnecessary copies.
+ *
+ * @return Reference to the stored diagnostic.
+ */
 const Diag &Expected<void>::error() const &
 {
     return *error_;
@@ -34,6 +65,17 @@ const Diag &Expected<void>::error() const &
 
 namespace detail
 {
+/**
+ * @brief Converts a severity enum into a printable string.
+ *
+ * The function matches the enumeration against the supported severities and
+ * produces lowercase strings used in diagnostic output.  An empty string is
+ * returned if an unknown severity is encountered, which should not happen in
+ * normal operation.
+ *
+ * @param severity Diagnostic severity to format.
+ * @return String literal describing the severity.
+ */
 const char *diagSeverityToString(Severity severity)
 {
     switch (severity)
@@ -49,11 +91,32 @@ const char *diagSeverityToString(Severity severity)
 }
 } // namespace detail
 
+/**
+ * @brief Creates an error diagnostic with the supplied message and location.
+ *
+ * The helper centralizes construction so that error diagnostics consistently
+ * use severity `Error` and capture the provided source location.
+ *
+ * @param loc Optional source location associated with the error.
+ * @param msg Human-readable message text.
+ * @return Diagnostic marked with severity `Error`.
+ */
 Diag makeError(SourceLoc loc, std::string msg)
 {
     return Diag{Severity::Error, std::move(msg), loc};
 }
 
+/**
+ * @brief Formats a diagnostic and writes it to an output stream.
+ *
+ * The printer optionally consults a `SourceManager` to translate file
+ * identifiers into canonical paths.  When a valid location is present, it emits
+ * `path:line:column:` as a prefix followed by the severity label and message.
+ *
+ * @param diag Diagnostic to print.
+ * @param os Output stream receiving the formatted diagnostic.
+ * @param sm Optional source manager for resolving file identifiers.
+ */
 void printDiag(const Diag &diag, std::ostream &os, const SourceManager *sm)
 {
     if (diag.loc.isValid() && sm)

--- a/src/support/diagnostics.cpp
+++ b/src/support/diagnostics.cpp
@@ -1,8 +1,13 @@
-// File: src/support/diagnostics.cpp
-// Purpose: Implements diagnostic reporting utilities.
-// Key invariants: None.
-// Ownership/Lifetime: Diagnostic engine owns stored messages.
-// Links: docs/codemap.md
+/**
+ * @file diagnostics.cpp
+ * @brief Implements the diagnostic engine responsible for collecting messages.
+ * @copyright
+ *     MIT License. See the LICENSE file in the project root for full terms.
+ * @details
+ *     The diagnostic engine aggregates messages emitted throughout compilation
+ *     and keeps track of severity counts.  Diagnostics are stored until callers
+ *     explicitly print or inspect them.
+ */
 
 #include "diagnostics.hpp"
 #include "diag_expected.hpp"
@@ -10,9 +15,15 @@
 
 namespace il::support
 {
-/// @brief Record a diagnostic and update counters.
-/// @param d Diagnostic to store.
-/// @note Increments error or warning counts based on severity.
+/**
+ * @brief Adds a diagnostic to the engine and updates severity counters.
+ *
+ * The diagnostic is appended to the internal vector for later inspection.  The
+ * method increments the error or warning counter depending on the diagnostic's
+ * severity, leaving other severities (e.g. notes) unchanged.
+ *
+ * @param d Diagnostic to record; moved into the engine's storage.
+ */
 void DiagnosticEngine::report(Diagnostic d)
 {
     if (d.severity == Severity::Error)
@@ -22,10 +33,17 @@ void DiagnosticEngine::report(Diagnostic d)
     diags_.push_back(std::move(d));
 }
 
-/// @brief Print all recorded diagnostics.
-/// @param os Output stream receiving diagnostic text.
-/// @param sm Optional source manager for resolving locations.
-/// @note Each diagnostic appears on its own line with severity and message.
+/**
+ * @brief Writes all stored diagnostics to the provided output stream.
+ *
+ * The function iterates through the recorded messages and delegates formatting
+ * to `printDiag`, which knows how to incorporate optional source locations.  If
+ * a `SourceManager` pointer is supplied, it is passed along so that file paths
+ * can be resolved for diagnostics with location information.
+ *
+ * @param os Output stream that receives the formatted diagnostics.
+ * @param sm Optional source manager used to translate file identifiers.
+ */
 void DiagnosticEngine::printAll(std::ostream &os, const SourceManager *sm) const
 {
     for (const auto &d : diags_)
@@ -34,15 +52,27 @@ void DiagnosticEngine::printAll(std::ostream &os, const SourceManager *sm) const
     }
 }
 
-/// @brief Retrieve the number of diagnostics reported as errors.
-/// @return Count of error-severity diagnostics recorded so far.
+/**
+ * @brief Returns the number of error-severity diagnostics recorded so far.
+ *
+ * The count is incremented whenever `report` receives a diagnostic classified
+ * as an error and never decreases unless the engine itself is discarded.
+ *
+ * @return Number of stored diagnostics with severity `Error`.
+ */
 size_t DiagnosticEngine::errorCount() const
 {
     return errors_;
 }
 
-/// @brief Retrieve the number of diagnostics reported as warnings.
-/// @return Count of warning-severity diagnostics recorded so far.
+/**
+ * @brief Returns the number of warning-severity diagnostics recorded so far.
+ *
+ * The count is maintained alongside the error count and reflects how many
+ * warnings have been reported since the engine was created or last cleared.
+ *
+ * @return Number of stored diagnostics with severity `Warning`.
+ */
 size_t DiagnosticEngine::warningCount() const
 {
     return warnings_;

--- a/src/support/source_location.cpp
+++ b/src/support/source_location.cpp
@@ -1,15 +1,28 @@
-// File: src/support/source_location.cpp
-// Purpose: Implements helpers for source location metadata.
-// Key invariants: File identifier 0 indicates an unknown location.
-// Ownership/Lifetime: Provides value-type utilities with no dynamic ownership.
-// Links: docs/codemap.md
+/**
+ * @file source_location.cpp
+ * @brief Defines helpers for dealing with source file coordinates.
+ * @copyright
+ *     MIT License. See the LICENSE file in the project root for full terms.
+ * @details
+ *     Source locations are represented as lightweight value types.  A zero
+ *     `file_id` denotes an unknown origin; positive identifiers reference paths
+ *     stored in the `SourceManager`.
+ */
 
 #include "support/source_location.hpp"
 
 namespace il::support
 {
-/// @brief Determine whether the source location refers to a registered file.
-/// @return True when file_id is non-zero, indicating a valid location.
+/**
+ * @brief Reports whether the location refers to a known source file.
+ *
+ * The check simply tests the stored `file_id` against zero.  When the location
+ * was created from a `SourceManager`, the identifier is a 1-based index into the
+ * manager's file table; otherwise it remains zero to indicate an unspecified
+ * origin.
+ *
+ * @return `true` when the location carries a valid file identifier.
+ */
 bool SourceLoc::isValid() const
 {
     return file_id != 0;

--- a/src/support/source_manager.cpp
+++ b/src/support/source_manager.cpp
@@ -1,9 +1,13 @@
-// File: src/support/source_manager.cpp
-// Purpose: Implements utilities to manage source buffers.
-// License: MIT License. See LICENSE in the project root for details.
-// Key invariants: None.
-// Ownership/Lifetime: SourceManager owns loaded buffers.
-// Links: docs/codemap.md
+/**
+ * @file source_manager.cpp
+ * @brief Implements the source manager responsible for tracking file paths.
+ * @copyright
+ *     MIT License. See the LICENSE file in the project root for full terms.
+ * @details
+ *     The source manager assigns monotonically increasing identifiers to source
+ *     files and exposes utilities for path lookup used by diagnostics and
+ *     parsing.
+ */
 
 #include "source_manager.hpp"
 
@@ -12,9 +16,16 @@
 namespace il::support
 {
 
-/// @brief Register a new file path and assign it a unique identifier.
-/// @param path Filesystem path to lexically normalize and store.
-/// @return Identifier (>0) representing the stored path.
+/**
+ * @brief Registers a file path and returns its numeric identifier.
+ *
+ * The path is normalized to a portable string representation before being
+ * stored.  Identifiers are 1-based and correspond to the index of the path in
+ * the internal array, making `0` a sentinel for "unknown".
+ *
+ * @param path Path to record.
+ * @return New identifier that can later be used with `getPath`.
+ */
 uint32_t SourceManager::addFile(std::string path)
 {
     std::filesystem::path p(std::move(path));
@@ -22,9 +33,16 @@ uint32_t SourceManager::addFile(std::string path)
     return static_cast<uint32_t>(files_.size());
 }
 
-/// @brief Retrieve the canonical path associated with @p file_id.
-/// @param file_id 1-based identifier previously returned by addFile().
-/// @return Stored path, or empty string view if @p file_id is invalid.
+/**
+ * @brief Resolves a previously registered identifier back to its path.
+ *
+ * The function validates the identifier range and, if valid, returns a view into
+ * the stored canonical string.  Invalid identifiers yield an empty view so that
+ * callers can detect missing entries.
+ *
+ * @param file_id Identifier returned by `addFile`.
+ * @return Canonical string path, or empty when @p file_id is invalid.
+ */
 std::string_view SourceManager::getPath(uint32_t file_id) const
 {
     if (file_id == 0 || file_id > files_.size())

--- a/src/support/string_interner.cpp
+++ b/src/support/string_interner.cpp
@@ -1,21 +1,32 @@
-// File: src/support/string_interner.cpp
-// Purpose: Implements string interning facility.
-// Key invariants: Symbol id 0 is reserved.
-// Ownership/Lifetime: Interner owns interned strings.
-// Links: docs/codemap.md
+/**
+ * @file string_interner.cpp
+ * @brief Implements the string interning facility used across the compiler.
+ * @copyright
+ *     MIT License. See the LICENSE file in the project root for full terms.
+ * @details
+ *     The interner assigns compact `Symbol` identifiers to canonical copies of
+ *     strings.  Identifier value `0` is reserved to denote "no symbol"; real
+ *     identifiers are 1-based indices into the backing storage vector.
+ */
 
 #include "string_interner.hpp"
 
 namespace il::support
 {
 
-// Intern the given string by assigning a new symbol if necessary.
-//
-// The interner stores owned strings in `storage_` and maps them to their
-// corresponding `Symbol` via `map_`.  When a string is interned for the first
-// time, a copy is appended to `storage_` and a new symbol is created using the
-// 1-based index of that storage slot.  If the string already exists, the
-// previous symbol is reused.  Symbol id 0 is reserved and never produced.
+/**
+ * @brief Interns the provided string and returns its stable symbol.
+ *
+ * The method first checks the hash map for an existing entry to avoid copying
+ * duplicate text.  When the string is new, it appends an owned copy to
+ * `storage_`, constructs a `Symbol` using the resulting 1-based index, and
+ * inserts the mapping into `map_` using the stored string view as the key.  The
+ * function never produces identifier `0`, preserving the invariant that this
+ * value signals "invalid".
+ *
+ * @param str String slice to canonicalize.
+ * @return Symbol handle representing the canonicalized string.
+ */
 Symbol StringInterner::intern(std::string_view str)
 {
     auto it = map_.find(str);
@@ -27,11 +38,17 @@ Symbol StringInterner::intern(std::string_view str)
     return sym;
 }
 
-// Retrieve the original string for @p sym.
-//
-// A valid symbol has an id in the range [1, storage_.size()].  Requests outside
-// this range, including the reserved id 0, yield an empty view indicating an
-// invalid lookup.
+/**
+ * @brief Retrieves the canonical string associated with a symbol.
+ *
+ * The lookup verifies that the identifier falls within the valid range of the
+ * storage vector (1..N).  Requests outside that range—including identifier `0`
+ * used for "no symbol"—return an empty `std::string_view` to signal the caller
+ * that the lookup failed.
+ *
+ * @param sym Symbol that was previously produced by the interner.
+ * @return View into the stored string, or an empty view when @p sym is invalid.
+ */
 std::string_view StringInterner::lookup(Symbol sym) const
 {
     if (sym.id == 0 || sym.id > storage_.size())

--- a/src/support/symbol.cpp
+++ b/src/support/symbol.cpp
@@ -1,33 +1,58 @@
-// File: src/support/symbol.cpp
-// Purpose: Implements helpers for the Symbol identifier type.
-// Key invariants: Symbol value 0 remains reserved for invalid identifiers.
-// Ownership/Lifetime: Operates on value types without owning resources.
-// Links: docs/codemap.md
+/**
+ * @file symbol.cpp
+ * @brief Provides comparison helpers and utilities for the `Symbol` type.
+ * @copyright
+ *     MIT License. See the LICENSE file in the project root for full terms.
+ * @details
+ *     Symbols are lightweight wrappers around 32-bit identifiers produced by
+ *     the string interner.  Identifier value `0` is reserved to indicate the
+ *     absence of a symbol, while all other values correspond to interned
+ *     strings.
+ */
 
 #include "support/symbol.hpp"
 
 namespace il::support
 {
-/// @brief Compare two symbols for equality.
-/// @param a First symbol to compare.
-/// @param b Second symbol to compare.
-/// @return True when both symbols refer to the same identifier.
+/**
+ * @brief Tests whether two symbol handles refer to the same interned string.
+ *
+ * Because `Symbol` stores only a numeric identifier, equality reduces to
+ * comparing the identifiers.  This comparison is noexcept and can be used in
+ * containers or algorithms without throwing.
+ *
+ * @param a First symbol to compare.
+ * @param b Second symbol to compare.
+ * @return `true` when the identifiers are equal.
+ */
 bool operator==(Symbol a, Symbol b) noexcept
 {
     return a.id == b.id;
 }
 
-/// @brief Compare two symbols for inequality.
-/// @param a First symbol to compare.
-/// @param b Second symbol to compare.
-/// @return True when the symbols refer to different identifiers.
+/**
+ * @brief Tests whether two symbol handles refer to different interned strings.
+ *
+ * Inequality is implemented directly in terms of the stored identifiers and is
+ * likewise noexcept.
+ *
+ * @param a First symbol to compare.
+ * @param b Second symbol to compare.
+ * @return `true` when the identifiers differ.
+ */
 bool operator!=(Symbol a, Symbol b) noexcept
 {
     return a.id != b.id;
 }
 
-/// @brief Check whether the symbol denotes a valid interned string.
-/// @return True when the identifier is non-zero.
+/**
+ * @brief Converts the symbol to a boolean indicating whether it is valid.
+ *
+ * The implicit conversion returns `true` for any identifier other than zero,
+ * allowing callers to use symbols in conditionals to test for presence.
+ *
+ * @return `true` when the symbol denotes an interned string.
+ */
 Symbol::operator bool() const noexcept
 {
     return id != 0;
@@ -36,9 +61,16 @@ Symbol::operator bool() const noexcept
 
 namespace std
 {
-/// @brief Compute a hash value for an interned string symbol.
-/// @param s Symbol handle to hash.
-/// @return Stable hash derived from the underlying identifier.
+/**
+ * @brief Computes a hash code for a `Symbol` so it can be stored in unordered containers.
+ *
+ * The hash uses the numeric identifier directly, preserving the distribution
+ * characteristics of the underlying interner index while remaining
+ * deterministic across process runs.
+ *
+ * @param s Symbol to hash.
+ * @return Hash code corresponding to the symbol identifier.
+ */
 size_t hash<il::support::Symbol>::operator()(il::support::Symbol s) const noexcept
 {
     return s.id;


### PR DESCRIPTION
## Summary
- add MIT license headers and file purpose documentation to support and opcode source files
- document each function with detailed Doxygen comments explaining behaviour and invariants

## Testing
- cmake -S . -B build
- cmake --build build -j2
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e670b398648324b8ca96615a70354f