### PR TITLE
fix(tests): include cstdlib for std::abort in draco probe test

### DIFF
--- a/src/tests/unit/test_rt_gltf_draco_probe.cpp
+++ b/src/tests/unit/test_rt_gltf_draco_probe.cpp
@@ -23,6 +23,7 @@
 #include "rt_gltf.h"
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <vector>
 
 extern "C" void vm_trap(const char *msg) {


### PR DESCRIPTION
The gltf draco probe test calls std::abort() but relied on a transitive
include for <cstdlib>, which breaks compilation with Clang 18 on Ubuntu
24.04 (libstdc++ 13 no longer pulls it in via cstdio/cstdint).

tests: test_rt_gltf_draco_probe compiles and links on Linux/Clang 18