### PR TITLE
feat(tools): add agent-facing CLI surface and structured server diagn…

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "zia": {
-      "command": "/Users/stephen/git/viper/build/src/tools/zia-server/zia-server",
+      "command": "build/src/tools/zia-server/zia-server",
       "args": ["--mcp"]
     }
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,87 @@
+# AGENTS.md — Operating Guide for AI Coding Assistants
+
+This file is the tool-agnostic operating guide for AI coding agents (Codex,
+Copilot Workspace, Cursor, etc.) working on Viper. Claude Code users: CLAUDE.md
+is the authoritative version of these rules; this file mirrors its essentials
+and documents the agent-facing toolchain surface.
+
+## Ground Rules
+
+- **Spec first.** `/docs/il-guide.md#reference` (IL v0.2.0) is normative.
+  Never change it, or `.github/workflows/*`, without an ADR.
+- **Always green.** Build and tests must pass locally before proposing changes.
+- **Zero dependencies.** Viper is 100% from-scratch. Never introduce external
+  libraries or package downloads into the product.
+- **Cross-platform always.** Every change must work on macOS, Windows, and
+  Linux. Use `src/common/PlatformCapabilities.hpp` or `src/runtime/rt_platform.h`;
+  raw `_WIN32`/`__APPLE__`/`__linux__` checks belong only in approved adapter layers.
+  Run `./scripts/lint_platform_policy.sh` for cross-platform-sensitive work.
+- **Conventional commits**, no AI attribution or generated-by footers.
+- **Full Viper source headers** on all new/modified source files (see CLAUDE.md
+  for the template). Format with `.clang-format`; zero warnings.
+
+## Build & Test
+
+Always use the build scripts, never raw cmake for full builds:
+
+```sh
+./scripts/build_viper_linux.sh     # or build_viper_mac.sh / build_viper_win.cmd
+```
+
+Fast iteration knobs (environment variables, all platforms):
+
+| Variable | Effect |
+|----------|--------|
+| `VIPER_SKIP_CLEAN=1` | Incremental rebuild (skip the clean-all step) |
+| `VIPER_SKIP_TESTS=1` | Build only; skip ctest |
+| `VIPER_TEST_LABEL=<label>` | Run only tests with that ctest label |
+| `VIPER_SKIP_LINT=1 VIPER_SKIP_AUDIT=1 VIPER_SKIP_SMOKE=1 VIPER_SKIP_INSTALL=1` | Skip non-test stages |
+| `VIPER_CMAKE_GENERATOR=Ninja` | Use Ninja |
+
+ccache is auto-detected (disable with `VIPER_NO_CCACHE=1`).
+
+Targeted test runs after an incremental build:
+
+```sh
+ctest --test-dir build -L codegen --output-on-failure   # by label
+ctest --test-dir build -R test_zia_lexer                # by name
+./build/src/tests/test_foo --filter=Suite.Name          # single case
+./scripts/update_goldens.sh [filter]                    # regenerate goldens
+```
+
+See `src/tests/CMakeLists.txt` and `docs/testing.md` for the label taxonomy.
+
+## Agent-Facing Toolchain Surface
+
+These commands are designed for programmatic use; prefer them over parsing
+human-oriented output.
+
+| Command | Purpose |
+|---------|---------|
+| `viper check <file\|dir> --diagnostic-format=json` | Type-check + verify a file or project without running. Exit 0 = clean, 1 = usage/target error, 2 = compile errors. JSON diagnostics (stderr) carry code, stage, range, notes, and machine-applicable `fixits`. |
+| `viper eval 'expr' [--json] [--type] [--il]` | One-shot snippet evaluation (Zia default, `--lang basic`). Exit 0/1/2/3 = ok/usage/compile/trap. Reads stdin when no code argument. |
+| `viper explain <CODE> [--json]` | Describe a diagnostic code (e.g., `V-ZIA-UNDEFINED`, `B2001`, `W008`). `viper explain --list --json` dumps the catalog. |
+| `viper --print-error-codes [--json]` | Full diagnostic-code catalog. |
+| `viper --dump-runtime-api` | JSON inventory of the entire runtime surface (functions + classes with members), generated from the live registry. |
+| `viper --dump-opcodes` | JSON registry of all IL opcodes with arity, operand types, and effects. |
+| `viper run program.zia --diagnostic-format=json` | Compile and execute; same structured diagnostics. |
+| `viper run program.il --max-steps N` | Step-budgeted execution (safe for untrusted generated code on the VM). |
+| `--dump-tokens / --dump-ast / --dump-sema-ast / --dump-il / --dump-il-opt / --dump-il-passes` | Pipeline introspection at every stage (see docs/debugging.md). |
+| `viper run --debug-adapter` | VM-backed debugger over newline-delimited JSON (breakpoints, stepping, call stacks, locals). |
+
+## MCP Language Server
+
+`zia-server --mcp` exposes the Zia compiler over the Model Context Protocol
+(11 tools: check, compile, completions, hover, symbols, IL/AST/token dumps,
+runtime-classes/-methods/-search). The repo's `.mcp.json` points at the build
+output (`build/src/tools/zia-server/zia-server`); build the project first.
+See docs/zia-server.md and docs/zia-server-mcp-tools.md. A BASIC equivalent
+ships as `vbasic-server`.
+
+## Key Docs
+
+- Architecture: `docs/architecture.md` · Code map: `docs/codemap.md` (+ `docs/codemap/`)
+- Languages: `docs/zia-reference.md`, `docs/basic-reference.md`
+- IL: `docs/il-quickstart.md`, `docs/il-guide.md` (normative)
+- Debugging & diagnostics: `docs/debugging.md` · Tools: `docs/tools.md`
+- Testing: `docs/testing.md`

--- a/scripts/build_viper_unix.sh
+++ b/scripts/build_viper_unix.sh
@@ -30,6 +30,10 @@ SKIP_AUDIT="${VIPER_SKIP_AUDIT:-0}"
 SKIP_LINT="${VIPER_SKIP_LINT:-0}"
 LINT_CHANGED_ONLY="${VIPER_LINT_CHANGED_ONLY:-1}"
 SKIP_SMOKE="${VIPER_SKIP_SMOKE:-0}"
+SKIP_TESTS="${VIPER_SKIP_TESTS:-0}"
+SKIP_CLEAN="${VIPER_SKIP_CLEAN:-0}"
+TEST_LABEL="${VIPER_TEST_LABEL:-}"
+NO_CCACHE="${VIPER_NO_CCACHE:-0}"
 RUN_SLOW_TESTS="${VIPER_RUN_SLOW_TESTS:-0}"
 CTEST_TIMEOUT="${VIPER_CTEST_TIMEOUT:-}"
 INSTALL_PREFIX="${VIPER_INSTALL_PREFIX:-/usr/local}"
@@ -49,13 +53,24 @@ elif command -v gcc >/dev/null 2>&1; then
     CONFIGURE_ARGS+=(-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++)
 fi
 
+# Compiler cache: speeds up rebuilds after clean or branch switches.
+# Auto-detected; set VIPER_NO_CCACHE=1 to disable.
+if [[ "$NO_CCACHE" != "1" ]] && command -v ccache >/dev/null 2>&1; then
+    echo "[build_viper] ccache detected; enabling compiler launcher (set VIPER_NO_CCACHE=1 to disable)"
+    CONFIGURE_ARGS+=(-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache)
+fi
+
 if [[ -n "${VIPER_EXTRA_CMAKE_ARGS:-}" ]]; then
     # shellcheck disable=SC2206
     EXTRA_ARGS=( ${VIPER_EXTRA_CMAKE_ARGS} )
     CONFIGURE_ARGS+=("${EXTRA_ARGS[@]}")
 fi
 
-cmake --build "$BUILD_DIR" --target clean-all 2>/dev/null || true
+if [[ "$SKIP_CLEAN" != "1" ]]; then
+    cmake --build "$BUILD_DIR" --target clean-all 2>/dev/null || true
+else
+    echo "[build_viper] Skipping clean (VIPER_SKIP_CLEAN=1); incremental rebuild"
+fi
 cmake "${CONFIGURE_ARGS[@]}"
 cmake --build "$BUILD_DIR" -j"$JOBS"
 
@@ -66,18 +81,29 @@ else
     cmake -E sleep 1
 fi
 
-rm -rf "$BUILD_DIR/Testing"
-echo "[build_viper] Running full test suite..."
-CTEST_ARGS=(--test-dir "$BUILD_DIR" --output-on-failure -j"$JOBS")
-if [[ -n "$CTEST_TIMEOUT" ]]; then
-    CTEST_ARGS+=(--timeout "$CTEST_TIMEOUT")
+if [[ "$SKIP_TESTS" == "1" ]]; then
+    echo "[build_viper] Skipping tests (VIPER_SKIP_TESTS=1)"
+else
+    rm -rf "$BUILD_DIR/Testing"
+    if [[ -n "$TEST_LABEL" ]]; then
+        echo "[build_viper] Running tests labeled '$TEST_LABEL' (VIPER_TEST_LABEL)..."
+    else
+        echo "[build_viper] Running full test suite..."
+    fi
+    CTEST_ARGS=(--test-dir "$BUILD_DIR" --output-on-failure -j"$JOBS")
+    if [[ -n "$TEST_LABEL" ]]; then
+        CTEST_ARGS+=(-L "$TEST_LABEL")
+    fi
+    if [[ -n "$CTEST_TIMEOUT" ]]; then
+        CTEST_ARGS+=(--timeout "$CTEST_TIMEOUT")
+    fi
+    if [[ "$RUN_SLOW_TESTS" != "1" ]]; then
+        echo "[build_viper] Skipping tests labeled slow (set VIPER_RUN_SLOW_TESTS=1 to include them)"
+        CTEST_ARGS+=(-LE slow)
+    fi
+    ctest "${CTEST_ARGS[@]}"
+    echo "[build_viper] Test run complete"
 fi
-if [[ "$RUN_SLOW_TESTS" != "1" ]]; then
-    echo "[build_viper] Skipping tests labeled slow (set VIPER_RUN_SLOW_TESTS=1 to include them)"
-    CTEST_ARGS+=(-LE slow)
-fi
-ctest "${CTEST_ARGS[@]}"
-echo "[build_viper] Full test suite complete"
 
 if [[ "$SKIP_LINT" != "1" && -x "$SCRIPT_DIR/lint_platform_policy.sh" ]]; then
     echo "[build_viper] Running platform policy lint..."

--- a/scripts/build_viper_win.cmd
+++ b/scripts/build_viper_win.cmd
@@ -31,6 +31,7 @@ if "%VIPER_SKIP_LINT%"=="" set "VIPER_SKIP_LINT=0"
 if "%VIPER_SKIP_AUDIT%"=="" set "VIPER_SKIP_AUDIT=0"
 if "%VIPER_LINT_CHANGED_ONLY%"=="" set "VIPER_LINT_CHANGED_ONLY=1"
 if "%VIPER_SKIP_SMOKE%"=="" set "VIPER_SKIP_SMOKE=0"
