### PR TITLE
Fix BASIC string predicates to reject unknown types

### DIFF
--- a/src/frontends/basic/SemanticAnalyzer.Exprs.cpp
+++ b/src/frontends/basic/SemanticAnalyzer.Exprs.cpp
@@ -49,7 +49,7 @@ constexpr bool isBooleanType(SemanticAnalyzer::Type type) noexcept
 constexpr bool isStringType(SemanticAnalyzer::Type type) noexcept
 {
     using Type = SemanticAnalyzer::Type;
-    return type == Type::String || type == Type::Unknown;
+    return type == Type::String;
 }
 
 SemanticAnalyzer::Type commonNumericType(SemanticAnalyzer::Type lhs,

--- a/tests/frontends/basic/SemanticAnalyzerBinaryExprTests.cpp
+++ b/tests/frontends/basic/SemanticAnalyzerBinaryExprTests.cpp
@@ -272,6 +272,21 @@ int main()
         assert(*aType == SemanticAnalyzer::Type::Int);
     }
 
+    {
+        const std::string src =
+            "10 LET X = 1 : IF X = \"A\" THEN END\n20 END\n";
+        auto result = analyzeSnippet(src);
+        assert(result.errors == 1);
+        assert(result.output.find("error[B2001]") != std::string::npos);
+    }
+
+    {
+        const std::string src =
+            "10 LET S$ = \"A\" : IF S$ = \"A\" THEN END\n20 END\n";
+        auto result = analyzeSnippet(src);
+        assert(result.errors == 0);
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- stop treating UNKNOWN as a string in the BASIC semantic analyzer
- add regression coverage for numeric vs string comparisons and valid string equality

## Testing
- cmake -S . -B build
- cmake --build build -j
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e68ae00d508324b2e4f71e757fa57f