### PR TITLE
fix(tests): whitelist requires_linux test labels

### DIFF
--- a/src/tests/cmake/TestHelpers.cmake
+++ b/src/tests/cmake/TestHelpers.cmake
@@ -27,6 +27,9 @@ set(_VIPER_TEST_LABEL_WHITELIST
         requires_display
         requires_graphics_disabled
         requires_ipv6
+        requires_linux
+        requires_linux_deb
+        requires_linux_rpm
         requires_local_bind
         requires_macos
         requires_posix_shell


### PR DESCRIPTION
The Linux installer smoke tests in src/tests/tools/CMakeLists.txt apply requires_linux, requires_linux_deb, and requires_linux_rpm labels, but these were missing from _VIPER_TEST_LABEL_WHITELIST in TestHelpers.cmake. Because those tests are gated behind 'if (UNIX AND NOT APPLE)', the unknown labels were never registered on macOS/Windows, so the gap only aborted CMake configuration on Linux. Add the three labels alongside the existing requires_macos/requires_windows entries.