+if "%VIPER_SKIP_CLEAN%"=="" set "VIPER_SKIP_CLEAN=0"
 
 set "CONFIG_ARGS="
 if not "%VIPER_CMAKE_GENERATOR%"=="" (
@@ -74,7 +75,9 @@ call :reset_stale_compiler_cache
 if errorlevel 1 exit /b 1
 
 REM --- Clean previous build ---------------------------------------------------
-if "%CACHE_RESET%"=="0" (
+if "%VIPER_SKIP_CLEAN%"=="1" (
+    echo Skipping clean ^(VIPER_SKIP_CLEAN=1^); incremental rebuild
+) else if "%CACHE_RESET%"=="0" (
     cmake --build "%VIPER_BUILD_DIR%" --target clean-all 2>nul
     if errorlevel 1 (
         REM clean-all target may not exist on first build; ignore
@@ -115,7 +118,12 @@ if "%VIPER_SKIP_TESTS%"=="1" (
 )
 
 echo Running tests...
-ctest --test-dir "%VIPER_BUILD_DIR%" -C %VIPER_BUILD_TYPE% --output-on-failure -j %JOBS%
+set "CTEST_LABEL_ARGS="
+if not "%VIPER_TEST_LABEL%"=="" (
+    echo Running only tests labeled "%VIPER_TEST_LABEL%" ^(VIPER_TEST_LABEL^)
+    set "CTEST_LABEL_ARGS=-L %VIPER_TEST_LABEL%"
+)
+ctest --test-dir "%VIPER_BUILD_DIR%" -C %VIPER_BUILD_TYPE% --output-on-failure -j %JOBS% %CTEST_LABEL_ARGS%
 if errorlevel 1 (
     set TESTS_FAILED=1
     echo.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -461,6 +461,8 @@ set(VIPER_CLI_SOURCES
         tools/viper/cmd_package.cpp
         tools/viper/cmd_install_package.cpp
         tools/viper/cmd_repl.cpp
+        tools/viper/cmd_eval.cpp
+        tools/viper/cmd_explain.cpp
         tools/viper/cli.cpp
         tools/viper/break_spec.cpp)
 

--- a/src/runtime/audio/rt_audio.c
+++ b/src/runtime/audio/rt_audio.c
@@ -131,6 +131,7 @@ static void audio_group_copy_name(char *dst, size_t cap, rt_string name) {
     dst[len] = '\0';
 }
 
+#ifdef VIPER_ENABLE_AUDIO
 static const char *audio_path_cstr(rt_string path) {
     if (!path)
         return NULL;
@@ -142,6 +143,7 @@ static const char *audio_path_cstr(rt_string path) {
         return NULL;
     return path_str;
 }
+#endif /* VIPER_ENABLE_AUDIO */
 
 /// @brief Find an in-use mix group by name. @return its group id, or -1 if
 ///        no such group (empty/NULL name yields -1). Caller holds the lock.
@@ -189,6 +191,7 @@ static int8_t audio_group_id_valid_unlocked(int64_t group) {
 
 /// @brief Convert a fade/duration in seconds to whole milliseconds, saturating
 ///        at INT64_MAX; non-finite or non-positive input yields 0.
+#ifdef VIPER_ENABLE_AUDIO
 static int64_t seconds_to_ms_i64(float seconds) {
     if (!isfinite(seconds) || seconds <= 0.0f)
         return 0;
@@ -197,6 +200,7 @@ static int64_t seconds_to_ms_i64(float seconds) {
         return INT64_MAX;
     return (int64_t)(ms + 0.5);
 }
+#endif /* VIPER_ENABLE_AUDIO */
 
 #ifdef VIPER_ENABLE_AUDIO
 #include "vaud.h"

--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(viper_support STATIC
         arena.cpp
         diag_expected.cpp
         diag_capture.cpp
+        diag_catalog.cpp
 )
 
 target_include_directories(viper_support PUBLIC

--- a/src/support/diag_catalog.cpp
+++ b/src/support/diag_catalog.cpp
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Viper project, under the GNU GPL v3.
+// See LICENSE for license information.
+//
+//===----------------------------------------------------------------------===//
+//
+// File: support/diag_catalog.cpp
+// Purpose: Implements diagnostic-code catalog lookup with prefix fallback.
+// Key invariants:
+//   - The catalog is materialized once and never mutated.
+//   - Prefix matching checks the most specific families first.
+// Ownership/Lifetime:
+//   - Static data with program lifetime.
+// Links: support/diag_catalog.hpp, support/diag_catalog.def
+//
+//===----------------------------------------------------------------------===//
+
+#include "support/diag_catalog.hpp"
+
+#include <algorithm>
+#include <cctype>
+
+namespace il::support {
+
+const std::vector<DiagCatalogEntry> &diagCatalog() {
+    static const std::vector<DiagCatalogEntry> entries = {
+#define DIAG_CODE(code, subsystem, summary) DiagCatalogEntry{code, subsystem, summary},
+#include "support/diag_catalog.def"
+#undef DIAG_CODE
+    };
+    return entries;
+}
+
+const DiagCatalogEntry *findDiagCode(std::string_view code) {
+    const auto &entries = diagCatalog();
+    auto it = std::find_if(entries.begin(), entries.end(), [&](const DiagCatalogEntry &e) {
+        return e.code == code;
+    });
+    return it == entries.end() ? nullptr : &*it;
+}
+
+std::optional<std::string_view> diagCodeFamily(std::string_view code) {
+    struct Family {
+        std::string_view prefix;
+        std::string_view description;
+    };
+    // Most specific prefixes first.
+    static constexpr Family kFamilies[] = {
+        {"V-ZIA-LEX", "Zia lexer diagnostics"},
+        {"V-ZIA-PARSE", "Zia parser diagnostics"},
+        {"V-ZIA-LOWER", "Zia lowering invariant diagnostics"},
+        {"V-ZIA-", "Zia semantic analysis diagnostics"},
+        {"V-IL-", "IL verification diagnostics"},
+        {"V-BC-", "Bytecode compiler diagnostics"},
+        {"V-CG-", "Native codegen diagnostics"},
+        {"V-OPT-", "IL optimizer pipeline diagnostics"},
+        {"V-SRC-", "Source loading and registration diagnostics"},
+        {"V-LSP-", "Language server bridge diagnostics"},
+        {"IL", "IL parser/serializer diagnostics"},
+    };
+    for (const auto &family : kFamilies) {
+        if (code.size() >= family.prefix.size() &&
+            code.substr(0, family.prefix.size()) == family.prefix)
+            return family.description;
+    }
+
+    auto allDigitsFrom = [&](size_t start) {
+        if (code.size() <= start)
+            return false;
+        for (size_t i = start; i < code.size(); ++i) {
+            if (!std::isdigit(static_cast<unsigned char>(code[i])))
+                return false;
+        }
+        return true;
+    };
+    if (!code.empty() && code[0] == 'B' && allDigitsFrom(1)) {
+        if (code.size() >= 2 && code[1] == '9')
+            return "BASIC frontend warnings";
+        return "BASIC frontend diagnostics";
+    }
+    if (!code.empty() && code[0] == 'W' && allDigitsFrom(1))
+        return "Zia warnings";
+    if (!code.empty() && code[0] == 'E' && allDigitsFrom(1))
+        return "BASIC semantic analysis diagnostics";
+    return std::nullopt;
+}
+
+} // namespace il::support

--- a/src/support/diag_catalog.def
+++ b/src/support/diag_catalog.def
@@ -1,0 +1,188 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Viper project, under the GNU GPL v3.
+// See LICENSE for license information.
+//
+//===----------------------------------------------------------------------===//
+//
+// File: support/diag_catalog.def
+// Purpose: Central catalog of diagnostic codes for `viper explain` and
+//          `viper --print-error-codes`. X-macro consumers define
+//          DIAG_CODE(code, subsystem, summary) before including this file.
+// Key invariants:
+//   - Codes are unique and sorted by subsystem then code.
+//   - Summaries are one sentence, present tense, no trailing period.
+//   - Codes not listed here still resolve through prefix-family fallback in
+//     diag_catalog.cpp; add entries here as codes stabilize.
+// Ownership/Lifetime:
+//   - Static data compiled into viper_support.
+// Links: support/diag_catalog.hpp, docs/debugging.md
+//
+//===----------------------------------------------------------------------===//
+
+// ===== Zia lexer (V-ZIA-LEX*) =====
+DIAG_CODE("V-ZIA-LEX", "zia-lexer", "Generic lexical error in Zia source")
+DIAG_CODE("V-ZIA-LEX-ESCAPE", "zia-lexer", "Invalid escape sequence in a string or character literal")
+DIAG_CODE("V-ZIA-LEX-IDENTIFIER", "zia-lexer", "Malformed identifier token")
+DIAG_CODE("V-ZIA-LEX-LITERAL", "zia-lexer", "Malformed numeric or character literal")
+DIAG_CODE("V-ZIA-LEX-UNTERMINATED-COMMENT", "zia-lexer", "Block comment is missing its closing delimiter")
+DIAG_CODE("V-ZIA-LEX-UNTERMINATED-STRING", "zia-lexer", "String literal is missing its closing quote")
+
+// ===== Zia parser (V-ZIA-PARSE*) =====
+DIAG_CODE("V-ZIA-PARSE", "zia-parser", "Generic syntax error in Zia source")
+DIAG_CODE("V-ZIA-PARSE-ASSIGNMENT", "zia-parser", "Invalid assignment target or malformed assignment statement")
+DIAG_CODE("V-ZIA-PARSE-DECL", "zia-parser", "Malformed declaration (module, func, class, var, or bind)")
+DIAG_CODE("V-ZIA-PARSE-DEPTH", "zia-parser", "Expression or statement nesting exceeds the parser depth limit")
+DIAG_CODE("V-ZIA-PARSE-EXPECTED", "zia-parser", "A specific token was expected at this position")
+DIAG_CODE("V-ZIA-PARSE-EXPR", "zia-parser", "Malformed expression")
+DIAG_CODE("V-ZIA-PARSE-LAMBDA", "zia-parser", "Malformed lambda expression or lambda parameter list")
+DIAG_CODE("V-ZIA-PARSE-LITERAL", "zia-parser", "Literal value is out of range or malformed")
+DIAG_CODE("V-ZIA-PARSE-PATTERN", "zia-parser", "Malformed pattern in a match arm")
+DIAG_CODE("V-ZIA-PARSE-STRING", "zia-parser", "Malformed string interpolation or string literal expression")
+DIAG_CODE("V-ZIA-PARSE-TYPE", "zia-parser", "Malformed type annotation or generic argument list")
+DIAG_CODE("V-ZIA-PARSE-UNEXPECTED", "zia-parser", "Unexpected token at this position")
+
+// ===== Zia semantic analysis (V-ZIA-*) =====
+DIAG_CODE("V-ZIA-BOUNDS", "zia-sema", "Array or fixed-size collection index is out of bounds at compile time")
+DIAG_CODE("V-ZIA-DUPLICATE", "zia-sema", "Duplicate definition of a symbol in the same scope")
+DIAG_CODE("V-ZIA-INDEX", "zia-sema", "Invalid index expression for this collection type")
+DIAG_CODE("V-ZIA-OPTIONAL", "zia-sema", "Optional value used without a null check or unwrap")
+DIAG_CODE("V-ZIA-RETURN", "zia-sema", "Function is missing a return value on some control path")
+DIAG_CODE("V-ZIA-SEMA", "zia-sema", "Generic semantic error in Zia source")
+DIAG_CODE("V-ZIA-TYPE-MISMATCH", "zia-sema", "Expression type does not match the expected type")
+DIAG_CODE("V-ZIA-UNDEFINED", "zia-sema", "Use of an undefined identifier; may include a did-you-mean fix-it")
+
+// ===== Zia lowering invariants (V-ZIA-LOWER*) =====
+DIAG_CODE("V-ZIA-LOWER-DEPTH", "zia-lower", "Lowering recursion depth limit exceeded")
+DIAG_CODE("V-ZIA-LOWER-MISSING-RUNTIME", "zia-lower", "Required runtime function is not registered")
+DIAG_CODE("V-ZIA-LOWER-MISSING-TYPE", "zia-lower", "Internal lowering error: expression has no resolved type")
+DIAG_CODE("V-ZIA-LOWER-NULL-EXPR", "zia-lower", "Internal lowering error: null expression node")
+DIAG_CODE("V-ZIA-LOWER-NULL-STMT", "zia-lower", "Internal lowering error: null statement node")
+DIAG_CODE("V-ZIA-LOWER-TUPLE-DESTRUCTURE", "zia-lower", "Invalid tuple destructuring target")
+DIAG_CODE("V-ZIA-LOWER-TUPLE-DESTRUCTURE-ARITY", "zia-lower", "Tuple destructuring arity does not match the tuple size")
+DIAG_CODE("V-ZIA-LOWER-UNKNOWN-EXPR", "zia-lower", "Internal lowering error: unknown expression kind")
+DIAG_CODE("V-ZIA-LOWER-UNRESOLVED-TYPE", "zia-lower", "Internal lowering error: unresolved semantic type")
+
+// ===== Zia warnings (W001..W019) =====
+DIAG_CODE("W001", "zia-warning", "Variable is declared but never used")
+DIAG_CODE("W002", "zia-warning", "Code is unreachable")
+DIAG_CODE("W003", "zia-warning", "Implicit narrowing conversion may lose information")
+DIAG_CODE("W004", "zia-warning", "Variable shadows a declaration from an outer scope")
+DIAG_CODE("W005", "zia-warning", "Floating-point values compared with == or !=")
+DIAG_CODE("W006", "zia-warning", "Loop body is empty")
+DIAG_CODE("W007", "zia-warning", "Assignment used inside a condition; did you mean ==")
+DIAG_CODE("W008", "zia-warning", "Function may exit without returning a value (promoted to error under strict diagnostics)")
+DIAG_CODE("W009", "zia-warning", "Value is assigned to itself")
+DIAG_CODE("W010", "zia-warning", "Constant division by zero (promoted to error under strict diagnostics)")
+DIAG_CODE("W011", "zia-warning", "Redundant comparison against a boolean literal")
+DIAG_CODE("W012", "zia-warning", "Duplicate bind of the same module or namespace")
+DIAG_CODE("W013", "zia-warning", "Declaration body is empty")
+DIAG_CODE("W014", "zia-warning", "Expression result is computed but never used")
+DIAG_CODE("W015", "zia-warning", "Variable may be read before initialization (promoted to error under strict diagnostics)")
+DIAG_CODE("W016", "zia-warning", "Optional accessed without a null check (promoted to error under strict diagnostics)")
+DIAG_CODE("W017", "zia-warning", "'^' is bitwise xor in Zia; use Viper.Math.Pow for exponentiation")
+DIAG_CODE("W018", "zia-warning", "'&' is bitwise and; did you mean logical 'and'")
+DIAG_CODE("W019", "zia-warning", "Match expression does not cover all cases (promoted to error under strict diagnostics)")
+
+// ===== Shared source loading (V-SRC-*) =====
+DIAG_CODE("V-SRC-FILE-ID", "source", "Source file could not be registered or resolved by the source manager")
+
+// ===== Language server bridge (V-LSP-*) =====
+DIAG_CODE("V-LSP-ANALYSIS", "language-server", "Internal error: analysis did not produce a result")
+
+// ===== IL verification (V-IL-*) =====
+DIAG_CODE("V-IL-VERIFY", "il-verify", "IL module failed verification (type, control-flow, or EH invariants)")
+DIAG_CODE("V-IL-WARN", "il-verify", "IL verifier warning; the module is valid but suspicious")
+
+// ===== Optimizer pipeline (V-OPT-*) =====
+DIAG_CODE("V-OPT-PIPELINE", "il-optimizer", "Optimization pipeline failed to run to completion")
+DIAG_CODE("V-OPT-VERIFY", "il-optimizer", "IL failed verification after an optimization pass (use --verify-each to isolate)")
+
+// ===== Bytecode compiler (V-BC-*) =====
+DIAG_CODE("V-BC-BRANCH-ARGS", "bytecode", "Branch instruction has malformed block arguments")
+DIAG_CODE("V-BC-BRANCH-FIXUP", "bytecode", "Branch target could not be patched during bytecode emission")
+DIAG_CODE("V-BC-BRANCH-RANGE", "bytecode", "Branch offset exceeds the encodable range")
+DIAG_CODE("V-BC-CALL-ARGS", "bytecode", "Call instruction has malformed arguments")
+DIAG_CODE("V-BC-DUPLICATE-BLOCK", "bytecode", "Duplicate basic block label in a function")
+DIAG_CODE("V-BC-DUPLICATE-FUNCTION", "bytecode", "Duplicate function name in the module")
+DIAG_CODE("V-BC-DUPLICATE-GLOBAL", "bytecode", "Duplicate global definition in the module")
+DIAG_CODE("V-BC-FAST-ARRAY-ARGS", "bytecode", "Fast-path array opcode has malformed arguments")
+DIAG_CODE("V-BC-FAST-ARRAY-RESULT", "bytecode", "Fast-path array opcode has a malformed result")
+DIAG_CODE("V-BC-FUNCTION-TABLE", "bytecode", "Function table construction failed")
+DIAG_CODE("V-BC-GLOBAL-INIT", "bytecode", "Global initializer is unsupported or malformed")
+DIAG_CODE("V-BC-GLOBAL-TABLE", "bytecode", "Global table construction failed")
+DIAG_CODE("V-BC-HANDLER-SIGNATURE", "bytecode", "Exception handler block has a malformed parameter signature")
+DIAG_CODE("V-BC-IL-VERIFY", "bytecode", "IL failed verification before bytecode compilation")
+DIAG_CODE("V-BC-INTERNAL", "bytecode", "Internal bytecode compiler error")
+DIAG_CODE("V-BC-LOCAL-OVERFLOW", "bytecode", "Function exceeds the bytecode local-slot limit")
+DIAG_CODE("V-BC-MALFORMED-INSTR", "bytecode", "IL instruction is malformed for bytecode lowering")
+DIAG_CODE("V-BC-METADATA", "bytecode", "Bytecode metadata table is malformed")
+DIAG_CODE("V-BC-NATIVE-TABLE", "bytecode", "Native call table construction failed")
+DIAG_CODE("V-BC-POOL-OVERFLOW", "bytecode", "Constant pool exceeds the encodable size")
+DIAG_CODE("V-BC-RETURN", "bytecode", "Return instruction is inconsistent with the function signature")
+DIAG_CODE("V-BC-STACK-ACCOUNTING", "bytecode", "Operand stack accounting mismatch during bytecode emission")
+DIAG_CODE("V-BC-STACK-UNDERFLOW", "bytecode", "Operand stack underflow during bytecode emission")
+DIAG_CODE("V-BC-SWITCH-CASE", "bytecode", "Switch instruction has malformed cases")
+DIAG_CODE("V-BC-SYNTHETIC-LABEL", "bytecode", "Synthetic label generation failed")
+DIAG_CODE("V-BC-UNKNOWN-BRANCH-TARGET", "bytecode", "Branch references an unknown block label")
+DIAG_CODE("V-BC-UNKNOWN-GLOBAL", "bytecode", "Reference to an unknown global")
+DIAG_CODE("V-BC-UNKNOWN-SSA", "bytecode", "Reference to an undefined SSA value")
+DIAG_CODE("V-BC-UNKNOWN-STRING-GLOBAL", "bytecode", "Reference to an unknown string global")
+DIAG_CODE("V-BC-UNRESOLVED-BRANCH", "bytecode", "Branch target was never resolved")
+DIAG_CODE("V-BC-UNSUPPORTED-GLOBAL-TYPE", "bytecode", "Global has a type the bytecode VM cannot represent")
+DIAG_CODE("V-BC-UNSUPPORTED-OP", "bytecode", "IL opcode is not supported by the bytecode VM")
+
+// ===== Native codegen (V-CG-*) =====
+DIAG_CODE("V-CG-AARCH64-REGALLOC", "codegen", "AArch64 register allocation failed")
+DIAG_CODE("V-CG-ERROR", "codegen", "Native code generation failed")
+DIAG_CODE("V-CG-PASS-EXCEPTION", "codegen", "A backend pass raised an internal exception")
+DIAG_CODE("V-CG-WARN", "codegen", "Native code generation warning")
+
+// ===== BASIC parser (B0xxx) =====
+DIAG_CODE("B0000", "basic-parser", "Generic BASIC parse error")
+DIAG_CODE("B0001", "basic-parser", "Label is already defined")
+DIAG_CODE("B0002", "basic-parser", "GOTO/GOSUB target label is not defined")
+DIAG_CODE("B0003", "basic-parser", "Invalid escape sequence in a string literal")
+DIAG_CODE("B0004", "basic-parser", "Unexpected token at this position")
+DIAG_CODE("B0005", "basic-parser", "Identifier expected at this position")
+DIAG_CODE("B0006", "basic-parser", "Duplicate variable declaration")
+DIAG_CODE("B0007", "basic-parser", "Invalid type suffix on an identifier")
+DIAG_CODE("B0008", "basic-parser", "Expression expected at this position")
+DIAG_CODE("B0009", "basic-parser", "String literal is missing its closing quote")
+DIAG_CODE("B0010", "basic-parser", "Malformed numeric literal")
+DIAG_CODE("B0801", "basic-parser", "TRY requires CATCH, FINALLY, or both")
+
+// ===== BASIC semantic analysis (B1xxx) =====
+DIAG_CODE("B1000", "basic-sema", "Type mismatch between expression and expected type")
+DIAG_CODE("B1001", "basic-sema", "Use of an undefined variable")
+DIAG_CODE("B1002", "basic-sema", "Call to an undefined function or procedure")
+DIAG_CODE("B1003", "basic-sema", "Wrong number of arguments in call")
+DIAG_CODE("B1004", "basic-sema", "Operand type is invalid for this operator")
+DIAG_CODE("B1005", "basic-sema", "Value cannot be converted to the target type")
+DIAG_CODE("B1006", "basic-sema", "Array dimension is invalid")
+DIAG_CODE("B1007", "basic-sema", "FOR loop variable is invalid")
+DIAG_CODE("B1008", "basic-sema", "EXIT/BREAK used outside a loop")
+DIAG_CODE("B1009", "basic-sema", "CONTINUE used outside a loop")
+DIAG_CODE("B1010", "basic-sema", "RETURN value type does not match the function declaration")
+DIAG_CODE("B1011", "basic-sema", "Call matches more than one overload")
+DIAG_CODE("B1012", "basic-sema", "RESUME requires an active error handler")
+
+// ===== BASIC lowering (B2xxx core) =====
+DIAG_CODE("B2000", "basic-lower", "Expression cannot be lowered to IL")
+DIAG_CODE("B2001", "basic-lower", "Statement cannot be lowered to IL (includes assignment/operator type mismatches)")
+DIAG_CODE("B2002", "basic-lower", "Language feature is not supported by the lowering pipeline")
+DIAG_CODE("B2003", "basic-lower", "Internal compiler error during lowering")
+
+// ===== BASIC warnings (B9xxx) =====
+DIAG_CODE("B9000", "basic-warning", "Variable is declared but never used")
+DIAG_CODE("B9001", "basic-warning", "Variable shadows an outer declaration")
+DIAG_CODE("B9002", "basic-warning", "Code is unreachable")
+DIAG_CODE("B9003", "basic-warning", "Implicit conversion may lose information")
+
+// ===== BASIC semantic analyzer (E1xxx) =====
+DIAG_CODE("E1001", "basic-sema", "Conditional expression is not boolean")
+DIAG_CODE("E1002", "basic-sema", "Logical operator operand is not boolean")
+DIAG_CODE("E1003", "basic-sema", "NOT operand is not boolean")
+
+// ===== IL parse/serialize (ILxxx) =====
+DIAG_CODE("IL001", "il-parse", "Malformed textual IL input")

--- a/src/support/diag_catalog.hpp
+++ b/src/support/diag_catalog.hpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Viper project, under the GNU GPL v3.
+// See LICENSE for license information.
+//
+//===----------------------------------------------------------------------===//
+//
+// File: support/diag_catalog.hpp
+// Purpose: Declares the diagnostic-code catalog backing `viper explain` and
+//          `viper --print-error-codes`.
+// Key invariants:
+//   - Catalog entries are unique by code and stable across a release.
+//   - Lookup never fails hard: unknown codes fall back to a prefix-family
+//     description when the prefix is recognized.
+// Ownership/Lifetime:
+//   - All entries are static data with program lifetime.
+// Links: support/diag_catalog.def, docs/debugging.md
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <optional>
+#include <string_view>
+#include <vector>
+
+namespace il::support {
+
+/// @brief One catalog entry describing a diagnostic code.
+/// @invariant code and subsystem are non-empty; summary is one sentence.
+/// @ownership Static storage; string_views point at string literals.
+struct DiagCatalogEntry {
+    std::string_view code;      ///< Stable diagnostic code (e.g., "V-ZIA-UNDEFINED").
+    std::string_view subsystem; ///< Emitting subsystem (e.g., "zia-sema").
+    std::string_view summary;   ///< One-sentence description of the condition.
+};
+
+/// @brief All cataloged diagnostic codes in definition order.
+const std::vector<DiagCatalogEntry> &diagCatalog();
+
+/// @brief Find the catalog entry for @p code.
+/// @return The entry, or nullptr when the code is not cataloged.
+const DiagCatalogEntry *findDiagCode(std::string_view code);
+
+/// @brief Describe the subsystem family for @p code from its prefix.
+/// @details Used as a fallback for codes that are not (yet) cataloged, so
+///          tooling can always say which component emitted a diagnostic.
+/// @return Subsystem description, or std::nullopt for unrecognized prefixes.
+std::optional<std::string_view> diagCodeFamily(std::string_view code);
+
+} // namespace il::support

--- a/src/support/diag_expected.cpp
+++ b/src/support/diag_expected.cpp
@@ -573,6 +573,10 @@ void printJsonDiagObject(const Diag &diag, std::ostream &os, const SourceManager
 }
 } // namespace
 
+void printJsonStringEscaped(std::ostream &os, std::string_view text) {
+    printJsonEscaped(os, text);
+}
+
 /// @brief Construct an Expected<void> that stores a diagnostic error state.
 ///
 /// @details The constructor moves the provided diagnostic into the optional

--- a/src/support/diag_expected.hpp
+++ b/src/support/diag_expected.hpp
@@ -24,6 +24,7 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -165,4 +166,11 @@ void printDiagnosticsJson(const std::vector<Diag> &diagnostics,
 /// @param os Output stream receiving JSON.
 /// @param sm Optional source manager used to resolve file paths.
 void printDiagJson(const Diag &diag, std::ostream &os, const SourceManager *sm = nullptr);
+
+/// @brief Emit @p text as a JSON-escaped, double-quoted string literal.
+/// @details Shared by tools that hand-build small JSON documents (eval,
+///          explain, runtime API dumps) so escaping rules stay in one place.
+/// @param os Output stream receiving the quoted literal.
+/// @param text Raw text to escape and quote.
+void printJsonStringEscaped(std::ostream &os, std::string_view text);
 } // namespace il::support

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -464,10 +464,13 @@ viper_add_test(test_mp3_decode
         ${CMAKE_CURRENT_SOURCE_DIR}/unit/runtime/TestMp3Decode.cpp
         LIBS viper_runtime viper_test_common)
 
-viper_add_test(test_wav_stream
-        ${CMAKE_CURRENT_SOURCE_DIR}/unit/runtime/TestWavStream.cpp
-        LIBS viperaud viper_test_common
-        INCLUDES ${CMAKE_SOURCE_DIR}/src/lib/audio/include ${CMAKE_SOURCE_DIR}/src/lib/audio/src)
+# viperaud only exists when an audio backend is available (ALSA/CoreAudio/WASAPI).
+if (TARGET viperaud)
+    viper_add_test(test_wav_stream
+            ${CMAKE_CURRENT_SOURCE_DIR}/unit/runtime/TestWavStream.cpp
+            LIBS viperaud viper_test_common
+            INCLUDES ${CMAKE_SOURCE_DIR}/src/lib/audio/include ${CMAKE_SOURCE_DIR}/src/lib/audio/src)
+endif ()
 
 viper_add_test(test_stl_load
         ${CMAKE_CURRENT_SOURCE_DIR}/unit/runtime/TestStlLoad.cpp

--- a/src/tests/tools/AgentCliTests.cmake
+++ b/src/tests/tools/AgentCliTests.cmake
@@ -1,0 +1,202 @@
+# Tests for the agent-facing CLI surface: viper check, viper eval,
+# viper explain, --print-error-codes, --dump-runtime-api, --dump-opcodes.
+# Validates exit-code contracts and machine-readable output shapes.
+cmake_minimum_required(VERSION 3.20)
+
+if (NOT DEFINED VIPER_EXE)
+    message(FATAL_ERROR "VIPER_EXE must be provided")
+endif ()
+if (NOT DEFINED TEST_WORK_DIR)
+    message(FATAL_ERROR "TEST_WORK_DIR must be provided")
+endif ()
+
+file(REMOVE_RECURSE "${TEST_WORK_DIR}")
+file(MAKE_DIRECTORY "${TEST_WORK_DIR}")
+
+# ===== viper check: clean file exits 0 =====
+set(_ok_zia "${TEST_WORK_DIR}/ok.zia")
+file(WRITE "${_ok_zia}" "module T;\nbind Viper.Terminal;\nfunc start() {\n    Say(\"hi\");\n}\n")
+
+execute_process(
+        COMMAND "${VIPER_EXE}" check "${_ok_zia}"
+        RESULT_VARIABLE _check_ok_rc
+        OUTPUT_VARIABLE _check_ok_out
+        ERROR_VARIABLE _check_ok_err)
+if (NOT _check_ok_rc EQUAL 0)
+    message(FATAL_ERROR "viper check on a clean file should exit 0, got ${_check_ok_rc}:\n${_check_ok_err}")
+endif ()
+
+# ===== viper check: compile errors exit 2 with structured JSON =====
+set(_bad_zia "${TEST_WORK_DIR}/bad.zia")
+file(WRITE "${_bad_zia}" "module T;\nbind Viper.Terminal;\nfunc start() {\n    var count = 1;\n    SayInt(cout + count);\n}\n")
+
+execute_process(
+        COMMAND "${VIPER_EXE}" check "${_bad_zia}" --diagnostic-format=json
+        RESULT_VARIABLE _check_bad_rc
+        OUTPUT_VARIABLE _check_bad_out
+        ERROR_VARIABLE _check_bad_err)
+if (NOT _check_bad_rc EQUAL 2)
+    message(FATAL_ERROR "viper check on a broken file should exit 2, got ${_check_bad_rc}:\n${_check_bad_err}")
+endif ()
+if (NOT _check_bad_err MATCHES "\"code\":\"V-ZIA-UNDEFINED\"")
+    message(FATAL_ERROR "viper check JSON did not include the V-ZIA-UNDEFINED code:\n${_check_bad_err}")
+endif ()
+if (NOT _check_bad_err MATCHES "\"fixits\"" OR NOT _check_bad_err MATCHES "\"replacement\":\"count\"")
+    message(FATAL_ERROR "viper check JSON did not carry the did-you-mean fix-it:\n${_check_bad_err}")
+endif ()
+
+# ===== viper check: unresolvable target exits 1 =====
+execute_process(
+        COMMAND "${VIPER_EXE}" check "${TEST_WORK_DIR}/does-not-exist.zia"
+        RESULT_VARIABLE _check_missing_rc
+        OUTPUT_VARIABLE _check_missing_out
+        ERROR_VARIABLE _check_missing_err)
+if (NOT _check_missing_rc EQUAL 1)
+    message(FATAL_ERROR "viper check on a missing target should exit 1, got ${_check_missing_rc}")
+endif ()
+
+# ===== viper check: rejects run/build-only flags =====
+execute_process(
+        COMMAND "${VIPER_EXE}" check "${_ok_zia}" -o out.il
+        RESULT_VARIABLE _check_o_rc
+        OUTPUT_VARIABLE _check_o_out
+        ERROR_VARIABLE _check_o_err)
+if (_check_o_rc EQUAL 0)
+    message(FATAL_ERROR "viper check should reject -o")
+endif ()
+
+# ===== viper eval: expression auto-print, exit 0 =====
+execute_process(
+        COMMAND "${VIPER_EXE}" eval "2 + 3 * 4"
+        RESULT_VARIABLE _eval_rc
+        OUTPUT_VARIABLE _eval_out
+        ERROR_VARIABLE _eval_err)
+if (NOT _eval_rc EQUAL 0)
+    message(FATAL_ERROR "viper eval should exit 0, got ${_eval_rc}:\n${_eval_err}")
+endif ()
+if (NOT _eval_out MATCHES "14")
+    message(FATAL_ERROR "viper eval '2 + 3 * 4' should print 14, got:\n${_eval_out}")
+endif ()
+
+# ===== viper eval --json --type: structured result =====
+execute_process(
+        COMMAND "${VIPER_EXE}" eval --json --type "1 + 1"
+        RESULT_VARIABLE _eval_json_rc
+        OUTPUT_VARIABLE _eval_json_out
+        ERROR_VARIABLE _eval_json_err)
+if (NOT _eval_json_rc EQUAL 0)
+    message(FATAL_ERROR "viper eval --json should exit 0, got ${_eval_json_rc}:\n${_eval_json_err}")
+endif ()
+if (NOT _eval_json_out MATCHES "\"success\":true" OR NOT _eval_json_out MATCHES "\"resultType\":\"Integer\"")
+    message(FATAL_ERROR "viper eval --json output malformed:\n${_eval_json_out}")
+endif ()
+if (NOT _eval_json_out MATCHES "\"type\":\"Integer\"")
+    message(FATAL_ERROR "viper eval --type did not report the inferred type:\n${_eval_json_out}")
+endif ()
+
+# ===== viper eval: compile errors exit 2 =====
+execute_process(
+        COMMAND "${VIPER_EXE}" eval "thisIsNotDefined + 1"
+        RESULT_VARIABLE _eval_bad_rc
+        OUTPUT_VARIABLE _eval_bad_out
+        ERROR_VARIABLE _eval_bad_err)
+if (NOT _eval_bad_rc EQUAL 2)
+    message(FATAL_ERROR "viper eval on bad code should exit 2, got ${_eval_bad_rc}")
+endif ()
+
+# ===== viper eval: runtime traps exit 3 =====
+execute_process(
+        COMMAND "${VIPER_EXE}" eval "1 / 0"
+        RESULT_VARIABLE _eval_trap_rc
+        OUTPUT_VARIABLE _eval_trap_out
+        ERROR_VARIABLE _eval_trap_err)
+if (NOT _eval_trap_rc EQUAL 3)
+    message(FATAL_ERROR "viper eval on trapping code should exit 3, got ${_eval_trap_rc}")
+endif ()
+
+# ===== viper explain: cataloged code =====
+execute_process(
+        COMMAND "${VIPER_EXE}" explain V-ZIA-UNDEFINED
+        RESULT_VARIABLE _explain_rc
+        OUTPUT_VARIABLE _explain_out
+        ERROR_VARIABLE _explain_err)
+if (NOT _explain_rc EQUAL 0)
+    message(FATAL_ERROR "viper explain V-ZIA-UNDEFINED should exit 0, got ${_explain_rc}:\n${_explain_err}")
+endif ()
+if (NOT _explain_out MATCHES "zia-sema")
+    message(FATAL_ERROR "viper explain output missing subsystem:\n${_explain_out}")
+endif ()
+
+# ===== viper explain --json =====
+execute_process(
+        COMMAND "${VIPER_EXE}" explain W001 --json
+        RESULT_VARIABLE _explain_json_rc
+        OUTPUT_VARIABLE _explain_json_out
+        ERROR_VARIABLE _explain_json_err)
+if (NOT _explain_json_rc EQUAL 0 OR NOT _explain_json_out MATCHES "\"code\":\"W001\"")
+    message(FATAL_ERROR "viper explain W001 --json malformed:\n${_explain_json_out}")
+endif ()
+
+# ===== viper explain: uncataloged code with known prefix still resolves =====
+execute_process(
+        COMMAND "${VIPER_EXE}" explain B2113
+        RESULT_VARIABLE _explain_family_rc
+        OUTPUT_VARIABLE _explain_family_out
+        ERROR_VARIABLE _explain_family_err)
+if (NOT _explain_family_rc EQUAL 0)
+    message(FATAL_ERROR "viper explain on an uncataloged BASIC code should fall back to its family, got ${_explain_family_rc}")
+endif ()
+
+# ===== viper explain: unknown code exits 1 =====
+execute_process(
+        COMMAND "${VIPER_EXE}" explain TOTALLY-BOGUS
+        RESULT_VARIABLE _explain_unknown_rc
+        OUTPUT_VARIABLE _explain_unknown_out
+        ERROR_VARIABLE _explain_unknown_err)
+if (_explain_unknown_rc EQUAL 0)
+    message(FATAL_ERROR "viper explain on an unknown code should exit non-zero")
+endif ()
+
+# ===== --print-error-codes --json =====
+execute_process(
+        COMMAND "${VIPER_EXE}" --print-error-codes --json
+        RESULT_VARIABLE _codes_rc
+        OUTPUT_VARIABLE _codes_out
+        ERROR_VARIABLE _codes_err)
+if (NOT _codes_rc EQUAL 0)
+    message(FATAL_ERROR "--print-error-codes --json should exit 0, got ${_codes_rc}")
+endif ()
+if (NOT _codes_out MATCHES "\"code\":\"V-ZIA-TYPE-MISMATCH\"" OR NOT _codes_out MATCHES "\"code\":\"B2001\"")
+    message(FATAL_ERROR "--print-error-codes catalog is missing expected entries:\n${_codes_out}")
+endif ()
+
+# ===== --dump-runtime-api =====
+execute_process(
+        COMMAND "${VIPER_EXE}" --dump-runtime-api
+        RESULT_VARIABLE _api_rc
+        OUTPUT_VARIABLE _api_out
+        ERROR_VARIABLE _api_err)
+if (NOT _api_rc EQUAL 0)
+    message(FATAL_ERROR "--dump-runtime-api should exit 0, got ${_api_rc}")
+endif ()
+if (NOT _api_out MATCHES "\"functions\":" OR NOT _api_out MATCHES "\"classes\":")
+    message(FATAL_ERROR "--dump-runtime-api missing top-level sections")
+endif ()
+if (NOT _api_out MATCHES "Viper.Terminal.Say")
+    message(FATAL_ERROR "--dump-runtime-api missing canonical function entries")
+endif ()
+
+# ===== --dump-opcodes =====
+execute_process(
+        COMMAND "${VIPER_EXE}" --dump-opcodes
+        RESULT_VARIABLE _ops_rc
+        OUTPUT_VARIABLE _ops_out
+        ERROR_VARIABLE _ops_err)
+if (NOT _ops_rc EQUAL 0)
+    message(FATAL_ERROR "--dump-opcodes should exit 0, got ${_ops_rc}")
+endif ()
+if (NOT _ops_out MATCHES "\"mnemonic\":\"add\"" OR NOT _ops_out MATCHES "\"opcodes\":")
+    message(FATAL_ERROR "--dump-opcodes output malformed:\n${_ops_out}")
+endif ()
+
+message(STATUS "Agent CLI tests passed")

--- a/src/tests/tools/CMakeLists.txt
+++ b/src/tests/tools/CMakeLists.txt
@@ -46,6 +46,13 @@ function(viper_add_tools_tests)
             -P ${_VIPER_TOOLS_DIR}/CliHelpTests.cmake)
     viper_add_test_labels(cli_help tools)
 
+    viper_add_ctest(agent_cli
+            ${CMAKE_COMMAND}
+            -DVIPER_EXE=$<TARGET_FILE:viper>
+            -DTEST_WORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/agent_cli
+            -P ${_VIPER_TOOLS_DIR}/AgentCliTests.cmake)
+    viper_add_test_labels(agent_cli tools zia)
+
     viper_add_test(test_tools_frontend_native_compiler
             ${_VIPER_TOOLS_DIR}/FrontendToolAndNativeCompilerTests.cpp
             ${CMAKE_SOURCE_DIR}/src/tools/viper/cmd_codegen_x64.cpp)

--- a/src/tests/unit/CMakeLists.txt
+++ b/src/tests/unit/CMakeLists.txt
@@ -73,6 +73,10 @@ function(viper_add_unit_support_tests)
     viper_add_test(test_support ${VIPER_TESTS_DIR}/unit/test_support.cpp)
     target_link_libraries(test_support PRIVATE ${VIPER_UNIT_SUPPORT_LIBS})
     viper_add_ctest(test_support test_support)
+
+    viper_add_test(test_diag_catalog ${VIPER_TESTS_DIR}/unit/test_diag_catalog.cpp)
+    target_link_libraries(test_diag_catalog PRIVATE ${VIPER_UNIT_SUPPORT_LIBS})
+    viper_add_ctest(test_diag_catalog test_diag_catalog)
 endfunction()
 
 if (NOT TARGET test_basic_terminal_scan)

--- a/src/tests/unit/test_diag_catalog.cpp
+++ b/src/tests/unit/test_diag_catalog.cpp
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Viper project, under the GNU GPL v3.
+// See LICENSE for license information.
+//
+//===----------------------------------------------------------------------===//
+//
+// File: tests/unit/test_diag_catalog.cpp
+// Purpose: Unit tests for the diagnostic-code catalog backing `viper explain`.
+// Key invariants:
+//   - Catalog entries are unique, non-empty, and cover the core code families.
+//   - Prefix-family fallback resolves every code family used in the tree.
+// Ownership/Lifetime:
+//   - Test-only file
+// Links: support/diag_catalog.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#include "support/diag_catalog.hpp"
+#include "tests/TestHarness.hpp"
+
+#include <set>
+#include <string>
+
+using namespace il::support;
+
+TEST(DiagCatalog, EntriesAreUniqueAndWellFormed) {
+    const auto &entries = diagCatalog();
+    EXPECT_GT(entries.size(), 100u);
+
+    std::set<std::string> seen;
+    for (const auto &e : entries) {
+        EXPECT_TRUE(!e.code.empty());
+        EXPECT_TRUE(!e.subsystem.empty());
+        EXPECT_TRUE(!e.summary.empty());
+        auto inserted = seen.insert(std::string(e.code));
+        EXPECT_TRUE(inserted.second); // no duplicate codes
+    }
+}
+
+TEST(DiagCatalog, FindsCoreCodes) {
+    const auto *undef = findDiagCode("V-ZIA-UNDEFINED");
+    EXPECT_TRUE(undef != nullptr);
+    if (undef)
+        EXPECT_EQ(std::string(undef->subsystem), std::string("zia-sema"));
+
+    EXPECT_TRUE(findDiagCode("V-ZIA-TYPE-MISMATCH") != nullptr);
+    EXPECT_TRUE(findDiagCode("W001") != nullptr);
+    EXPECT_TRUE(findDiagCode("W019") != nullptr);
+    EXPECT_TRUE(findDiagCode("B2001") != nullptr);
+    EXPECT_TRUE(findDiagCode("V-IL-VERIFY") != nullptr);
+    EXPECT_TRUE(findDiagCode("V-BC-UNSUPPORTED-OP") != nullptr);
+}
+
+TEST(DiagCatalog, UnknownCodeReturnsNull) {
+    EXPECT_TRUE(findDiagCode("TOTALLY-BOGUS") == nullptr);
+    EXPECT_TRUE(findDiagCode("") == nullptr);
+}
+
+TEST(DiagCatalog, FamilyFallbackCoversKnownPrefixes) {
+    EXPECT_TRUE(diagCodeFamily("V-ZIA-SOMETHING-NEW").has_value());
+    EXPECT_TRUE(diagCodeFamily("V-ZIA-PARSE-FUTURE").has_value());
+    EXPECT_TRUE(diagCodeFamily("V-BC-FUTURE").has_value());
+    EXPECT_TRUE(diagCodeFamily("V-CG-FUTURE").has_value());
+    EXPECT_TRUE(diagCodeFamily("B2113").has_value());
+    EXPECT_TRUE(diagCodeFamily("B9007").has_value());
+    EXPECT_TRUE(diagCodeFamily("W042").has_value());
+    EXPECT_TRUE(diagCodeFamily("E1009").has_value());
+    EXPECT_FALSE(diagCodeFamily("XYZZY").has_value());
+    EXPECT_FALSE(diagCodeFamily("B12X4").has_value());
+}

--- a/src/tests/zia-server/test_compiler_bridge.cpp
+++ b/src/tests/zia-server/test_compiler_bridge.cpp
@@ -77,6 +77,59 @@ func start() {
     EXPECT_TRUE(diags[0].line > 0u);
 }
 
+TEST(CompilerBridge, CheckPopulatesRangeStageHelpNotesAndFixits) {
+    CompilerBridge bridge;
+    // "cout" is one edit away from "count", so Sema emits a did-you-mean
+    // suggestion with a related note and a machine-applicable fix-it.
+    auto diags = bridge.check(R"(
+module Test;
+func start() {
+    var count = 1;
+    var x = cout;
+    Viper.Terminal.SayInt(x + count);
+}
+)",
+                              "test.zia");
+    const DiagnosticInfo *undef = nullptr;
+    for (const auto &d : diags) {
+        if (d.code == "V-ZIA-UNDEFINED") {
+            undef = &d;
+            break;
+        }
+    }
+    EXPECT_TRUE(undef != nullptr);
+    if (!undef)
+        return;
+
+    EXPECT_EQ(undef->severity, 2);
+    EXPECT_EQ(undef->file, std::string("test.zia"));
+    EXPECT_TRUE(undef->line > 0u);
+    EXPECT_TRUE(undef->column > 0u);
+    // Concrete same-line range covering the identifier "cout".
+    EXPECT_EQ(undef->endLine, undef->line);
+    EXPECT_EQ(undef->endColumn, undef->column + 4u);
+    EXPECT_EQ(undef->stage, std::string("sema"));
+    EXPECT_TRUE(!undef->help.empty());
+
+    // Did-you-mean note points at the candidate symbol.
+    EXPECT_TRUE(undef->notes.size() > 0u);
+    if (!undef->notes.empty()) {
+        EXPECT_CONTAINS(undef->notes[0].message, "count");
+        EXPECT_TRUE(undef->notes[0].line > 0u);
+        EXPECT_EQ(undef->notes[0].file, std::string("test.zia"));
+    }
+
+    // Fix-it replaces the bad identifier with the suggestion.
+    EXPECT_TRUE(undef->fixits.size() > 0u);
+    if (!undef->fixits.empty()) {
+        EXPECT_EQ(undef->fixits[0].replacement, std::string("count"));
+        EXPECT_EQ(undef->fixits[0].line, undef->line);
+        EXPECT_EQ(undef->fixits[0].column, undef->column);
+        EXPECT_EQ(undef->fixits[0].endLine, undef->line);
+        EXPECT_EQ(undef->fixits[0].endColumn, undef->column + 4u);
+    }
+}
+
 // ===== compile() =====
 
 TEST(CompilerBridge, CompileValidSource) {
@@ -140,6 +193,33 @@ TEST(CompilerBridge, HoverOnLocalVariable) {
     EXPECT_FALSE(result.empty());
     EXPECT_TRUE(result.find("var x") != std::string::npos);
     EXPECT_TRUE(result.find("Integer") != std::string::npos);
+}
+
+TEST(CompilerBridge, HoverOnLocalVariableUseSite) {
+    CompilerBridge bridge;
+    // Line 4: "    Viper.Terminal.SayInt(x);" — cursor on the use of 'x' at col 27
+    std::string source =
+        "module Test;\nfunc start() {\n    var x = 42;\n    Viper.Terminal.SayInt(x);\n}\n";
+    auto result = bridge.hover(source, 4, 27, "test.zia");
+    EXPECT_FALSE(result.empty());
+    EXPECT_CONTAINS(result, "x");
+    EXPECT_CONTAINS(result, "Integer");
+}
+
+TEST(CompilerBridge, HoverOnLocalInsideNestedBlock) {
+    CompilerBridge bridge;
+    // Line 5: "        Viper.Terminal.SayInt(total);" — cursor on 'total' at col 31
+    std::string source = "module Test;\n"
+                         "func start() {\n"
+                         "    var total = 0;\n"
+                         "    if total == 0 {\n"
+                         "        Viper.Terminal.SayInt(total);\n"
+                         "    }\n"
+                         "}\n";
+    auto result = bridge.hover(source, 5, 31, "test.zia");
+    EXPECT_FALSE(result.empty());
+    EXPECT_CONTAINS(result, "total");
+    EXPECT_CONTAINS(result, "Integer");
 }
 
 TEST(CompilerBridge, HoverOnFunctionParameter) {

--- a/src/tests/zia-server/test_lsp_handler.cpp
+++ b/src/tests/zia-server/test_lsp_handler.cpp
@@ -154,6 +154,53 @@ TEST(LspHandler, DidOpenPublishesDiagnostics) {
     EXPECT_EQ(diag["params"]["uri"].asString(), "file:///test.zia");
 }
 
+TEST(LspHandler, DiagnosticsCarryRangeCodeAndRelatedInformation) {
+    CompilerBridge bridge;
+    MockTransport transport;
+    LspHandler handler(bridge, transport, {"zia-server", "0.1.0", "zia", "zia", ".zia", "Zia"});
+    startLspSession(handler);
+
+    // "cout" triggers an undefined-identifier error with a did-you-mean note.
+    auto params = JsonValue::object({
+        {"textDocument",
+         JsonValue::object({
+             {"uri", JsonValue("file:///test.zia")},
+             {"languageId", JsonValue("zia")},
+             {"version", JsonValue(1)},
+             {"text",
+              JsonValue("module Test;\nfunc start() {\n    var count = 1;\n    var x = cout;\n"
+                        "    Viper.Terminal.SayInt(x + count);\n}\n")},
+         })},
+    });
+    handler.handleRequest(makeNotif("textDocument/didOpen", std::move(params)));
+
+    EXPECT_TRUE(transport.written.size() > 0u);
+    auto notif = JsonValue::parse(transport.written[0]);
+    EXPECT_EQ(notif["method"].asString(), "textDocument/publishDiagnostics");
+
+    bool found = false;
+    for (const auto &d : notif["params"]["diagnostics"].asArray()) {
+        if (!d.has("code") || d["code"].asString() != "V-ZIA-UNDEFINED")
+            continue;
+        found = true;
+        EXPECT_EQ(d["severity"].asInt(), 1); // LSP Error
+        // Range derived from the compiler's concrete span: "cout" is 4 chars.
+        auto range = d["range"];
+        EXPECT_EQ(range["start"]["line"].asInt(), 3); // 0-based line 3
+        EXPECT_EQ(range["end"]["line"].asInt(), 3);
+        EXPECT_EQ(range["end"]["character"].asInt() - range["start"]["character"].asInt(), 4);
+        // Did-you-mean note arrives as relatedInformation in this document.
+        EXPECT_TRUE(d.has("relatedInformation"));
+        if (d.has("relatedInformation")) {
+            EXPECT_TRUE(d["relatedInformation"].size() > 0u);
+            auto rel = d["relatedInformation"].at(0);
+            EXPECT_EQ(rel["location"]["uri"].asString(), "file:///test.zia");
+            EXPECT_TRUE(!rel["message"].asString().empty());
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
 TEST(LspHandler, DidChangeUpdatesDiagnostics) {
     CompilerBridge bridge;
     MockTransport transport;

--- a/src/tests/zia-server/test_mcp_handler.cpp
+++ b/src/tests/zia-server/test_mcp_handler.cpp
@@ -237,6 +237,49 @@ TEST(McpHandler, ToolsCallCheck) {
     EXPECT_EQ(content.at(0)["type"].asString(), "text");
 }
 
+TEST(McpHandler, ToolsCallCheckEmitsStructuredDiagnostics) {
+    CompilerBridge bridge;
+    McpHandler handler(bridge, {"zia-server", "0.1.0", "zia", "zia", ".zia", "Zia"});
+    startMcpSession(handler);
+
+    auto params = JsonValue::object({
+        {"name", JsonValue("zia/check")},
+        {"arguments",
+         JsonValue::object({
+             {"source",
+              JsonValue("module Test;\nfunc start() {\n    var count = 1;\n    var x = cout;\n"
+                        "    Viper.Terminal.SayInt(x + count);\n}\n")},
+         })},
+    });
+    auto resp = parseResponse(handler.handleRequest(makeReq("tools/call", std::move(params))));
+    auto text = resp["result"]["content"].at(0)["text"].asString();
+    auto parsed = JsonValue::parse(text);
+    EXPECT_TRUE(parsed.size() > 0u);
+
+    // Locate the undefined-identifier diagnostic and verify the structured shape.
+    bool found = false;
+    for (const auto &d : parsed.asArray()) {
+        if (d["code"].asString() != "V-ZIA-UNDEFINED")
+            continue;
+        found = true;
+        EXPECT_EQ(d["severity"].asInt(), 2);
+        EXPECT_TRUE(d["line"].asInt() > 0);
+        EXPECT_TRUE(d["column"].asInt() > 0);
+        EXPECT_EQ(d["endLine"].asInt(), d["line"].asInt());
+        EXPECT_TRUE(d["endColumn"].asInt() > d["column"].asInt());
+        EXPECT_EQ(d["stage"].asString(), "sema");
+        EXPECT_TRUE(!d["help"].asString().empty());
+        EXPECT_TRUE(d["notes"].size() > 0u);
+        EXPECT_TRUE(d["fixits"].size() > 0u);
+        if (d["fixits"].size() > 0u) {
+            auto fix = d["fixits"].at(0);
+            EXPECT_EQ(fix["replacement"].asString(), "count");
+            EXPECT_TRUE(fix["endColumn"].asInt() > fix["column"].asInt());
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
 TEST(McpHandler, ToolsCallCompile) {
     CompilerBridge bridge;
     McpHandler handler(bridge, {"zia-server", "0.1.0", "zia", "zia", ".zia", "Zia"});

--- a/src/tools/lsp-common/DiagnosticUtils.cpp
+++ b/src/tools/lsp-common/DiagnosticUtils.cpp
@@ -9,6 +9,8 @@
 // Purpose: Implementation of shared diagnostic extraction utility.
 // Key invariants:
 //   - Severity mapping: Note=0, Warning=1, Error=2
+//   - End range fields are populated only for concrete, ordered ranges that
+//     live in the same file as the primary location
 // Ownership/Lifetime:
 //   - All returned data is fully owned
 // Links: tools/lsp-common/DiagnosticUtils.hpp
@@ -18,10 +20,19 @@
 #include "tools/lsp-common/DiagnosticUtils.hpp"
 
 #include "support/diagnostics.hpp"
+#include "support/source_manager.hpp"
 
 namespace viper::server {
 
-std::vector<DiagnosticInfo> extractDiagnostics(const il::support::DiagnosticEngine &diag) {
+/// @brief Resolve a file id to its registered path, or empty when unknown.
+static std::string resolvePath(const il::support::SourceManager *sm, uint32_t fileId) {
+    if (!sm || fileId == 0)
+        return {};
+    return std::string(sm->getPath(fileId));
+}
+
+std::vector<DiagnosticInfo> extractDiagnostics(const il::support::DiagnosticEngine &diag,
+                                               const il::support::SourceManager *sm) {
     std::vector<DiagnosticInfo> result;
     for (const auto &d : diag.diagnostics()) {
         DiagnosticInfo info;
@@ -37,9 +48,52 @@ std::vector<DiagnosticInfo> extractDiagnostics(const il::support::DiagnosticEngi
                 break;
         }
         info.message = d.message;
+        info.file = resolvePath(sm, d.loc.file_id);
         info.line = d.loc.line;
         info.column = d.loc.column;
         info.code = d.code;
+        info.stage = d.stage;
+        info.help = d.help;
+
+        // Only forward machine-usable ranges: concrete (strictly ordered) and
+        // anchored in the same file as the primary location.
+        if (d.range.isConcrete() &&
+            (d.loc.file_id == 0 || d.range.begin.file_id == d.loc.file_id)) {
+            info.endLine = d.range.end.line;
+            info.endColumn = d.range.end.column;
+        }
+
+        info.notes.reserve(d.notes.size());
+        for (const auto &n : d.notes) {
+            DiagnosticNoteInfo note;
+            note.message = n.message;
+            note.file = resolvePath(sm, n.loc.file_id);
+            note.line = n.loc.line;
+            note.column = n.loc.column;
+            info.notes.push_back(std::move(note));
+        }
+
+        info.fixits.reserve(d.fixits.size());
+        for (const auto &f : d.fixits) {
+            DiagnosticFixItInfo fix;
+            fix.message = f.message;
+            fix.replacement = f.replacement;
+            if (f.range.isConcrete()) {
+                fix.line = f.range.begin.line;
+                fix.column = f.range.begin.column;
+                fix.endLine = f.range.end.line;
+                fix.endColumn = f.range.end.column;
+            } else if (f.range.isInsertion()) {
+                fix.line = f.range.begin.line;
+                fix.column = f.range.begin.column;
+            } else {
+                // Fall back to the diagnostic's primary location as an insertion point.
+                fix.line = d.loc.line;
+                fix.column = d.loc.column;
+            }
+            info.fixits.push_back(std::move(fix));
+        }
+
         result.push_back(std::move(info));
     }
     return result;

--- a/src/tools/lsp-common/DiagnosticUtils.hpp
+++ b/src/tools/lsp-common/DiagnosticUtils.hpp
@@ -24,16 +24,21 @@
 
 namespace il::support {
 class DiagnosticEngine;
-}
+class SourceManager;
+} // namespace il::support
 
 namespace viper::server {
 
 /// @brief Extract structured diagnostics from a DiagnosticEngine.
 /// @details Converts each engine diagnostic into a server-agnostic DiagnosticInfo
-///          (message, severity, and 0-based line/column range) suitable for LSP or
-///          MCP responses, independent of any particular frontend.
+///          (message, severity, 1-based location and optional end range, code,
+///          stage, help, related notes, and fix-its) suitable for LSP or MCP
+///          responses, independent of any particular frontend.
 /// @param diag Diagnostic engine holding the collected frontend diagnostics.
+/// @param sm Optional source manager used to resolve file paths for the primary
+///           location and related notes; pass nullptr when unavailable.
 /// @return One DiagnosticInfo per diagnostic, in engine order.
-std::vector<DiagnosticInfo> extractDiagnostics(const il::support::DiagnosticEngine &diag);
+std::vector<DiagnosticInfo> extractDiagnostics(const il::support::DiagnosticEngine &diag,
+                                               const il::support::SourceManager *sm = nullptr);
 
 } // namespace viper::server

--- a/src/tools/lsp-common/LspHandler.cpp
+++ b/src/tools/lsp-common/LspHandler.cpp
@@ -436,6 +436,51 @@ JsonValue diagnosticRangeForLocation(const std::string &content,
     return makeRange(lspLine, lspCol, endLine, endCol);
 }
 
+/// @brief Convert a 1-based compiler diagnostic span into an LSP range.
+/// @details Used when the frontend supplied a concrete end position. Both
+///          endpoints are interpreted as byte columns and converted to UTF-16
+///          code units. Falls back to diagnosticRangeForLocation when the end
+///          position is missing, malformed, or precedes the start.
+JsonValue diagnosticRangeForSpan(const std::string &content,
+                                 uint32_t beginLine,
+                                 uint32_t beginColumn,
+                                 uint32_t endLine,
+                                 uint32_t endColumn) {
+    if (endLine == 0 || endColumn == 0 || endLine < beginLine ||
+        (endLine == beginLine && endColumn <= beginColumn))
+        return diagnosticRangeForLocation(content, beginLine, beginColumn);
+
+    auto byteOffsetFor =
+        [&content](uint32_t oneBasedLine, uint32_t oneBasedColumn, size_t &offset) -> bool {
+        const int line = oneBasedLine > 0 && oneBasedLine <= static_cast<uint32_t>(
+                                                                 std::numeric_limits<int>::max())
+                             ? static_cast<int>(oneBasedLine) - 1
+                             : 0;
+        size_t lineStart = 0;
+        size_t lineEnd = 0;
+        if (!sourceLineByteSpan(content, line, lineStart, lineEnd))
+            return false;
+        const size_t byteColumn =
+            oneBasedColumn > 0 ? static_cast<size_t>(oneBasedColumn - 1u) : 0u;
+        offset = std::min(lineStart + byteColumn, lineEnd);
+        return true;
+    };
+
+    size_t beginOffset = 0;
+    size_t endOffset = 0;
+    if (!byteOffsetFor(beginLine, beginColumn, beginOffset) ||
+        !byteOffsetFor(endLine, endColumn, endOffset) || endOffset < beginOffset)
+        return diagnosticRangeForLocation(content, beginLine, beginColumn);
+
+    int startLspLine = 0;
+    int startLspCol = 0;
+    int endLspLine = 0;
+    int endLspCol = 0;
+    byteOffsetToLspPosition(content, beginOffset, startLspLine, startLspCol);
+    byteOffsetToLspPosition(content, endOffset, endLspLine, endLspCol);
+    return makeRange(startLspLine, startLspCol, endLspLine, endLspCol);
+}
+
 /// @brief Return true for methods that are request/response-shaped in LSP.
 /// @details Notifications must not receive responses. Dispatch uses this helper
 ///          to suppress accidental responses for missing-id calls to request
@@ -816,7 +861,7 @@ void LspHandler::publishDiagnostics(const std::string &uri) {
                 break;
         }
 
-        auto range = diagnosticRangeForLocation(*content, d.line, d.column);
+        auto range = diagnosticRangeForSpan(*content, d.line, d.column, d.endLine, d.endColumn);
 
         auto diag = JsonValue::object({
             {"range", std::move(range)},
@@ -828,6 +873,37 @@ void LspHandler::publishDiagnostics(const std::string &uri) {
         if (!d.code.empty()) {
             auto diagObj = diag.asObject();
             diagObj.push_back({"code", JsonValue(d.code)});
+            diag = JsonValue(std::move(diagObj));
+        }
+
+        if (!d.notes.empty()) {
+            // The single-document server only knows this document's URI. Notes
+            // anchored in this document point at their own range; notes from
+            // other files (or without a location) anchor at the primary range
+            // with the original path preserved in the message text.
+            JsonValue::ArrayType related;
+            related.reserve(d.notes.size());
+            for (const auto &n : d.notes) {
+                const bool sameFile = n.file.empty() || n.file == path;
+                const bool hasLoc = n.line > 0;
+                JsonValue noteRange =
+                    (sameFile && hasLoc)
+                        ? diagnosticRangeForLocation(*content, n.line, n.column)
+                        : diagnosticRangeForSpan(*content, d.line, d.column, d.endLine,
+                                                 d.endColumn);
+                std::string noteMessage = n.message;
+                if (!sameFile && hasLoc) {
+                    noteMessage = n.file + ":" + std::to_string(n.line) + ":" +
+                                  std::to_string(n.column) + ": " + noteMessage;
+                }
+                related.push_back(JsonValue::object({
+                    {"location",
+                     JsonValue::object({{"uri", JsonValue(uri)}, {"range", std::move(noteRange)}})},
+                    {"message", JsonValue(std::move(noteMessage))},
+                }));
+            }
+            auto diagObj = diag.asObject();
+            diagObj.push_back({"relatedInformation", JsonValue(std::move(related))});
             diag = JsonValue(std::move(diagObj));
         }
 

--- a/src/tools/lsp-common/McpHandler.cpp
+++ b/src/tools/lsp-common/McpHandler.cpp
@@ -432,6 +432,50 @@ std::string McpHandler::handleToolsCall(const JsonRpcRequest &req) {
 
 // --- Tool implementations ---
 
+/// @brief Serialize one DiagnosticInfo into the MCP diagnostic JSON shape.
+/// @details The shape is stable for machine consumers: endLine/endColumn are 0
+///          when no concrete range is known, and notes/fixits are always
+///          present (possibly empty arrays).
+static JsonValue diagnosticToJson(const DiagnosticInfo &d) {
+    JsonValue::ArrayType noteArr;
+    noteArr.reserve(d.notes.size());
+    for (const auto &n : d.notes) {
+        noteArr.push_back(JsonValue::object({
+            {"message", JsonValue(n.message)},
+            {"file", JsonValue(n.file)},
+            {"line", JsonValue(static_cast<int64_t>(n.line))},
+            {"column", JsonValue(static_cast<int64_t>(n.column))},
+        }));
+    }
+
+    JsonValue::ArrayType fixArr;
+    fixArr.reserve(d.fixits.size());
+    for (const auto &f : d.fixits) {
+        fixArr.push_back(JsonValue::object({
+            {"message", JsonValue(f.message)},
+            {"replacement", JsonValue(f.replacement)},
+            {"line", JsonValue(static_cast<int64_t>(f.line))},
+            {"column", JsonValue(static_cast<int64_t>(f.column))},
+            {"endLine", JsonValue(static_cast<int64_t>(f.endLine))},
+            {"endColumn", JsonValue(static_cast<int64_t>(f.endColumn))},
+        }));
+    }
+
+    return JsonValue::object({
+        {"severity", JsonValue(d.severity)},
+        {"message", JsonValue(d.message)},
+        {"line", JsonValue(static_cast<int64_t>(d.line))},
+        {"column", JsonValue(static_cast<int64_t>(d.column))},
+        {"code", JsonValue(d.code)},
+        {"endLine", JsonValue(static_cast<int64_t>(d.endLine))},
+        {"endColumn", JsonValue(static_cast<int64_t>(d.endColumn))},
+        {"stage", JsonValue(d.stage)},
+        {"help", JsonValue(d.help)},
+        {"notes", JsonValue(std::move(noteArr))},
+        {"fixits", JsonValue(std::move(fixArr))},
+    });
+}
+
 JsonValue McpHandler::callCheck(const JsonValue &args) {
     std::string source = args["source"].asString();
     std::string path = args.has("path") ? args["path"].asString() : "untitled" + config_.defaultExt;
@@ -440,15 +484,8 @@ JsonValue McpHandler::callCheck(const JsonValue &args) {
 
     JsonValue::ArrayType diagArr;
     diagArr.reserve(diags.size());
-    for (const auto &d : diags) {
-        diagArr.push_back(JsonValue::object({
-            {"severity", JsonValue(d.severity)},
-            {"message", JsonValue(d.message)},
-            {"line", JsonValue(static_cast<int64_t>(d.line))},
-            {"column", JsonValue(static_cast<int64_t>(d.column))},
-            {"code", JsonValue(d.code)},
-        }));
-    }
+    for (const auto &d : diags)
+        diagArr.push_back(diagnosticToJson(d));
 
     return textContent(JsonValue(std::move(diagArr)).toCompactString());
 }
@@ -461,15 +498,8 @@ JsonValue McpHandler::callCompile(const JsonValue &args) {
 
     JsonValue::ArrayType diagArr;
     diagArr.reserve(result.diagnostics.size());
-    for (const auto &d : result.diagnostics) {
-        diagArr.push_back(JsonValue::object({
-            {"severity", JsonValue(d.severity)},
-            {"message", JsonValue(d.message)},
-            {"line", JsonValue(static_cast<int64_t>(d.line))},
-            {"column", JsonValue(static_cast<int64_t>(d.column))},
-            {"code", JsonValue(d.code)},
-        }));
-    }
+    for (const auto &d : result.diagnostics)
+        diagArr.push_back(diagnosticToJson(d));
 
     auto obj = JsonValue::object({
         {"succeeded", JsonValue(result.succeeded)},

--- a/src/tools/lsp-common/ServerTypes.hpp
+++ b/src/tools/lsp-common/ServerTypes.hpp
@@ -25,14 +25,40 @@
 
 namespace viper::server {
 
+/// @brief Related location attached to a diagnostic (e.g., "previous definition is here").
+struct DiagnosticNoteInfo {
+    std::string message; ///< Human-readable note text.
+    std::string file;    ///< Source file the note refers to; empty when unknown.
+    uint32_t line{0};    ///< 1-based line number; 0 when unknown.
+    uint32_t column{0};  ///< 1-based column number; 0 when unknown.
+};
+
+/// @brief Machine-applicable replacement attached to a diagnostic.
+/// @details The range is half-open: [line:column, endLine:endColumn). When
+///          endLine/endColumn are 0 the fix-it is an insertion at line:column.
+struct DiagnosticFixItInfo {
+    std::string message;     ///< Human-readable description of the fix.
+    std::string replacement; ///< Replacement text for the range.
+    uint32_t line{0};        ///< 1-based begin line.
+    uint32_t column{0};      ///< 1-based begin column.
+    uint32_t endLine{0};     ///< 1-based end line (exclusive); 0 for insertions.
+    uint32_t endColumn{0};   ///< 1-based end column (exclusive); 0 for insertions.
+};
+
 /// @brief Structured diagnostic from a compiler frontend.
 struct DiagnosticInfo {
-    int severity{0};     ///< 0 = note, 1 = warning, 2 = error
-    std::string message; ///< Human-readable diagnostic text.
-    std::string file;    ///< Source file the diagnostic refers to.
-    uint32_t line{0};    ///< 1-based line number.
-    uint32_t column{0};  ///< 1-based column number.
-    std::string code;    ///< Warning/error code (e.g., "W001", "B1001")
+    int severity{0};       ///< 0 = note, 1 = warning, 2 = error
+    std::string message;   ///< Human-readable diagnostic text.
+    std::string file;      ///< Source file the diagnostic refers to.
+    uint32_t line{0};      ///< 1-based line number.
+    uint32_t column{0};    ///< 1-based column number.
+    std::string code;      ///< Warning/error code (e.g., "W001", "B1001")
+    uint32_t endLine{0};   ///< 1-based end line of the underlined range; 0 when unknown.
+    uint32_t endColumn{0}; ///< 1-based end column (exclusive); 0 when unknown.
+    std::string stage;     ///< Pipeline stage (parse, sema, lower, verify, runtime); may be empty.
+    std::string help;      ///< Help text or URL for this diagnostic code; may be empty.
+    std::vector<DiagnosticNoteInfo> notes;   ///< Related locations, in engine order.
+    std::vector<DiagnosticFixItInfo> fixits; ///< Machine-applicable fixes, in engine order.
 };
 
 /// @brief Symbol information from semantic analysis.

--- a/src/tools/vbasic-server/BasicCompilerBridge.cpp
+++ b/src/tools/vbasic-server/BasicCompilerBridge.cpp
@@ -178,14 +178,15 @@ std::vector<DiagnosticInfo> BasicCompilerBridge::check(const std::string &source
     il::support::SourceManager sm;
     BasicCompilerInput input{.source = source, .path = path};
     auto result = parseAndAnalyzeBasic(input, sm);
-    if (!result)
-        return {{2,
-                 "internal error: BASIC analysis did not produce a result",
-                 path,
-                 0,
-                 0,
-                 "V-LSP-ANALYSIS"}};
-    return extractDiagnostics(result->diagnostics);
+    if (!result) {
+        DiagnosticInfo info;
+        info.severity = 2;
+        info.message = "internal error: BASIC analysis did not produce a result";
+        info.file = path;
+        info.code = "V-LSP-ANALYSIS";
+        return {info};
+    }
+    return extractDiagnostics(result->diagnostics, &sm);
 }
 
 CompileResult BasicCompilerBridge::compile(const std::string &source, const std::string &path) {
@@ -194,7 +195,7 @@ CompileResult BasicCompilerBridge::compile(const std::string &source, const std:
     BasicCompilerOptions opts{};
 
     auto result = compileBasic(input, opts, sm);
-    return {result.succeeded(), extractDiagnostics(result.diagnostics)};
+    return {result.succeeded(), extractDiagnostics(result.diagnostics, &sm)};
 }
 
 // --- IDE Features ---

--- a/src/tools/viper/cli.hpp
+++ b/src/tools/viper/cli.hpp
@@ -244,6 +244,17 @@ int cmdRun(int argc, char **argv);
 /// @return `0` on success, non-zero on failure.
 int cmdBuild(int argc, char **argv);
 
+/// @brief Handle `viper check` subcommand.
+///
+/// Compiles and verifies a Viper project without executing or emitting output.
+/// Diagnostics honor --diagnostic-format for machine-readable JSON.
+///
+/// @param argc Number of arguments following `check`.
+/// @param argv Array of argument strings.
+/// @return `0` when no errors, `1` on usage/target-resolution errors, `2` on
+///         compile or verification errors.
+int cmdCheck(int argc, char **argv);
+
 /// @brief Handle `viper init` subcommand.
 ///
 /// Scaffolds a new Viper project with a viper.project manifest and an
@@ -277,6 +288,33 @@ int cmdInstallPackage(int argc, char **argv);
 /// @param argv Array of argument strings.
 /// @return `0` on success, non-zero on failure.
 int cmdRepl(int argc, char **argv);
+
+/// @brief Handle `viper eval` subcommand.
+///
+/// Evaluates a single Zia or BASIC snippet through a fresh REPL session and
+/// prints the result, optionally as a structured JSON object (--json).
+///
+/// @param argc Number of arguments following `eval`.
+/// @param argv Array of argument strings.
+/// @return `0` on success, `1` on usage errors, `2` on compile/eval errors,
+///         `3` on runtime traps.
+int cmdEval(int argc, char **argv);
+
+/// @brief Handle `viper explain` subcommand.
+///
+/// Describes a diagnostic code from the central catalog, or lists the whole
+/// catalog with `--list`. Supports `--json` for machine-readable output.
+///
+/// @param argc Number of arguments following `explain`.
+/// @param argv Array of argument strings.
+/// @return `0` when the code resolves, `1` on usage error or unknown code.
+int cmdExplain(int argc, char **argv);
+
+/// @brief Implement the `--print-error-codes [--json]` driver flag.
+///
+/// @param json True to emit the catalog as a JSON array.
+/// @return `0` on success.
+int printErrorCodes(bool json);
 
 /// @brief Print usage information for viper.
 ///

--- a/src/tools/viper/cmd_eval.cpp
+++ b/src/tools/viper/cmd_eval.cpp
@@ -1,0 +1,206 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Viper project, under the GNU GPL v3.
+// See LICENSE for license information.
+//
+//===----------------------------------------------------------------------===//
+//
+// File: src/tools/viper/cmd_eval.cpp
+// Purpose: Entry point for the `viper eval` subcommand. Evaluates a single
+//          Zia or BASIC snippet through the REPL adapters and reports the
+//          result on stdout, optionally as structured JSON.
+// Key invariants:
+//   - The snippet is evaluated as one REPL input with a fresh session.
+//   - Exit codes are stable: 0 success, 1 usage error, 2 compile/eval error,
+//     3 runtime trap.
+//   - JSON output is a single object on stdout; diagnostics stay on stderr.
+// Ownership/Lifetime:
+//   - The language adapter lives for the duration of the command.
+// Links: src/repl/ReplSession.hpp, src/repl/ZiaReplAdapter.hpp,
+//        src/repl/BasicReplAdapter.hpp, docs/tools.md
+//
+//===----------------------------------------------------------------------===//
+
+#include "repl/BasicReplAdapter.hpp"
+#include "repl/ReplSession.hpp"
+#include "repl/ZiaReplAdapter.hpp"
+#include "support/diag_expected.hpp"
+
+#include <cstring>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <string_view>
+
+namespace {
+
+/// @brief Print usage for `viper eval` to the given stream.
+void printEvalUsage(std::ostream &os) {
+    os << "Usage: viper eval [options] [code]\n"
+       << "\n"
+       << "Evaluate a single Zia or BASIC snippet and print the result.\n"
+       << "Reads the snippet from stdin when no code argument is given.\n"
+       << "\n"
+       << "Options:\n"
+       << "  --lang zia|basic   Snippet language (default: zia)\n"
+       << "  --json             Emit a structured JSON result object on stdout\n"
+       << "  --type             Include the inferred expression type (Zia only)\n"
+       << "  --il               Include the generated IL (Zia only)\n"
+       << "  -h, --help         Show this help\n"
+       << "\n"
+       << "Exit codes:\n"
+       << "  0  evaluation succeeded\n"
+       << "  1  usage error\n"
+       << "  2  compile or evaluation error\n"
+       << "  3  runtime trap\n"
+       << "\n"
+       << "Examples:\n"
+       << "  viper eval '2 + 3 * 4'\n"
+       << "  viper eval --json --type 'Viper.Math.Sqrt(2.0)'\n"
+       << "  echo 'Say(\"hi\")' | viper eval\n";
+}
+
+/// @brief Map a REPL result type to its stable JSON string name.
+std::string_view resultTypeName(viper::repl::ResultType type) {
+    switch (type) {
+        case viper::repl::ResultType::None:
+            return "none";
+        case viper::repl::ResultType::Statement:
+            return "statement";
+        case viper::repl::ResultType::Integer:
+            return "Integer";
+        case viper::repl::ResultType::Number:
+            return "Number";
+        case viper::repl::ResultType::String:
+            return "String";
+        case viper::repl::ResultType::Boolean:
+            return "Boolean";
+        case viper::repl::ResultType::Object:
+            return "Object";
+    }
+    return "none";
+}
+
+/// @brief Emit a string as a JSON-escaped, double-quoted literal.
+void printJsonString(std::ostream &os, std::string_view text) {
+    il::support::printJsonStringEscaped(os, text);
+}
+
+} // namespace
+
+/// @brief Entry point for `viper eval [options] [code]`.
+/// @param argc Argument count (after "eval" is stripped).
+/// @param argv Argument vector.
+/// @return 0 on success, 1 on usage error, 2 on compile/eval error, 3 on trap.
+int cmdEval(int argc, char **argv) {
+    std::string lang = "zia";
+    std::string code;
+    bool haveCode = false;
+    bool jsonOutput = false;
+    bool wantType = false;
+    bool wantIL = false;
+
+    for (int i = 0; i < argc; ++i) {
+        std::string_view arg = argv[i];
+        if (arg == "--help" || arg == "-h") {
+            printEvalUsage(std::cout);
+            return 0;
+        } else if (arg == "--json") {
+            jsonOutput = true;
+        } else if (arg == "--type") {
+            wantType = true;
+        } else if (arg == "--il") {
+            wantIL = true;
+        } else if (arg == "--lang") {
+            if (i + 1 >= argc) {
+                std::cerr << "error: --lang requires 'zia' or 'basic'\n";
+                return 1;
+            }
+            lang = argv[++i];
+        } else if (arg.substr(0, 7) == "--lang=") {
+            lang = std::string(arg.substr(7));
+        } else if (!arg.empty() && arg[0] == '-') {
+            std::cerr << "error: unknown flag: " << arg << "\n";
+            printEvalUsage(std::cerr);
+            return 1;
+        } else if (!haveCode) {
+            code = std::string(arg);
+            haveCode = true;
+        } else {
+            std::cerr << "error: multiple code arguments; quote the snippet as one argument\n";
+            return 1;
+        }
+    }
+
+    if (lang != "zia" && lang != "basic") {
+        std::cerr << "error: --lang must be 'zia' or 'basic'\n";
+        return 1;
+    }
+    if (lang != "zia" && (wantType || wantIL)) {
+        std::cerr << "error: --type and --il are only supported with --lang zia\n";
+        return 1;
+    }
+
+    if (!haveCode) {
+        code.assign(std::istreambuf_iterator<char>(std::cin), std::istreambuf_iterator<char>());
+    }
+    if (code.empty()) {
+        std::cerr << "error: no code to evaluate (pass a snippet or pipe it on stdin)\n";
+        return 1;
+    }
+
+    std::unique_ptr<viper::repl::ReplAdapter> adapter;
+    if (lang == "basic")
+        adapter = std::make_unique<viper::repl::BasicReplAdapter>();
+    else
+        adapter = std::make_unique<viper::repl::ZiaReplAdapter>();
+
+    // Type/IL queries run before evaluation so they reflect the same session
+    // state the snippet itself sees (an empty session).
+    std::string exprType;
+    if (wantType)
+        exprType = adapter->getExprType(code);
+    std::string ilText;
+    if (wantIL)
+        ilText = adapter->getIL(code);
+
+    auto result = adapter->eval(code);
+
+    if (jsonOutput) {
+        std::ostream &os = std::cout;
+        os << "{\"success\":" << (result.success ? "true" : "false")
+           << ",\"trapped\":" << (result.trapped ? "true" : "false") << ",\"resultType\":";
+        printJsonString(os, resultTypeName(result.resultType));
+        os << ",\"output\":";
+        printJsonString(os, result.output);
+        os << ",\"error\":";
+        printJsonString(os, result.errorMessage);
+        if (wantType) {
+            os << ",\"type\":";
+            printJsonString(os, exprType);
+        }
+        if (wantIL) {
+            os << ",\"il\":";
+            printJsonString(os, ilText);
+        }
+        os << "}\n";
+    } else {
+        if (wantType)
+            std::cout << "type: " << exprType << "\n";
+        if (!result.output.empty()) {
+            std::cout << result.output;
+            if (result.output.back() != '\n')
+                std::cout << '\n';
+        }
+        if (wantIL)
+            std::cout << ilText << (ilText.empty() || ilText.back() == '\n' ? "" : "\n");
+        if (!result.success && !result.errorMessage.empty())
+            std::cerr << result.errorMessage << "\n";
+    }
+
+    if (result.trapped)
+        return 3;
+    return result.success ? 0 : 2;
+}

--- a/src/tools/viper/cmd_explain.cpp
+++ b/src/tools/viper/cmd_explain.cpp
@@ -1,0 +1,152 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the Viper project, under the GNU GPL v3.
+// See LICENSE for license information.
+//
+//===----------------------------------------------------------------------===//
+//
+// File: src/tools/viper/cmd_explain.cpp
+// Purpose: Entry point for `viper explain` and the `--print-error-codes`
+//          driver flag. Resolves diagnostic codes against the central catalog
+//          and prints human- or machine-readable descriptions.
+// Key invariants:
+//   - Lookup degrades gracefully: uncataloged codes with a recognized prefix
+//     still report their subsystem family.
+//   - JSON output is a stable array of {code, subsystem, summary} objects.
+// Ownership/Lifetime:
+//   - Catalog data is static; no allocation beyond output formatting.
+// Links: support/diag_catalog.hpp, docs/debugging.md, docs/tools.md
+//
+//===----------------------------------------------------------------------===//
+
+#include "support/diag_catalog.hpp"
+#include "support/diag_expected.hpp"
+
+#include <iostream>
+#include <ostream>
+#include <string>
+#include <string_view>
+
+namespace {
+
+/// @brief Emit a string as a JSON-escaped, double-quoted literal.
+void printJsonString(std::ostream &os, std::string_view text) {
+    il::support::printJsonStringEscaped(os, text);
+}
+
+/// @brief Print every cataloged code, optionally as JSON.
+int printAllCodes(bool json) {
+    const auto &entries = il::support::diagCatalog();
+    if (json) {
+        std::cout << "[";
+        bool first = true;
+        for (const auto &e : entries) {
+            if (!first)
+                std::cout << ",";
+            first = false;
+            std::cout << "{\"code\":";
+            printJsonString(std::cout, e.code);
+            std::cout << ",\"subsystem\":";
+            printJsonString(std::cout, e.subsystem);
+            std::cout << ",\"summary\":";
+            printJsonString(std::cout, e.summary);
+            std::cout << "}";
+        }
+        std::cout << "]\n";
+        return 0;
+    }
+    for (const auto &e : entries)
+        std::cout << e.code << "\t" << e.subsystem << "\t" << e.summary << "\n";
+    return 0;
+}
+
+void printExplainUsage(std::ostream &os) {
+    os << "Usage: viper explain <code> [--json]\n"
+       << "       viper explain --list [--json]\n"
+       << "\n"
+       << "Describe a diagnostic code (e.g., V-ZIA-UNDEFINED, B2001, W008).\n"
+       << "--list prints the full catalog; with --json the output is a JSON\n"
+       << "array of {code, subsystem, summary} objects on stdout.\n";
+}
+
+} // namespace
+
+/// @brief Entry point for `viper explain <code> [--json]` / `viper explain --list`.
+/// @param argc Argument count (after "explain" is stripped).
+/// @param argv Argument vector.
+/// @return 0 when the code (or family) resolves, 1 on usage error or unknown code.
+int cmdExplain(int argc, char **argv) {
+    bool json = false;
+    bool list = false;
+    std::string code;
+
+    for (int i = 0; i < argc; ++i) {
+        std::string_view arg = argv[i];
+        if (arg == "--help" || arg == "-h") {
+            printExplainUsage(std::cout);
+            return 0;
+        } else if (arg == "--json") {
+            json = true;
+        } else if (arg == "--list") {
+            list = true;
+        } else if (!arg.empty() && arg[0] == '-') {
+            std::cerr << "error: unknown flag: " << arg << "\n";
+            printExplainUsage(std::cerr);
+            return 1;
+        } else if (code.empty()) {
+            code = std::string(arg);
+        } else {
+            std::cerr << "error: explain takes a single diagnostic code\n";
+            return 1;
+        }
+    }
+
+    if (list)
+        return printAllCodes(json);
+    if (code.empty()) {
+        printExplainUsage(std::cerr);
+        return 1;
+    }
+
+    const auto *entry = il::support::findDiagCode(code);
+    if (entry) {
+        if (json) {
+            std::cout << "{\"code\":";
+            printJsonString(std::cout, entry->code);
+            std::cout << ",\"subsystem\":";
+            printJsonString(std::cout, entry->subsystem);
+            std::cout << ",\"summary\":";
+            printJsonString(std::cout, entry->summary);
+            std::cout << "}\n";
+        } else {
+            std::cout << entry->code << " (" << entry->subsystem << ")\n  " << entry->summary
+                      << "\n";
+        }
+        return 0;
+    }
+
+    if (auto family = il::support::diagCodeFamily(code)) {
+        if (json) {
+            std::cout << "{\"code\":";
+            printJsonString(std::cout, code);
+            std::cout << ",\"subsystem\":";
+            printJsonString(std::cout, *family);
+            std::cout << ",\"summary\":\"\"}\n";
+        } else {
+            std::cout << code << "\n  Not in the catalog yet; the prefix belongs to: " << *family
+                      << "\n";
+        }
+        return 0;
+    }
+
+    std::cerr << "error: unknown diagnostic code: " << code << "\n"
+              << "Use 'viper explain --list' to see the catalog.\n";
+    return 1;
+}
+
+/// @brief Implement the `--print-error-codes [--json]` driver flag.
+/// @param json True to emit the catalog as JSON.
+/// @return 0 on success.
+int printErrorCodes(bool json) {
+    return printAllCodes(json);
+}

--- a/src/tools/viper/cmd_run.cpp
+++ b/src/tools/viper/cmd_run.cpp
@@ -55,7 +55,7 @@ using namespace il::tools::common;
 
 namespace {
 
-enum class RunMode { Run, Build };
+enum class RunMode { Run, Build, Check };
 
 /// @brief Return an ASCII-lowercased copy of @p value.
 /// @details Project entry extension checks are command-line syntax, so ASCII folding is enough and
@@ -159,8 +159,27 @@ struct RunBuildConfig {
     std::optional<bool> windowsDebugRuntimeOverride;      ///< Windows debug/release runtime.
 };
 
-/// @brief Print usage for the `viper run` or `viper build` subcommand to stderr.
+/// @brief Print usage for the `viper run`, `viper build`, or `viper check` subcommand to stderr.
 void printRunBuildUsage(RunMode mode) {
+    if (mode == RunMode::Check) {
+        std::cerr
+            << "Usage: viper check [target] [options]\n"
+            << "\n"
+            << "Type-check and verify a .zia file, .bas file, project directory, or\n"
+            << "viper.project without running or emitting anything.\n"
+            << "\n"
+            << "Check options:\n"
+            << "  --diagnostic-format text|json Diagnostic output format (stderr)\n"
+            << "  --no-strict-diagnostics       Keep safety warnings as warnings\n"
+            << "  --quiet-warnings              Suppress warning output\n"
+            << "  -h, --help                    Show this help\n"
+            << "\n"
+            << "Exit codes:\n"
+            << "  0  no errors (warnings allowed)\n"
+            << "  1  usage error or target could not be resolved\n"
+            << "  2  compile or verification errors\n";
+        return;
+    }
     if (mode == RunMode::Run) {
         std::cerr << "Usage: viper run [target] [options] [-- program-args...]\n"
                   << "\n"
@@ -267,7 +286,7 @@ il::support::Expected<RunBuildConfig> parseRunBuildArgs(RunMode mode, int argc, 
         std::string_view arg = argv[i];
 
         if (arg == "--") {
-            if (mode == RunMode::Build) {
+            if (mode != RunMode::Run) {
                 return il::support::Expected<RunBuildConfig>(il::support::Diagnostic{
                     il::support::Severity::Error,
                     "program arguments after -- are only valid with 'run'",
@@ -794,8 +813,9 @@ int runOrBuild(RunMode mode, int argc, char **argv) {
     }
     if (config.optimizeLevelOverride)
         proj.optimizeLevel = *config.optimizeLevelOverride;
-    if (mode == RunMode::Run && !config.buildProfileOverride && !config.optimizeLevelOverride &&
+    if (mode != RunMode::Build && !config.buildProfileOverride && !config.optimizeLevelOverride &&
         !proj.buildProfileExplicit && !proj.optimizeLevelExplicit) {
+        // run: keep instruction-to-source mapping; check: fastest path to diagnostics.
         proj.buildProfile = "debug";
         proj.optimizeLevel = "O0";
     }
@@ -812,11 +832,25 @@ int runOrBuild(RunMode mode, int argc, char **argv) {
     printCompileTime(config.shared, "source-to-il", compileStart);
 
     if (!moduleResult)
-        return 1; // diagnostics already printed
+        return mode == RunMode::Check ? 2 : 1; // diagnostics already printed
 
     CompiledProjectModule compiled = std::move(moduleResult.value());
     il::core::Module module = std::move(compiled.module);
     bool moduleVerified = compiled.verified;
+
+    // Check mode: verify and stop without emitting or executing.
+    if (mode == RunMode::Check) {
+        const auto verifyStart = std::chrono::steady_clock::now();
+        if (!moduleVerified && !reportVerifierDiagnostics(module,
+                                                          std::cerr,
+                                                          sm,
+                                                          config.shared.diagnosticFormat,
+                                                          config.shared.showWarnings)) {
+            return 2;
+        }
+        printCompileTime(config.shared, "final-verify", verifyStart);
+        return 0;
+    }
 
     // Build mode: emit IL or compile to native binary
     if (mode == RunMode::Build) {
@@ -942,4 +976,8 @@ int cmdRun(int argc, char **argv) {
 
 int cmdBuild(int argc, char **argv) {
     return runOrBuild(RunMode::Build, argc, argv);
+}
+
+int cmdCheck(int argc, char **argv) {
+    return runOrBuild(RunMode::Check, argc, argv);
 }

--- a/src/tools/viper/main.cpp
+++ b/src/tools/viper/main.cpp
@@ -21,8 +21,10 @@
 #include "cmd_codegen_arm64.hpp"
 #include "cmd_codegen_x64.hpp"
 #include "il/core/Module.hpp"
+#include "il/core/OpcodeInfo.hpp"
 #include "il/runtime/RuntimeSignatures.hpp"
 #include "il/runtime/classes/RuntimeClasses.hpp"
+#include "support/diag_expected.hpp"
 #include "viper/version.hpp"
 #include <algorithm>
 #include <iostream>
@@ -188,6 +190,172 @@ int dumpRuntimeDescriptors() {
 } // namespace
 
 namespace {
+/// @brief Map an opcode TypeCategory to its stable JSON name.
+const char *typeCategoryName(il::core::TypeCategory category) {
+    using il::core::TypeCategory;
+    switch (category) {
+        case TypeCategory::None:
+            return "none";
+        case TypeCategory::Void:
+            return "void";
+        case TypeCategory::I1:
+            return "i1";
+        case TypeCategory::I16:
+            return "i16";
+        case TypeCategory::I32:
+            return "i32";
+        case TypeCategory::I64:
+            return "i64";
+        case TypeCategory::F64:
+            return "f64";
+        case TypeCategory::Ptr:
+            return "ptr";
+        case TypeCategory::Str:
+            return "str";
+        case TypeCategory::Error:
+            return "error";
+        case TypeCategory::ResumeTok:
+            return "resume_tok";
+        case TypeCategory::Any:
+            return "any";
+        case TypeCategory::InstrType:
+            return "instr_type";
+        case TypeCategory::Dynamic:
+            return "dynamic";
+    }
+    return "none";
+}
+
+/// @brief Implement `--dump-opcodes`: print the IL opcode registry as a JSON
+///        array on stdout, generated from the live opcode metadata table so it
+///        cannot drift from Opcode.def.
+/// @return 0 on success.
+int dumpOpcodes() {
+    using il::core::ResultArity;
+    using il::support::printJsonStringEscaped;
+    std::ostream &os = std::cout;
+
+    os << "{\"ilVersion\":\"0.2.0\",\"opcodes\":[";
+    bool first = true;
+    for (const auto op : il::core::all_opcodes()) {
+        const auto &info = il::core::getOpcodeInfo(op);
+        if (!first)
+            os << ",";
+        first = false;
+        os << "{\"mnemonic\":";
+        printJsonStringEscaped(os, info.name);
+        os << ",\"resultArity\":\""
+           << (info.resultArity == ResultArity::None
+                   ? "none"
+                   : (info.resultArity == ResultArity::One ? "one" : "optional"))
+           << "\"";
+        os << ",\"resultType\":\"" << typeCategoryName(info.resultType) << "\"";
+        os << ",\"operandsMin\":" << static_cast<int>(info.numOperandsMin);
+        if (info.numOperandsMax == il::core::kVariadicOperandCount)
+            os << ",\"operandsMax\":-1";
+        else
+            os << ",\"operandsMax\":" << static_cast<int>(info.numOperandsMax);
+        os << ",\"operandTypes\":[";
+        for (size_t i = 0; i < info.operandTypes.size(); ++i) {
+            if (i)
+                os << ",";
+            os << "\"" << typeCategoryName(info.operandTypes[i]) << "\"";
+        }
+        os << "]";
+        os << ",\"sideEffects\":" << (info.hasSideEffects ? "true" : "false");
+        os << ",\"successors\":" << static_cast<int>(info.numSuccessors);
+        os << ",\"terminator\":" << (info.isTerminator ? "true" : "false");
+        os << "}";
+    }
+    os << "]}\n";
+    return 0;
+}
+
+/// @brief Implement `--dump-runtime-api`: print the full runtime surface
+///        (global functions and classes with members) as one JSON document on
+///        stdout. The document is generated from the live registry, so it can
+///        never drift from the binary.
+/// @return 0 on success.
+int dumpRuntimeApi() {
+    using il::support::printJsonStringEscaped;
+    std::ostream &os = std::cout;
+
+    os << "{\"version\":";
+    printJsonStringEscaped(os, VIPER_VERSION_STR);
+
+    // Global runtime functions with canonical Viper.* names.
+    os << ",\"functions\":[";
+    {
+        const auto &reg = il::runtime::runtimeRegistry();
+        bool first = true;
+        for (const auto &d : reg) {
+            if (d.name.rfind("Viper.", 0) != 0)
+                continue; // skip rt_* aliases; canonical names carry the API
+            if (!first)
+                os << ",";
+            first = false;
+            const auto &sig = d.signature;
+            std::string sigText = sig.retType.toString();
+            sigText += '(';
+            for (size_t i = 0; i < sig.paramTypes.size(); ++i) {
+                if (i)
+                    sigText += ',';
+                sigText += sig.paramTypes[i].toString();
+            }
+            sigText += ')';
+            os << "{\"name\":";
+            printJsonStringEscaped(os, d.name);
+            os << ",\"signature\":";
+            printJsonStringEscaped(os, sigText);
+            os << "}";
+        }
+    }
+    os << "]";
+
+    // Runtime classes with properties and methods.
+    os << ",\"classes\":[";
+    {
+        const auto &classes = il::runtime::runtimeClassCatalog();
+        bool firstClass = true;
+        for (const auto &c : classes) {
+            if (!firstClass)
+                os << ",";
+            firstClass = false;
+            os << "{\"name\":";
+            printJsonStringEscaped(os, c.qname ? c.qname : "");
+            os << ",\"constructor\":";
+            printJsonStringEscaped(os, c.ctor ? c.ctor : "");
+            os << ",\"properties\":[";
+            bool firstProp = true;
+            for (const auto &p : c.properties) {
+                if (!firstProp)
+                    os << ",";
+                firstProp = false;
+                os << "{\"name\":";
+                printJsonStringEscaped(os, p.name ? p.name : "");
+                os << ",\"type\":";
+                printJsonStringEscaped(os, p.type ? p.type : "");
+                os << ",\"readonly\":" << (p.readonly ? "true" : "false") << "}";
+            }
+            os << "],\"methods\":[";
+            bool firstMethod = true;
+            for (const auto &m : c.methods) {
+                if (!firstMethod)
+                    os << ",";
+                firstMethod = false;
+                os << "{\"name\":";
+                printJsonStringEscaped(os, m.name ? m.name : "");
+                os << ",\"signature\":";
+                printJsonStringEscaped(os, m.signature ? m.signature : "");
+                os << "}";
+            }
+            os << "]}";
+        }
+    }
+    os << "]}\n";
+    return 0;
+}
+
 /// @brief Implement `--dump-runtime-classes`: print the runtime class catalog
 ///        (properties, methods, constructors) in a stable format to stdout.
 /// @return 0 on success.
@@ -226,8 +394,11 @@ void usage() {
         << "Common commands:\n"
         << "       viper run [target] [options] [-- program-args...]\n"
         << "       viper build [target] [-o output] [options]\n"
+        << "       viper check [target] [options]\n"
         << "       viper init <project-name> [--lang zia|basic]\n"
         << "       viper repl [zia|basic]\n"
+        << "       viper eval [options] [code]\n"
+        << "       viper explain <diagnostic-code>\n"
         << "       viper package [target] [--target macos|linux|windows|tarball] [-o output]\n"
         << "\n"
         << "Developer commands:\n"
@@ -324,11 +495,24 @@ int main(int argc, char **argv) {
     if (cmd == "--dump-runtime-classes") {
         return dumpRuntimeClasses();
     }
+    if (cmd == "--dump-runtime-api") {
+        return dumpRuntimeApi();
+    }
+    if (cmd == "--dump-opcodes") {
+        return dumpOpcodes();
+    }
+    if (cmd == "--print-error-codes") {
+        const bool json = argc >= 3 && std::string_view(argv[2]) == "--json";
+        return printErrorCodes(json);
+    }
     if (cmd == "run") {
         return cmdRun(argc - 2, argv + 2);
     }
     if (cmd == "build") {
         return cmdBuild(argc - 2, argv + 2);
+    }
+    if (cmd == "check") {
+        return cmdCheck(argc - 2, argv + 2);
     }
     if (cmd == "init") {
         return cmdInit(argc - 2, argv + 2);
@@ -342,6 +526,12 @@ int main(int argc, char **argv) {
     if (cmd == "repl") {
         return cmdRepl(argc - 2, argv + 2);
     }
+    if (cmd == "eval") {
+        return cmdEval(argc - 2, argv + 2);
+    }
+    if (cmd == "explain") {
+        return cmdExplain(argc - 2, argv + 2);
+    }
     if (cmd == "help") {
         if (argc < 3) {
             usage();
@@ -352,6 +542,8 @@ int main(int argc, char **argv) {
             return invokeHelp(cmdRun);
         if (topic == "build")
             return invokeHelp(cmdBuild);
+        if (topic == "check")
+            return invokeHelp(cmdCheck);
         if (topic == "init")
             return invokeHelp(cmdInit);
         if (topic == "package")
@@ -360,6 +552,10 @@ int main(int argc, char **argv) {
             return invokeHelp(cmdInstallPackage);
         if (topic == "repl")
             return invokeHelp(cmdRepl);
+        if (topic == "eval")
+            return invokeHelp(cmdEval);
+        if (topic == "explain")
+            return invokeHelp(cmdExplain);
         if (topic == "-run")
             return invokeHelp(cmdRunIL);
         if (topic == "il-opt")

--- a/src/tools/zia-server/CompilerBridge.cpp
+++ b/src/tools/zia-server/CompilerBridge.cpp
@@ -115,14 +115,15 @@ std::vector<DiagnosticInfo> CompilerBridge::check(const std::string &source,
     CompilerOptions opts{};
 
     auto result = parseAndAnalyze(input, opts, sm);
-    if (!result)
-        return {{2,
-                 "internal error: Zia analysis did not produce a result",
-                 path,
-                 0,
-                 0,
-                 "V-LSP-ANALYSIS"}};
-    return extractDiagnostics(result->diagnostics);
+    if (!result) {
+        DiagnosticInfo info;
+        info.severity = 2;
+        info.message = "internal error: Zia analysis did not produce a result";
+        info.file = path;
+        info.code = "V-LSP-ANALYSIS";
+        return {info};
+    }
+    return extractDiagnostics(result->diagnostics, &sm);
 }
 
 CompileResult CompilerBridge::compile(const std::string &source, const std::string &path) {
@@ -131,7 +132,7 @@ CompileResult CompilerBridge::compile(const std::string &source, const std::stri
     CompilerOptions opts{};
 
     auto result = il::frontends::zia::compile(input, opts, sm);
-    return {result.succeeded(), extractDiagnostics(result.diagnostics)};
+    return {result.succeeded(), extractDiagnostics(result.diagnostics, &sm)};
 }
 
 // --- Hover helpers ---


### PR DESCRIPTION
…ostics

- viper check: project type-check/verify gate with differentiated exit codes
- viper eval: one-shot snippet evaluation with JSON results and trap exit code
- viper explain and --print-error-codes: central diagnostic-code catalog
- --dump-runtime-api / --dump-opcodes: machine-readable registry dumps
- zia-server/vbasic-server diagnostics now carry ranges, stage, help, notes, and fix-its through MCP and LSP (did-you-mean fixes reach clients)
- build scripts: VIPER_SKIP_TESTS, VIPER_SKIP_CLEAN, VIPER_TEST_LABEL, ccache
- fix audio-disabled Linux build (unused helpers, viperaud test guard)
- portable .mcp.json; add AGENTS.md

tests: agent_cli CMake suite, diag catalog unit tests, structured diagnostic coverage for bridge/MCP/LSP, hover use-site cases